### PR TITLE
spec-062: public read-side echo primitive for external wrappers (increment 1 of #163)

### DIFF
--- a/docs/_pipeline/templates/control-reconciler-protocol.md.dt
+++ b/docs/_pipeline/templates/control-reconciler-protocol.md.dt
@@ -278,10 +278,10 @@ suppresses that echo with a per-control counter:
 | Method | When to call | Effect |
 |---|---|---|
 | `binding.WriteSuppressed(mutate)` | Inside `Update` when writing a controlled prop | Increments the suppress counter, runs the mutate, decrements |
-| `ChangeEchoSuppressor.ShouldSuppress(fe)` | Inside an event trampoline | Drains a pending suppress count and returns true; trampoline short-circuits |
+| `ReactorBinding.ShouldSuppressEcho(fe)` | Inside an event trampoline | Drains a pending suppress count and returns true; trampoline short-circuits |
 
 The trampolines `ReactorBinding.OnCustomEvent<TArgs>` generates call
-`ShouldSuppress` on entry — every controlled prop in every built-in
+`ShouldSuppressEcho` on entry — every controlled prop in every built-in
 handler is echo-safe without the handler author having to think
 about it. Hand-authored trampolines (the ones that bypass
 `OnCustomEvent` for performance) follow the same shape; see

--- a/docs/_pipeline/templates/control-reconciler-protocol.md.dt
+++ b/docs/_pipeline/templates/control-reconciler-protocol.md.dt
@@ -280,8 +280,8 @@ suppresses that echo with a per-control counter:
 | `binding.WriteSuppressed(mutate)` | Inside `Update` when writing a controlled prop | Increments the suppress counter, runs the mutate, decrements |
 | `ReactorBinding.ShouldSuppressEcho(fe)` | Inside an event trampoline | Drains a pending suppress count and returns true; trampoline short-circuits |
 
-The trampolines `ReactorBinding.OnCustomEvent<TArgs>` generates call
-`ShouldSuppressEcho` on entry — every controlled prop in every built-in
+The trampolines that `ReactorBinding.OnCustomEvent<TArgs>` generates drain
+the suppress counter on entry — every controlled prop in every built-in
 handler is echo-safe without the handler author having to think
 about it. Hand-authored trampolines (the ones that bypass
 `OnCustomEvent` for performance) follow the same shape; see

--- a/docs/guide/control-reconciler-protocol.md
+++ b/docs/guide/control-reconciler-protocol.md
@@ -534,8 +534,8 @@ suppresses that echo with a per-control counter:
 | `binding.WriteSuppressed(mutate)` | Inside `Update` when writing a controlled prop | Increments the suppress counter, runs the mutate, decrements |
 | `ReactorBinding.ShouldSuppressEcho(fe)` | Inside an event trampoline | Drains a pending suppress count and returns true; trampoline short-circuits |
 
-The trampolines `ReactorBinding.OnCustomEvent<TArgs>` generates call
-`ShouldSuppressEcho` on entry — every controlled prop in every built-in
+The trampolines that `ReactorBinding.OnCustomEvent<TArgs>` generates drain
+the suppress counter on entry — every controlled prop in every built-in
 handler is echo-safe without the handler author having to think
 about it. Hand-authored trampolines (the ones that bypass
 `OnCustomEvent` for performance) follow the same shape; see

--- a/docs/guide/control-reconciler-protocol.md
+++ b/docs/guide/control-reconciler-protocol.md
@@ -532,10 +532,10 @@ suppresses that echo with a per-control counter:
 | Method | When to call | Effect |
 |---|---|---|
 | `binding.WriteSuppressed(mutate)` | Inside `Update` when writing a controlled prop | Increments the suppress counter, runs the mutate, decrements |
-| `ChangeEchoSuppressor.ShouldSuppress(fe)` | Inside an event trampoline | Drains a pending suppress count and returns true; trampoline short-circuits |
+| `ReactorBinding.ShouldSuppressEcho(fe)` | Inside an event trampoline | Drains a pending suppress count and returns true; trampoline short-circuits |
 
 The trampolines `ReactorBinding.OnCustomEvent<TArgs>` generates call
-`ShouldSuppress` on entry — every controlled prop in every built-in
+`ShouldSuppressEcho` on entry — every controlled prop in every built-in
 handler is echo-safe without the handler author having to think
 about it. Hand-authored trampolines (the ones that bypass
 `OnCustomEvent` for performance) follow the same shape; see

--- a/docs/specs/062-third-party-registration-and-package-boundaries.md
+++ b/docs/specs/062-third-party-registration-and-package-boundaries.md
@@ -317,6 +317,15 @@ types a wrapper hands back or receives (`Element`, `Optional<T>`, the `ChildrenS
 records) — is part of the ABI closure and is preserved along with the member. A frozen
 signature is only as stable as the transitive types it names.
 
+**Deliberately *outside* the frozen seam:** the per-host explicit-registration API
+(`Reconciler.RegisterType` / `RegisterHandler`, §8) is public and useful for app-local
+bespoke controls, but it is **not** part of the R7-frozen surface. It is per-host and aimed
+at apps (which recompile against their target runtime) and framework-internal controls
+(`ResizeGrip`, docking); a *compiled* control library that must roll forward registers
+through the global `ControlRegistry.Register*` seam above, or via the generator (which
+does). Keeping per-host registration unfrozen holds the seam to the minimum a rolled-forward
+binary actually binds.
+
 **Two compatibility tiers — *prove* vs *promise*.** Every supported public API — the
 control-authoring seam **and** the app-facing DSL (~200 factory methods, ~600 fluent
 modifiers, and the hooks) — is a **within-major ABI**: it does not break within a SemVer
@@ -534,14 +543,28 @@ them:
    `Application.Current.Resources`. This is ordinary WinUI app-startup work, not Reactor
    control registration, and is often too late if deferred to a render pass.
 
-**The mechanism is what already exists — no new abstraction.** Both cases use the public
-`ControlRegistry.Register` / `RegisterDecorator` / `RegisterForDerivedTypes` (already part
-of the §6.1 seam) from the app's existing `ReactorApp.Run(...)` startup delegate. A library
-that needs eager setup ships its own ordinary `public static void UseAcme()` (or an
-extension method) built on those APIs and documents "call it at startup." Reactor
-deliberately does **not** standardize a per-library `IReactorLibrary` interface: that would
-add frozen ABI surface Track A works to *minimize*, in exchange for sugar over a one-line
-call an author can already write.
+**Two explicit-registration paths already exist — no new abstraction.** Both run from the
+app's existing `ReactorApp.Run(...)` startup delegate; pick by scope:
+
+- **Global, ABI-stable — `ControlRegistry.Register` / `RegisterDecorator` /
+  `RegisterForDerivedTypes`.** Process-wide, part of the frozen §6.1 seam, so a *reusable or
+  shipped* control library that registers this way rolls forward under R7. The handler
+  factory must be `static` (no captures; per-instance state lives in the `IElementHandler`
+  class). This is the path for library-level overrides and eager global init; a library that
+  needs eager setup ships its own ordinary `public static void UseAcme()` over it.
+- **Per-host, ergonomic — `host.Reconciler.RegisterType(...)` / `RegisterHandler(...)`.**
+  Registers one host's reconciler with **inline** mount/update/unmount delegates (no
+  `IElementHandler` class) that **may capture** host-local state, and different hosts may
+  register different implementations for the same element type. This is the right tool for a
+  *bespoke, app-local* custom control — the shape Reactor's own `ResizeGrip` / docking
+  natives and the Monaco / regedit samples use. It is deliberately **outside** the §6.1
+  frozen seam: apps recompile against their target runtime, so they need no roll-forward
+  promise — a control that must roll forward as a *compiled* dependency uses the global seam
+  (or the generator) instead.
+
+Reactor deliberately does **not** add a per-library `IReactorLibrary` interface on top of
+either path: that would add frozen ABI surface Track A works to *minimize*, in exchange for
+sugar over a one-line call an author can already write.
 
 ## §9 Self-registration vs. explicit registration
 
@@ -557,9 +580,10 @@ discovery scan — is the default.
   types the trimmer would otherwise drop.
 
 **Recommendation:** lazy self-registration is the norm — a control's code is rooted only
-when its element is constructed (§3). The *only* explicit registration is the narrow §8
-escape hatch (overrides and eager global init), written directly against the public
-`ControlRegistry.Register*` APIs. Reactor ships **no** marker-driven discovery pass
+when its element is constructed (§3). Explicit registration is the narrow §8 escape hatch,
+along one of two paths: the global `ControlRegistry.Register*` seam (library-level overrides
+/ eager init, R7-stable) or the per-host `Reconciler.RegisterType` / `RegisterHandler`
+(app-local bespoke controls, not frozen). Reactor ships **no** marker-driven discovery pass
 (`[assembly: ReactorLibrary]` / `UseDiscoveredLibraries()`): it would be either a trimmer
 root or a `[RequiresUnreferencedCode]` opt-out, and lazy registration already delivers
 zero-ceremony wiring without it.
@@ -577,9 +601,10 @@ trigger, or a third-party override that was never registered.
 - **Reword the runtime throw** to point at those causes rather than a forgotten `UseX()`:
   *"No handler registered for `FooElement`. Create it through its factory (built-in /
   Pattern-B controls self-register on the factory call), ensure its generated wrapper is
-  referenced so its self-registration runs, or — if this is a third-party override —
-  register it at startup via `ControlRegistry.Register…`."* Reflection-light and AOT-safe:
-  it names only `element.GetType()`.
+  referenced so its self-registration runs, register a third-party override at startup via
+  `ControlRegistry.Register…`, or — for a bespoke app-local control — register it on the
+  host's reconciler via `Reconciler.RegisterType`/`RegisterHandler` before first mount
+  (§8)."* Reflection-light and AOT-safe: it names only `element.GetType()`.
 - **Keep the direct-record construction guardrail.** Warn when a *factory-registered* element
   record (a built-in / Pattern-B-style control, where the registration link lives on the
   factory) is constructed directly (`new FooElement(...)`) rather than via its factory — the
@@ -599,8 +624,9 @@ Both tracks preserve spec 048's reachability model (R5):
   `Reactor.Advanced` changes the *assembly* they live in, not what roots them. The
   regression gates are `CoreControlFamilyBoundaryTests` (the IL boundary scan) and the
   AOT-proof harness (`tests/aot_trim_proof`), which must stay green through each move.
-- **Explicit registration stays lazy-friendly.** The §8 escape hatch calls the existing
-  `ControlRegistry.Register*` only for overrides / eager init; there is no bulk per-library
+- **Explicit registration stays lazy-friendly.** The §8 escape hatch — global
+  `ControlRegistry.Register*` for overrides / eager init, or per-host `Reconciler.RegisterType`
+  for app-local controls — registers only what the app names; there is no bulk per-library
   root and no discovery scan (§9), so an app still pays only for the controls it constructs.
 
 ## §12 Open questions

--- a/docs/specs/062-third-party-registration-and-package-boundaries.md
+++ b/docs/specs/062-third-party-registration-and-package-boundaries.md
@@ -172,8 +172,9 @@ authoring ABI (§6), a leaner core with the heavy subsystems in `Reactor.Advance
 The core authoring types are structurally coupled to WinUI: `Element` and its
 subclasses reference `Microsoft.UI.Xaml`/`…Controls`/`…Media`, and
 `IElementHandler<TElement,TControl>` / `ControlDescriptor<TElement,TControl>`
-constrain `where TControl : UIElement` — a handler's whole purpose is to mount and
-patch a real WinUI control. So "define a custom element type" *inherently* names
+constrain `TControl` to a live WinUI control type (`IElementHandler` to `UIElement`,
+`ControlDescriptor` to `FrameworkElement, new()`) — a handler's whole purpose is to
+mount and patch a real WinUI control. So "define a custom element type" *inherently* names
 WinUI types; a wrapper transitively depends on WinUI no matter how Reactor is sliced.
 
 The smallest WinUI slice is the `Microsoft.WindowsAppSDK.WinUI` sub-package (Windows
@@ -260,7 +261,7 @@ element, the bound surface is enumerable and, as of this change, entirely public
 
 | Frozen ABI surface | Where |
 |---|---|
-| `Element` base + `Key` / `Modifiers` (`ElementModifiers` value types) | `Core/Element.cs` (reconciler reads only base members) |
+| `Element` base + `Key` / `Modifiers` (`ElementModifiers` records) | `Core/Element.cs` (reconciler reads only base members) |
 | `Optional<T>` | `Core` (emitted by generated init-props) |
 | `ControlDescriptor<E,C>` + its builder methods, including the hand-coding arms (`Imperative`, `HandCodedControlled`, `HandCodedEvent`) and the `ChildrenStrategy` taxonomy (`SingleContent` / `Panel` / `ItemsHost` / element-slots) | `Core/V1Protocol` |
 | `IElementHandler<E,C>` / `IDecoratorElementHandler<E>` / `DescriptorHandler<E,C>` | `Core/V1Protocol` |
@@ -423,7 +424,8 @@ public interface IReactorLibraryBuilder
 }
 ```
 
-**The app-facing call** folds into the existing `ReactorApp` startup surface:
+**The app-facing call** extends the `ReactorApp` startup surface (today
+`ReactorApp.Run(...)`) with a builder form:
 
 ```csharp
 ReactorApp.CreateBuilder()

--- a/docs/specs/062-third-party-registration-and-package-boundaries.md
+++ b/docs/specs/062-third-party-registration-and-package-boundaries.md
@@ -445,11 +445,6 @@ intact either way.
   `Directory.Build.targets` injection rule, so the package's `.nuspec`/csproj must
   carry the `.WinUI` sub-package reference and the `net10.0-windows…` TFM explicitly
   (mirroring how `Reactor.Advanced` is packaged).
-- **The Abstractions NuGet declares its own `Microsoft.WindowsAppSDK.WinUI`
-  dependency and TFM rules.** External consumers do **not** inherit this repo's
-  `Directory.Build.targets` injection rule, so the package's `.nuspec`/csproj must
-  carry the `.WinUI` sub-package reference and the `net10.0-windows…` TFM explicitly
-  (mirroring how `Reactor.Advanced` is packaged).
 
 ## §6 Source generators, authoring attributes, and the Abstractions boundary
 

--- a/docs/specs/062-third-party-registration-and-package-boundaries.md
+++ b/docs/specs/062-third-party-registration-and-package-boundaries.md
@@ -12,8 +12,8 @@ wrapper source generator ([spec 058](058-control-wrapper-generator.md)) — and 
 packaging/distribution model ([spec 022](022-packaging-and-distribution.md)). It
 settles the *delta* those specs did not cover: keeping a third-party control
 library's **compiled output runnable across Reactor versions**, **slimming Reactor's
-monolithic package**, and giving apps a **standard one-call-per-library registration
-convention**.
+monolithic package**, and confirming apps need **no per-library registration
+ceremony** — controls self-register when first used.
 
 One small enabling change ships alongside this spec:
 `ReactorBinding.ShouldSuppressEcho` is now public (§3), closing the last internal
@@ -29,9 +29,9 @@ design, phased in §13.
 > authoring seam inside the one Reactor runtime** — *not* a separate abstractions
 > package.
 > Reactor's own package stays lean by keeping heavy optional subsystems out of the
-> default reference. App developers get **one obvious registration call per
-> library**, and a missing registration fails **loudly and helpfully**, never as a
-> blank screen.
+> default reference. App developers need **no registration ceremony** — a control
+> self-registers the first time its element is built — and the rare genuine miss fails
+> **loudly and helpfully**, never as a blank screen.
 
 ---
 
@@ -50,7 +50,7 @@ design, phased in §13.
   - [§6.2 Governance — three pieces that do not exist yet](#62-governance--three-pieces-that-do-not-exist-yet)
   - [§6.3 Evolution discipline](#63-evolution-discipline)
 - [§7 Track B — consolidate heavy subsystems into `Reactor.Advanced`](#7-track-b--consolidate-heavy-subsystems-into-reactoradvanced)
-- [§8 Library registration API — `UseLibrary`](#8-library-registration-api--uselibrary)
+- [§8 Explicit registration — the narrow escape hatch](#8-explicit-registration--the-narrow-escape-hatch)
 - [§9 Self-registration vs. explicit registration](#9-self-registration-vs-explicit-registration)
 - [§10 Diagnostics](#10-diagnostics)
 - [§11 Trimming and AOT](#11-trimming-and-aot)
@@ -76,10 +76,12 @@ Issue #163 raises four coupled frustrations that remain:
    Reactor-enabled libraries built against different versions may therefore fail to
    compose.
 
-2. **Registration has no standard shape.** Registration happens per control (a
-   factory touch, or a Pattern-A static constructor — spec 048 §6). There is no
-   single "wire up everything this library needs" entry point analogous to .NET
-   MAUI's `builder.UseSkiaSharp()`.
+2. **Registration is per control, with no library-level convention.** Registration
+   happens per control (a factory touch, or a Pattern-A static constructor — spec 048
+   §6). Some authors expect a single MAUI-style `builder.UseSkiaSharp()` to "wire up the
+   library." Reactor's lazy self-registration means there is usually **nothing** to wire
+   up (§8) — but the expectation, and the two cases lazy genuinely can't cover (handler
+   overrides, eager global init), deserve an explicit answer.
 
 3. **Missing registration can still fail quietly.** Spec 048 made the reconciler
    throw an actionable exception on an unregistered element, but only when that
@@ -97,9 +99,14 @@ Issue #163 raises four coupled frustrations that remain:
 runtime without recompilation (see R7 / §6). This is the load-bearing requirement;
 it supersedes any notion of a separate "abstractions" reference (§4.2 / §5.1).
 
-**R2 — Standard registration convention.** One explicit, conventional call per
-library (`builder.UseMyLibrary()` or equivalent) that centralizes that library's
-element/handler registration and initialization.
+**R2 — Registration is automatic; explicit only where lazy can't reach.** The common
+case needs *no* per-library call: a control self-registers when its element is first
+constructed (§3), and families register the same lazy way through a base-type entry.
+Explicit registration — via the existing public `ControlRegistry.Register*` at startup —
+is reserved for the two cases construction cannot trigger: a handler for an element the
+library does not construct (e.g. an override), and eager global init (e.g. a XAML resource
+dictionary). Reactor adds **no** bulk "register-the-whole-library" API — it would
+re-introduce the trim opt-out spec 048 removed (R5).
 
 **R3 — Loud, helpful failure.** A missing registration produces a clear diagnostic
 that names the missing library and suggests the fix — never a blank screen.
@@ -191,8 +198,8 @@ This spec is a *delta*, so it is worth being precise about what already exists.
 
 What is **not** yet present, and is the subject of this spec: a *governed* stable
 authoring ABI (§6), a leaner core with the heavy subsystems in `Reactor.Advanced`
-(§7), a library-level `UseLibrary` convention (§8), and library-scoped diagnostics
-(§10).
+(§7), and — where lazy self-registration cannot reach — a narrow explicit-registration
+escape hatch (§8) plus reframed diagnostics (§10).
 
 ## §4 Two hard constraints that shape the design
 
@@ -252,8 +259,9 @@ either order:
   charting, docking, markdown, and the data grid out of core into the existing
   advanced assembly, largely keeping their namespaces (§7). Delivers R4.
 
-Registration ergonomics (`UseLibrary` + diagnostics, §8–§10) is a third, independent
-workstream that serves R2 / R3 and can interleave with either track.
+Registration needs no track of its own: lazy self-registration already satisfies R2
+(§8), leaving only a narrow explicit escape hatch and the reframed R3 diagnostic (§10)
+as small, independent clean-ups that can interleave with either track.
 
 ### §5.1 Rejected alternatives
 
@@ -500,101 +508,46 @@ Each move is gated on: no new `internal` cross-boundary reach that `InternalsVis
 cannot cleanly express, `CoreControlFamilyBoundaryTests` and the AOT-proof harness stay
 green, and the subsystem's selftests/E2E still pass.
 
-## §8 Library registration API — `UseLibrary`
+## §8 Explicit registration — the narrow escape hatch
 
-Give Reactor a MAUI-style, one-call-per-library registration convention (R2).
+**The common case needs no registration call.** A control self-registers the first time
+its element is constructed: a generated wrapper's Pattern-A cctor sits on the element
+record itself, and the built-in catalog / a base-derived family registers through the
+`Reg<>` / `RegBase<>` factory touch or a base-type static constructor (§3). Because a
+Reactor app builds its element tree *before* it reconciles, construction always precedes
+dispatch — so there is nothing to "wire up" for the controls a library owns, and no
+MAUI-style `UseMyLibrary()` step.
 
-**What `UseLibrary` is for — and what it is not.** Per-control factory
-self-registration (spec 048 / Pattern A) *remains the trim-safe default*: touching a
-generated factory registers *that one control*, rooting nothing else. `UseLibrary` is
-scoped to what per-control registration cannot do:
+An earlier draft proposed exactly such a bulk `UseLibrary<T>()` / `IReactorLibrary`
+convention (R2). It is **dropped**: rooting a library's whole `Register` body is the same
+trim opt-out spec 048 deliberately removed (R5), and it merely duplicates the registration
+that constructing the element already performs.
 
-1. **Library-level initialization** that is not per control (metadata provider
-   registration, resource dictionaries, one-time setup).
-2. **Base-derived registrations** (`RegisterForDerivedTypes`) that intentionally cover
-   a family in one entry.
-3. **The direct-record idiom against *factory-carried* registration** — some registrations
-   live on a *factory*, not the element record: the built-in catalog (Pattern B, a `Reg<>`
-   static-field initializer in the `Factories` partial) and any library that follows that
-   shape. For those, an app that builds records directly (`new ButtonElement(...)`) instead
-   of via the factory bypasses registration and needs a bulk opt-in — `UseLibrary`, like
-   `RegisterAllBuiltIns()`, is that documented trim opt-out, not the default path.
-   *Generated wrappers (058) do **not** need this*: their Pattern-A registration static
-   constructor is emitted **on the element record itself** (`partial record {Elem}` +
-   `static {Elem}()`), so `new FooElement(...)` triggers the type initializer and
-   self-registers — identically to calling the factory.
-4. **A discoverability + diagnostics anchor** (§10) the analyzer and runtime throw can
-   point at.
+**Two cases genuinely need an explicit call**, because no element construction triggers
+them:
 
-**The contract:**
+1. **A handler for an element the library does not construct** — e.g. a library that
+   registers an *override* handler for the built-in `ButtonElement`. Constructing a
+   `ButtonElement` runs the *owner's* cctor, never the override's, so the override must
+   register at startup, before that element is first used (registration is first-wins).
+2. **Eager global initialization** — e.g. merging a XAML `ResourceDictionary` into
+   `Application.Current.Resources`. This is ordinary WinUI app-startup work, not Reactor
+   control registration, and is often too late if deferred to a render pass.
 
-```csharp
-namespace Microsoft.UI.Reactor;
-
-/// <summary>One place a Reactor-enabled library wires up everything it needs:
-/// element/handler registration, generated metadata, initialization.</summary>
-public interface IReactorLibrary
-{
-    void Register(IReactorLibraryBuilder builder);
-}
-```
-
-`IReactorLibraryBuilder` is a thin façade over `ControlRegistry` (plus future
-per-library init hooks) so a library never touches the registry directly:
-
-```csharp
-public interface IReactorLibraryBuilder
-{
-    IReactorLibraryBuilder Register<TElement, TControl>(Func<IElementHandler<TElement, TControl>> handler)
-        where TElement : Element where TControl : UIElement;
-    IReactorLibraryBuilder RegisterDecorator<TElement>(Func<IDecoratorElementHandler<TElement>> handler)
-        where TElement : Element;
-    // …RegisterForDerivedTypes, and future init hooks…
-}
-```
-
-**The app-facing call** extends the `ReactorApp` startup surface (today
-`ReactorApp.Run(...)`) with a builder form:
-
-```csharp
-ReactorApp.CreateBuilder()
-    .UseLibrary<MyControls.MyControlsLibrary>()   // one call per library
-    .UseLibrary(new AcmeCharts.AcmeChartsLibrary(options))
-    .Run(App);
-```
-
-`UseLibrary<T>()` news up `T` and calls `Register`; the instance overload supports
-libraries needing construction options. A library ships a friendly extension so app
-authors get the MAUI feel:
-
-```csharp
-namespace MyControls;
-public static class MyControlsRegistration
-{
-    public static IReactorAppBuilder UseMyControls(this IReactorAppBuilder b)
-        => b.UseLibrary<MyControlsLibrary>();
-}
-```
-
-**Built-ins and Advanced fold into the same shape.** `ReactorApp.RegisterAllBuiltIns()`
-*is* the built-in library's `Register` body; reframe it as `UseLibrary<BuiltInControlsLibrary>()`
-(the old method stays as a compatibility shim). Each consolidated Advanced subsystem
-(§7) ships its own `UseCharting()` / `UseDataGrid()` / `UseDocking()` /
-`UseMarkdown()` extension over the same interface — dogfooding the third-party model
-with Reactor's own components.
-
-**Trim note.** `UseLibrary<T>()` names `T`, whose `Register` body names whatever it
-registers — so it roots exactly that surface, the *same trim opt-out shape* as
-`RegisterAllBuiltIns()`. Libraries should keep their per-control factories
-self-registering so an app that never calls `UseLibrary` still pays only for the
-controls it touches (R5). A large subsystem may expose finer modules
-(`UseChartsCore()` / `UseChartsInteractive()`) so an app roots only the sub-surface it
-needs.
+**The mechanism is what already exists — no new abstraction.** Both cases use the public
+`ControlRegistry.Register` / `RegisterDecorator` / `RegisterForDerivedTypes` (already part
+of the §6.1 seam) from the app's existing `ReactorApp.Run(...)` startup delegate. A library
+that needs eager setup ships its own ordinary `public static void UseAcme()` (or an
+extension method) built on those APIs and documents "call it at startup." Reactor
+deliberately does **not** standardize a per-library `IReactorLibrary` interface: that would
+add frozen ABI surface Track A works to *minimize*, in exchange for sugar over a one-line
+call an author can already write.
 
 ## §9 Self-registration vs. explicit registration
 
 Spec 048 already analyzed and rejected the *unconditional-eager* forms for the
-built-in catalog; that analysis carries over.
+built-in catalog; that analysis carries over and is why lazy self-registration — not a
+discovery scan — is the default.
 
 - **`[ModuleInitializer]` / assembly-load registration is a trimmer root.** It runs on
   first type-load and names every handler + control, so the trimmer can never prove it
@@ -603,44 +556,34 @@ built-in catalog; that analysis carries over.
 - **Reflection-based assembly scanning** is AOT-hostile, startup-costly, and roots
   types the trimmer would otherwise drop.
 
-**Recommendation:** keep *explicit* registration the norm — the trim-safe default is
-per-control factory self-registration; `UseLibrary` (§8) is the bulk / direct-record
-opt-in. Layer *optional* discovery on top for teams that value zero ceremony over
-binary size:
-
-1. **`[assembly: ReactorLibrary(typeof(MyControlsLibrary))]`** — a *marker*, not an
-   eager root. It registers nothing at load time; it exists so diagnostics (§10) can
-   point at the exact `UseX()` a developer forgot, and so an explicitly opted-in
-   discovery pass can find libraries.
-2. **`ReactorApp…UseDiscoveredLibraries()`** — an explicit opt-out of the trim story
-   (mirrors `RegisterAllBuiltIns()`): an ordinary, removable method that scans
-   `[assembly: ReactorLibrary]` markers and registers each. It (and any marker scan)
-   is annotated `[RequiresUnreferencedCode]` so the trim/AOT analyzers — hard errors in
-   this repo — flag it at the call site.
+**Recommendation:** lazy self-registration is the norm — a control's code is rooted only
+when its element is constructed (§3). The *only* explicit registration is the narrow §8
+escape hatch (overrides and eager global init), written directly against the public
+`ControlRegistry.Register*` APIs. Reactor ships **no** marker-driven discovery pass
+(`[assembly: ReactorLibrary]` / `UseDiscoveredLibraries()`): it would be either a trimmer
+root or a `[RequiresUnreferencedCode]` opt-out, and lazy registration already delivers
+zero-ceremony wiring without it.
 
 ## §10 Diagnostics
 
 Layer library-scoped diagnostics on top of 048's runtime throw (R3).
 
-- **Enrich the runtime throw.** When the unregistered element's *assembly* carries
-  `[assembly: ReactorLibrary(typeof(X))]`, name the specific missing call — e.g.
-  *"`MarqueeElement` is defined in `MyControls`, which declares a Reactor library but
-  was never registered. Call `builder.UseMyControls()` at startup."* Keep this
-  reflection-light and AOT-safe: read the marker off the already-loaded
-  `element.GetType().Assembly` custom-attribute (no scan, no extra assembly load) and
-  fall back to the generic message if the attribute was trimmed.
-- **Add a build-time analyzer / `mur check` rule.** Flag a project that references a
-  `[ReactorLibrary]` library but never calls the corresponding `UseX()` /
-  `UseLibrary<>()`. Scope it to a high-confidence heuristic (a direct `UseX()` call
-  somewhere in the compilation) with a suppression — "never registered anywhere" is a
-  whole-program question the analyzer can only approximate. The R3 diagnostic must
-  **not** force an unconditional `UseLibrary` call (that would push every app into
-  rooting whole libraries, §8); it fires only when an element is actually used via the
-  direct-record idiom with no registration in reach.
-- **Direct-record construction guardrail.** Warn when a *factory-registered* element record
-  (a built-in / Pattern-B-style control, where the registration link lives on the factory) is
-  constructed directly (`new FooElement(...)`) rather than via its factory, mirroring the
-  runtime message's most common cause. It must **not** fire on generated wrappers (058),
+Keep 048's runtime throw on an unregistered mount (R3), but — with lazy self-registration
+the norm — reframe *what it blames*. A "mounted but unregistered" element is now almost
+unreachable for generated wrappers (constructing the element self-registers it); it survives
+only for a factory-carried control constructed by raw `new` that bypassed the factory
+trigger, or a third-party override that was never registered.
+
+- **Reword the runtime throw** to point at those causes rather than a forgotten `UseX()`:
+  *"No handler registered for `FooElement`. Create it through its factory (built-in /
+  Pattern-B controls self-register on the factory call), ensure its generated wrapper is
+  referenced so its self-registration runs, or — if this is a third-party override —
+  register it at startup via `ControlRegistry.Register…`."* Reflection-light and AOT-safe:
+  it names only `element.GetType()`.
+- **Keep the direct-record construction guardrail.** Warn when a *factory-registered* element
+  record (a built-in / Pattern-B-style control, where the registration link lives on the
+  factory) is constructed directly (`new FooElement(...)`) rather than via its factory — the
+  most common cause of the throw above. It must **not** fire on generated wrappers (058),
   whose element-rooted Pattern-A cctor makes direct construction self-registering and safe.
 
 ## §11 Trimming and AOT
@@ -656,8 +599,9 @@ Both tracks preserve spec 048's reachability model (R5):
   `Reactor.Advanced` changes the *assembly* they live in, not what roots them. The
   regression gates are `CoreControlFamilyBoundaryTests` (the IL boundary scan) and the
   AOT-proof harness (`tests/aot_trim_proof`), which must stay green through each move.
-- **`UseLibrary` roots per-library**, a documented opt-out identical to
-  `RegisterAllBuiltIns()`; self-registration discovery (§9) is opt-in only.
+- **Explicit registration stays lazy-friendly.** The §8 escape hatch calls the existing
+  `ControlRegistry.Register*` only for overrides / eager init; there is no bulk per-library
+  root and no discovery scan (§9), so an app still pays only for the controls it constructs.
 
 ## §12 Open questions
 
@@ -667,9 +611,8 @@ Both tracks preserve spec 048's reachability model (R5):
 | Q2 | Exact freeze boundary — is the *entire* §6.1 surface committed, or a named subset (e.g. is the full `MountContext` surface frozen, or only the members generated code + hand-authors actually bind)? | Freeze the members generated code and `external_proof` bind; mark the rest "public, Tier 1 — within-major by discipline, not in the Tier-2 gate." Settle with the interop harness. |
 | Q3 | Loader policy — strong-name + pin `AssemblyVersion` now, or stay unsigned/default-ALC and only *document* the roll-forward requirement? | Document now; revisit strong-naming when the API stabilizes past preview. |
 | Q4 | The data-grid **and markdown** `using static …Advanced.Factories` source break (§7) — acceptable in preview, or ship a type-forward / compat shim? | Accept in preview; call it out in release notes. A core-side compat shim isn't viable (core can't reference Advanced), so a `using static` is the honest fix. |
-| Q5 | `UseLibrary` granularity — one `UseX()` per library, or sub-modules for large subsystems? | One per library by default; sub-modules where trimming a sub-surface matters (charts). |
-| Q6 | Should the wrapper attributes + generator ship as a standalone `Reactor.Wrappers` package, or stay bundled in core (status quo)? | Independent of both tracks; keep bundled unless a concrete author asks — revisit later. |
-| Q7 | Ship a `Microsoft.UI.Reactor.All` metapackage (core + Advanced) for a batteries-included reference? | Optional convenience; add if consumer feedback wants it. |
+| Q5 | Should the wrapper attributes + generator ship as a standalone `Reactor.Wrappers` package, or stay bundled in core (status quo)? | Independent of both tracks; keep bundled unless a concrete author asks — revisit later. |
+| Q6 | Ship a `Microsoft.UI.Reactor.All` metapackage (core + Advanced) for a batteries-included reference? | Optional convenience; add if consumer feedback wants it. |
 
 ## §13 Phasing
 
@@ -681,9 +624,10 @@ Both tracks preserve spec 048's reachability model (R5):
   document the loader/version policy (Q3).
 - **Track B — consolidate into Advanced.** B1: charting + docking → `Reactor.Advanced`.
   B2: markdown (with the §7 factory note, Q4). B3: data grid (§7 factory note, Q4).
-- **Registration ergonomics — independent.** E1: `IReactorLibrary` / `UseLibrary` +
-  built-ins/Advanced fold-in (§8). E2: `[ReactorLibrary]` marker + enriched throw +
-  analyzer (§10). E3: opt-in `UseDiscoveredLibraries()` (§9).
+- **Registration clean-ups — independent, small.** E1: reword the R3 runtime throw and
+  keep the direct-record guardrail (§10). E2: document the §8 explicit-registration escape
+  hatch (overrides / eager init) against the existing `ControlRegistry.Register*`. No
+  `IReactorLibrary`, marker, or discovery pass ships.
 
-Tracks A and B share no dependency and can land in either order; the ergonomics
-workstream can interleave with either.
+Tracks A and B share no dependency and can land in either order; the registration
+clean-ups can interleave with either.

--- a/docs/specs/062-third-party-registration-and-package-boundaries.md
+++ b/docs/specs/062-third-party-registration-and-package-boundaries.md
@@ -2,58 +2,35 @@
 
 ## Status
 
-**Proposed — design v0.3 (2026-07-16). No code changes.** This is a design
-document responding to [issue #163](https://github.com/microsoft/microsoft-ui-reactor/issues/163)
+**Proposed.** Design document responding to
+[issue #163](https://github.com/microsoft/microsoft-ui-reactor/issues/163)
 ("Simplify third-party control registration and package boundaries for custom
-element types"). It builds on the *already-shipped* extensibility stack — the V1
+element types"). It builds on the already-shipped extensibility stack — the V1
 handler protocol ([spec 047](047-extensible-control-model.md)), lazy trimmable
-registration ([spec 048](048-control-registration-and-trimming.md)), and the
-control wrapper source generator ([spec 058](058-control-wrapper-generator.md)) —
-and on the packaging/distribution model ([spec 022](022-packaging-and-distribution.md)).
-Its job is to settle the *delta* those specs did not cover: **package boundaries**
-(carving a lightweight authoring package out of the monolithic `Reactor.dll`) and
-a **standard library-registration convention** (`builder.UseMyLibrary()`).
+registration ([spec 048](048-control-registration-and-trimming.md)), and the control
+wrapper source generator ([spec 058](058-control-wrapper-generator.md)) — and on the
+packaging/distribution model ([spec 022](022-packaging-and-distribution.md)). It
+settles the *delta* those specs did not cover: keeping a third-party control
+library's **compiled output runnable across Reactor versions**, **slimming Reactor's
+monolithic package**, and giving apps a **standard one-call-per-library registration
+convention**.
 
-**The decisions below are left open for the maintainer (@azchohfi).** Where this
-doc lists options it states a recommendation, but the recommendation is not a
-decision — [§12 Open questions](#12-open-questions) is the decision surface.
-
-> **Review note (v0.2).** A cross-model design review (GPT-5.5 + Gemini 3.1 Pro,
-> both cross-checked against source) found that the authoring types are far more
-> entangled with the Reactor *runtime* (`Reconciler`, `RenderContext`, `Factories`,
-> the internal `IV1HandlerEntry`/`ChangeEchoSuppressor`) than a clean "move the
-> abstractions into their own assembly" framing implies. This revision folds those
-> findings in: the package split is still the right direction, but **Phase 1 is a
-> decoupling-design task (a runtime-seam abstraction), not a file move.** The
-> affected sections (§4–§7) call out the specific coupling and the resolution.
-
-> **Implementation-readiness note (v0.3, 2026-07-16).** Before committing to build,
-> the four load-bearing assumptions were spiked directly against source. All the
-> visibility/citation claims **hold**. The spike also *sharpened* three design
-> points that would have cost implementation time:
-> - **§5.2 correction:** the adapter cannot be materialized "after `TryResolve`" —
->   the registry is keyed by element type only, so `TControl` lives solely in the
->   `Register<E,C>` closure, and rebuilding the adapter later needs `MakeGenericType`,
->   which `ControlRegistry` forbids. The seam factory must run *inside* the generic
->   `Register` frame (new **Q13**).
-> - **§5.1 breaking-change:** the `string → Element` implicit operator cannot follow
->   `Element` into Abstractions without a reference cycle; it must be dropped or moved
->   to the core DSL — a real (if small) source break (new **Q12**).
-> - **§5.1/§5.3 scope:** the carve-out cluster includes `UnmountContext` **and**
->   `ReactorBinding<TElement>`, not just the two contexts.
->
-> These are folded into §5 and §12. Net: the direction is sound and the seam is
-> small and enumerable (§5.3 table), so the design is **ready to implement**, with
-> Q9/Q12/Q13 as the Phase-1 spikes to settle first.
+One small enabling change ships alongside this spec:
+`ReactorBinding.ShouldSuppressEcho` is now public (§3), closing the last internal
+symbol the wrapper generator baked into external code. Everything else here is
+design, phased in §13.
 
 ### North star
 
-> A third-party control library should be able to add Reactor support by taking
-> the **smallest possible dependency** — the abstractions needed to *define* a
-> custom element type — without pulling in the reconciler, hosting, the built-in
-> control catalog, or the optional feature libraries. App developers get **one
-> obvious registration call per library**, and a missing registration fails
-> **loudly and helpfully**, never as a blank screen.
+> A third-party control library adds Reactor support by wrapping its WinUI control,
+> and that **compiled wrapper keeps running against newer Reactor runtimes without
+> recompilation** — the roll-forward model teams expect from
+> `Microsoft.Extensions.*`. It gets that from a **stable, additive-only authoring
+> seam inside the one Reactor runtime** — *not* a separate abstractions package.
+> Reactor's own package stays lean by keeping heavy optional subsystems out of the
+> default reference. App developers get **one obvious registration call per
+> library**, and a missing registration fails **loudly and helpfully**, never as a
+> blank screen.
 
 ---
 
@@ -62,602 +39,343 @@ decision — [§12 Open questions](#12-open-questions) is the decision surface.
 - [§1 Motivation](#1-motivation)
 - [§2 Requirements](#2-requirements)
 - [§3 Current state — what 047 / 048 / 058 already deliver](#3-current-state--what-047--048--058-already-deliver)
-- [§4 The hard constraint — the abstractions are coupled to WinUI](#4-the-hard-constraint--the-abstractions-are-coupled-to-winui)
-  - [§4.1 The deeper coupling — the authoring types entangle the runtime](#41-the-deeper-coupling--the-authoring-types-entangle-the-runtime-not-just-winui)
-- [§5 Proposed package layout](#5-proposed-package-layout)
-  - [§5.1 `Element` carve-out](#51-element-carve-out)
-  - [§5.2 `ControlRegistry` — split the stored shape from the dispatch adapter](#52-controlregistry--split-the-stored-shape-from-the-dispatch-adapter)
-  - [§5.3 Contexts, descriptors, `Reg` visibility, and the WinUI dependency](#53-contexts-descriptors-reg-visibility-and-the-winui-dependency)
-- [§6 Source generators, authoring attributes, and the Abstractions boundary](#6-source-generators-authoring-attributes-and-the-abstractions-boundary)
-- [§7 Library registration API — `UseLibrary`](#7-library-registration-api--uselibrary)
-- [§8 Self-registration vs. explicit registration](#8-self-registration-vs-explicit-registration)
-- [§9 Diagnostics](#9-diagnostics)
-- [§10 Trimming and AOT](#10-trimming-and-aot)
-- [§11 Migration — dogfooding with charting / data-grid / docking](#11-migration--dogfooding-with-charting--data-grid--docking)
+- [§4 Two hard constraints that shape the design](#4-two-hard-constraints-that-shape-the-design)
+  - [§4.1 A wrapper inherently names WinUI](#41-a-wrapper-inherently-names-winui)
+  - [§4.2 The authoring seam is welded to the runtime](#42-the-authoring-seam-is-welded-to-the-runtime)
+- [§5 The decision — two independent tracks](#5-the-decision--two-independent-tracks)
+  - [§5.1 Rejected alternatives](#51-rejected-alternatives)
+- [§6 Track A — a stable authoring ABI, in place](#6-track-a--a-stable-authoring-abi-in-place)
+  - [§6.1 The seam to freeze](#61-the-seam-to-freeze)
+  - [§6.2 Governance — three pieces that do not exist yet](#62-governance--three-pieces-that-do-not-exist-yet)
+  - [§6.3 Evolution discipline](#63-evolution-discipline)
+- [§7 Track B — consolidate heavy subsystems into `Reactor.Advanced`](#7-track-b--consolidate-heavy-subsystems-into-reactoradvanced)
+- [§8 Library registration API — `UseLibrary`](#8-library-registration-api--uselibrary)
+- [§9 Self-registration vs. explicit registration](#9-self-registration-vs-explicit-registration)
+- [§10 Diagnostics](#10-diagnostics)
+- [§11 Trimming and AOT](#11-trimming-and-aot)
 - [§12 Open questions](#12-open-questions)
 - [§13 Phasing](#13-phasing)
-- [§14 Cross-version library interop — stable ABI](#14-cross-version-library-interop--stable-abi)
 
 ---
 
 ## §1 Motivation
 
-Issue #163 lays out four coupled frustrations. Reactor is not missing
-extensibility — spec 047 delivered the public `IElementHandler` /
-`ControlDescriptor` surface, spec 048 made registration lazy and trim-safe, and
-spec 058 added a `[GenerateReactorWrapper]` source generator that emits the
-descriptor + registration + factory for a wrapped WinUI/WinRT control. What is
-still awkward is the *shape of the dependency and the setup ceremony* around that
-capability:
+Reactor is not missing extensibility — spec 047 delivered the public
+`IElementHandler` / `ControlDescriptor` surface, spec 048 made registration lazy and
+trim-safe, and spec 058 added a `[GenerateReactorWrapper]` source generator that
+emits the descriptor + registration + factory for a wrapped WinUI/WinRT control.
+Issue #163 raises four coupled frustrations that remain:
 
-1. **The dependency is too heavy.** To *define* one custom element, a third-party
-   library must reference the whole of `Reactor.dll` — the reconciler, hooks,
-   hosting, every built-in control, charting, the data grid, docking. That is a
-   large, opinionated dependency for a library whose own consumers may not even
-   use Reactor. The alternative — shipping a *second* "MyControls.Reactor"
-   integration package — doubles the maintenance surface and makes Reactor support
-   look like an afterthought.
+1. **The dependency is heavy and version-locked.** To *define* one custom element a
+   library references the whole of `Reactor.dll`. Worse, because its compiled output
+   binds concrete runtime types, that output is locked to the exact version it built
+   against — it cannot roll forward to a newer runtime an app happens to pull in. Two
+   Reactor-enabled libraries built against different versions cannot compose.
 
-2. **Registration has no standard shape.** Registration today happens per control
-   (a factory touch, or a Pattern-A static constructor — spec 048 §6). There is no
+2. **Registration has no standard shape.** Registration happens per control (a
+   factory touch, or a Pattern-A static constructor — spec 048 §6). There is no
    single "wire up everything this library needs" entry point analogous to .NET
-   MAUI's `builder.UseSkiaSharp()` / `ConfigureMauiHandlers(...)`. An app author
-   bringing in a Reactor-enabled dependency has to *know* the library's per-control
-   registration convention.
+   MAUI's `builder.UseSkiaSharp()`.
 
-3. **Missing registration can still fail quietly.** Spec 048 already made the
-   *reconciler* throw an actionable exception when it hits an unregistered element
-   (see §9), but the failure only surfaces when that element is actually mounted;
-   an element on a code path that renders late — or conditionally — can still
-   present as missing UI until it hits. A library-scoped diagnostic ("you
-   referenced *MyControls* but never called `UseMyControls()`") would catch the
-   whole class up front.
+3. **Missing registration can still fail quietly.** Spec 048 made the reconciler
+   throw an actionable exception on an unregistered element, but only when that
+   element is actually mounted — an element on a late or conditional path can present
+   as missing UI until it hits.
 
-4. **The package is monolithic.** Charting, the data grid, and docking all ship
-   inside the one `Microsoft.UI.Reactor` package. The same split that would help
-   third-party adoption also forces Reactor to prove out its own componentization
-   story — a healthy pressure.
+4. **The package is monolithic.** Charting, the data grid, docking, and markdown all
+   ship inside the one `Microsoft.UI.Reactor` package, so every app and every wrapper
+   author carries them whether or not they are used.
 
 ## §2 Requirements
 
-**R1 — Minimal authoring dependency.** A library can define custom element types
-by referencing one small package that carries only the authoring abstractions,
-not the Reactor runtime.
+**R1 — Durable authoring ABI.** A library's *compiled* wrapper output binds a
+**stable, additive-only authoring seam** and keeps running against a newer Reactor
+runtime without recompilation (see R7 / §6). This is the load-bearing requirement;
+it supersedes any notion of a separate "abstractions" reference (§4.2 / §5.1).
 
 **R2 — Standard registration convention.** One explicit, conventional call per
-library (`builder.UseMyLibrary()` or equivalent) that centralizes all of that
-library's element/handler registration and initialization.
+library (`builder.UseMyLibrary()` or equivalent) that centralizes that library's
+element/handler registration and initialization.
 
-**R3 — Loud, helpful failure.** A missing registration produces a clear
-diagnostic that names the missing library and suggests the fix — never a blank
-screen. (Extends 048's runtime throw with library-scoped, ideally build-time,
-diagnostics.)
+**R3 — Loud, helpful failure.** A missing registration produces a clear diagnostic
+that names the missing library and suggests the fix — never a blank screen.
 
-**R4 — Componentized layout.** Built-in features (charting, data grid, docking)
-split into optional packages that mirror the third-party extensibility story.
+**R4 — Leaner core.** The heavy optional subsystems (charting, data grid, docking,
+markdown) move out of the default core reference so every app — and every wrapper
+author — carries a smaller Reactor.
 
-**R5 — Do not regress the trim/AOT story.** Every proposal must preserve spec
-048's load-bearing property: an app roots (and the trimmer keeps) only the
-controls it actually reaches. A package split that re-roots the whole catalog is a
-non-starter.
+**R5 — Do not regress the trim/AOT story.** Every proposal must preserve spec 048's
+property: an app roots (and the trimmer keeps) only the controls it actually reaches.
 
 **R6 — Do not regress authoring ergonomics.** The hand-authored `IElementHandler`
 recipe (spec 047, `tests/external_proof`) and the `[GenerateReactorWrapper]`
-generator (spec 058) must keep working against the new, smaller dependency —
-ideally with a *smaller* reference footprint, never a larger one.
+generator (spec 058) keep working, ideally with a smaller footprint, never larger.
 
-**R7 — Cross-version library interop (stable ABI).** A control library built
-against `Reactor.Abstractions` version *N* must load and run, **without
-recompilation**, against a host that supplies a *different* core runtime version
-*M* ≥ *N* — the roll-forward/unification model of `Microsoft.Extensions.*.Abstractions`.
-Concretely: an app that transitively pulls `LibA` (built against Reactor *N*) and
-`LibB` (built against Reactor *M*) unifies to a **single** runtime, and both
-libraries' controls must mount, update, and echo correctly against it. This makes
-the Abstractions surface a **versioned, additive-only contract**, not just a
-smaller reference — see [§14](#14-cross-version-library-interop--stable-abi).
+**R7 — Cross-version library interop (stable ABI).** A control library built against
+Reactor version *N* must load and run, **without recompilation**, against a host that
+supplies a *newer* runtime version *M* ≥ *N* — the roll-forward/unification model of
+`Microsoft.Extensions.*`. An app that transitively pulls `LibA` (built against *N*)
+and `LibB` (built against *M*) unifies to a **single** runtime, and both libraries'
+controls must mount, update, and echo correctly against it.
 
 ## §3 Current state — what 047 / 048 / 058 already deliver
 
-This spec is a *delta*, so it is worth being precise about what already exists so
-we do not re-propose it.
+This spec is a *delta*, so it is worth being precise about what already exists.
 
 - **The registration runtime is already lazy and trim-safe (048).** The global
   `ControlRegistry` (`src/Reactor/Core/V1Protocol/ControlRegistry.cs`) holds
-  `Type → Func<IV1HandlerEntry>` entries; every static reference to a handler /
-  control type lives in the *caller* of `Register<TElement,TControl>` (a per-control
-  factory cctor — Pattern A — or a `Reg<…>` static-field initializer — Pattern B),
-  each on a per-control rooted path. Registration is idempotent first-wins. The
-  opt-in `ReactorApp.RegisterAllBuiltIns()` roots the whole catalog for apps that
-  want the direct-record idiom; apps that want a small binary simply do not call it.
+  `Type → Func<…>` entries; every static reference to a handler / control type lives
+  in the *caller* of `Register<TElement,TControl>` (a per-control factory cctor —
+  Pattern A — or a `Reg<…>` static-field initializer — Pattern B), each on a
+  per-control rooted path. Registration is idempotent first-wins. The opt-in
+  `ReactorApp.RegisterAllBuiltIns()` roots the whole catalog for apps that want the
+  direct-record idiom; apps that want a small binary simply do not call it.
 
 - **Hand-authoring already works against the public surface only (047).**
   `tests/external_proof/Reactor.External.TestControl` ships an element + control +
   handler in a *separate assembly* with **no** `InternalsVisibleTo` — proving the
-  public V1 surface is sufficient. Its `Marquee` holder (spec 048 §6, Pattern A)
-  registers via a `static` cctor calling `ControlRegistry.Register<…>`.
+  public V1 surface is sufficient.
 
 - **Generated authoring already works (058).** `[GenerateReactorWrapper]` on a
-  partial record emits the init-props, child/items slots, `On{Event}` callbacks,
-  the `ControlDescriptor`, Pattern-A registration, and a factory — see
-  `samples/apps/wct-controls`. The generator is a `netstandard2.0` Roslyn component
-  that emits *strings* and binds attributes by metadata name, so it references
-  neither `Reactor.dll` nor its own attributes assembly at build time.
+  partial record emits the init-props, child/items slots, `On{Event}` callbacks, the
+  `ControlDescriptor`, Pattern-A registration, and a factory. The generator is a
+  `netstandard2.0` Roslyn component that emits *strings* and binds attributes by
+  metadata name, so it references neither `Reactor.dll` nor its own attributes
+  assembly at build time.
 
 - **The missing-handler failure already throws helpfully (048).**
   `Reconciler.ThrowNoHandlerRegistered` (`src/Reactor/Core/Reconciler.Mount.cs`)
-  raises an `InvalidOperationException` naming the element type and listing four
-  concrete fixes.
+  raises an `InvalidOperationException` naming the element type and listing concrete
+  fixes.
 
-What is **not** yet present, and is the subject of this spec: a lightweight
-authoring *package* (everything above still lives inside `Reactor.dll`), a
-library-level `UseLibrary` convention, library-scoped diagnostics, and a
-componentized feature-package layout.
+- **The last internal-symbol leak is closed (this change).**
+  `ReactorBinding.ShouldSuppressEcho(UIElement)` is now a **public** read-side echo
+  primitive, and the wrapper generator's deferred-controlled trampoline emits it
+  instead of the internal `ChangeEchoSuppressor.ShouldSuppress`. Every symbol the
+  generator bakes into external generated code is now public — the precondition for
+  Track A (§6).
 
-## §4 The hard constraint — the abstractions are coupled to WinUI
+What is **not** yet present, and is the subject of this spec: a *governed* stable
+authoring ABI (§6), a leaner core with the heavy subsystems in `Reactor.Advanced`
+(§7), a library-level `UseLibrary` convention (§8), and library-scoped diagnostics
+(§10).
 
-The issue asks for a package that lets a library "add Reactor support … even when
-the consumer of the library may not even be using Reactor." It is important to
-state plainly what is and is not achievable here.
+## §4 Two hard constraints that shape the design
 
-**A truly WinUI-free abstractions package is not feasible.** The core authoring
-types are structurally coupled to WinUI:
+### §4.1 A wrapper inherently names WinUI
 
-- `Element` (`src/Reactor/Core/Element.cs`) and its subclasses reference
-  `Microsoft.UI.Xaml`, `…Xaml.Controls`, `…Xaml.Media`, `Microsoft.UI.Text`, etc.
-- `IElementHandler<TElement, TControl>` and `ControlDescriptor<TElement, TControl>`
-  constrain `where TControl : UIElement`. The handler's whole purpose is to mount
-  and patch a real WinUI control.
+The core authoring types are structurally coupled to WinUI: `Element` and its
+subclasses reference `Microsoft.UI.Xaml`/`…Controls`/`…Media`, and
+`IElementHandler<TElement,TControl>` / `ControlDescriptor<TElement,TControl>`
+constrain `where TControl : UIElement` — a handler's whole purpose is to mount and
+patch a real WinUI control. So "define a custom element type" *inherently* names
+WinUI types; a wrapper transitively depends on WinUI no matter how Reactor is sliced.
 
-So "define a custom element type" *inherently* means naming WinUI types. A library
-that takes the authoring dependency will transitively depend on WinUI regardless
-of how we slice Reactor.
+The smallest WinUI slice is the `Microsoft.WindowsAppSDK.WinUI` sub-package (Windows
+App SDK 2.0 split the monolithic metapackage into independently-versioned
+sub-packages; this repo already injects only `.WinUI` for framework-dependent library
+projects via `Directory.Build.targets`), **not** the full `Microsoft.WindowsAppSDK`
+metapackage. This bounds R7: the roll-forward guarantee is "one Reactor runtime + one
+compatible Windows App SDK," the same single-WinUI-per-process constraint apps
+already accept — not "any WinUI."
 
-**What *is* achievable — and what the issue is really after — is decoupling from
-the Reactor *runtime*, and shrinking the WinUI dependency to its smallest slice:**
+### §4.2 The authoring seam is welded to the runtime
 
-- The minimal Reactor dependency becomes the authoring abstractions only — no
-  reconciler, no hooks, no hosting, no built-in catalog, no feature libraries.
-- The minimal **WinUI** dependency is the `Microsoft.WindowsAppSDK.WinUI`
-  sub-package, **not** the full `Microsoft.WindowsAppSDK` metapackage. Windows App
-  SDK 2.0 split the monolithic metapackage into independently-versioned
-  sub-packages; this repo already references only `.WinUI` for framework-dependent
-  library projects (see the injection rule in `Directory.Build.targets`; the WinUI
-  sub-package currently tracks `2.1.0` vs the `2.1.3` aggregate). The abstractions
-  package inherits that same floor — it pulls the WinUI slice, not the Runtime +
-  DWriteCore redist.
+The authoring *execution* seam cannot be lifted into a separate assembly. Verified
+against source:
 
-This is the honest framing to carry into the design: **"minimal dependency" means
-`Reactor.Abstractions` + `Microsoft.WindowsAppSDK.WinUI` — not zero Reactor and
-not zero WinUI.**
+- `MountContext` / `UpdateContext` / `UnmountContext`
+  (`src/Reactor/Core/V1Protocol/MountContext.cs`) are `public readonly ref struct`s
+  that each hold a `private readonly Reconciler _reconciler`, **expose it publicly**
+  (`public Reconciler Reconciler => _reconciler;`, offered as an "escape hatch"), and
+  proxy roughly a dozen reconciler operations (`MountChild`, `ReconcileV1Child`,
+  `RentControl`, `PushContext`/stagger scopes, `ApplySetters`, …) on the per-mount,
+  allocation-free hot path.
+- `ControlDescriptor` references `MountContext` (its `AfterChildrenMount` callback),
+  and `OneWayBridgedSetter` takes a `Reconciler` directly.
+- The generator emits direct calls to `Reconciler.SetElementTag` / `GetElementTag` /
+  `DetachReactorState` / `ApplySetters`, `ReactorApp.TryRegisterControlAssembly`, and
+  `ElementExtensions.OnMountAdd` / `OnUnmountAdd`. (All of these are **public** as of
+  this change — §3 — but they name the concrete `Reconciler` / `ReactorApp`.)
 
-### §4.1 The deeper coupling — the authoring types entangle the *runtime*, not just WinUI
+Splitting this seam into its own assembly would either drag `Reconciler` along (no
+real split) or invert it into a broad `IRuntimeOps`-style interface that relocates
+the same freeze onto a hot-path ref struct while adding dispatch cost — for a
+single-implementation runtime that needs no polymorphism. That is why the ABI is
+stabilized **in place** (§6), not carved out (§5.1).
 
-The WinUI coupling above is the *easy* half. The design review surfaced a harder
-one: the types we would put in `Reactor.Abstractions` currently reach into the
-Reactor **runtime** (`Reconciler`, `RenderContext`, `Factories`), so a naïve file
-move would drag the runtime down into the "abstractions" layer or create a
-reference cycle. Concretely (all verified against source):
+## §5 The decision — two independent tracks
 
-- **`Element` depends on the built-in factories.** `Element.cs:342` defines
-  `public static implicit operator Element(string) => Factories.TextBlock(text)`,
-  and `FuncElement`/`MemoElement` (`Element.cs:1510-1516`) are
-  `record …(Func<RenderContext, Element> …)` — so the `Element` base file pulls
-  `Factories` (built-in catalog) and `RenderContext` (core hooks runtime). Moving
-  "the `Element` base" is therefore a *carve-out*, not a move (§5.1).
-- **The dispatch entry is internal and names `Reconciler`.** `IV1HandlerEntry`
-  (`V1HandlerRegistry.cs:30-40`) is `internal` and its `Mount`/`Update` take a
-  `Reconciler`. `ControlRegistry` builds `V1HandlerAdapter` instances that
-  implement it (`ControlRegistry.cs:112-113`). So `ControlRegistry` cannot move
-  without either dragging `Reconciler` down or splitting its stored shape (§5.2).
-- **The public author contexts expose `Reconciler`.** `MountContext` holds and
-  exposes a `Reconciler` "escape hatch" (`MountContext.cs:50-65`);
-  `ControlDescriptor.OneWayBridged` takes a delegate over `Reconciler`;
-  `DescriptorHandler` calls `ctx.Reconciler`. Any of these in Abstractions drags
-  the runtime (§5.3).
-- **The generator emits direct runtime calls** (`Reconciler.SetElementTag`,
-  `GetElementTag`, `DetachReactorState`, `ApplySetters`, plus
-  `ReactorApp.TryRegisterControlAssembly` and `ElementExtensions.OnMount/UnmountAdd`,
-  and the internal `ChangeEchoSuppressor.ShouldSuppress`) — the full closure and
-  its resolution are §6.
+Issue #163's goals are met by two tracks that share no dependency and can land in
+either order:
 
-**None of this kills the proposal** — it changes its shape. The unit of work in
-Phase 1 is *designing a minimal runtime seam* (a small interface / delegate surface
-in Abstractions that the core `Reconciler` implements) so the authoring types name
-the seam, not `Reconciler`. §5 and §6 specify that seam's required members.
+- **Track A — a stable authoring ABI, in place (§6).** Treat the (now fully public)
+  authoring seam as a versioned, additive-only contract in the one runtime, enforced
+  by a real API-compat gate and a binary-compat interop harness. Delivers R1 / R7.
+- **Track B — consolidate heavy subsystems into `Reactor.Advanced` (§7).** Move
+  charting, docking, markdown, and the data grid out of core into the existing
+  advanced assembly, keeping their namespaces. Delivers R4.
 
-## §5 Proposed package layout
+Registration ergonomics (`UseLibrary` + diagnostics, §8–§10) is a third, independent
+workstream that serves R2 / R3 and can interleave with either track.
 
-A layered set of packages, each depending only on the layer below:
+### §5.1 Rejected alternatives
 
-| Package | Contains | Heavy deps |
-|---|---|---|
-| **`Microsoft.UI.Reactor.Abstractions`** | `Element` primitive base + the authoring contract (element records' modifier/attribute surface), `IElementHandler` / `IDecoratorElementHandler`, `ControlDescriptor` + descriptor kinds (`SingleContent` / `Panel` / `ItemsHost`), `PropEntry`, `ControlRegistry` (storing a **neutral** registration record — §5.2), `ReactorBinding` primitives, the author-facing `MountContext`/`UpdateContext`/`UnmountContext` re-shaped over a **runtime-seam interface** (§5.3), and that seam interface itself. **Not** here: `Reconciler`, `RenderContext`, `Factories`, `FuncElement`/`MemoElement`, `IV1HandlerEntry`/`V1HandlerAdapter`, the internal `Reg`/`ChangeEchoSuppressor` (§5.1–5.3). | `Microsoft.WindowsAppSDK.WinUI` |
-| **`Microsoft.UI.Reactor`** (core) | Reconciler, hooks, `RenderContext`, hosting (`ReactorApp` / windows / render loop), the built-in control catalog + DSL factories (`Factories`, `Dsl.cs`), Flex/Yoga. | `Reactor.Abstractions` |
-| **`Microsoft.UI.Reactor.Charting`** | The charting subsystem (`src/Reactor/Charting`). | `Reactor` |
-| **`Microsoft.UI.Reactor.DataGrid`** | The data grid (`src/Reactor/Controls/DataGrid`). | `Reactor` |
-| **`Microsoft.UI.Reactor.Docking`** | Docking windows (`src/Reactor/Docking`). | `Reactor` |
-| **`Microsoft.UI.Reactor.Advanced`** *(exists)* | Win2D canvas (spec 053). | `Reactor` + Win2D |
-| **`Microsoft.UI.Reactor.All`** *(metapackage)* | No code — references core + every feature package for a "batteries-included" experience. | all of the above |
+- **A `Reactor.Abstractions` interfaces/DI package.** There is a single runtime
+  implementation, loaded once, with no polymorphism or load-isolation requirement;
+  Elements are immutable *data records*, not services. The three classic
+  `.Abstractions` criteria (multiple implementations, independent consumers, an
+  independently versioned contract) all fail. It would add a versioning unit and
+  interface-dispatch overhead for no gain.
+- **Splitting the authoring seam into its own assembly (no interfaces).** Rejected on
+  contract-breadth, not perf: the seam is welded to `Reconciler` (§4.2). A split
+  drags the runtime along or inverts to a broad runtime interface that merely
+  relocates the freeze. One runtime → one versioning unit is simpler and honest.
+- **A fan-out of per-feature packages** (`.Charting` / `.DataGrid` / `.Docking` /
+  `.Markdown`). Each assembly carries fixed load/metadata overhead; a dozen small
+  DLLs cost more than they save for the common app. Track B consolidates into the one
+  existing `Reactor.Advanced` assembly instead.
+- **Carving the built-in control catalog out of core behind a metapackage.** Large,
+  invasive churn (the built-in element records are the bulk of `Element.cs`) that
+  neither track needs; deferred indefinitely.
 
-Notes:
+## §6 Track A — a stable authoring ABI, in place
 
-- **A third-party control library references `Reactor.Abstractions` only** (R1).
-  The existing `tests/external_proof` project is the acceptance shape: it should
-  compile and register against `Reactor.Abstractions` with no reference to the
-  core runtime.
-- **An app references `Microsoft.UI.Reactor`** (which brings the reconciler +
-  built-ins), plus whichever feature packages it wants — or `…Reactor.All` for
-  everything. Because feature packages self-register lazily (048), referencing a
-  feature package does **not** root its whole surface unless the app actually uses
-  it (R5).
-- **The split is a boundary move, not a rewrite.** `Reactor.Advanced` already
-  proves the "feature library as a separate package that references core" shape;
-  charting / data-grid / docking follow the same pattern (§11).
-- **`ControlRegistry` lives in Abstractions, not core.** Both the *definer* side
-  (a library calling `Register`) and the *consumer* side (the reconciler calling
-  `TryResolve`) need it, and the reconciler's dependency flows the correct
-  direction (core → abstractions). `TryResolve` / the base-derived cache are
-  `internal`; the reconciler in the core package reaches them via
-  `InternalsVisibleTo` (already the pattern between test assemblies).
+The goal (R1/R7) is that a *compiled* wrapper binds a fixed subset of Reactor's
+public surface and keeps working against a newer runtime. .NET default-context
+assembly binding is by type/member signature and NuGet unifies to a single assembly,
+so *old generated code binds to a newer runtime as long as every symbol it references
+is unchanged*. The guarantee reduces to one discipline: **enumerate the surface a
+wrapper binds, and evolve it additive-only.**
 
-- **`ControlRegistry` lives in Abstractions, but its stored shape must be split
-  from core's dispatch adapter** (§5.2). Both the *definer* side (a library calling
-  `Register`) and the *consumer* side (the reconciler resolving) need the registry,
-  but the internal `IV1HandlerEntry`/`V1HandlerAdapter` that it currently constructs
-  name `Reconciler` and stay in core.
+### §6.1 The seam to freeze
 
-**Open design point:** the exact contents of the Abstractions package are *defined*
-by §6's emitted-reference closure plus the hand-author surface **plus the §4.1
-runtime seam**, not chosen freely. Anything the generator or a hand-written handler
-*names* must resolve to Abstractions (directly, or via the seam interface that core
-implements); anything else stays in core. That closure is the acceptance criterion,
-and resolving it — §5.1 (`Element` carve-out), §5.2 (`ControlRegistry` split), §5.3
-(contexts/descriptors/`Reg`) — is the main engineering risk of Phase 1.
+Grounded against the generator's emit and the reconciler's reads of a foreign
+element, the bound surface is enumerable and, as of this change, entirely public:
 
-### §5.1 `Element` carve-out
+| Frozen ABI surface | Where |
+|---|---|
+| `Element` base + `Key` / `Modifiers` (`ElementModifiers` value types) | `Core/Element.cs` (reconciler reads only base members) |
+| `Optional<T>` | `Core` (emitted by generated init-props) |
+| `ControlDescriptor<E,C>` + its builder methods, including the hand-coding arms (`Imperative`, `HandCodedControlled`, `HandCodedEvent`) and the `ChildrenStrategy` taxonomy (`SingleContent` / `Panel` / `ItemsHost` / element-slots) | `Core/V1Protocol` |
+| `IElementHandler<E,C>` / `IDecoratorElementHandler<E>` / `DescriptorHandler<E,C>` | `Core/V1Protocol` |
+| `MountContext` / `UpdateContext` / `UnmountContext` + `ReactorBinding<TElement>` | `Core/V1Protocol` |
+| `ControlRegistry.Register*` | `Core/V1Protocol/ControlRegistry.cs` |
+| `ReactorBinding.ShouldSuppressEcho` / `WriteSuppressed` | `Core` |
+| `Reconciler.SetElementTag` / `GetElementTag` / `DetachReactorState` / `ApplySetters` (tag get/set) | `Core/Reconciler.*` |
+| `ElementExtensions.OnMountAdd` / `OnUnmountAdd` | `Elements` |
+| `ReactorApp.TryRegisterControlAssembly` | `Hosting` |
 
-"Move the `Element` base to Abstractions" is a carve-out, not a file move (§4.1).
-Grounding note: the whole element catalog lives in one 6865-line `Element.cs`, so
-this is also a physical file split (the base record + contracts move; every
-concrete built-in element record — `TextBlockElement` at `Element.cs:2616`, etc. —
-stays in core).
+**What is *not* part of the binary freeze:** the app-facing DSL — the ~200 factory
+methods, ~600 fluent modifiers, and the hooks — is bound by the **recompiling app**,
+not by a shipped wrapper binary. It carries a softer, source-level add-only
+compatibility expectation (don't gratuitously break `Text("x").Bold()`), but it is
+not part of the versioned binary ABI a wrapper rolls forward against.
 
-- **The base `Element` record itself is nearly clean.** Verified: it carries only
-  `Key`, `Modifiers` (`ElementModifiers`, `Element.cs:1768` — WinUI *value* types,
-  fine under the §4 WinUI floor), and the outer-margin shim. The one true runtime
-  coupling is the implicit `string → Factories.TextBlock` conversion (`Element.cs:342`).
-- **The implicit-conversion carve-out is a breaking-change decision, not a free move.**
-  A `string → Element` implicit operator **must be declared on `Element`** (the other
-  operand, `string`, is a sealed BCL type). Its body needs a *concrete built-in*
-  (`Factories.TextBlock` → `new TextBlockElement(...)`, `Element.cs:2616`) that stays
-  in core — so if `Element` moves to Abstractions and keeps the operator, we get an
-  **Abstractions → core reference cycle**. There is no in-place fix: the operator
-  must either be **dropped** (source-breaking — container factories like `VStack("hi")`
-  / `Grid("x")` rely on `string → Element` today) or the string-convenience must be
-  **relocated into the core DSL** as `params`-overloads on the container factories.
-  Recommendation: drop the implicit operator, add `string`-accepting convenience to
-  the core containers; document as a one-time DSL migration. (New open question Q12.)
-- `FuncElement`/`MemoElement` (`Element.cs:1510-1516`) depend on `RenderContext`
-  (a core hooks-runtime type). **Resolution:** these are *composition primitives*,
-  not authoring contracts — leave them (and the animation/resource/input
-  conveniences) in **core**, and move only the pure `Element` record base + the
-  modifier/attribute contract to Abstractions.
-- **The author-facing type cluster that holds a `Reconciler` field is larger than
-  just the contexts.** Verified: `MountContext` (`MountContext.cs:50`),
-  `UpdateContext` (`:128`), `UnmountContext` (`:166`) **and** `ReactorBinding<TElement>`
-  (`ReactorBindingT.cs`, constructed with `_reconciler` at `MountContext.cs:92`) all
-  store a `Reconciler`. All four must be re-typed against the §5.3 seam, not just the
-  two contexts the earlier draft named. `ReactorBinding<TElement>` is on the author
-  hot path (`ctx.BindFor(ctrl, el).WriteSuppressed(...)`), so it is a required
-  carve-out target.
-- Net: Abstractions gets the pure `Element` primitive, the handler/descriptor
-  contract, the three contexts, and `ReactorBinding<TElement>` (all seam-typed); core
-  keeps `Factories`, `RenderContext`, `FuncElement`/`MemoElement`, the concrete
-  element catalog, and the composition sugar. The carve-out line is "does a *definer*
-  of a custom element need it?" — if not, it stays in core.
+### §6.2 Governance — three pieces that do not exist yet
 
-### §5.2 `ControlRegistry` — split the stored shape from the dispatch adapter
+1. **A real API-compat gate.** Today `tests/Reactor.Tests/Tooling/ApiIndexGeneratorTests.Index_IsUpToDate`
+   only byte-compares the generated `reactor.api.txt` for *staleness* — regenerating
+   it makes the test pass, so it *blesses* breaking changes rather than blocking them.
+   Add an additive-only gate — `Microsoft.CodeAnalysis.PublicApiAnalyzers`
+   (`PublicAPI.Shipped.txt` / `.Unshipped.txt`) or `Microsoft.DotNet.ApiCompat`
+   against the last shipped `Reactor.dll` — scoped to the §6.1 seam, so removing or
+   changing a frozen member fails the build.
 
-`ControlRegistry.Register<TElement,TControl>` currently wraps the handler factory
-in a `V1HandlerAdapter` implementing the **internal** `IV1HandlerEntry`, whose
-`Mount`/`Update`/`Unmount` take a `Reconciler` *in their signatures*
-(`V1HandlerRegistry.cs:32,40,46`; adapter built at `ControlRegistry.cs:112-113`).
-Moving the registry as-is drags `Reconciler` into Abstractions.
+2. **A binary-compat interop harness.** Additive signatures are necessary but not
+   sufficient — a wrapper depends on *behavior* (echo semantics, child reconcile,
+   registration timing, descriptor ordering). Analogous to the existing AOT-proof
+   harness, build `Reactor.External.TestControl` against an **older** Reactor, then
+   load the **compiled DLL** (a binary drop, not a project reference) into a host
+   running the HEAD runtime and assert mount / update / echo-suppress all succeed
+   through the public surface only. A two-NuGet-version matrix can follow in CI.
 
-**Grounding correction (this changes the recommended mechanism).** The earlier
-draft said "core materializes the adapter *after* `TryResolve`." That is **not
-AOT-legal as written**: the registry dictionary is keyed by `typeof(TElement)`
-*only* (`ControlRegistry.cs:118`), so the closed `TControl` survives **solely inside
-the `Register<TElement,TControl>` generic-frame closure**. Rebuilding
-`V1HandlerAdapter<TElement,TControl>` at dispatch time — outside that frame — would
-require `Type.MakeGenericType`, which the registry **explicitly forbids**
-(`ControlRegistry.cs:38-43`, the AOT contract). The adapter *must* be constructed
-in the generic `Register` frame. So the split is:
+3. **A loader / version policy.** Roll-forward works today partly by luck:
+   `Reactor.dll` is **not strong-named** (no `SignAssembly`/key in `Reactor.csproj`)
+   and its assembly version tracks the package version, so default-`AssemblyLoadContext`
+   unification lets an old wrapper bind a newer runtime. Make this a *decision*: pin an
+   explicit assembly-version / strong-name policy and document that the guarantee holds
+   in the default load context with NuGet highest-wins unification. **Side-by-side**
+   (two runtimes in separate `AssemblyLoadContext`s) is **out of scope** — `Element`
+   records from different contexts are different `Type`s a shared reconciler cannot
+   process; custom/plugin ALCs break the guarantee by design.
 
-- **Abstractions** holds the public `Register`/`RegisterDecorator`/
-  `RegisterForDerivedTypes` surface and stores a **type-erased** `Func<object>`
-  entry keyed by element type. The adapter is still produced *inside* the generic
-  `Register<TElement,TControl>` frame (preserving static `TControl` visibility — no
-  `MakeGenericType`), via one of:
-  1. **Move `IV1HandlerEntry` + `V1HandlerAdapter` + `V1DecoratorHandlerAdapter`
-     into Abstractions, re-typed from `Reconciler` to the §5.3 seam.** Cleanest for
-     `Register` (its body is unchanged), but the adapters are *heavy* — they do child
-     -strategy dispatch, element-tag anchoring, and component-teardown against the
-     reconciler (`V1HandlerAdapter.cs:29-120`), so this pulls a lot of logic behind
-     the seam.
-  2. **Keep the adapters in core**, and have Abstractions' `Register<E,C>` call a
-     core-supplied generic factory seam (`IReactorRuntime.CreateEntry<E,C>(handler)`)
-     *from within* its own generic frame, storing the returned `Func<object>`. Keeps
-     the heavy adapter logic in core; the only new cost is one generic interface
-     method (statically instantiated per call site → AOT-legal, still no
-     `MakeGenericType`).
-- **Core** downcasts the stored `object` back to `IV1HandlerEntry` on the dispatch
-  path (`TryResolve` consumer). `TryResolve` itself (`ControlRegistry.cs:267`) must
-  then return the neutral `Func<object>`, not `Func<IV1HandlerEntry>`.
+### §6.3 Evolution discipline
 
-Recommendation: **option 2** — it keeps the reconciler-coupled adapter logic in core
-and moves the minimum across the boundary. This is a Phase-1 spike (Q9/Q13). The
-public `Register` surface and the first-wins/base-derived semantics of 048 §8 stay
-intact either way.
+- **Additive-only.** Never remove or change the signature of a §6.1 member. New seam
+  behavior arrives as new members (new overloads; default-interface-methods on the
+  handler/descriptor interfaces), never as edits to existing ones.
+- **Records stay evolvable.** The reconciler dispatches by element `Type` → registered
+  entry and reads only base `Element` members; it never reconstructs a derived record
+  positionally across the boundary. A library's own element record shape is therefore
+  private — only additive changes to the *base* `Element` are ABI-visible.
+- **One versioning unit.** The core runtime churns freely as long as it keeps the
+  §6.1 seam additive; there is no separate contract assembly to keep in lockstep.
 
-### §5.3 Contexts, descriptors, `Reg` visibility, and the WinUI dependency
+## §7 Track B — consolidate heavy subsystems into `Reactor.Advanced`
 
-- **Author contexts must stop exposing `Reconciler`.** `MountContext` exposes a
-  public `Reconciler` escape hatch (`MountContext.cs:64`; `UpdateContext.cs`-equiv
-  `:138`, `UnmountContext` `:174`); `ControlDescriptor.OneWayBridged` and
-  `DescriptorHandler` consume it. **Resolution:** replace the public `Reconciler`
-  member with the minimal **runtime-seam** the context surface + generated code
-  actually need. Grounded against source, the seam is small and enumerable — the
-  union of what `MountContext`/`UpdateContext`/`UnmountContext` delegate to the
-  reconciler plus what the generator emits:
+Today only Win2D is extracted: `Reactor.Advanced` (`<Description>Advanced Reactor
+components — first inhabitant: Win2D canvas.</Description>`, with `charts` already in
+its `PackageTags`) is a one-way `ProjectReference` on core. Core still carries the
+heavy leaves — charting/D3, docking, markdown, and the data grid — which dominate the
+~3.5 MB `Reactor.dll`.
 
-  | Seam member | Backing today | Used by |
-  |---|---|---|
-  | `Mount(Element, Action)` | `_reconciler.Mount` (`MountContext.cs:69`) | `MountChild` |
-  | `ReconcileV1Child(old,new,existing,rerender)` | `:79` | `ReconcileChild`, `[WrapElementSlot]` |
-  | `RentControl<T>(policy,factory)` | `:97` | `MountContext.RentControl` |
-  | `PushContextDisposable<T>` / `PushStaggerScopeDisposable` | `:102,:106` | context/stagger scopes |
-  | `ReturnControl<T>` | `UnmountContext` `:179` | unmount pooling |
-  | `SetElementTag` / `GetElementTag` / `DetachReactorState` | `Reconciler` `public static` `516/627/732` | generator (`1233,1243,1253,1313,1483,1498`) |
-  | `ApplySetters<T>` | `Reconciler` `public static 2647` (also `ctx.ApplySetters` `:84`) | generator (`1314,1328,1332`) |
-  | read-side echo check | `ChangeEchoSuppressor.ShouldSuppress` **internal** `68` | generator deferred path (`1497`) — the §6.2 gap |
-  | assembly-register | `ReactorApp.TryRegisterControlAssembly` `public static`, **Hosting** `282` | generator (`1716`) |
-  | lifecycle add | `ElementExtensions.OnMountAdd/OnUnmountAdd` `2470/2495` | generator (`1784,1786`) |
+**Plan: move charting, docking, markdown, and the data grid into
+`Reactor.Advanced`.** This follows the colleague-endorsed "one advanced assembly, not
+a dozen DLLs" shape and reuses Advanced's existing self-registering
+`Advanced.Factories` mirror pattern.
 
-  Notes that fell out of the spike: (a) `ApplySetters` is a **static** method, so it
-  is a static helper on the seam/Abstractions, not an instance member; (b) the
-  assembly-register member currently lives in **Hosting** (`ReactorApp`) — the seam
-  lets generated code name Abstractions instead of dragging hosting; (c) `BindFor`
-  constructs `ReactorBinding<TElement>`, so that type is part of the carve-out (§5.1),
-  not the seam. Abstractions declares the seam interface (`IReactorRuntime`, working
-  name); core's `Reconciler` implements it (shape is **Q9**). Any descriptor entry
-  that genuinely needs the full `Reconciler` (rare) stays a core-only API.
-- **`Reg`/`RegDecorator`/`RegBase` are `internal`** (`Reg.cs:66`), and 048 §8
-  deliberately steers 3P authors to the *public* `ControlRegistry.Register`. Feature
-  packages (§11) that want Pattern-B scale registration would need these.
-  **Decision required (Q7):** either (a) keep `Reg` internal and have feature
-  packages self-register via generated Pattern-A cctors (the 058 path), or (b)
-  promote a supported *public* bulk/factory registration primitive. Recommendation:
-  (a) — do not widen `Reg` to public; feature packages use the same generated
-  Pattern-A shape a 3P library uses, which is the dogfooding point.
-- **The Abstractions NuGet declares its own `Microsoft.WindowsAppSDK.WinUI`
-  dependency and TFM rules.** External consumers do **not** inherit this repo's
-  `Directory.Build.targets` injection rule, so the package's `.nuspec`/csproj must
-  carry the `.WinUI` sub-package reference and the `net10.0-windows…` TFM explicitly
-  (mirroring how `Reactor.Advanced` is packaged).
+- **The moves are mechanical.** [PR #627](https://github.com/microsoft/microsoft-ui-reactor/pull/627)
+  (merged, closed #498) already did the hard *dependency inversion* for the family:
+  it introduced runtime seams (`IChartingHostBridge`, `IScanExtension`,
+  `Element.OwnPropsEqualOverride`, `PathDataParser` relocated into core,
+  `ChartingRuntime.Activate`) so a chart-free app trims charting/docking out, and
+  added `CoreControlFamilyBoundaryTests` (an IL scan that *fails the build* if
+  Core/Hosting statically reference charting/docking). Core holds **zero hard type
+  references** to these subsystems, so relocating them across an assembly boundary is
+  a project-file move, not a rewrite.
+- **Namespaces stay put.** A namespace is not an assembly in C#, so charting, docking,
+  and markdown keep their existing namespaces when they move to the Advanced
+  *assembly* — a consumer adds only the `Reactor.Advanced` package reference, with
+  **no source change**.
+- **The data grid is the one exception.** Its factories are woven into the shared core
+  `Factories` partial (`src/Reactor/Controls/DataGrid/DataGridFactories.cs` and
+  `ColumnFactories.cs` are `public static partial class Factories` in namespace
+  `Microsoft.UI.Reactor`). A partial class cannot span assemblies, so in Advanced they
+  become `Microsoft.UI.Reactor.Advanced.Factories`, and a data-grid app author adds one
+  line: `using static Microsoft.UI.Reactor.Advanced.Factories;`. The element records
+  and column types keep their namespace, so `with`/record usage is unaffected. This is
+  a minor, preview-window source break (§12 Q4).
+- **Sequence:** charting + docking first (already decoupled and boundary-guarded),
+  then markdown, then the data grid (with the factory note above).
 
-## §6 Source generators, authoring attributes, and the Abstractions boundary
+**Win:** smaller default JIT ship size, a smaller core NuGet package, and a smaller
+core dependency for wrapper authors — with AOT already covered by #627's trimming
+inversion. Each move is gated on: no new `internal` cross-boundary reach that
+`InternalsVisibleTo` cannot cleanly express, `CoreControlFamilyBoundaryTests` and the
+AOT-proof harness stay green, and the subsystem's selftests/E2E still pass.
 
-This section answers the review question: *where do the generator and its
-attributes live, and should the wrappers be their own NuGet package?*
-
-### §6.1 What the generator emits — the closure that defines the boundary
-
-The wrapper generator (`src/Reactor.Wrappers.Generator/WrapperGenerator.cs`) emits
-source that references a broad set of `Reactor.Core` / `V1Protocol` types. A scan
-of the emit paths (line numbers verified against the current source) shows the
-closure is **larger than a v0 draft assumed** — it includes direct static calls
-into the runtime, not just type names:
-
-*Authoring-contract types (map cleanly to Abstractions):*
-
-- `Microsoft.UI.Reactor.Core.Element`
-- `…Core.V1Protocol.ControlRegistry` (`Register` / `RegisterDecorator`) — `1716`, `1262`
-- `…V1Protocol.Descriptor.ControlDescriptor<TElement,TControl>`, `DescriptorHandler<…>`
-- `…V1Protocol.SingleContent<…>`, `Panel<…>`, `ItemsHost<…>`, `Descriptor.PropEntry`
-- `…Core.ReactorBinding` / `ReactorBinding<TElement>`
-- `…V1Protocol.MountContext` / `UpdateContext` / `UnmountContext`
-
-*Runtime members (the real work — these must resolve through the §5.3 seam, not a move):*
-
-- `Reconciler.SetElementTag` — `1233`, `1243`, `1313`, `1327`, `1331`
-- `Reconciler.GetElementTag` — `1483`, `1498` (event trampolines)
-- `Reconciler.DetachReactorState` — `1253`
-- `Reconciler.ApplySetters` — `1314`, `1328`, `1332`
-- `ChangeEchoSuppressor.ShouldSuppress` — `1497` (**internal**, read-side)
-- `ReactorApp.TryRegisterControlAssembly` — `1716`
-- `ElementExtensions.OnMountAdd` / `OnUnmountAdd` — `1784`, `1786`
-
-**The acceptance criterion for the package split is: *this entire emitted-reference
-closure must resolve against `Reactor.Abstractions`*** — either because the type
-lives there (authoring-contract types) or because the call goes through the §5.3
-runtime-seam interface that core's `Reconciler` implements (runtime members). If any
-emitted symbol resolves only to `Reactor.dll`, generated wrapper code in a library
-that references only `Reactor.Abstractions` fails to compile — or transitively drags
-full Reactor — defeating R1.
-
-The runtime members are the sharp edge, and two need explicit correction from the
-v0 draft:
-
-- **`Reconciler.*` are direct `public static` calls, not "namespace anchors."**
-  `SetElementTag`/`GetElementTag`/`DetachReactorState`/`ApplySetters` are element-tag
-  and setter primitives the generated mount/update/trampoline code calls directly.
-  **Resolution:** put these on the Abstractions runtime seam (e.g. as methods on the
-  re-shaped `MountContext`/`UpdateContext`, or a static `ReactorElementState` helper
-  in Abstractions whose implementation core supplies). The generator then emits
-  `ctx.SetElementTag(...)` / `ctx.GetElementTag(...)` instead of naming `Reconciler`.
-- **`ChangeEchoSuppressor.ShouldSuppress` is a READ-side check** (`1497`), so the v0
-  "emit `WriteSuppressed` instead" idea is wrong — `WriteSuppressed` only *arms* the
-  token on the write; the generated event trampoline still needs a way to *consume*
-  it and early-return on the echo. **Resolution options:** (a) expose a public
-  read-side primitive in Abstractions (e.g. `ReactorBinding.IsEchoSuppressed(control)`)
-  that core's suppressor backs; (b) route generated deferred-controlled props
-  exclusively through the `.Controlled` descriptor entry (`1582-1611`), which already
-  avoids the direct suppressor reference, and **forbid** the raw-trampoline
-  deferred path in Abstractions-only wrappers; (c) a thin Abstractions shim the
-  suppressor implements. **Recommendation: (a)+(b)** — prefer `.Controlled`, and
-  provide the public read-side primitive for the cases that genuinely need the
-  deferred trampoline. `ShouldSuppress` being `internal` today is exactly why this
-  path does not yet compile for a true external assembly (§6.2).
-- **`ReactorApp.TryRegisterControlAssembly`, `OnMountAdd`/`OnUnmountAdd`** likewise
-  join the seam (assembly-register + lifecycle-add), so generated lifecycle/registration
-  code names Abstractions surface, not `ReactorApp`/`ElementExtensions` in core.
-
-Resolving this closure (i.e. designing the §5.3 seam and re-pointing the generator's
-emit at it) is **Phase 1 work** and is the gating dependency for §6.3 Shape B.
-
-### §6.2 What is already decoupled
-
-- **The generator** references neither `Reactor.dll` nor its attributes assembly at
-  build time (it emits strings, binds by metadata name). It ships today as an
-  analyzer asset (`OutputItemType="Analyzer"`, `ReferenceOutputAssembly="false"`).
-- **The attributes** (`Reactor.Wrappers.Abstractions` — `[GenerateReactorWrapper]`,
-  `[WrapControlled]`, `[WrapEvent]`, `[WrapElementSlot]`, `[WrapLifecycle]`, …)
-  are a standalone assembly with **no** reference to `Reactor.dll`. Today it is
-  `IsPackable=false` and bundled into the `Microsoft.UI.Reactor` package's `lib/`
-  via the `_BundleWrappersAbstractions` target (`PrivateAssets="all"` so NuGet
-  emits no phantom dependency).
-
-Net effect today: an author gets the generator + attributes **only** by referencing
-the full `Microsoft.UI.Reactor` package. Splitting them out is a real packaging
-change, not a rename.
-
-> **Latent gap worth noting.** Because the generator emits a call to the
-> **internal** `ChangeEchoSuppressor.ShouldSuppress` (§6.1), the deferred-controlled
-> trampoline path only compiles in assemblies granted `InternalsVisibleTo` from
-> Reactor core (tests, devtools) — *not* a true external library. So one generated
-> code path already fails the "public surface is sufficient" bar today; the §6.1
-> read-side-primitive work fixes it as a side effect.
->
-> **Verified against source (2026-07-16).** The emit is literal — `WrapperGenerator.cs:1497`
-> writes `if (global::Microsoft.UI.Reactor.Core.ChangeEchoSuppressor.ShouldSuppress(__c)) return;`
-> and `ChangeEchoSuppressor` is `internal static` (`ChangeEchoSuppressor.cs:49`). The
-> IVT grants (`Reactor.csproj`) go only to `Reactor.Tests`, `Reactor.AppTests.Host`,
-> `Reactor.Fuzz`, `Reactor.Markdown.TestRenderer`, `Microsoft.UI.Reactor.Devtools`,
-> `PerfBench.*` — **not** `tests/external_proof`. So `tests/external_proof/Reactor.External.TestControl`
-> is the exact Phase-1 gate: add a **deferred** `[WrapControlled]` prop there and it
-> fails to compile *today*, proving the gap; the public read-side primitive (Q2/Q11)
-> is what makes it pass. Note the **non-deferred** `.Controlled` path is already clean
-> — echo suppression is encapsulated in the public descriptor entry
-> (`WrapperGenerator.cs:1584`, no internal reference).
-
-### §6.3 Three candidate shapes (evaluate, then decide)
-
-**Shape A — fold into Abstractions.** The attributes fold into
-`Reactor.Abstractions`; the generator ships as an analyzer asset *inside*
-`Reactor.Abstractions`. A single `<PackageReference Include="Microsoft.UI.Reactor.Abstractions">`
-gives an author the abstractions, the attributes, and the generator — covering both
-hand-authoring and generated authoring.
-- *Buys:* one reference for everything an author needs; nothing extra to publish.
-- *Costs:* bundles a build-only analyzer into a runtime-carrying package (minor —
-  analyzers are `PrivateAssets`/build-time and don't flow to the author's own
-  consumers); a hand-author who never uses the generator still *has* it available
-  (harmless, unused).
-
-**Shape B — standalone `Reactor.Wrappers` (the review proposal).**
-`Reactor.Abstractions` carries runtime types only; a separate `Reactor.Wrappers`
-package carries the attributes + generator and takes a normal (transitive)
-`PackageReference` on `Reactor.Abstractions`.
-- *Buys:* a hand-author (external_proof/Marquee style) references only
-  `Reactor.Abstractions` and never pulls the generator; a `[GenerateReactorWrapper]`
-  user adds exactly one package (`Reactor.Wrappers`) that transitively brings
-  Abstractions + attributes + generator; the generator/attributes can version
-  independently of the runtime and of Abstractions.
-- *Costs:* an extra package to build / sign / publish / version (spec 022 CI
-  surface). Its entire value is **contingent** on §6.1 — the emitted closure must
-  already be ⊆ Abstractions, else generated code forces a full-Reactor reference and
-  the split buys nothing.
-
-**Shape C — bundled in core (status-quo mechanics).** The attributes + generator
-stay bundled inside `Microsoft.UI.Reactor`, unchanged.
-- *Buys:* zero new packaging work; one obvious "batteries-included" reference for
-  app authors; no new versioning coordination.
-- *Costs:* an author who wants only to *define* a custom element still references
-  the full runtime — the exact friction #163 raises (R1). It also does not compose
-  with the Abstractions split unless the emitted closure is *also* reachable from
-  Abstractions; if it is, then Shape C is effectively "Shape A's contents, shipped
-  in the core package instead of the abstractions package," which re-imposes the
-  heavy dependency on definers.
-
-**Hybrid B+C.** Ship the attributes + generator standalone (`Reactor.Wrappers`,
-Shape B) *and* have the core `Microsoft.UI.Reactor` package transitively include
-them (so batteries-included app authors need not add a second reference). Costs the
-Shape B publishing surface but gives both the minimal-definer path and the
-one-reference app path.
-
-### §6.4 Recommendation
-
-The wrappers-packaging choice (A/B/C) is a **packaging decision that only becomes
-real once the §6.1 runtime closure is clean** — until generated code resolves fully
-against `Reactor.Abstractions`, *no* packaging arrangement lets a definer avoid the
-full-Reactor reference. So the recommendation is sequenced:
-
-1. **Phase 1 gate first:** design the §5.3 seam and re-point the generator's emit at
-   it (§6.1). This is the load-bearing work; packaging is downstream of it.
-2. **Then adopt Shape B, in the B+C hybrid form:** `Reactor.Abstractions` carries
-   the authoring types; a standalone `Reactor.Wrappers` (attributes + generator)
-   takes a transitive reference on it; the core `Microsoft.UI.Reactor` package also
-   includes `Reactor.Wrappers` so app authors keep a single reference. This is the
-   only shape that fully satisfies R1 for a *definer* (references `Reactor.Abstractions`
-   alone; adds `Reactor.Wrappers` only to opt into generation) while keeping the
-   app-author experience batteries-included.
-
-**Fallbacks, corrected from v0.1:**
-
-- If the §6.1 closure work is *not yet done*, **Shape A does not rescue it** — folding
-  the generator into `Reactor.Abstractions` does nothing if the emitted code still
-  names `Reactor.dll` types; the definer still transitively pulls full Reactor. So the
-  genuine interim fallback is **Shape C (status quo: everything in
-  `Microsoft.UI.Reactor`)** *or* a **reduced generator feature set** (emit only the
-  subset whose closure is already ⊆ Abstractions, e.g. one-way/leaf wrappers, and
-  defer controlled/deferred paths). Shape A is only meaningful *after* the closure is
-  clean, at which point Shape B is strictly better anyway.
-- Shape C long-term is not recommended (it does not move the definer off the full
-  runtime — the core R1 friction), but it is the correct *no-op* state if the split
-  is deferred entirely.
-
-## §7 Library registration API — `UseLibrary`
+## §8 Library registration API — `UseLibrary`
 
 Give Reactor a MAUI-style, one-call-per-library registration convention (R2).
 
-### §7.0 What `UseLibrary` is *for* — and what it deliberately is not
+**What `UseLibrary` is for — and what it is not.** Per-control factory
+self-registration (spec 048 / Pattern A) *remains the trim-safe default*: touching a
+generated factory registers *that one control*, rooting nothing else. `UseLibrary` is
+scoped to what per-control registration cannot do:
 
-The design review flagged a real tension: **per-control factory self-registration
-(spec 048 / Pattern A) is already the trim-safe default**, and it stays that way.
-Calling `Marquee.Of(...)` or a generated `SettingsCard(...)` factory registers *that
-one control* on first use, rooting nothing else. `UseLibrary` must **not** be
-positioned as the thing an app "has to call or the library won't work," because a
-`Register` body that news up every control would root the whole library — exactly
-the per-control trimming 048 fought to get, lost.
-
-So `UseLibrary` is scoped to what per-control factory registration *cannot* do:
-
-1. **Library-level initialization** that is not per control — XAML metadata provider
-   registration, resource dictionaries, one-time service setup.
-2. **Base-derived registrations** (`RegisterForDerivedTypes`) that intentionally
-   cover a family in one entry.
+1. **Library-level initialization** that is not per control (metadata provider
+   registration, resource dictionaries, one-time setup).
+2. **Base-derived registrations** (`RegisterForDerivedTypes`) that intentionally cover
+   a family in one entry.
 3. **The direct-record idiom opt-in** — an app that builds element records directly
    (`new FooElement(...)`) instead of via factories needs *something* to register;
-   `UseLibrary` is that opt-in, and — like `RegisterAllBuiltIns()` — it is
-   **explicitly documented as a bulk trim opt-out**, not the default path.
-4. **Discoverability + diagnostics** (§9) — a single call site the analyzer and the
-   runtime throw can point at.
+   `UseLibrary` is that opt-in, and — like `RegisterAllBuiltIns()` — it is explicitly
+   a documented bulk trim opt-out, not the default path.
+4. **A discoverability + diagnostics anchor** (§10) the analyzer and runtime throw can
+   point at.
 
-**The trim-safe default remains: reference the library, use its factories, pay only
-for the controls you touch.** `UseLibrary` is the convenience/robustness layer on
-top, with its rooting cost called out.
-
-### §7.1 The contract
+**The contract:**
 
 ```csharp
 namespace Microsoft.UI.Reactor;
@@ -670,9 +388,8 @@ public interface IReactorLibrary
 }
 ```
 
-`IReactorLibraryBuilder` is a thin façade over `ControlRegistry` (+ any future
-per-library metadata/init hooks) so a library never touches the registry directly
-and Reactor keeps a seam to add cross-cutting setup later:
+`IReactorLibraryBuilder` is a thin façade over `ControlRegistry` (plus future
+per-library init hooks) so a library never touches the registry directly:
 
 ```csharp
 public interface IReactorLibraryBuilder
@@ -685,9 +402,7 @@ public interface IReactorLibraryBuilder
 }
 ```
 
-### §7.2 The app-facing call
-
-Fold into the existing `ReactorApp` startup surface (`src/Reactor/Hosting/ReactorApp.cs`):
+**The app-facing call** folds into the existing `ReactorApp` startup surface:
 
 ```csharp
 ReactorApp.CreateBuilder()
@@ -696,9 +411,9 @@ ReactorApp.CreateBuilder()
     .Run(App);
 ```
 
-`UseLibrary<T>()` news up `T` (parameterless) and calls `Register`; the instance
-overload supports libraries that need construction options. A library exposes a
-friendly extension so app authors get the MAUI feel:
+`UseLibrary<T>()` news up `T` and calls `Register`; the instance overload supports
+libraries needing construction options. A library ships a friendly extension so app
+authors get the MAUI feel:
 
 ```csharp
 namespace MyControls;
@@ -709,314 +424,112 @@ public static class MyControlsRegistration
 }
 ```
 
-### §7.3 How built-ins and feature packages fold in
+**Built-ins and Advanced fold into the same shape.** `ReactorApp.RegisterAllBuiltIns()`
+*is* the built-in library's `Register` body; reframe it as `UseLibrary<BuiltInControlsLibrary>()`
+(the old method stays as a compatibility shim). Each consolidated Advanced subsystem
+(§7) ships its own `UseCharting()` / `UseDataGrid()` / `UseDocking()` /
+`UseMarkdown()` extension over the same interface — dogfooding the third-party model
+with Reactor's own components.
 
-The existing `ReactorApp.RegisterAllBuiltIns()` (spec 048 §3.4 option A) *is* the
-built-in library's `Register` body. Reframe it as the built-in `IReactorLibrary`
-so the whole model is uniform: `RegisterAllBuiltIns()` becomes `UseLibrary<BuiltInControlsLibrary>()`
-(the old method stays as a compatibility shim). Each feature package
-(`…Charting`, `…DataGrid`, `…Docking`) ships its own `UseCharting()` /
-`UseDataGrid()` / `UseDocking()` extension over the same interface. This directly
-dogfoods the third-party model with Reactor's own components (R4, §11).
+**Trim note.** `UseLibrary<T>()` names `T`, whose `Register` body names whatever it
+registers — so it roots exactly that surface, the *same trim opt-out shape* as
+`RegisterAllBuiltIns()`. Libraries should keep their per-control factories
+self-registering so an app that never calls `UseLibrary` still pays only for the
+controls it touches (R5). A large subsystem may expose finer modules
+(`UseChartsCore()` / `UseChartsInteractive()`) so an app roots only the sub-surface it
+needs.
 
-**Trim note (corrected).** `UseLibrary<T>()` names `T`, whose `Register` body names
-whatever it registers — so calling it roots exactly that surface. If `Register`
-bulk-registers every control, `UseLibrary` roots the whole library: that is the
-**same trim opt-out shape as `RegisterAllBuiltIns()`**, not the per-control default.
-Per §7.0, this is *intended* — `UseLibrary` is the convenience/direct-record path,
-and libraries should keep their per-control factories self-registering so an app
-that prefers the factory path (and never calls `UseLibrary`) still pays only for the
-controls it touches (R5). Two consequences the design must honor:
+## §9 Self-registration vs. explicit registration
 
-- **The R3 "you forgot to register" diagnostic (§9) must NOT force an unconditional
-  `UseLibrary` call**, or it would push every app into rooting whole libraries. It
-  fires only when an element is *actually used via the direct-record idiom* with no
-  registration in reach — not merely because a `[ReactorLibrary]` package is
-  referenced.
-- **Finer-grained modules are allowed.** A large library may expose
-  `UseChartsCore()` / `UseChartsInteractive()` rather than one all-controls
-  `UseCharts()`, so an app roots only the sub-surface it needs. Recommended for the
-  feature packages in §11.
-
-## §8 Self-registration vs. explicit registration
-
-The issue asks whether custom element types can register themselves (static
-initialization / assembly discovery) instead of requiring an explicit setup call.
-Spec 048 already analyzed and **rejected the unconditional-eager forms** for the
+Spec 048 already analyzed and rejected the *unconditional-eager* forms for the
 built-in catalog; that analysis carries over.
 
-- **`[ModuleInitializer]` / unconditional assembly-load registration is a trimmer
-  root.** It runs on first type-load of the assembly, so the trimmer can never
-  prove it dead, and its body names every handler + control → the whole library is
-  kept. This defeats R5. Spec 048 §3.4 deleted exactly this shape (the eager
-  `RegisterV1BuiltInHandlers` bootstrap) for that reason.
-
-- **Reflection-based assembly scanning** (enumerate loaded assemblies for
-  `[ReactorLibrary]` and invoke each) is AOT-hostile and startup-costly, and roots
+- **`[ModuleInitializer]` / assembly-load registration is a trimmer root.** It runs on
+  first type-load and names every handler + control, so the trimmer can never prove it
+  dead and keeps the whole library. This defeats R5. (Spec 048 §3.4 deleted exactly
+  this shape.)
+- **Reflection-based assembly scanning** is AOT-hostile, startup-costly, and roots
   types the trimmer would otherwise drop.
 
-**Recommendation:** keep *explicit* registration the norm over eager auto-discovery,
-and offer self-registration only as **opt-in**. "Explicit" here means the two
-trim-honest paths from §7: per-control factory self-registration (the trim-safe
-**default** — pay only for controls you touch) and `UseLibrary` (the bulk /
-direct-record opt-in, itself a documented trim opt-out per §7.0). Both are
-AOT-friendly and statically discoverable by the trimmer; neither relies on
-load-time or reflection-driven rooting. Layer *optional* discovery on top:
+**Recommendation:** keep *explicit* registration the norm — the trim-safe default is
+per-control factory self-registration; `UseLibrary` (§8) is the bulk / direct-record
+opt-in. Layer *optional* discovery on top for teams that value zero ceremony over
+binary size:
 
 1. **`[assembly: ReactorLibrary(typeof(MyControlsLibrary))]`** — a *marker*, not an
-   eager root. It does not register anything at load time. It exists so (a)
-   diagnostics (§9) can point a developer at the exact `UseX()` they forgot, and
-   (b) an *explicitly opted-in* discovery pass (for non-trimmed apps that value
-   convenience over binary size) can find libraries to auto-`UseLibrary`.
+   eager root. It registers nothing at load time; it exists so diagnostics (§10) can
+   point at the exact `UseX()` a developer forgot, and so an explicitly opted-in
+   discovery pass can find libraries.
+2. **`ReactorApp…UseDiscoveredLibraries()`** — an explicit opt-out of the trim story
+   (mirrors `RegisterAllBuiltIns()`): an ordinary, removable method that scans
+   `[assembly: ReactorLibrary]` markers and registers each. It (and any marker scan)
+   is annotated `[RequiresUnreferencedCode]` so the trim/AOT analyzers — hard errors in
+   this repo — flag it at the call site.
 
-2. **`ReactorApp…UseDiscoveredLibraries()`** — an explicit opt-out of the trim
-   story (mirrors `RegisterAllBuiltIns()`): an ordinary method the trimmer removes
-   when unreachable, that scans `[assembly: ReactorLibrary]` markers and registers
-   each. Apps that want zero ceremony and don't care about trimming call it; apps
-   that want a small binary do not. **It (and any reflection-based marker scan) is
-   annotated `[RequiresUnreferencedCode]`** so the trim/AOT analyzers — which this
-   repo treats as hard errors (`Directory.Build.targets`) — flag it at the call
-   site rather than letting it silently defeat trimming.
+## §10 Diagnostics
 
-This keeps the trim-safe default while giving the "I don't want to remember setup"
-crowd a documented, opt-in escape hatch — the same philosophy as 048's
-`RegisterAllBuiltIns()`.
+Layer library-scoped diagnostics on top of 048's runtime throw (R3).
 
-## §9 Diagnostics
-
-Layer library-scoped diagnostics on top of 048's existing runtime throw (R3).
-
-- **Keep and enrich the runtime throw.** `ThrowNoHandlerRegistered` already lists
-  four fixes. Enrich it: when the unregistered element's *assembly* carries
+- **Enrich the runtime throw.** When the unregistered element's *assembly* carries
   `[assembly: ReactorLibrary(typeof(X))]`, name the specific missing call — e.g.
-  *"`MarqueeElement` is defined in `MyControls`, which declares a Reactor library
-  but was never registered. Call `builder.UseMyControls()` (or
-  `UseLibrary<MyControls.MyControlsLibrary>()`) at startup."* This turns the most
-  common third-party failure from a generic message into an exact instruction.
-  **Keep this enrichment reflection-light and AOT-safe:** read the marker via the
-  already-loaded `element.GetType().Assembly` custom-attribute (the element type is
-  necessarily loaded at the throw site, so no extra assembly is force-loaded and no
-  scan runs), and guard it so a trimmed-away attribute simply falls back to the
-  generic message. Prefer the build-time analyzer below as the *primary* signal;
-  the runtime enrichment is the backstop.
+  *"`MarqueeElement` is defined in `MyControls`, which declares a Reactor library but
+  was never registered. Call `builder.UseMyControls()` at startup."* Keep this
+  reflection-light and AOT-safe: read the marker off the already-loaded
+  `element.GetType().Assembly` custom-attribute (no scan, no extra assembly load) and
+  fall back to the generic message if the attribute was trimmed.
+- **Add a build-time analyzer / `mur check` rule.** Flag a project that references a
+  `[ReactorLibrary]` library but never calls the corresponding `UseX()` /
+  `UseLibrary<>()`. Scope it to a high-confidence heuristic (a direct `UseX()` call
+  somewhere in the compilation) with a suppression — "never registered anywhere" is a
+  whole-program question the analyzer can only approximate. The R3 diagnostic must
+  **not** force an unconditional `UseLibrary` call (that would push every app into
+  rooting whole libraries, §8); it fires only when an element is actually used via the
+  direct-record idiom with no registration in reach.
+- **Direct-record construction guardrail.** Warn when an element record from a
+  `[ReactorLibrary]` assembly is constructed directly (`new FooElement(...)`) rather
+  than via its factory, mirroring the runtime message's most common cause.
 
-- **Add a build-time analyzer / `mur check` rule.** Flag the case where a project
-  references a library that declares `[ReactorLibrary]` but the app never calls the
-  corresponding `UseX()` / `UseLibrary<>()` — catching the whole class of "forgot
-  to register" up front rather than at first mount. This lives alongside the
-  existing analyzer suite (spec 060) and the `mur check` did-you-mean rules
-  (spec 038). *Caveat:* detecting "never registered anywhere in the app" reliably is
-  a whole-program question the analyzer can only approximate (registration can be
-  indirect); scope it to a high-confidence heuristic (a direct `UseX()` call
-  somewhere in the compilation) with a suppression, per the §4-core discipline in
-  spec 060.
+## §11 Trimming and AOT
 
-- **Direct-record construction guardrail.** Extend the analyzer to warn when an
-  element record from a `[ReactorLibrary]` assembly is constructed directly
-  (`new FooElement(...)`) rather than via its factory, mirroring the runtime
-  message's "most common cause."
+Both tracks preserve spec 048's reachability model (R5):
 
-## §10 Trimming and AOT
-
-Every proposal above is constructed to preserve spec 048's reachability model (R5):
-
-- **Package split (§5) is trim-neutral.** Carving `Element` / `ControlRegistry`'s
-  stored shape / descriptors into `Reactor.Abstractions` — and routing runtime calls
-  through the §5.3 seam — does not change *what roots what*: the registration link
-  (factory → `Register` → handler → control) is unchanged; only the assembly the
-  link's endpoints live in changes, and the seam is an interface the trimmer follows
-  like any other. The trimmer follows references across assemblies exactly as within
-  one.
-
-- **`UseLibrary<T>()` (§7) roots per-library.** It names `T`; `T.Register` names
-  that library's controls. No `[ModuleInitializer]`, so an unreached `UseX()` is
-  removed with everything it names — identical to `RegisterAllBuiltIns()` today.
-
-- **Self-registration (§8) stays opt-in.** The `[ReactorLibrary]` marker roots
-  nothing; only the explicit `UseDiscoveredLibraries()` opt-out re-roots, and it is
-  an ordinary (removable) method.
-
-- **Abstractions package sets `IsAotCompatible=true`** (as the core library does),
-  so trim/AOT analyzers run on it; `ControlRegistry` already avoids reflection and
-  `MakeGenericType` (048 §8), which the move preserves.
-
-- **`Reactor.Abstractions` `IsTrimmable` / self-contained flags** follow the
-  existing library conventions (`WindowsAppSDKSelfContained=false`; only app exes
-  own self-contained packaging).
-
-The AOT-proof harness (`tests/aot_trim_proof`) is the regression gate: after the
-split it must still show the Hello-World app dropping every control it doesn't use,
-and the external-proof AOT publish (spec 048 §11) must still succeed with the
-library referencing only `Reactor.Abstractions`.
-
-## §11 Migration — dogfooding with charting / data-grid / docking
-
-Reactor's own optional features are the proving ground (R4). The `Reactor.Advanced`
-package (Win2D, spec 053) already demonstrates the shape: a feature library in a
-separate package/assembly that references core and self-registers lazily. The
-migration extracts charting, data grid, and docking the same way:
-
-1. Move `src/Reactor/Charting` → `src/Reactor.Charting` (new project, references
-   `Reactor`), ship as `Microsoft.UI.Reactor.Charting`. Expose `UseCharting()`.
-2. Repeat for `src/Reactor/Controls/DataGrid` → `Reactor.DataGrid` and
-   `src/Reactor/Docking` → `Reactor.Docking`.
-3. Provide `Microsoft.UI.Reactor.All` metapackage referencing core + all features
-   so existing "everything" consumers get a one-line migration.
-4. Update the ReactorGallery + samples to reference the specific feature packages
-   they use — proving the split from the consumer side and exercising the
-   `UseX()` convention end-to-end.
-
-Each extraction is gated on: no `internal` cross-boundary reach that
-`InternalsVisibleTo` can't cleanly express, no regression in the AOT-proof harness,
-and the feature's selftests/E2E still green.
+- **Track A is trim-neutral.** Stabilizing the seam in place adds no new roots — the
+  seam is already public and reached through the existing registration link
+  (factory → `Register` → handler → control). An API-compat gate is a build-time
+  analyzer, not a runtime root.
+- **Track B is trim-neutral.** #627 already inverted the core→feature dependencies so
+  an app trims the subsystems it does not use; moving those subsystems into
+  `Reactor.Advanced` changes the *assembly* they live in, not what roots them. The
+  regression gates are `CoreControlFamilyBoundaryTests` (the IL boundary scan) and the
+  AOT-proof harness (`tests/aot_trim_proof`), which must stay green through each move.
+- **`UseLibrary` roots per-library**, a documented opt-out identical to
+  `RegisterAllBuiltIns()`; self-registration discovery (§9) is opt-in only.
 
 ## §12 Open questions
 
-These are the decision surface for @azchohfi. Each states a recommendation but is
-`TBD`.
-
 | # | Question | Recommendation |
 |---|---|---|
-| Q1 | Wrappers packaging: Shape A (fold) / B (standalone `Reactor.Wrappers`) / C (bundled) / B+C hybrid? | B+C hybrid, gated on the §6.1 closure; if the closure slips, fall back to **Shape C or a reduced generator feature set** (not Shape A — §6.4). |
-| Q2 | Is the §6.1 emitted-reference closure cleanly hoistable into Abstractions, or does it force runtime types into the "abstractions" package? | Neither `Reconciler` nor `ChangeEchoSuppressor` move. Introduce the §5.3 runtime seam and re-point the generator's emit at it; expose a public **read-side** echo-suppress check (the current `ChangeEchoSuppressor.ShouldSuppress` is internal + read-side — the v0.1 "emit `WriteSuppressed`" idea was wrong, that primitive is write-side). Phase 1 spike. |
-| Q3 | Registration: explicit `UseLibrary` only, or also opt-in discovery? | Explicit default + opt-in `[ReactorLibrary]` marker + `UseDiscoveredLibraries()` escape hatch. |
-| Q4 | Package granularity: one `Reactor.Abstractions`, or split further (e.g. `…Abstractions` vs `…Authoring`)? | Single `Reactor.Abstractions`; revisit only if the closure proves it too heavy. |
-| Q5 | Feature-package boundaries: charting / data-grid / docking each their own package, or a single `…Extras`? | Per-feature packages (mirrors the 3P story more honestly). |
-| Q6 | Versioning across split packages — lockstep with the core version, or independent? Ties to spec 022 (versioning) and 057 (release channels). | Lockstep for core+features; the standalone `Reactor.Wrappers` may float. |
-| Q7 | `Reg`/`RegDecorator`/`RegBase` are `internal` today (048 §8 steers 3P authors to public `ControlRegistry.Register`). Keep them internal, or promote a public bulk primitive? | Keep internal; feature packages register via generated Pattern-A cctors. Revisit only if a public bulk API proves necessary. |
-| Q8 | Is the "define an element without any Reactor runtime" goal worth the packaging cost given the WinUI coupling (§4) is unavoidable anyway? | Yes for the runtime decoupling + smaller WinUI slice; but this is the strategic call. |
-| Q9 | **Runtime-seam design (§5.3).** What is the minimal interface Abstractions declares and core's `Reconciler` implements (child mount/reconcile, `ApplySetters`, tag get/set, detach, echo-suppress read, lifecycle-add, assembly-register)? Should `MountContext`/`UpdateContext` expose *it* instead of the concrete `Reconciler`? | Design a single `IReactorRuntime` (working name) seam; contexts expose the seam, not `Reconciler`. The load-bearing Phase-1 deliverable. |
-| Q10 | **Element carve-out (§5.1).** `Element` has an implicit `string → Factories.TextBlock` conversion and `FuncElement`/`MemoElement` depend on `RenderContext`. Which Element surface is the pure primitive that moves, and which convenience stays in core? | Move the pure `Element` primitive + handler/descriptor contract; keep `Factories`, `RenderContext`, `FuncElement`/`MemoElement`, and the implicit-conversion sugar in core. |
-| Q11 | **Deferred-controlled in Abstractions-only.** Generated deferred-controlled wrappers read the internal `ShouldSuppress`, so today they only compile under `InternalsVisibleTo`. Expose a public read-side primitive, route through `.Controlled`, or forbid the pattern in Abstractions-only libraries? | Expose a public read-side echo-suppress check on the seam (ties to Q2); `.Controlled` remains the higher-level path. |
-| Q12 | **`string → Element` implicit operator (§5.1).** It must be declared on `Element` but its body needs a core built-in (`TextBlockElement`) → Abstractions↔core cycle if `Element` moves. Drop it (source-breaks `VStack("hi")`-style DSL), or relocate the string convenience to core container factories? | Drop the operator; add `string`-accepting convenience to the core container factories; document as a one-time DSL migration. Confirm blast radius before Phase 1. |
-| Q13 | **Adapter materialization mechanism (§5.2).** Given `TControl` lives only in the `Register<E,C>` closure and `MakeGenericType` is forbidden, do we (1) move `IV1HandlerEntry`+adapters to Abstractions re-typed against the seam, or (2) keep adapters in core behind a generic `IReactorRuntime.CreateEntry<E,C>` factory invoked from the `Register` frame? | Option 2 — keeps the heavy reconciler-coupled adapter logic in core; only a type-erased `Func<object>` + one generic interface method cross the boundary. |
-| Q14 | **Element/record ABI evolution policy (§14).** What is the committed compatibility contract for the base `Element` record and the descriptor authoring shapes once they are the ABI — additive-only members, no positional-param changes, DIM-only seam growth? Do we gate it with a public-API baseline test (`reactor.api.txt`-style) scoped to the Abstractions assembly? | Yes: freeze the Abstractions surface behind an API-baseline gate; additive-only; new seam behavior via default-interface-methods. |
-| Q15 | **WinUI-version compatibility bound (§14).** Since `Reactor.Abstractions` references the Windows App SDK, the R7 roll-forward guarantee is bounded by WinUI's own ABI across the versions in play. Do we pin a documented minimum Windows App SDK per Abstractions version, and test the interop harness across the supported WinUI range? | Document a per-Abstractions-version minimum WinUI; the interop-proof harness pins one WinUI; a broader matrix is CI follow-up. |
+| Q1 | API-compat gate tool: `Microsoft.CodeAnalysis.PublicApiAnalyzers` (`PublicAPI.*.txt`) or `Microsoft.DotNet.ApiCompat` against the last shipped DLL? | PublicApiAnalyzers for the authoring seam (in-repo, incremental, IDE-visible); ApiCompat as a CI backstop. |
+| Q2 | Exact freeze boundary — is the *entire* §6.1 surface committed, or a named subset (e.g. is the full `MountContext` surface frozen, or only the members generated code + hand-authors actually bind)? | Freeze the members generated code and `external_proof` bind; mark the rest "public, not frozen." Settle with the interop harness. |
+| Q3 | Loader policy — strong-name + pin `AssemblyVersion` now, or stay unsigned/default-ALC and only *document* the roll-forward requirement? | Document now; revisit strong-naming when the API stabilizes past preview. |
+| Q4 | The data-grid `using static …Advanced.Factories` source break (§7) — acceptable in preview, or ship a type-forward / compat shim? | Accept in preview; call it out in release notes. |
+| Q5 | `UseLibrary` granularity — one `UseX()` per library, or sub-modules for large subsystems? | One per library by default; sub-modules where trimming a sub-surface matters (charts). |
+| Q6 | Should the wrapper attributes + generator ship as a standalone `Reactor.Wrappers` package, or stay bundled in core (status quo)? | Independent of both tracks; keep bundled unless a concrete author asks — revisit later. |
+| Q7 | Ship a `Microsoft.UI.Reactor.All` metapackage (core + Advanced) for a batteries-included reference? | Optional convenience; add if consumer feedback wants it. |
 
 ## §13 Phasing
 
-- **Phase 1 — Abstractions carve-out + runtime seam (the load-bearing phase).**
-  This is a *decoupling design task, not a file move.* Create
-  `Microsoft.UI.Reactor.Abstractions` and:
-  - Design the §5.3 runtime seam (Q9) — the small, enumerated interface (see the
-    §5.3 table) core's `Reconciler` implements — and make `MountContext`/
-    `UpdateContext`/`UnmountContext` **and `ReactorBinding<TElement>`** hold the seam
-    instead of the concrete `Reconciler`.
-  - Re-point the wrapper generator's emit (§6.1) at that seam + public primitives;
-    expose the public read-side echo-suppress check (Q2/Q11) so the deferred-controlled
-    path compiles without `InternalsVisibleTo`.
-  - Carve out the pure `Element` primitive + handler/descriptor/`PropEntry` contract
-    (Q10), leaving `Factories`/`RenderContext`/`FuncElement`/`MemoElement` in core;
-    resolve the `string → Element` implicit-operator cycle (Q12).
-  - Split `ControlRegistry` so the public `Register` surface + a type-erased
-    `Func<object>` store live in Abstractions while the reconciler-coupled adapter is
-    produced *inside* the generic `Register<E,C>` frame via the core factory seam
-    (§5.2 / Q13) — **not** rebuilt post-`TryResolve` (that would need the forbidden
-    `MakeGenericType`).
-  - Gate: `tests/external_proof/Reactor.External.TestControl` compiles + registers
-    against Abstractions only (it has **no** `InternalsVisibleTo` grant), **including
-    a deferred `[WrapControlled]` prop** (the exact case that fails to compile today,
-    per §6.2); the generator's full emitted closure resolves against Abstractions; the
-    AOT-proof harness (`tests/aot_trim_proof`) stays green.
-- **Phase 2 — `UseLibrary` + diagnostics.** Add `IReactorLibrary` /
-  `IReactorLibraryBuilder` / `UseLibrary`; reframe `RegisterAllBuiltIns` as the
-  built-in library; add the `[ReactorLibrary]` marker + enriched runtime throw +
-  the analyzer/`mur check` rule (§9).
-- **Phase 3 — feature-package extraction.** Split charting / data-grid / docking
-  into packages with `UseX()` extensions; add the `…All` metapackage; migrate
-  samples/gallery (§11).
-- **Phase 4 — opt-in self-registration.** `UseDiscoveredLibraries()` + the
-  discovery pass over `[ReactorLibrary]` markers, documented as the trim opt-out.
+- **Increment 1 — done (this change).** Public `ReactorBinding.ShouldSuppressEcho`;
+  generator repointed off the last internal symbol. The wrapper-bound surface is now
+  fully public (§3).
+- **Track A — stable ABI in place.** A1: enumerate and lock the §6.1 seam behind the
+  API-compat gate (Q1/Q2). A2: build the binary-compat interop harness. A3: settle and
+  document the loader/version policy (Q3).
+- **Track B — consolidate into Advanced.** B1: charting + docking → `Reactor.Advanced`.
+  B2: markdown. B3: data grid (with the §7 factory note, Q4).
+- **Registration ergonomics — independent.** E1: `IReactorLibrary` / `UseLibrary` +
+  built-ins/Advanced fold-in (§8). E2: `[ReactorLibrary]` marker + enriched throw +
+  analyzer (§10). E3: opt-in `UseDiscoveredLibraries()` (§9).
 
-Phases 1–2 are the core of issue #163; Phase 3 is the dogfooding proof; Phase 4 is
-the convenience layer and can slip without blocking the rest.
-
-## §14 Cross-version library interop — stable ABI
-
-**Driver (R7).** The strongest reason to carve out `Reactor.Abstractions` is not
-trimming — it is letting a Reactor control library be *consumed by another Reactor
-library* without version-skew runtime failures. Today a control library
-`ProjectReference`s the whole of core `Reactor.dll` (see
-`tests/external_proof/Reactor.External.TestControl.csproj` line 55). So `LibA`
-binds to core *N*'s types and `LibB` to core *M*'s; when an app pulls both, NuGet
-unifies to **one** runtime, and whichever library did not match the surviving
-version can fail to bind at load time.
-
-**Scope: roll-forward unification, not side-by-side.** We target the
-`Microsoft.Extensions.*.Abstractions` model: one runtime per process, chosen by
-NuGet's highest-wins, and every library binary-compatible with it. True
-side-by-side (two core runtimes in separate `AssemblyLoadContext`s) is **out of
-scope** — `Element` records from one context are a different `Type` than the
-other's, so a shared reconciler cannot process both. Roll-forward is the tractable,
-common case and is what the split below enables.
-
-**Why this is feasible.** .NET assembly binding in the default load context is by
-type/member signature, not by exact strong-name version, and NuGet unifies to a
-single assembly. So *old generated code binds to a newer runtime* as long as every
-symbol it references is unchanged. The guarantee therefore reduces to a single
-discipline: **everything a library's compiled output references must live in
-`Reactor.Abstractions`, and that surface must evolve additive-only.**
-
-**The frozen ABI surface.** Grounded against the generator emit
-(`WrapperGenerator.cs`) and the reconciler's reads of a foreign element, the exact
-closure a control library binds to is enumerable:
-
-| ABI member (emitted/referenced) | Source today | Stability action |
-|---|---|---|
-| `Element` base + `Key`, `Modifiers` (`ElementModifiers`) | core `Element.cs` (reconciler reads `Reconciler.cs:597,609`) | move to Abstractions; freeze base members |
-| `Optional<T>` | core (`WrapperGenerator.cs:727,1140,1628`) | move to Abstractions |
-| `ControlDescriptor<E,C>` / `DescriptorHandler<E,C>` | core V1Protocol (`:1382,1383`) | move authoring shapes to Abstractions |
-| child strategies `SingleContent`/`Panel`/`ItemsHost`/element-slots | core V1Protocol (`:1384–1386,1426–1438`) | move to Abstractions |
-| `ControlRegistry.Register<E,C>` + stored entry (`IV1HandlerEntry`) | core (`:1717`) | public `Register` in Abstractions; adapter built in-frame (Q13) |
-| runtime seam: `GetElementTag`/`SetElementTag`/`DetachReactorState`/`ApplySetters` | core `Reconciler` **static** (`:1483,1498`, §5.3) | expose as Abstractions seam; **stop referencing concrete `Reconciler`** |
-| read-side echo check `ShouldSuppress` | core `ChangeEchoSuppressor` **internal** (`:1497`) | **public read-side primitive** (Q2/Q11) — hardest blocker |
-| `MountContext`/`UpdateContext`/`UnmountContext` + `ReactorBinding<T>` | core V1Protocol (§5.1/§5.3) | move to Abstractions over the seam |
-| `ElementExtensions` lifecycle add | core (`:1779`) | move/relocate to Abstractions |
-| `ReactorApp.TryRegisterControlAssembly` | core **Hosting** namespace (`:1716`) | relocate to an Abstractions/core seam — a control lib must not bind Hosting |
-
-**Two current violations** make cross-version binding impossible *today*, and both
-are already tracked: (1) the deferred-controlled trampoline emits the **internal**
-`ChangeEchoSuppressor.ShouldSuppress` (only compiles under `InternalsVisibleTo`;
-Q11); (2) generated code references the **concrete `Reconciler`** and
-Hosting's `ReactorApp`, so a library binds core directly rather than a stable
-subset. Closing both is the load-bearing Phase-1 work.
-
-**WinUI-coupling caveat.** `Reactor.Abstractions` is **not** pure-managed. The
-authoring shapes are generic over the control type (`ControlDescriptor<E, C> where
-C : FrameworkElement`), contexts hand out `FrameworkElement`, and the generator
-emits `Microsoft.UI.Xaml.FrameworkElement`/`UIElement` (`WrapperGenerator.cs:1376,
-1483`). So Abstractions references the Windows App SDK, and the R7 guarantee is
-bounded by **WinUI's own ABI stability** across the versions in play: it is "one
-Reactor runtime + one compatible Windows App SDK," not "any WinUI." This is the
-same constraint apps already accept (a process has one Windows App SDK), so it is a
-statement of the boundary, not a new limitation. (Contrast the existing
-`Reactor.Wrappers.Abstractions`, which holds only the compile-time authoring
-*attributes* and is genuinely WinUI-free — a different assembly from the runtime
-`Reactor.Abstractions` proposed here.)
-
-**Evolution discipline.**
-
-- *Additive-only.* Never remove or change the signature of an ABI member the
-  generator or a hand-authored handler could bind to. New seam behavior arrives as
-  new members (default-interface-methods on the seam interface; new static
-  overloads), never as edits to existing ones.
-- *Records stay evolvable.* The reconciler dispatches by element `Type` → registered
-  entry and reads only base `Element` members — it never reconstructs a derived
-  record positionally across the boundary. So a library's own element record shape
-  is private; only additive changes to the *base* `Element` are ABI-visible.
-- *Independent versioning.* `Reactor.Abstractions` gets its own slow SemVer; the
-  `Reactor.Wrappers` generator package version tracks the Abstractions surface it
-  emits against; core runtime churns freely as long as it keeps implementing the
-  Abstractions contract backward-compatibly. This is exactly the
-  `Microsoft.Extensions.*.Abstractions` playbook.
-
-**Regression gate — a real two-version interop harness.** Analogous to the existing
-AOT-proof harness, R7 needs an executable proof: build
-`Reactor.External.TestControl` against `Reactor.Abstractions` *N*, then load the
-**compiled DLL** (not a project reference) into a host running core *M* and assert
-mount / update / echo all succeed through the public surface only. A binary-drop
-test (reference the built assembly, not source) is the closest in-repo proxy for
-the "no recompilation" clause; a full two-NuGet-version matrix can follow in CI.
-
-New open questions **Q14** (Element/record ABI evolution policy) and **Q15**
-(WinUI-version compatibility bound) are added to §12.
+Tracks A and B share no dependency and can land in either order; the ergonomics
+workstream can interleave with either.

--- a/docs/specs/062-third-party-registration-and-package-boundaries.md
+++ b/docs/specs/062-third-party-registration-and-package-boundaries.md
@@ -295,21 +295,36 @@ not part of the versioned binary ABI a wrapper rolls forward against.
 
 ### §6.2 Governance — three pieces that do not exist yet
 
-1. **A real API-compat gate.** Today `tests/Reactor.Tests/Tooling/ApiIndexGeneratorTests.Index_IsUpToDate`
-   only byte-compares the generated `reactor.api.txt` for *staleness* — regenerating
-   it makes the test pass, so it *blesses* breaking changes rather than blocking them.
-   Add an additive-only gate — `Microsoft.CodeAnalysis.PublicApiAnalyzers`
-   (`PublicAPI.Shipped.txt` / `.Unshipped.txt`) or `Microsoft.DotNet.ApiCompat`
-   against the last shipped `Reactor.dll` — scoped to the §6.1 seam, so removing or
-   changing a frozen member fails the build.
+Three complementary mechanisms, each a *different kind* of check: a build-time gate (1),
+a runtime test (2), and a load-time policy (3).
 
-2. **A binary-compat interop harness.** Additive signatures are necessary but not
-   sufficient — a wrapper depends on *behavior* (echo semantics, child reconcile,
-   registration timing, descriptor ordering). Analogous to the existing AOT-proof
-   harness, build `Reactor.External.TestControl` against an **older** Reactor, then
-   load the **compiled DLL** (a binary drop, not a project reference) into a host
-   running the HEAD runtime and assert mount / update / echo-suppress all succeed
-   through the public surface only. A two-NuGet-version matrix can follow in CI.
+1. **A real API-compat gate — a *build-time* check, not a test.** It runs during
+   compilation and fails the build before any test executes. Today
+   `tests/Reactor.Tests/Tooling/ApiIndexGeneratorTests.Index_IsUpToDate` *is* a test, and a
+   toothless one: it only byte-compares the generated `reactor.api.txt` for *staleness*, so
+   regenerating the file makes it green — it *blesses* breaking changes rather than blocking
+   them. Replace it with an additive-only gate scoped to the §6.1 seam:
+   - **`Microsoft.CodeAnalysis.PublicApiAnalyzers`** — a Roslyn analyzer over checked-in
+     `PublicAPI.Shipped.txt` (the frozen surface) + `PublicAPI.Unshipped.txt` (pending
+     adds). Removing or changing a shipped member raises `RS0017` at compile; adding public
+     API not listed raises `RS0016`, forcing a reviewable txt-file diff. Additive by
+     construction.
+   - **`Microsoft.DotNet.ApiCompat`** — diffs the just-built `Reactor.dll` against the
+     last-shipped baseline and fails on any binary-incompatible delta (the mechanism the
+     .NET runtime uses for its own ref assemblies).
+
+   Either way, removing or changing a frozen member is a red build, not a snapshot to bless.
+
+2. **A binary-compat interop harness — a *runtime* test the gate can't replace.**
+   Additive signatures are necessary but not sufficient: a wrapper also depends on
+   *behavior* (echo semantics, child reconcile, registration timing, descriptor ordering),
+   which no API diff can see. This is an integration test with one non-negotiable shape — it
+   loads a **pre-compiled DLL** (a binary drop, **not** a project reference; a project
+   reference recompiles against HEAD and hides the very break we are hunting). Analogous to
+   the existing AOT-proof harness, build `Reactor.External.TestControl` against an
+   **older** Reactor, then load that unchanged DLL into a host running the HEAD runtime and
+   assert mount / update / echo-suppress all succeed through the public surface only. A
+   two-NuGet-version matrix can follow in CI.
 
 3. **A loader / version policy.** Roll-forward works today partly by luck:
    `Reactor.dll` is **not strong-named** (no `SignAssembly`/key in `Reactor.csproj`)
@@ -345,11 +360,14 @@ not part of the versioned binary ABI a wrapper rolls forward against.
 
 ## §7 Track B — consolidate heavy subsystems into `Reactor.Advanced`
 
-Today only Win2D is extracted: `Reactor.Advanced` (`<Description>Advanced Reactor
-components — first inhabitant: Win2D canvas.</Description>`, with `charts` already in
-its `PackageTags`) is a one-way `ProjectReference` on core. Core still carries the
-heavy leaves — charting/D3, docking, markdown, and the data grid — which dominate the
-~3.5 MB `Reactor.dll`.
+Today only Win2D is extracted. `Reactor.Advanced` is its **own** NuGet package
+(`PackageId` `Microsoft.UI.Reactor.Advanced`; `<Description>… first inhabitant: Win2D
+canvas.</Description>`; `charts` already in its `PackageTags`) that **depends on** core —
+the in-repo one-way `ProjectReference` to `Reactor.csproj` becomes a package dependency at
+pack, so the direction is **Advanced → core**, never the reverse. An app opts in with a
+single `PackageReference` to `Microsoft.UI.Reactor.Advanced`; NuGet then transitively
+resolves core. Core still carries the heavy leaves — charting/D3, docking, markdown, and the
+data grid — which dominate the ~3.5 MB `Reactor.dll`.
 
 **Plan: move charting, docking, markdown, and the data grid into
 `Reactor.Advanced`.** This follows the colleague-endorsed "one advanced assembly, not
@@ -387,15 +405,50 @@ a dozen DLLs" shape and reuses Advanced's existing self-registering
   unaffected. A core-side compat shim is **not** an option: core is a one-way
   `ProjectReference` *target* of Advanced, so it cannot call back into the relocated
   implementation. These are minor, preview-window source breaks (§12 Q4).
+- **Namespaces stay put — the assemblies move, the namespaces do not.** As above, the
+  relocated types keep their existing names
+  (`Microsoft.UI.Reactor.Charting` / `.Docking` / `.Markdown`; the data grid's
+  `Microsoft.UI.Reactor.Controls` records) even though they now ship in `Reactor.Advanced`.
+  Rebranding them to `Microsoft.UI.Reactor.Advanced.*` would break every consumer's `using`
+  directives and type references for **no** compatibility benefit — the avoidable break §6.3
+  tells us not to make. (Win2D is `…Advanced.Win2D` only because it was *greenfield* in
+  Advanced and never had a core namespace to preserve.) One honest caveat: for an
+  already-*compiled* consumer the assembly move is a binary break regardless of namespace —
+  its metadata still names `…, Reactor` for a type now in `…, Reactor.Advanced` — and the
+  usual `[TypeForwardedTo]` softener is **unavailable**, because core is Advanced's one-way
+  dependency *target* and cannot reference it back without a cycle. Compiled consumers
+  therefore recompile (picking up the new assembly with zero code edits beyond the two
+  `using static` lines above), consistent with this being a deliberate, major-versioned move.
 - **Sequence:** charting + docking first (already decoupled, boundary-guarded, and
   source-clean), then markdown, then the data grid (the last two each carry the factory
   note above).
 
-**Win:** smaller default JIT ship size, a smaller core NuGet package, and a smaller
-core dependency for wrapper authors — with AOT already covered by #627's trimming
-inversion. Each move is gated on: no new `internal` cross-boundary reach that
-`InternalsVisibleTo` cannot cleanly express, `CoreControlFamilyBoundaryTests` and the
-AOT-proof harness stay green, and the subsystem's selftests/E2E still pass.
+**Who benefits — and who does not.** Because Advanced sits *on top of* core, moving the
+heavy leaves shrinks **core**, so the win is asymmetric:
+
+- **Core-only consumers win.** The common app that never touches
+  charting/docking/markdown/data-grid — and, per #163, the 3P wrapper author who references
+  only core to define a custom element — gets a ~1.6 MB-smaller download and a **narrower**
+  core surface in IntelliSense, the API index, and the frozen §6.1 ABI. That last point is a
+  direct Track A synergy: fewer controls in core is a smaller surface to keep stable.
+- **Advanced consumers see no reduction.** They opted into the heavy stuff and get core +
+  the leaves either way; the data grid's AOT/reflection caveats simply now sit behind an
+  explicit opt-in package instead of in everyone's core.
+
+**What this is _not_ — the spec should not oversell it.**
+
+- **AOT/trimmed apps already get it.** #627's trimming inversion drops unreferenced
+  charting/docking to ~0 in a NativeAOT / `PublishTrimmed` publish, so this is really a
+  **default-JIT** ship-size win, where the whole `Reactor.dll` ships regardless.
+- **The boundary is deliberately coarse.** Advanced is one grab-bag ("no dozen DLLs"), so an
+  app that wants only the data grid still pulls charting + docking + markdown. Fine-grained
+  "pay only for what you use" is what AOT trimming already delivers; the split does not try
+  to reproduce it. Not doing Track B at all — and relying solely on #627 — stays a
+  legitimate choice for AOT-first shops.
+
+Each move is gated on: no new `internal` cross-boundary reach that `InternalsVisibleTo`
+cannot cleanly express, `CoreControlFamilyBoundaryTests` and the AOT-proof harness stay
+green, and the subsystem's selftests/E2E still pass.
 
 ## §8 Library registration API — `UseLibrary`
 

--- a/docs/specs/062-third-party-registration-and-package-boundaries.md
+++ b/docs/specs/062-third-party-registration-and-package-boundaries.md
@@ -24,9 +24,10 @@ design, phased in §13.
 
 > A third-party control library adds Reactor support by wrapping its WinUI control,
 > and that **compiled wrapper keeps running against newer Reactor runtimes without
-> recompilation** — the roll-forward model teams expect from
-> `Microsoft.Extensions.*`. It gets that from a **stable, additive-only authoring
-> seam inside the one Reactor runtime** — *not* a separate abstractions package.
+> recompilation** — the binary roll-forward .NET already gives any additive,
+> signature-compatible NuGet dependency. It gets that from a **stable, additive-only
+> authoring seam inside the one Reactor runtime** — *not* a separate abstractions
+> package.
 > Reactor's own package stays lean by keeping heavy optional subsystems out of the
 > default reference. App developers get **one obvious registration call per
 > library**, and a missing registration fails **loudly and helpfully**, never as a
@@ -113,8 +114,9 @@ generator (spec 058) keep working, ideally with a smaller footprint, never large
 
 **R7 — Cross-version library interop (stable ABI).** A control library built against
 Reactor version *N* must load and run, **without recompilation**, against a host that
-supplies a *newer* runtime version *M* ≥ *N* — the roll-forward/unification model of
-`Microsoft.Extensions.*`. An app that transitively pulls `LibA` (built against *N*)
+supplies a *newer* runtime version *M* ≥ *N* — the NuGet single-version unification and
+assembly roll-forward that .NET applies to any additive-compatible dependency. An app
+that transitively pulls `LibA` (built against *N*)
 and `LibB` (built against *M*) unifies to a **single** runtime, and both libraries'
 controls must mount, update, and echo correctly against it.
 
@@ -302,9 +304,14 @@ not part of the versioned binary ABI a wrapper rolls forward against.
 
 ### §6.3 Evolution discipline
 
-- **Additive-only.** Never remove or change the signature of a §6.1 member. New seam
-  behavior arrives as new members (new overloads; default-interface-methods on the
-  handler/descriptor interfaces), never as edits to existing ones.
+- **Additive by default; break only when nothing simpler works.** New seam behavior
+  arrives as *new* members (new overloads; default-interface-methods on the
+  handler/descriptor interfaces), never as edits to existing ones — a §6.1 signature is
+  never removed or changed when an additive change would achieve the same result.
+  Reactor still reserves the right to break the seam, but only as a genuine last resort
+  when no compatible change exists; every such break is a deliberate, versioned,
+  release-noted exception — not routine churn (and, in preview, expected to grow rarer
+  as the API settles).
 - **Records stay evolvable.** The reconciler dispatches by element `Type` → registered
   entry and reads only base `Element` members; it never reconstructs a derived record
   positionally across the boundary. A library's own element record shape is therefore

--- a/docs/specs/062-third-party-registration-and-package-boundaries.md
+++ b/docs/specs/062-third-party-registration-and-package-boundaries.md
@@ -67,11 +67,14 @@ trim-safe, and spec 058 added a `[GenerateReactorWrapper]` source generator that
 emits the descriptor + registration + factory for a wrapped WinUI/WinRT control.
 Issue #163 raises four coupled frustrations that remain:
 
-1. **The dependency is heavy and version-locked.** To *define* one custom element a
-   library references the whole of `Reactor.dll`. Worse, because its compiled output
-   binds concrete runtime types, that output is locked to the exact version it built
-   against — it cannot roll forward to a newer runtime an app happens to pull in. Two
-   Reactor-enabled libraries built against different versions cannot compose.
+1. **The dependency is heavy, and forward-compatibility isn't guaranteed.** To *define*
+   one custom element a library references the whole of `Reactor.dll`. And because its
+   compiled output binds concrete runtime types across a seam with no stability
+   guarantee, nothing ensures that output keeps working against a newer runtime an app
+   happens to pull in — .NET *can* roll the binding forward, but only as long as every
+   bound symbol is still present and unchanged, which today nothing enforces. Two
+   Reactor-enabled libraries built against different versions may therefore fail to
+   compose.
 
 2. **Registration has no standard shape.** Registration happens per control (a
    factory touch, or a Pattern-A static constructor — spec 048 §6). There is no

--- a/docs/specs/062-third-party-registration-and-package-boundaries.md
+++ b/docs/specs/062-third-party-registration-and-package-boundaries.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-**Proposed — design v0.2 (2026-07-15). No code changes.** This is a design
+**Proposed — design v0.3 (2026-07-16). No code changes.** This is a design
 document responding to [issue #163](https://github.com/microsoft/microsoft-ui-reactor/issues/163)
 ("Simplify third-party control registration and package boundaries for custom
 element types"). It builds on the *already-shipped* extensibility stack — the V1
@@ -26,6 +26,25 @@ decision — [§12 Open questions](#12-open-questions) is the decision surface.
 > findings in: the package split is still the right direction, but **Phase 1 is a
 > decoupling-design task (a runtime-seam abstraction), not a file move.** The
 > affected sections (§4–§7) call out the specific coupling and the resolution.
+
+> **Implementation-readiness note (v0.3, 2026-07-16).** Before committing to build,
+> the four load-bearing assumptions were spiked directly against source. All the
+> visibility/citation claims **hold**. The spike also *sharpened* three design
+> points that would have cost implementation time:
+> - **§5.2 correction:** the adapter cannot be materialized "after `TryResolve`" —
+>   the registry is keyed by element type only, so `TControl` lives solely in the
+>   `Register<E,C>` closure, and rebuilding the adapter later needs `MakeGenericType`,
+>   which `ControlRegistry` forbids. The seam factory must run *inside* the generic
+>   `Register` frame (new **Q13**).
+> - **§5.1 breaking-change:** the `string → Element` implicit operator cannot follow
+>   `Element` into Abstractions without a reference cycle; it must be dropped or moved
+>   to the core DSL — a real (if small) source break (new **Q12**).
+> - **§5.1/§5.3 scope:** the carve-out cluster includes `UnmountContext` **and**
+>   `ReactorBinding<TElement>`, not just the two contexts.
+>
+> These are folded into §5 and §12. Net: the direction is sound and the seam is
+> small and enumerable (§5.3 table), so the design is **ready to implement**, with
+> Q9/Q12/Q13 as the Phase-1 spikes to settle first.
 
 ### North star
 
@@ -286,55 +305,122 @@ and resolving it — §5.1 (`Element` carve-out), §5.2 (`ControlRegistry` split
 
 ### §5.1 `Element` carve-out
 
-"Move the `Element` base to Abstractions" is a carve-out, not a file move (§4.1):
+"Move the `Element` base to Abstractions" is a carve-out, not a file move (§4.1).
+Grounding note: the whole element catalog lives in one 6865-line `Element.cs`, so
+this is also a physical file split (the base record + contracts move; every
+concrete built-in element record — `TextBlockElement` at `Element.cs:2616`, etc. —
+stays in core).
 
-- `Element`'s implicit `string → Factories.TextBlock` conversion (`Element.cs:342`)
-  pulls the built-in catalog. **Resolution:** drop the implicit conversion from the
-  Abstractions `Element` and re-add it as an extension/convenience in core (it is a
-  DSL nicety, not part of the authoring contract), or have it call a seam hook the
-  core populates.
+- **The base `Element` record itself is nearly clean.** Verified: it carries only
+  `Key`, `Modifiers` (`ElementModifiers`, `Element.cs:1768` — WinUI *value* types,
+  fine under the §4 WinUI floor), and the outer-margin shim. The one true runtime
+  coupling is the implicit `string → Factories.TextBlock` conversion (`Element.cs:342`).
+- **The implicit-conversion carve-out is a breaking-change decision, not a free move.**
+  A `string → Element` implicit operator **must be declared on `Element`** (the other
+  operand, `string`, is a sealed BCL type). Its body needs a *concrete built-in*
+  (`Factories.TextBlock` → `new TextBlockElement(...)`, `Element.cs:2616`) that stays
+  in core — so if `Element` moves to Abstractions and keeps the operator, we get an
+  **Abstractions → core reference cycle**. There is no in-place fix: the operator
+  must either be **dropped** (source-breaking — container factories like `VStack("hi")`
+  / `Grid("x")` rely on `string → Element` today) or the string-convenience must be
+  **relocated into the core DSL** as `params`-overloads on the container factories.
+  Recommendation: drop the implicit operator, add `string`-accepting convenience to
+  the core containers; document as a one-time DSL migration. (New open question Q12.)
 - `FuncElement`/`MemoElement` (`Element.cs:1510-1516`) depend on `RenderContext`
   (a core hooks-runtime type). **Resolution:** these are *composition primitives*,
-  not authoring contracts — leave them (and `ElementExtras`' animation/resource/
-  input conveniences) in **core**, and move only the pure `Element` record base +
-  the modifier/attribute contract to Abstractions.
-- Net: Abstractions gets the pure `Element` primitive and the handler/descriptor
-  contract; core keeps `Factories`, `RenderContext`, `FuncElement`/`MemoElement`,
-  and the composition sugar. The carve-out line is "does a *definer* of a custom
-  element need it?" — if not, it stays in core.
+  not authoring contracts — leave them (and the animation/resource/input
+  conveniences) in **core**, and move only the pure `Element` record base + the
+  modifier/attribute contract to Abstractions.
+- **The author-facing type cluster that holds a `Reconciler` field is larger than
+  just the contexts.** Verified: `MountContext` (`MountContext.cs:50`),
+  `UpdateContext` (`:128`), `UnmountContext` (`:166`) **and** `ReactorBinding<TElement>`
+  (`ReactorBindingT.cs`, constructed with `_reconciler` at `MountContext.cs:92`) all
+  store a `Reconciler`. All four must be re-typed against the §5.3 seam, not just the
+  two contexts the earlier draft named. `ReactorBinding<TElement>` is on the author
+  hot path (`ctx.BindFor(ctrl, el).WriteSuppressed(...)`), so it is a required
+  carve-out target.
+- Net: Abstractions gets the pure `Element` primitive, the handler/descriptor
+  contract, the three contexts, and `ReactorBinding<TElement>` (all seam-typed); core
+  keeps `Factories`, `RenderContext`, `FuncElement`/`MemoElement`, the concrete
+  element catalog, and the composition sugar. The carve-out line is "does a *definer*
+  of a custom element need it?" — if not, it stays in core.
 
 ### §5.2 `ControlRegistry` — split the stored shape from the dispatch adapter
 
 `ControlRegistry.Register<TElement,TControl>` currently wraps the handler factory
 in a `V1HandlerAdapter` implementing the **internal** `IV1HandlerEntry`, whose
-`Mount`/`Update` take a `Reconciler` (`V1HandlerRegistry.cs:30-40`,
-`ControlRegistry.cs:112-113`). Moving the registry as-is drags `Reconciler` into
-Abstractions. **Resolution (recommended):** split the two roles —
+`Mount`/`Update`/`Unmount` take a `Reconciler` *in their signatures*
+(`V1HandlerRegistry.cs:32,40,46`; adapter built at `ControlRegistry.cs:112-113`).
+Moving the registry as-is drags `Reconciler` into Abstractions.
 
-- **Abstractions** holds `ControlRegistry` storing a *neutral* public registration
-  record — e.g. `Type → ReactorRegistration` where `ReactorRegistration` captures
-  the handler factory + kind (value / decorator / base-derived) with **no**
-  `Reconciler` in its signature.
-- **Core** materializes the `IV1HandlerEntry` dispatch adapter from that neutral
-  record *after* `TryResolve`, keeping `IV1HandlerEntry`/`V1HandlerAdapter`/
-  `V1DecoratorHandlerAdapter` (which name `Reconciler`) in core.
+**Grounding correction (this changes the recommended mechanism).** The earlier
+draft said "core materializes the adapter *after* `TryResolve`." That is **not
+AOT-legal as written**: the registry dictionary is keyed by `typeof(TElement)`
+*only* (`ControlRegistry.cs:118`), so the closed `TControl` survives **solely inside
+the `Register<TElement,TControl>` generic-frame closure**. Rebuilding
+`V1HandlerAdapter<TElement,TControl>` at dispatch time — outside that frame — would
+require `Type.MakeGenericType`, which the registry **explicitly forbids**
+(`ControlRegistry.cs:38-43`, the AOT contract). The adapter *must* be constructed
+in the generic `Register` frame. So the split is:
 
-This keeps the public `Register`/`RegisterDecorator`/`RegisterForDerivedTypes`
-surface (and the first-wins/base-derived semantics of 048 §8) in Abstractions while
-the runtime-typed adapter stays in core.
+- **Abstractions** holds the public `Register`/`RegisterDecorator`/
+  `RegisterForDerivedTypes` surface and stores a **type-erased** `Func<object>`
+  entry keyed by element type. The adapter is still produced *inside* the generic
+  `Register<TElement,TControl>` frame (preserving static `TControl` visibility — no
+  `MakeGenericType`), via one of:
+  1. **Move `IV1HandlerEntry` + `V1HandlerAdapter` + `V1DecoratorHandlerAdapter`
+     into Abstractions, re-typed from `Reconciler` to the §5.3 seam.** Cleanest for
+     `Register` (its body is unchanged), but the adapters are *heavy* — they do child
+     -strategy dispatch, element-tag anchoring, and component-teardown against the
+     reconciler (`V1HandlerAdapter.cs:29-120`), so this pulls a lot of logic behind
+     the seam.
+  2. **Keep the adapters in core**, and have Abstractions' `Register<E,C>` call a
+     core-supplied generic factory seam (`IReactorRuntime.CreateEntry<E,C>(handler)`)
+     *from within* its own generic frame, storing the returned `Func<object>`. Keeps
+     the heavy adapter logic in core; the only new cost is one generic interface
+     method (statically instantiated per call site → AOT-legal, still no
+     `MakeGenericType`).
+- **Core** downcasts the stored `object` back to `IV1HandlerEntry` on the dispatch
+  path (`TryResolve` consumer). `TryResolve` itself (`ControlRegistry.cs:267`) must
+  then return the neutral `Func<object>`, not `Func<IV1HandlerEntry>`.
+
+Recommendation: **option 2** — it keeps the reconciler-coupled adapter logic in core
+and moves the minimum across the boundary. This is a Phase-1 spike (Q9/Q13). The
+public `Register` surface and the first-wins/base-derived semantics of 048 §8 stay
+intact either way.
 
 ### §5.3 Contexts, descriptors, `Reg` visibility, and the WinUI dependency
 
 - **Author contexts must stop exposing `Reconciler`.** `MountContext` exposes a
-  `Reconciler` escape hatch (`MountContext.cs:50-65`); `ControlDescriptor.OneWayBridged`
-  and `DescriptorHandler` use it. **Resolution:** replace the public `Reconciler`
-  member with the minimal **runtime-seam** the generated/hand-written code actually
-  needs — `MountChild`, `ReconcileChild`, `ApplySetters`, element-tag get/set,
-  `DetachReactorState`, a read-side suppress-check, lifecycle add, and
-  assembly-register (the union of §6's closure). Abstractions declares the seam
-  interface; core's `Reconciler` implements it (the seam's shape is **Q9**). Any
-  descriptor entry that genuinely needs the full `Reconciler` (rare) stays a
-  core-only API.
+  public `Reconciler` escape hatch (`MountContext.cs:64`; `UpdateContext.cs`-equiv
+  `:138`, `UnmountContext` `:174`); `ControlDescriptor.OneWayBridged` and
+  `DescriptorHandler` consume it. **Resolution:** replace the public `Reconciler`
+  member with the minimal **runtime-seam** the context surface + generated code
+  actually need. Grounded against source, the seam is small and enumerable — the
+  union of what `MountContext`/`UpdateContext`/`UnmountContext` delegate to the
+  reconciler plus what the generator emits:
+
+  | Seam member | Backing today | Used by |
+  |---|---|---|
+  | `Mount(Element, Action)` | `_reconciler.Mount` (`MountContext.cs:69`) | `MountChild` |
+  | `ReconcileV1Child(old,new,existing,rerender)` | `:79` | `ReconcileChild`, `[WrapElementSlot]` |
+  | `RentControl<T>(policy,factory)` | `:97` | `MountContext.RentControl` |
+  | `PushContextDisposable<T>` / `PushStaggerScopeDisposable` | `:102,:106` | context/stagger scopes |
+  | `ReturnControl<T>` | `UnmountContext` `:179` | unmount pooling |
+  | `SetElementTag` / `GetElementTag` / `DetachReactorState` | `Reconciler` `public static` `516/627/732` | generator (`1233,1243,1253,1313,1483,1498`) |
+  | `ApplySetters<T>` | `Reconciler` `public static 2647` (also `ctx.ApplySetters` `:84`) | generator (`1314,1328,1332`) |
+  | read-side echo check | `ChangeEchoSuppressor.ShouldSuppress` **internal** `68` | generator deferred path (`1497`) — the §6.2 gap |
+  | assembly-register | `ReactorApp.TryRegisterControlAssembly` `public static`, **Hosting** `282` | generator (`1716`) |
+  | lifecycle add | `ElementExtensions.OnMountAdd/OnUnmountAdd` `2470/2495` | generator (`1784,1786`) |
+
+  Notes that fell out of the spike: (a) `ApplySetters` is a **static** method, so it
+  is a static helper on the seam/Abstractions, not an instance member; (b) the
+  assembly-register member currently lives in **Hosting** (`ReactorApp`) — the seam
+  lets generated code name Abstractions instead of dragging hosting; (c) `BindFor`
+  constructs `ReactorBinding<TElement>`, so that type is part of the carve-out (§5.1),
+  not the seam. Abstractions declares the seam interface (`IReactorRuntime`, working
+  name); core's `Reconciler` implements it (shape is **Q9**). Any descriptor entry
+  that genuinely needs the full `Reconciler` (rare) stays a core-only API.
 - **`Reg`/`RegDecorator`/`RegBase` are `internal`** (`Reg.cs:66`), and 048 §8
   deliberately steers 3P authors to the *public* `ControlRegistry.Register`. Feature
   packages (§11) that want Pattern-B scale registration would need these.
@@ -343,6 +429,11 @@ the runtime-typed adapter stays in core.
   promote a supported *public* bulk/factory registration primitive. Recommendation:
   (a) — do not widen `Reg` to public; feature packages use the same generated
   Pattern-A shape a 3P library uses, which is the dogfooding point.
+- **The Abstractions NuGet declares its own `Microsoft.WindowsAppSDK.WinUI`
+  dependency and TFM rules.** External consumers do **not** inherit this repo's
+  `Directory.Build.targets` injection rule, so the package's `.nuspec`/csproj must
+  carry the `.WinUI` sub-package reference and the `net10.0-windows…` TFM explicitly
+  (mirroring how `Reactor.Advanced` is packaged).
 - **The Abstractions NuGet declares its own `Microsoft.WindowsAppSDK.WinUI`
   dependency and TFM rules.** External consumers do **not** inherit this repo's
   `Directory.Build.targets` injection rule, so the package's `.nuspec`/csproj must
@@ -441,6 +532,18 @@ change, not a rename.
 > Reactor core (tests, devtools) — *not* a true external library. So one generated
 > code path already fails the "public surface is sufficient" bar today; the §6.1
 > read-side-primitive work fixes it as a side effect.
+>
+> **Verified against source (2026-07-16).** The emit is literal — `WrapperGenerator.cs:1497`
+> writes `if (global::Microsoft.UI.Reactor.Core.ChangeEchoSuppressor.ShouldSuppress(__c)) return;`
+> and `ChangeEchoSuppressor` is `internal static` (`ChangeEchoSuppressor.cs:49`). The
+> IVT grants (`Reactor.csproj`) go only to `Reactor.Tests`, `Reactor.AppTests.Host`,
+> `Reactor.Fuzz`, `Reactor.Markdown.TestRenderer`, `Microsoft.UI.Reactor.Devtools`,
+> `PerfBench.*` — **not** `tests/external_proof`. So `tests/external_proof/Reactor.External.TestControl`
+> is the exact Phase-1 gate: add a **deferred** `[WrapControlled]` prop there and it
+> fails to compile *today*, proving the gap; the public read-side primitive (Q2/Q11)
+> is what makes it pass. Note the **non-deferred** `.Controlled` path is already clean
+> — echo suppression is encapsulated in the public descriptor entry
+> (`WrapperGenerator.cs:1584`, no internal reference).
 
 ### §6.3 Three candidate shapes (evaluate, then decide)
 
@@ -779,25 +882,34 @@ These are the decision surface for @azchohfi. Each states a recommendation but i
 | Q9 | **Runtime-seam design (§5.3).** What is the minimal interface Abstractions declares and core's `Reconciler` implements (child mount/reconcile, `ApplySetters`, tag get/set, detach, echo-suppress read, lifecycle-add, assembly-register)? Should `MountContext`/`UpdateContext` expose *it* instead of the concrete `Reconciler`? | Design a single `IReactorRuntime` (working name) seam; contexts expose the seam, not `Reconciler`. The load-bearing Phase-1 deliverable. |
 | Q10 | **Element carve-out (§5.1).** `Element` has an implicit `string → Factories.TextBlock` conversion and `FuncElement`/`MemoElement` depend on `RenderContext`. Which Element surface is the pure primitive that moves, and which convenience stays in core? | Move the pure `Element` primitive + handler/descriptor contract; keep `Factories`, `RenderContext`, `FuncElement`/`MemoElement`, and the implicit-conversion sugar in core. |
 | Q11 | **Deferred-controlled in Abstractions-only.** Generated deferred-controlled wrappers read the internal `ShouldSuppress`, so today they only compile under `InternalsVisibleTo`. Expose a public read-side primitive, route through `.Controlled`, or forbid the pattern in Abstractions-only libraries? | Expose a public read-side echo-suppress check on the seam (ties to Q2); `.Controlled` remains the higher-level path. |
+| Q12 | **`string → Element` implicit operator (§5.1).** It must be declared on `Element` but its body needs a core built-in (`TextBlockElement`) → Abstractions↔core cycle if `Element` moves. Drop it (source-breaks `VStack("hi")`-style DSL), or relocate the string convenience to core container factories? | Drop the operator; add `string`-accepting convenience to the core container factories; document as a one-time DSL migration. Confirm blast radius before Phase 1. |
+| Q13 | **Adapter materialization mechanism (§5.2).** Given `TControl` lives only in the `Register<E,C>` closure and `MakeGenericType` is forbidden, do we (1) move `IV1HandlerEntry`+adapters to Abstractions re-typed against the seam, or (2) keep adapters in core behind a generic `IReactorRuntime.CreateEntry<E,C>` factory invoked from the `Register` frame? | Option 2 — keeps the heavy reconciler-coupled adapter logic in core; only a type-erased `Func<object>` + one generic interface method cross the boundary. |
 
 ## §13 Phasing
 
 - **Phase 1 — Abstractions carve-out + runtime seam (the load-bearing phase).**
   This is a *decoupling design task, not a file move.* Create
   `Microsoft.UI.Reactor.Abstractions` and:
-  - Design the §5.3 runtime seam (Q9) — the minimal interface core's `Reconciler`
-    implements — and make `MountContext`/`UpdateContext` expose it instead of the
-    concrete `Reconciler`.
+  - Design the §5.3 runtime seam (Q9) — the small, enumerated interface (see the
+    §5.3 table) core's `Reconciler` implements — and make `MountContext`/
+    `UpdateContext`/`UnmountContext` **and `ReactorBinding<TElement>`** hold the seam
+    instead of the concrete `Reconciler`.
   - Re-point the wrapper generator's emit (§6.1) at that seam + public primitives;
     expose the public read-side echo-suppress check (Q2/Q11) so the deferred-controlled
     path compiles without `InternalsVisibleTo`.
   - Carve out the pure `Element` primitive + handler/descriptor/`PropEntry` contract
-    (Q10), leaving `Factories`/`RenderContext`/`FuncElement`/`MemoElement` in core.
-  - Split `ControlRegistry` into a neutral stored-registration shape (Abstractions)
-    vs. core's `V1HandlerAdapter` dispatch (§5.2), materialized after `TryResolve`.
-  - Gate: `tests/external_proof` compiles + registers against Abstractions only
-    (with no `InternalsVisibleTo` grant); the generator's full emitted closure
-    resolves against Abstractions; the AOT-proof harness stays green.
+    (Q10), leaving `Factories`/`RenderContext`/`FuncElement`/`MemoElement` in core;
+    resolve the `string → Element` implicit-operator cycle (Q12).
+  - Split `ControlRegistry` so the public `Register` surface + a type-erased
+    `Func<object>` store live in Abstractions while the reconciler-coupled adapter is
+    produced *inside* the generic `Register<E,C>` frame via the core factory seam
+    (§5.2 / Q13) — **not** rebuilt post-`TryResolve` (that would need the forbidden
+    `MakeGenericType`).
+  - Gate: `tests/external_proof/Reactor.External.TestControl` compiles + registers
+    against Abstractions only (it has **no** `InternalsVisibleTo` grant), **including
+    a deferred `[WrapControlled]` prop** (the exact case that fails to compile today,
+    per §6.2); the generator's full emitted closure resolves against Abstractions; the
+    AOT-proof harness (`tests/aot_trim_proof`) stays green.
 - **Phase 2 — `UseLibrary` + diagnostics.** Add `IReactorLibrary` /
   `IReactorLibraryBuilder` / `UseLibrary`; reframe `RegisterAllBuiltIns` as the
   built-in library; add the `[ReactorLibrary]` marker + enriched runtime throw +

--- a/docs/specs/062-third-party-registration-and-package-boundaries.md
+++ b/docs/specs/062-third-party-registration-and-package-boundaries.md
@@ -102,14 +102,16 @@ it supersedes any notion of a separate "abstractions" reference (§4.2 / §5.1).
 **R2 — Registration is automatic; explicit only where lazy can't reach.** The common
 case needs *no* per-library call: a control self-registers when its element is first
 constructed (§3), and families register the same lazy way through a base-type entry.
-Explicit registration — via the existing public `ControlRegistry.Register*` at startup —
-is reserved for the two cases construction cannot trigger: a handler for an element the
-library does not construct (e.g. an override), and eager global init (e.g. a XAML resource
-dictionary). Reactor adds **no** bulk "register-the-whole-library" API — it would
-re-introduce the trim opt-out spec 048 removed (R5).
+Explicit registration — via the public `ControlRegistry.Register*` seam (for reusable
+libraries) or the per-host `Reconciler.RegisterType`/`RegisterHandler` (for app-local
+controls), both from app startup (§8) — is reserved for the two cases construction cannot
+trigger: a handler for an element the library does not construct (e.g. an override), and
+eager global init (e.g. a XAML resource dictionary). Reactor adds **no** bulk
+"register-the-whole-library" API — it would re-introduce the trim opt-out spec 048 removed
+(R5).
 
 **R3 — Loud, helpful failure.** A missing registration produces a clear diagnostic
-that names the missing library and suggests the fix — never a blank screen.
+that names the missing element type and how to register it — never a blank screen.
 
 **R4 — Leaner core.** The heavy optional subsystems (charting, data grid, docking,
 markdown) move out of the default core reference so every app — and every wrapper
@@ -230,9 +232,10 @@ against source:
   (`src/Reactor/Core/V1Protocol/MountContext.cs`) are `public readonly ref struct`s
   that each hold a `private readonly Reconciler _reconciler`, **expose it publicly**
   (`public Reconciler Reconciler => _reconciler;`, offered as an "escape hatch"), and
-  proxy roughly a dozen reconciler operations (`MountChild`, `ReconcileV1Child`,
+  proxy several reconciler operations (`MountChild`, `ReconcileChild`,
   `RentControl`, `PushContext`/stagger scopes, `ApplySetters`, …) on the per-mount,
-  allocation-free hot path.
+  allocation-free hot path (up to ~10 on `MountContext`, fewer on `UpdateContext` /
+  `UnmountContext`).
 - `ControlDescriptor` references `MountContext` (its `AfterChildrenMount` callback),
   and `OneWayBridgedSetter` takes a `Reconciler` directly.
 - The generator emits direct calls to `Reconciler.SetElementTag` / `GetElementTag` /
@@ -276,7 +279,7 @@ as small, independent clean-ups that can interleave with either track.
   drags the runtime along or inverts to a broad runtime interface that merely
   relocates the freeze. One runtime → one versioning unit is simpler and honest.
 - **A fan-out of per-feature packages** (`.Charting` / `.DataGrid` / `.Docking` /
-  `.Markdown`). Each assembly carries fixed load/metadata overhead; a dozen small
+  `.Markdown`). Each assembly carries fixed load/metadata overhead; several small
   DLLs cost more than they save for the common app. Track B consolidates into the one
   existing `Reactor.Advanced` assembly instead.
 - **Carving the built-in control catalog out of core behind a metapackage.** Large,
@@ -326,11 +329,12 @@ through the global `ControlRegistry.Register*` seam above, or via the generator 
 does). Keeping per-host registration unfrozen holds the seam to the minimum a rolled-forward
 binary actually binds.
 
-**Two compatibility tiers — *prove* vs *promise*.** Every supported public API — the
-control-authoring seam **and** the app-facing DSL (~200 factory methods, ~600 fluent
-modifiers, and the hooks) — is a **within-major ABI**: it does not break within a SemVer
-major, so a compiled binary that binds any of it rolls forward across a same-major runtime
-(R7). The tiers differ in *how* that is assured, not in *whether* it holds:
+**Two compatibility tiers — *prove* vs *promise*.** Under the R7 policy (a 1.0 commitment,
+not a preview guarantee — §2), every supported public API — the control-authoring seam
+**and** the app-facing DSL (~200 factory methods, ~600 fluent modifiers, and the hooks) — is
+treated as a **within-major ABI**: within a SemVer major it does not break, so a compiled
+binary that binds any of it rolls forward across a same-major runtime. The tiers differ in
+*how* that is assured, not in *whether* it holds:
 
 - **Tier 1 — promised (the DSL and the rest of the public surface).** Kept within-major
   stable by additive-only **discipline** + review + release notes. SemVer is a release
@@ -342,7 +346,9 @@ major, so a compiled binary that binds any of it rolls forward across a same-maj
   deliberately declined: it is large and evolving, and add-overload discipline already keeps
   it within-major-safe without freezing ~800 members to a checked-in txt file.
 - **Tier 2 — proven (the §6.1 seam).** On top of the same within-major promise, the ~35
-  seam members are additionally *mechanically* guaranteed — the API-compat gate fails the
+  seam members are additionally *mechanically* guaranteed (the exact gated boundary — the
+  whole §6.1 table vs the subset generated code + `external_proof` actually bind — is settled
+  in Q2) — the API-compat gate fails the
   build on any change, and the interop harness proves an old wrapper binary still
   mounts/updates/echo-suppresses on the HEAD runtime — and held to a stricter
   last-resort-only posture even across majors. Tier 2 is stronger **evidence**; it does
@@ -382,8 +388,9 @@ a runtime test (2), and a load-time policy (3).
    *behavior* (echo semantics, child reconcile, registration timing, descriptor ordering),
    which no API diff can see. This is an integration test with one non-negotiable shape — it
    loads a **pre-compiled DLL** (a binary drop, **not** a project reference; a project
-   reference recompiles against HEAD and hides the very break we are hunting). Analogous to
-   the existing AOT-proof harness, build `Reactor.External.TestControl` against an
+   reference recompiles against HEAD and hides the very break we are hunting). In the same
+   spirit as the existing AOT-proof harness (which inspects a shipped artifact rather than
+   recompiling from source), build `Reactor.External.TestControl` against an
    **older** Reactor, then load that unchanged DLL into a host running the HEAD runtime and
    assert mount / update / echo-suppress all succeed through the public surface only. A
    two-NuGet-version matrix can follow in CI.
@@ -397,7 +404,8 @@ a runtime test (2), and a load-time policy (3).
    graph. The same-major band is enforced at *restore*, not left to luck at load: a
    generated library package declares a **bounded** Reactor dependency range — lower bound
    its build version, upper bound the next major (e.g. `[1.2.0, 2.0.0)`) — so a graph that
-   mixes majors fails or warns during restore (NU1107/NU1608) instead of silently binding a
+   mixes majors fails or warns during restore (NU1107 conflict / NU1608 out-of-range /
+   NU1605 downgrade) instead of silently binding a
    mismatched runtime and throwing `MissingMethodException` at mount time. **Side-by-side**
    (two runtimes in separate `AssemblyLoadContext`s) is **out of scope** — `Element`
    records from different contexts are different `Type`s a shared reconciler cannot
@@ -521,8 +529,11 @@ green, and the subsystem's selftests/E2E still pass.
 
 **The common case needs no registration call.** A control self-registers the first time
 its element is constructed: a generated wrapper's Pattern-A cctor sits on the element
-record itself, and the built-in catalog / a base-derived family registers through the
-`Reg<>` / `RegBase<>` factory touch or a base-type static constructor (§3). Because a
+record itself; the built-in catalog self-registers from its factories (a `Reg<>` touch, or
+a generated element cctor for descriptor-backed built-ins), and a base-derived family
+through `RegBase<>` or an **explicit** base-type static constructor — explicit (not a
+`static`-field initializer) so the base type is not `beforefieldinit` and constructing a
+derived record is guaranteed to run it (§3). Because a
 Reactor app builds its element tree *before* it reconciles, construction always precedes
 dispatch — so there is nothing to "wire up" for the controls a library owns, and no
 MAUI-style `UseMyLibrary()` step.
@@ -549,13 +560,15 @@ app's existing `ReactorApp.Run(...)` startup delegate; pick by scope:
 - **Global, ABI-stable — `ControlRegistry.Register` / `RegisterDecorator` /
   `RegisterForDerivedTypes`.** Process-wide, part of the frozen §6.1 seam, so a *reusable or
   shipped* control library that registers this way rolls forward under R7. The handler
-  factory must be `static` (no captures; per-instance state lives in the `IElementHandler`
-  class). This is the path for library-level overrides and eager global init; a library that
+  factory should be `static` (the `StaticRegisterLambdaAnalyzer` warns otherwise) so it
+  captures nothing and is cached once; per-instance state lives in the `IElementHandler`
+  class. This is the path for library-level overrides and eager global init; a library that
   needs eager setup ships its own ordinary `public static void UseAcme()` over it.
 - **Per-host, ergonomic — `host.Reconciler.RegisterType(...)` / `RegisterHandler(...)`.**
-  Registers one host's reconciler with **inline** mount/update/unmount delegates (no
-  `IElementHandler` class) that **may capture** host-local state, and different hosts may
-  register different implementations for the same element type. This is the right tool for a
+  These register on one host's reconciler: `RegisterType` takes **inline** mount/update/unmount
+  delegates (no `IElementHandler` class needed) and `RegisterHandler` takes an `IElementHandler`
+  instance; either may **capture** host-local state, and different hosts may register
+  different implementations for the same element type. This is the right tool for a
   *bespoke, app-local* custom control — the shape Reactor's own `ResizeGrip` / docking
   natives and the Monaco / regedit samples use. It is deliberately **outside** the §6.1
   frozen seam: apps recompile against their target runtime, so they need no roll-forward
@@ -574,7 +587,7 @@ discovery scan — is the default.
 
 - **`[ModuleInitializer]` / assembly-load registration is a trimmer root.** It runs on
   first type-load and names every handler + control, so the trimmer can never prove it
-  dead and keeps the whole library. This defeats R5. (Spec 048 §3.4 deleted exactly
+  dead and keeps the whole library. This defeats R5. (Spec 048 §4 rejected exactly
   this shape.)
 - **Reflection-based assembly scanning** is AOT-hostile, startup-costly, and roots
   types the trimmer would otherwise drop.
@@ -590,22 +603,21 @@ zero-ceremony wiring without it.
 
 ## §10 Diagnostics
 
-Layer library-scoped diagnostics on top of 048's runtime throw (R3).
-
 Keep 048's runtime throw on an unregistered mount (R3), but — with lazy self-registration
 the norm — reframe *what it blames*. A "mounted but unregistered" element is now almost
 unreachable for generated wrappers (constructing the element self-registers it); it survives
 only for a factory-carried control constructed by raw `new` that bypassed the factory
 trigger, or a third-party override that was never registered.
 
-- **Reword the runtime throw** to point at those causes rather than a forgotten `UseX()`:
+- **Reword the runtime throw** to point at those causes rather than at a nonexistent
+  registration call:
   *"No handler registered for `FooElement`. Create it through its factory (built-in /
   Pattern-B controls self-register on the factory call), ensure its generated wrapper is
   referenced so its self-registration runs, register a third-party override at startup via
   `ControlRegistry.Register…`, or — for a bespoke app-local control — register it on the
   host's reconciler via `Reconciler.RegisterType`/`RegisterHandler` before first mount
   (§8)."* Reflection-light and AOT-safe: it names only `element.GetType()`.
-- **Keep the direct-record construction guardrail.** Warn when a *factory-registered* element
+- **Add a direct-record construction guardrail.** Warn when a *factory-registered* element
   record (a built-in / Pattern-B-style control, where the registration link lives on the
   factory) is constructed directly (`new FooElement(...)`) rather than via its factory — the
   most common cause of the throw above. It must **not** fire on generated wrappers (058),
@@ -616,8 +628,8 @@ trigger, or a third-party override that was never registered.
 Both tracks preserve spec 048's reachability model (R5):
 
 - **Track A is trim-neutral.** Stabilizing the seam in place adds no new roots — the
-  seam is already public and reached through the existing registration link
-  (factory → `Register` → handler → control). An API-compat gate is a build-time
+  seam is already public and reached through the existing registration links
+  (a factory or generated element cctor → `Register` → handler → control). An API-compat gate is a build-time
   analyzer, not a runtime root.
 - **Track B is trim-neutral.** #627 already inverted the core→feature dependencies so
   an app trims the subsystems it does not use; moving those subsystems into
@@ -645,13 +657,13 @@ Both tracks preserve spec 048's reachability model (R5):
 - **Increment 1 — done (this change).** Public `ReactorBinding.ShouldSuppressEcho`;
   generator repointed off the last internal symbol. The wrapper-bound surface is now
   fully public (§3).
-- **Track A — stable ABI in place.** A1: enumerate and lock the §6.1 seam behind the
+- **Track A — stabilize the ABI in place.** A1: enumerate and lock the §6.1 seam behind the
   API-compat gate (Q1/Q2). A2: build the binary-compat interop harness. A3: settle and
   document the loader/version policy (Q3).
 - **Track B — consolidate into Advanced.** B1: charting + docking → `Reactor.Advanced`.
   B2: markdown (with the §7 factory note, Q4). B3: data grid (§7 factory note, Q4).
 - **Registration clean-ups — independent, small.** E1: reword the R3 runtime throw and
-  keep the direct-record guardrail (§10). E2: document the §8 explicit-registration escape
+  add the direct-record guardrail (§10). E2: document the §8 explicit-registration escape
   hatch (overrides / eager init) against the existing `ControlRegistry.Register*`. No
   `IReactorLibrary`, marker, or discovery pass ships.
 

--- a/docs/specs/062-third-party-registration-and-package-boundaries.md
+++ b/docs/specs/062-third-party-registration-and-package-boundaries.md
@@ -214,7 +214,7 @@ either order:
   by a real API-compat gate and a binary-compat interop harness. Delivers R1 / R7.
 - **Track B — consolidate heavy subsystems into `Reactor.Advanced` (§7).** Move
   charting, docking, markdown, and the data grid out of core into the existing
-  advanced assembly, keeping their namespaces. Delivers R4.
+  advanced assembly, largely keeping their namespaces (§7). Delivers R4.
 
 Registration ergonomics (`UseLibrary` + diagnostics, §8–§10) is a third, independent
 workstream that serves R2 / R3 and can interleave with either track.
@@ -334,20 +334,31 @@ a dozen DLLs" shape and reuses Advanced's existing self-registering
   Core/Hosting statically reference charting/docking). Core holds **zero hard type
   references** to these subsystems, so relocating them across an assembly boundary is
   a project-file move, not a rewrite.
-- **Namespaces stay put.** A namespace is not an assembly in C#, so charting, docking,
-  and markdown keep their existing namespaces when they move to the Advanced
-  *assembly* — a consumer adds only the `Reactor.Advanced` package reference, with
-  **no source change**.
-- **The data grid is the one exception.** Its factories are woven into the shared core
-  `Factories` partial (`src/Reactor/Controls/DataGrid/DataGridFactories.cs` and
-  `ColumnFactories.cs` are `public static partial class Factories` in namespace
-  `Microsoft.UI.Reactor`). A partial class cannot span assemblies, so in Advanced they
-  become `Microsoft.UI.Reactor.Advanced.Factories`, and a data-grid app author adds one
-  line: `using static Microsoft.UI.Reactor.Advanced.Factories;`. The element records
-  and column types keep their namespace, so `with`/record usage is unaffected. This is
-  a minor, preview-window source break (§12 Q4).
-- **Sequence:** charting + docking first (already decoupled and boundary-guarded),
-  then markdown, then the data grid (with the factory note above).
+- **Charting and docking move source-clean.** Their public authoring surface lives under
+  `Microsoft.UI.Reactor.Charting` / `Microsoft.UI.Reactor.Docking` — its own namespaces,
+  *not* the shared core `Factories` partial. A namespace is not an assembly in C#, so
+  moving the code to the Advanced *assembly* leaves every type's full name unchanged: a
+  consumer adds only the `Reactor.Advanced` package reference, with **no source change**.
+- **The data grid and markdown each take a one-line source break.** Both expose their DSL
+  *entry points* through the shared core `Factories` partial, which cannot span assemblies:
+    - the data grid — `DataGridFactories.cs` / `ColumnFactories.cs`
+      (`public static partial class Factories` in namespace `Microsoft.UI.Reactor`);
+    - markdown — the `Markdown(string)` / `Markdown(string, MarkdownOptions)` methods
+      embedded in the core `Dsl.cs` `Factories` partial (`src/Reactor/Elements/Dsl.cs:1825`),
+      which delegate to `MarkdownBuilder` in `Microsoft.UI.Reactor.Markdown`.
+
+  On the move those entry points become `Microsoft.UI.Reactor.Advanced.Factories`, so a
+  data-grid or markdown app author adds one line:
+  `using static Microsoft.UI.Reactor.Advanced.Factories;`. Everything else keeps its
+  namespace — the data-grid element/column records and the `MarkdownOptions` record (in
+  `Microsoft.UI.Reactor.Markdown`) are untouched, and both factories return the base
+  `Element`, so no derived record is named across the boundary and `with`/record usage is
+  unaffected. A core-side compat shim is **not** an option: core is a one-way
+  `ProjectReference` *target* of Advanced, so it cannot call back into the relocated
+  implementation. These are minor, preview-window source breaks (§12 Q4).
+- **Sequence:** charting + docking first (already decoupled, boundary-guarded, and
+  source-clean), then markdown, then the data grid (the last two each carry the factory
+  note above).
 
 **Win:** smaller default JIT ship size, a smaller core NuGet package, and a smaller
 core dependency for wrapper authors — with AOT already covered by #627's trimming
@@ -512,7 +523,7 @@ Both tracks preserve spec 048's reachability model (R5):
 | Q1 | API-compat gate tool: `Microsoft.CodeAnalysis.PublicApiAnalyzers` (`PublicAPI.*.txt`) or `Microsoft.DotNet.ApiCompat` against the last shipped DLL? | PublicApiAnalyzers for the authoring seam (in-repo, incremental, IDE-visible); ApiCompat as a CI backstop. |
 | Q2 | Exact freeze boundary — is the *entire* §6.1 surface committed, or a named subset (e.g. is the full `MountContext` surface frozen, or only the members generated code + hand-authors actually bind)? | Freeze the members generated code and `external_proof` bind; mark the rest "public, not frozen." Settle with the interop harness. |
 | Q3 | Loader policy — strong-name + pin `AssemblyVersion` now, or stay unsigned/default-ALC and only *document* the roll-forward requirement? | Document now; revisit strong-naming when the API stabilizes past preview. |
-| Q4 | The data-grid `using static …Advanced.Factories` source break (§7) — acceptable in preview, or ship a type-forward / compat shim? | Accept in preview; call it out in release notes. |
+| Q4 | The data-grid **and markdown** `using static …Advanced.Factories` source break (§7) — acceptable in preview, or ship a type-forward / compat shim? | Accept in preview; call it out in release notes. A core-side compat shim isn't viable (core can't reference Advanced), so a `using static` is the honest fix. |
 | Q5 | `UseLibrary` granularity — one `UseX()` per library, or sub-modules for large subsystems? | One per library by default; sub-modules where trimming a sub-surface matters (charts). |
 | Q6 | Should the wrapper attributes + generator ship as a standalone `Reactor.Wrappers` package, or stay bundled in core (status quo)? | Independent of both tracks; keep bundled unless a concrete author asks — revisit later. |
 | Q7 | Ship a `Microsoft.UI.Reactor.All` metapackage (core + Advanced) for a batteries-included reference? | Optional convenience; add if consumer feedback wants it. |
@@ -526,7 +537,7 @@ Both tracks preserve spec 048's reachability model (R5):
   API-compat gate (Q1/Q2). A2: build the binary-compat interop harness. A3: settle and
   document the loader/version policy (Q3).
 - **Track B — consolidate into Advanced.** B1: charting + docking → `Reactor.Advanced`.
-  B2: markdown. B3: data grid (with the §7 factory note, Q4).
+  B2: markdown (with the §7 factory note, Q4). B3: data grid (§7 factory note, Q4).
 - **Registration ergonomics — independent.** E1: `IReactorLibrary` / `UseLibrary` +
   built-ins/Advanced fold-in (§8). E2: `[ReactorLibrary]` marker + enriched throw +
   analyzer (§10). E3: opt-in `UseDiscoveredLibraries()` (§9).

--- a/docs/specs/062-third-party-registration-and-package-boundaries.md
+++ b/docs/specs/062-third-party-registration-and-package-boundaries.md
@@ -115,17 +115,31 @@ property: an app roots (and the trimmer keeps) only the controls it actually rea
 recipe (spec 047, `tests/external_proof`) and the `[GenerateReactorWrapper]`
 generator (spec 058) keep working, ideally with a smaller footprint, never larger.
 
-**R7 — Cross-version library interop (stable ABI).** A control library built against
-Reactor version *N* loads and runs, **without recompilation**, against any host runtime
-*M* in the **same SemVer major** (*M* ≥ *N*) — the ABI compatibility band. Additive
-surface ships in **minor** releases (patch = compatible fixes only), and a compiled
-wrapper rolls forward across them because .NET binds a foreign assembly by type/member
-signature and NuGet resolves a **single** Reactor version into the graph. An app that
-transitively pulls `LibA` (built against *N*) and `LibB` (built against *M*, same major)
-unifies to that one runtime, and both libraries' controls must mount, update, and echo
-correctly against it. A deliberate break (§6.3) is confined to a **major** bump — the
-major number is the signal that the frozen surface may have moved. The binary guarantee
-begins at **1.0**; 0.x previews carry no durable ABI promise (Q3).
+**R7 — Cross-version library interop (stable ABI).** *A 1.0 commitment the seam is
+evolved toward — not a property preview can rely on today.* The **target**: a control
+library built against Reactor version *N* loads and runs, **without recompilation**,
+against any host runtime *M* in the **same SemVer major** (*M* ≥ *N*) — the ABI
+compatibility band. Additive surface ships in **minor** releases (patch = compatible fixes
+only), so a compiled wrapper can roll forward: NuGet resolves a **single** Reactor version
+into the graph, the default load context binds that one assembly by **identity** first, and
+the wrapper's member references then resolve against it so long as every bound type/member
+signature is unchanged. An app that transitively pulls `LibA` (built against *N*) and `LibB`
+(built against *M*, same major) unifies to that one runtime, and both libraries' controls
+must mount, update, and echo correctly against it — the *M* ≥ *N* direction holding only
+when the resolved host version satisfies **every** wrapper's declared lower bound (via
+bounded dependency ranges — §6.2), since NuGet's nearest-wins resolution or a direct/override
+dependency can otherwise pick *M* < *N*. A deliberate break (§6.3) is confined to a
+**major** bump.
+
+**Status — intended, not yet enforced.** The current architecture *can permit* roll-forward
+today (the bound surface is public and the runtime loads in the default context), but that
+is **unvalidated and not guaranteed**: nothing proves the bound signatures stay preserved or
+that mount/update/echo behavior holds across releases. The API-compat gate, the interop
+harness, and the loader/version policy (§6.2) do not exist yet, and the loader policy is
+deliberately deferred (Q3). R7 therefore
+becomes a **durable guarantee at 1.0, once that machinery lands** — 0.x previews carry no
+ABI promise. Until then it is the requirement the seam is designed and evolved toward (§6),
+not a contract a preview consumer should build on.
 
 ## §3 Current state — what 047 / 048 / 058 already deliver
 
@@ -232,7 +246,8 @@ either order:
 
 - **Track A — a stable authoring ABI, in place (§6).** Treat the (now fully public)
   authoring seam as a versioned, additive-only contract in the one runtime, enforced
-  by a real API-compat gate and a binary-compat interop harness. Delivers R1 / R7.
+  — *once built* — by a real API-compat gate and a binary-compat interop harness. Delivers
+  R1 / R7 (which become a durable guarantee only when that machinery lands — §6.2 / R7).
 - **Track B — consolidate heavy subsystems into `Reactor.Advanced` (§7).** Move
   charting, docking, markdown, and the data grid out of core into the existing
   advanced assembly, largely keeping their namespaces (§7). Delivers R4.
@@ -266,8 +281,9 @@ The goal (R1/R7) is that a *compiled* wrapper binds a fixed subset of Reactor's
 public surface and keeps working against a newer runtime. .NET default-context
 assembly binding is by type/member signature and NuGet unifies to a single assembly,
 so *old generated code binds to a newer runtime as long as every symbol it references
-is unchanged*. The guarantee reduces to one discipline: **enumerate the surface a
-wrapper binds, and evolve it additive-only.**
+is unchanged*. Making that a *durable* guarantee (rather than the by-construction
+behavior it is today — R7 status) reduces to one discipline plus the governance to
+enforce it (§6.2): **enumerate the surface a wrapper binds, and evolve it additive-only.**
 
 ### §6.1 The seam to freeze
 

--- a/docs/specs/062-third-party-registration-and-package-boundaries.md
+++ b/docs/specs/062-third-party-registration-and-package-boundaries.md
@@ -293,26 +293,34 @@ types a wrapper hands back or receives (`Element`, `Optional<T>`, the `ChildrenS
 records) — is part of the ABI closure and is preserved along with the member. A frozen
 signature is only as stable as the transitive types it names.
 
-**What is *not* part of the binary freeze — and the scope of the guarantee.** The
-roll-forward ABI guarantee is scoped to **control-wrapper / handler binaries**: a shipped
-wrapper's metadata references only the frozen seam above, so it rolls forward across a
-same-major runtime (§6.3 R7). The app-facing DSL — the ~200 factory methods, ~600 fluent
-modifiers, and the hooks — is deliberately **out** of that binary freeze: it is far too
-large and churny to pin as ABI, and freezing it would forfeit evolving overloads and adding
-parameters without a major bump. The DSL instead carries a *best-effort source*
-compatibility policy (don't gratuitously break `Text("x").Bold()`) — **not** a binary
-promise. Two consequences to state plainly:
+**Two compatibility tiers — *prove* vs *promise*.** Every supported public API — the
+control-authoring seam **and** the app-facing DSL (~200 factory methods, ~600 fluent
+modifiers, and the hooks) — is a **within-major ABI**: it does not break within a SemVer
+major, so a compiled binary that binds any of it rolls forward across a same-major runtime
+(R7). The tiers differ in *how* that is assured, not in *whether* it holds:
 
-- **Source-compatible is not binary-compatible.** Adding an optional parameter or otherwise
-  changing an existing DSL signature is a source-level non-event but a **binary** break for
-  an already-compiled caller; adding a *new* overload is normally binary-additive yet can
-  still break *recompilation* through overload ambiguity or changed inference. "Source
-  add-only" is a weaker, different contract than the seam's binary freeze.
-- **A binary that binds the DSL is not covered.** Applications recompile, so they never hit
-  this. But a *compiled* Reactor component/library binary (§8) whose `Render()` calls
-  `Text()` / `.Bold()` / `UseState()` bakes hard references to the DSL, so it is **outside**
-  the roll-forward guarantee — it must recompile against a newer Reactor, exactly like an
-  app. The ABI band protects the wrapper seam, not arbitrary DSL consumers.
+- **Tier 1 — promised (the DSL and the rest of the public surface).** Kept within-major
+  stable by additive-only **discipline** + review + release notes. SemVer is a release
+  policy, not a CLR verifier, so the promise is only as real as the discipline behind it
+  (§6.3): add overloads; never mutate an existing signature — no changed or added optional
+  parameters or defaults (an added optional param looks source-compatible but is a **binary**
+  break), no `ref`/`in`/`out` or return-type edits, no reshaped record primary constructors,
+  no new abstract interface/base members. Pinning the DSL as a *gated* surface is
+  deliberately declined: it is large and evolving, and add-overload discipline already keeps
+  it within-major-safe without freezing ~800 members to a checked-in txt file.
+- **Tier 2 — proven (the §6.1 seam).** On top of the same within-major promise, the ~35
+  seam members are additionally *mechanically* guaranteed — the API-compat gate fails the
+  build on any change, and the interop harness proves an old wrapper binary still
+  mounts/updates/echo-suppresses on the HEAD runtime — and held to a stricter
+  last-resort-only posture even across majors. Tier 2 is stronger **evidence**; it does
+  **not** relax Tier 1's obligations. It proves the subset the whole third-party-control
+  ecosystem binds.
+
+The only honest residual is at a **major** bump: a deliberate break (§6.3) may require
+DSL-binding binaries (a component/library binary per §8, or an app) to recompile — that is
+what a major signals — while the seam is held even harder. Seam-first gating is a
+*prioritization*, not an exclusion: the API-compat gate can grow to cover more of Tier 1
+over time.
 
 ### §6.2 Governance — three pieces that do not exist yet
 
@@ -364,9 +372,10 @@ a runtime test (2), and a load-time policy (3).
 
 ### §6.3 Evolution discipline
 
-- **Additive by default; break only when nothing simpler works.** New seam behavior
-  arrives as *new* members (new overloads; default-interface-methods on the
-  handler/descriptor interfaces), never as edits to existing ones — a §6.1 signature is
+- **Additive by default; break only when nothing simpler works.** This governs the whole
+  supported public API within a major (Tier 1), and the §6.1 seam most strictly (Tier 2):
+  new behavior arrives as *new* members (new overloads; default-interface-methods on the
+  handler/descriptor interfaces), never as edits to existing ones — an existing signature is
   never removed or changed when an additive change would achieve the same result.
   Reactor still reserves the right to break the seam, but only as a genuine last resort
   when no compatible change exists; every such break is a deliberate, **major-versioned**,
@@ -376,8 +385,12 @@ a runtime test (2), and a load-time policy (3).
   entry and reads only base `Element` members; it never reconstructs a derived record
   positionally across the boundary. A library's own element record shape is therefore
   private — only additive changes to the *base* `Element` are ABI-visible.
-- **One versioning unit.** The core runtime churns freely as long as it keeps the
-  §6.1 seam additive; there is no separate contract assembly to keep in lockstep.
+- **One versioning unit — internals churn, public signatures do not.** There is no separate
+  contract assembly to keep in lockstep, and the runtime's *internal* implementation and
+  *behavioral* details may churn freely between releases — but that freedom stops at the
+  **public signature**. Within a major, public signatures do not change (Tier 1 by
+  discipline, Tier 2 by the gate); "churns freely" never licenses breaking a public API
+  within a major.
 
 ## §7 Track B — consolidate heavy subsystems into `Reactor.Advanced`
 
@@ -627,7 +640,7 @@ Both tracks preserve spec 048's reachability model (R5):
 | # | Question | Recommendation |
 |---|---|---|
 | Q1 | API-compat gate tool: `Microsoft.CodeAnalysis.PublicApiAnalyzers` (`PublicAPI.*.txt`) or `Microsoft.DotNet.ApiCompat` against the last shipped DLL? | PublicApiAnalyzers for the authoring seam (in-repo, incremental, IDE-visible); ApiCompat as a CI backstop. |
-| Q2 | Exact freeze boundary — is the *entire* §6.1 surface committed, or a named subset (e.g. is the full `MountContext` surface frozen, or only the members generated code + hand-authors actually bind)? | Freeze the members generated code and `external_proof` bind; mark the rest "public, not frozen." Settle with the interop harness. |
+| Q2 | Exact freeze boundary — is the *entire* §6.1 surface committed, or a named subset (e.g. is the full `MountContext` surface frozen, or only the members generated code + hand-authors actually bind)? | Freeze the members generated code and `external_proof` bind; mark the rest "public, Tier 1 — within-major by discipline, not in the Tier-2 gate." Settle with the interop harness. |
 | Q3 | Loader policy — strong-name + pin `AssemblyVersion` now, or stay unsigned/default-ALC and only *document* the roll-forward requirement? | Document now; revisit strong-naming when the API stabilizes past preview. |
 | Q4 | The data-grid **and markdown** `using static …Advanced.Factories` source break (§7) — acceptable in preview, or ship a type-forward / compat shim? | Accept in preview; call it out in release notes. A core-side compat shim isn't viable (core can't reference Advanced), so a `using static` is the honest fix. |
 | Q5 | `UseLibrary` granularity — one `UseX()` per library, or sub-modules for large subsystems? | One per library by default; sub-modules where trimming a sub-surface matters (charts). |

--- a/docs/specs/062-third-party-registration-and-package-boundaries.md
+++ b/docs/specs/062-third-party-registration-and-package-boundaries.md
@@ -76,6 +76,7 @@ decision — [§12 Open questions](#12-open-questions) is the decision surface.
 - [§11 Migration — dogfooding with charting / data-grid / docking](#11-migration--dogfooding-with-charting--data-grid--docking)
 - [§12 Open questions](#12-open-questions)
 - [§13 Phasing](#13-phasing)
+- [§14 Cross-version library interop — stable ABI](#14-cross-version-library-interop--stable-abi)
 
 ---
 
@@ -144,6 +145,16 @@ non-starter.
 recipe (spec 047, `tests/external_proof`) and the `[GenerateReactorWrapper]`
 generator (spec 058) must keep working against the new, smaller dependency —
 ideally with a *smaller* reference footprint, never a larger one.
+
+**R7 — Cross-version library interop (stable ABI).** A control library built
+against `Reactor.Abstractions` version *N* must load and run, **without
+recompilation**, against a host that supplies a *different* core runtime version
+*M* ≥ *N* — the roll-forward/unification model of `Microsoft.Extensions.*.Abstractions`.
+Concretely: an app that transitively pulls `LibA` (built against Reactor *N*) and
+`LibB` (built against Reactor *M*) unifies to a **single** runtime, and both
+libraries' controls must mount, update, and echo correctly against it. This makes
+the Abstractions surface a **versioned, additive-only contract**, not just a
+smaller reference — see [§14](#14-cross-version-library-interop--stable-abi).
 
 ## §3 Current state — what 047 / 048 / 058 already deliver
 
@@ -884,6 +895,8 @@ These are the decision surface for @azchohfi. Each states a recommendation but i
 | Q11 | **Deferred-controlled in Abstractions-only.** Generated deferred-controlled wrappers read the internal `ShouldSuppress`, so today they only compile under `InternalsVisibleTo`. Expose a public read-side primitive, route through `.Controlled`, or forbid the pattern in Abstractions-only libraries? | Expose a public read-side echo-suppress check on the seam (ties to Q2); `.Controlled` remains the higher-level path. |
 | Q12 | **`string → Element` implicit operator (§5.1).** It must be declared on `Element` but its body needs a core built-in (`TextBlockElement`) → Abstractions↔core cycle if `Element` moves. Drop it (source-breaks `VStack("hi")`-style DSL), or relocate the string convenience to core container factories? | Drop the operator; add `string`-accepting convenience to the core container factories; document as a one-time DSL migration. Confirm blast radius before Phase 1. |
 | Q13 | **Adapter materialization mechanism (§5.2).** Given `TControl` lives only in the `Register<E,C>` closure and `MakeGenericType` is forbidden, do we (1) move `IV1HandlerEntry`+adapters to Abstractions re-typed against the seam, or (2) keep adapters in core behind a generic `IReactorRuntime.CreateEntry<E,C>` factory invoked from the `Register` frame? | Option 2 — keeps the heavy reconciler-coupled adapter logic in core; only a type-erased `Func<object>` + one generic interface method cross the boundary. |
+| Q14 | **Element/record ABI evolution policy (§14).** What is the committed compatibility contract for the base `Element` record and the descriptor authoring shapes once they are the ABI — additive-only members, no positional-param changes, DIM-only seam growth? Do we gate it with a public-API baseline test (`reactor.api.txt`-style) scoped to the Abstractions assembly? | Yes: freeze the Abstractions surface behind an API-baseline gate; additive-only; new seam behavior via default-interface-methods. |
+| Q15 | **WinUI-version compatibility bound (§14).** Since `Reactor.Abstractions` references the Windows App SDK, the R7 roll-forward guarantee is bounded by WinUI's own ABI across the versions in play. Do we pin a documented minimum Windows App SDK per Abstractions version, and test the interop harness across the supported WinUI range? | Document a per-Abstractions-version minimum WinUI; the interop-proof harness pins one WinUI; a broader matrix is CI follow-up. |
 
 ## §13 Phasing
 
@@ -922,3 +935,93 @@ These are the decision surface for @azchohfi. Each states a recommendation but i
 
 Phases 1–2 are the core of issue #163; Phase 3 is the dogfooding proof; Phase 4 is
 the convenience layer and can slip without blocking the rest.
+
+## §14 Cross-version library interop — stable ABI
+
+**Driver (R7).** The strongest reason to carve out `Reactor.Abstractions` is not
+trimming — it is letting a Reactor control library be *consumed by another Reactor
+library* without version-skew runtime failures. Today a control library
+`ProjectReference`s the whole of core `Reactor.dll` (see
+`tests/external_proof/Reactor.External.TestControl.csproj` line 55). So `LibA`
+binds to core *N*'s types and `LibB` to core *M*'s; when an app pulls both, NuGet
+unifies to **one** runtime, and whichever library did not match the surviving
+version can fail to bind at load time.
+
+**Scope: roll-forward unification, not side-by-side.** We target the
+`Microsoft.Extensions.*.Abstractions` model: one runtime per process, chosen by
+NuGet's highest-wins, and every library binary-compatible with it. True
+side-by-side (two core runtimes in separate `AssemblyLoadContext`s) is **out of
+scope** — `Element` records from one context are a different `Type` than the
+other's, so a shared reconciler cannot process both. Roll-forward is the tractable,
+common case and is what the split below enables.
+
+**Why this is feasible.** .NET assembly binding in the default load context is by
+type/member signature, not by exact strong-name version, and NuGet unifies to a
+single assembly. So *old generated code binds to a newer runtime* as long as every
+symbol it references is unchanged. The guarantee therefore reduces to a single
+discipline: **everything a library's compiled output references must live in
+`Reactor.Abstractions`, and that surface must evolve additive-only.**
+
+**The frozen ABI surface.** Grounded against the generator emit
+(`WrapperGenerator.cs`) and the reconciler's reads of a foreign element, the exact
+closure a control library binds to is enumerable:
+
+| ABI member (emitted/referenced) | Source today | Stability action |
+|---|---|---|
+| `Element` base + `Key`, `Modifiers` (`ElementModifiers`) | core `Element.cs` (reconciler reads `Reconciler.cs:597,609`) | move to Abstractions; freeze base members |
+| `Optional<T>` | core (`WrapperGenerator.cs:727,1140,1628`) | move to Abstractions |
+| `ControlDescriptor<E,C>` / `DescriptorHandler<E,C>` | core V1Protocol (`:1382,1383`) | move authoring shapes to Abstractions |
+| child strategies `SingleContent`/`Panel`/`ItemsHost`/element-slots | core V1Protocol (`:1384–1386,1426–1438`) | move to Abstractions |
+| `ControlRegistry.Register<E,C>` + stored entry (`IV1HandlerEntry`) | core (`:1717`) | public `Register` in Abstractions; adapter built in-frame (Q13) |
+| runtime seam: `GetElementTag`/`SetElementTag`/`DetachReactorState`/`ApplySetters` | core `Reconciler` **static** (`:1483,1498`, §5.3) | expose as Abstractions seam; **stop referencing concrete `Reconciler`** |
+| read-side echo check `ShouldSuppress` | core `ChangeEchoSuppressor` **internal** (`:1497`) | **public read-side primitive** (Q2/Q11) — hardest blocker |
+| `MountContext`/`UpdateContext`/`UnmountContext` + `ReactorBinding<T>` | core V1Protocol (§5.1/§5.3) | move to Abstractions over the seam |
+| `ElementExtensions` lifecycle add | core (`:1779`) | move/relocate to Abstractions |
+| `ReactorApp.TryRegisterControlAssembly` | core **Hosting** namespace (`:1716`) | relocate to an Abstractions/core seam — a control lib must not bind Hosting |
+
+**Two current violations** make cross-version binding impossible *today*, and both
+are already tracked: (1) the deferred-controlled trampoline emits the **internal**
+`ChangeEchoSuppressor.ShouldSuppress` (only compiles under `InternalsVisibleTo`;
+Q11); (2) generated code references the **concrete `Reconciler`** and
+Hosting's `ReactorApp`, so a library binds core directly rather than a stable
+subset. Closing both is the load-bearing Phase-1 work.
+
+**WinUI-coupling caveat.** `Reactor.Abstractions` is **not** pure-managed. The
+authoring shapes are generic over the control type (`ControlDescriptor<E, C> where
+C : FrameworkElement`), contexts hand out `FrameworkElement`, and the generator
+emits `Microsoft.UI.Xaml.FrameworkElement`/`UIElement` (`WrapperGenerator.cs:1376,
+1483`). So Abstractions references the Windows App SDK, and the R7 guarantee is
+bounded by **WinUI's own ABI stability** across the versions in play: it is "one
+Reactor runtime + one compatible Windows App SDK," not "any WinUI." This is the
+same constraint apps already accept (a process has one Windows App SDK), so it is a
+statement of the boundary, not a new limitation. (Contrast the existing
+`Reactor.Wrappers.Abstractions`, which holds only the compile-time authoring
+*attributes* and is genuinely WinUI-free — a different assembly from the runtime
+`Reactor.Abstractions` proposed here.)
+
+**Evolution discipline.**
+
+- *Additive-only.* Never remove or change the signature of an ABI member the
+  generator or a hand-authored handler could bind to. New seam behavior arrives as
+  new members (default-interface-methods on the seam interface; new static
+  overloads), never as edits to existing ones.
+- *Records stay evolvable.* The reconciler dispatches by element `Type` → registered
+  entry and reads only base `Element` members — it never reconstructs a derived
+  record positionally across the boundary. So a library's own element record shape
+  is private; only additive changes to the *base* `Element` are ABI-visible.
+- *Independent versioning.* `Reactor.Abstractions` gets its own slow SemVer; the
+  `Reactor.Wrappers` generator package version tracks the Abstractions surface it
+  emits against; core runtime churns freely as long as it keeps implementing the
+  Abstractions contract backward-compatibly. This is exactly the
+  `Microsoft.Extensions.*.Abstractions` playbook.
+
+**Regression gate — a real two-version interop harness.** Analogous to the existing
+AOT-proof harness, R7 needs an executable proof: build
+`Reactor.External.TestControl` against `Reactor.Abstractions` *N*, then load the
+**compiled DLL** (not a project reference) into a host running core *M* and assert
+mount / update / echo all succeed through the public surface only. A binary-drop
+test (reference the built assembly, not source) is the closest in-repo proxy for
+the "no recompilation" clause; a full two-NuGet-version matrix can follow in CI.
+
+New open questions **Q14** (Element/record ABI evolution policy) and **Q15**
+(WinUI-version compatibility bound) are added to §12.

--- a/docs/specs/062-third-party-registration-and-package-boundaries.md
+++ b/docs/specs/062-third-party-registration-and-package-boundaries.md
@@ -1,0 +1,812 @@
+# Third-Party Control Registration and Package Boundaries — Design Proposal
+
+## Status
+
+**Proposed — design v0.2 (2026-07-15). No code changes.** This is a design
+document responding to [issue #163](https://github.com/microsoft/microsoft-ui-reactor/issues/163)
+("Simplify third-party control registration and package boundaries for custom
+element types"). It builds on the *already-shipped* extensibility stack — the V1
+handler protocol ([spec 047](047-extensible-control-model.md)), lazy trimmable
+registration ([spec 048](048-control-registration-and-trimming.md)), and the
+control wrapper source generator ([spec 058](058-control-wrapper-generator.md)) —
+and on the packaging/distribution model ([spec 022](022-packaging-and-distribution.md)).
+Its job is to settle the *delta* those specs did not cover: **package boundaries**
+(carving a lightweight authoring package out of the monolithic `Reactor.dll`) and
+a **standard library-registration convention** (`builder.UseMyLibrary()`).
+
+**The decisions below are left open for the maintainer (@azchohfi).** Where this
+doc lists options it states a recommendation, but the recommendation is not a
+decision — [§12 Open questions](#12-open-questions) is the decision surface.
+
+> **Review note (v0.2).** A cross-model design review (GPT-5.5 + Gemini 3.1 Pro,
+> both cross-checked against source) found that the authoring types are far more
+> entangled with the Reactor *runtime* (`Reconciler`, `RenderContext`, `Factories`,
+> the internal `IV1HandlerEntry`/`ChangeEchoSuppressor`) than a clean "move the
+> abstractions into their own assembly" framing implies. This revision folds those
+> findings in: the package split is still the right direction, but **Phase 1 is a
+> decoupling-design task (a runtime-seam abstraction), not a file move.** The
+> affected sections (§4–§7) call out the specific coupling and the resolution.
+
+### North star
+
+> A third-party control library should be able to add Reactor support by taking
+> the **smallest possible dependency** — the abstractions needed to *define* a
+> custom element type — without pulling in the reconciler, hosting, the built-in
+> control catalog, or the optional feature libraries. App developers get **one
+> obvious registration call per library**, and a missing registration fails
+> **loudly and helpfully**, never as a blank screen.
+
+---
+
+## Table of Contents
+
+- [§1 Motivation](#1-motivation)
+- [§2 Requirements](#2-requirements)
+- [§3 Current state — what 047 / 048 / 058 already deliver](#3-current-state--what-047--048--058-already-deliver)
+- [§4 The hard constraint — the abstractions are coupled to WinUI](#4-the-hard-constraint--the-abstractions-are-coupled-to-winui)
+  - [§4.1 The deeper coupling — the authoring types entangle the runtime](#41-the-deeper-coupling--the-authoring-types-entangle-the-runtime-not-just-winui)
+- [§5 Proposed package layout](#5-proposed-package-layout)
+  - [§5.1 `Element` carve-out](#51-element-carve-out)
+  - [§5.2 `ControlRegistry` — split the stored shape from the dispatch adapter](#52-controlregistry--split-the-stored-shape-from-the-dispatch-adapter)
+  - [§5.3 Contexts, descriptors, `Reg` visibility, and the WinUI dependency](#53-contexts-descriptors-reg-visibility-and-the-winui-dependency)
+- [§6 Source generators, authoring attributes, and the Abstractions boundary](#6-source-generators-authoring-attributes-and-the-abstractions-boundary)
+- [§7 Library registration API — `UseLibrary`](#7-library-registration-api--uselibrary)
+- [§8 Self-registration vs. explicit registration](#8-self-registration-vs-explicit-registration)
+- [§9 Diagnostics](#9-diagnostics)
+- [§10 Trimming and AOT](#10-trimming-and-aot)
+- [§11 Migration — dogfooding with charting / data-grid / docking](#11-migration--dogfooding-with-charting--data-grid--docking)
+- [§12 Open questions](#12-open-questions)
+- [§13 Phasing](#13-phasing)
+
+---
+
+## §1 Motivation
+
+Issue #163 lays out four coupled frustrations. Reactor is not missing
+extensibility — spec 047 delivered the public `IElementHandler` /
+`ControlDescriptor` surface, spec 048 made registration lazy and trim-safe, and
+spec 058 added a `[GenerateReactorWrapper]` source generator that emits the
+descriptor + registration + factory for a wrapped WinUI/WinRT control. What is
+still awkward is the *shape of the dependency and the setup ceremony* around that
+capability:
+
+1. **The dependency is too heavy.** To *define* one custom element, a third-party
+   library must reference the whole of `Reactor.dll` — the reconciler, hooks,
+   hosting, every built-in control, charting, the data grid, docking. That is a
+   large, opinionated dependency for a library whose own consumers may not even
+   use Reactor. The alternative — shipping a *second* "MyControls.Reactor"
+   integration package — doubles the maintenance surface and makes Reactor support
+   look like an afterthought.
+
+2. **Registration has no standard shape.** Registration today happens per control
+   (a factory touch, or a Pattern-A static constructor — spec 048 §6). There is no
+   single "wire up everything this library needs" entry point analogous to .NET
+   MAUI's `builder.UseSkiaSharp()` / `ConfigureMauiHandlers(...)`. An app author
+   bringing in a Reactor-enabled dependency has to *know* the library's per-control
+   registration convention.
+
+3. **Missing registration can still fail quietly.** Spec 048 already made the
+   *reconciler* throw an actionable exception when it hits an unregistered element
+   (see §9), but the failure only surfaces when that element is actually mounted;
+   an element on a code path that renders late — or conditionally — can still
+   present as missing UI until it hits. A library-scoped diagnostic ("you
+   referenced *MyControls* but never called `UseMyControls()`") would catch the
+   whole class up front.
+
+4. **The package is monolithic.** Charting, the data grid, and docking all ship
+   inside the one `Microsoft.UI.Reactor` package. The same split that would help
+   third-party adoption also forces Reactor to prove out its own componentization
+   story — a healthy pressure.
+
+## §2 Requirements
+
+**R1 — Minimal authoring dependency.** A library can define custom element types
+by referencing one small package that carries only the authoring abstractions,
+not the Reactor runtime.
+
+**R2 — Standard registration convention.** One explicit, conventional call per
+library (`builder.UseMyLibrary()` or equivalent) that centralizes all of that
+library's element/handler registration and initialization.
+
+**R3 — Loud, helpful failure.** A missing registration produces a clear
+diagnostic that names the missing library and suggests the fix — never a blank
+screen. (Extends 048's runtime throw with library-scoped, ideally build-time,
+diagnostics.)
+
+**R4 — Componentized layout.** Built-in features (charting, data grid, docking)
+split into optional packages that mirror the third-party extensibility story.
+
+**R5 — Do not regress the trim/AOT story.** Every proposal must preserve spec
+048's load-bearing property: an app roots (and the trimmer keeps) only the
+controls it actually reaches. A package split that re-roots the whole catalog is a
+non-starter.
+
+**R6 — Do not regress authoring ergonomics.** The hand-authored `IElementHandler`
+recipe (spec 047, `tests/external_proof`) and the `[GenerateReactorWrapper]`
+generator (spec 058) must keep working against the new, smaller dependency —
+ideally with a *smaller* reference footprint, never a larger one.
+
+## §3 Current state — what 047 / 048 / 058 already deliver
+
+This spec is a *delta*, so it is worth being precise about what already exists so
+we do not re-propose it.
+
+- **The registration runtime is already lazy and trim-safe (048).** The global
+  `ControlRegistry` (`src/Reactor/Core/V1Protocol/ControlRegistry.cs`) holds
+  `Type → Func<IV1HandlerEntry>` entries; every static reference to a handler /
+  control type lives in the *caller* of `Register<TElement,TControl>` (a per-control
+  factory cctor — Pattern A — or a `Reg<…>` static-field initializer — Pattern B),
+  each on a per-control rooted path. Registration is idempotent first-wins. The
+  opt-in `ReactorApp.RegisterAllBuiltIns()` roots the whole catalog for apps that
+  want the direct-record idiom; apps that want a small binary simply do not call it.
+
+- **Hand-authoring already works against the public surface only (047).**
+  `tests/external_proof/Reactor.External.TestControl` ships an element + control +
+  handler in a *separate assembly* with **no** `InternalsVisibleTo` — proving the
+  public V1 surface is sufficient. Its `Marquee` holder (spec 048 §6, Pattern A)
+  registers via a `static` cctor calling `ControlRegistry.Register<…>`.
+
+- **Generated authoring already works (058).** `[GenerateReactorWrapper]` on a
+  partial record emits the init-props, child/items slots, `On{Event}` callbacks,
+  the `ControlDescriptor`, Pattern-A registration, and a factory — see
+  `samples/apps/wct-controls`. The generator is a `netstandard2.0` Roslyn component
+  that emits *strings* and binds attributes by metadata name, so it references
+  neither `Reactor.dll` nor its own attributes assembly at build time.
+
+- **The missing-handler failure already throws helpfully (048).**
+  `Reconciler.ThrowNoHandlerRegistered` (`src/Reactor/Core/Reconciler.Mount.cs`)
+  raises an `InvalidOperationException` naming the element type and listing four
+  concrete fixes.
+
+What is **not** yet present, and is the subject of this spec: a lightweight
+authoring *package* (everything above still lives inside `Reactor.dll`), a
+library-level `UseLibrary` convention, library-scoped diagnostics, and a
+componentized feature-package layout.
+
+## §4 The hard constraint — the abstractions are coupled to WinUI
+
+The issue asks for a package that lets a library "add Reactor support … even when
+the consumer of the library may not even be using Reactor." It is important to
+state plainly what is and is not achievable here.
+
+**A truly WinUI-free abstractions package is not feasible.** The core authoring
+types are structurally coupled to WinUI:
+
+- `Element` (`src/Reactor/Core/Element.cs`) and its subclasses reference
+  `Microsoft.UI.Xaml`, `…Xaml.Controls`, `…Xaml.Media`, `Microsoft.UI.Text`, etc.
+- `IElementHandler<TElement, TControl>` and `ControlDescriptor<TElement, TControl>`
+  constrain `where TControl : UIElement`. The handler's whole purpose is to mount
+  and patch a real WinUI control.
+
+So "define a custom element type" *inherently* means naming WinUI types. A library
+that takes the authoring dependency will transitively depend on WinUI regardless
+of how we slice Reactor.
+
+**What *is* achievable — and what the issue is really after — is decoupling from
+the Reactor *runtime*, and shrinking the WinUI dependency to its smallest slice:**
+
+- The minimal Reactor dependency becomes the authoring abstractions only — no
+  reconciler, no hooks, no hosting, no built-in catalog, no feature libraries.
+- The minimal **WinUI** dependency is the `Microsoft.WindowsAppSDK.WinUI`
+  sub-package, **not** the full `Microsoft.WindowsAppSDK` metapackage. Windows App
+  SDK 2.0 split the monolithic metapackage into independently-versioned
+  sub-packages; this repo already references only `.WinUI` for framework-dependent
+  library projects (see the injection rule in `Directory.Build.targets`; the WinUI
+  sub-package currently tracks `2.1.0` vs the `2.1.3` aggregate). The abstractions
+  package inherits that same floor — it pulls the WinUI slice, not the Runtime +
+  DWriteCore redist.
+
+This is the honest framing to carry into the design: **"minimal dependency" means
+`Reactor.Abstractions` + `Microsoft.WindowsAppSDK.WinUI` — not zero Reactor and
+not zero WinUI.**
+
+### §4.1 The deeper coupling — the authoring types entangle the *runtime*, not just WinUI
+
+The WinUI coupling above is the *easy* half. The design review surfaced a harder
+one: the types we would put in `Reactor.Abstractions` currently reach into the
+Reactor **runtime** (`Reconciler`, `RenderContext`, `Factories`), so a naïve file
+move would drag the runtime down into the "abstractions" layer or create a
+reference cycle. Concretely (all verified against source):
+
+- **`Element` depends on the built-in factories.** `Element.cs:342` defines
+  `public static implicit operator Element(string) => Factories.TextBlock(text)`,
+  and `FuncElement`/`MemoElement` (`Element.cs:1510-1516`) are
+  `record …(Func<RenderContext, Element> …)` — so the `Element` base file pulls
+  `Factories` (built-in catalog) and `RenderContext` (core hooks runtime). Moving
+  "the `Element` base" is therefore a *carve-out*, not a move (§5.1).
+- **The dispatch entry is internal and names `Reconciler`.** `IV1HandlerEntry`
+  (`V1HandlerRegistry.cs:30-40`) is `internal` and its `Mount`/`Update` take a
+  `Reconciler`. `ControlRegistry` builds `V1HandlerAdapter` instances that
+  implement it (`ControlRegistry.cs:112-113`). So `ControlRegistry` cannot move
+  without either dragging `Reconciler` down or splitting its stored shape (§5.2).
+- **The public author contexts expose `Reconciler`.** `MountContext` holds and
+  exposes a `Reconciler` "escape hatch" (`MountContext.cs:50-65`);
+  `ControlDescriptor.OneWayBridged` takes a delegate over `Reconciler`;
+  `DescriptorHandler` calls `ctx.Reconciler`. Any of these in Abstractions drags
+  the runtime (§5.3).
+- **The generator emits direct runtime calls** (`Reconciler.SetElementTag`,
+  `GetElementTag`, `DetachReactorState`, `ApplySetters`, plus
+  `ReactorApp.TryRegisterControlAssembly` and `ElementExtensions.OnMount/UnmountAdd`,
+  and the internal `ChangeEchoSuppressor.ShouldSuppress`) — the full closure and
+  its resolution are §6.
+
+**None of this kills the proposal** — it changes its shape. The unit of work in
+Phase 1 is *designing a minimal runtime seam* (a small interface / delegate surface
+in Abstractions that the core `Reconciler` implements) so the authoring types name
+the seam, not `Reconciler`. §5 and §6 specify that seam's required members.
+
+## §5 Proposed package layout
+
+A layered set of packages, each depending only on the layer below:
+
+| Package | Contains | Heavy deps |
+|---|---|---|
+| **`Microsoft.UI.Reactor.Abstractions`** | `Element` primitive base + the authoring contract (element records' modifier/attribute surface), `IElementHandler` / `IDecoratorElementHandler`, `ControlDescriptor` + descriptor kinds (`SingleContent` / `Panel` / `ItemsHost`), `PropEntry`, `ControlRegistry` (storing a **neutral** registration record — §5.2), `ReactorBinding` primitives, the author-facing `MountContext`/`UpdateContext`/`UnmountContext` re-shaped over a **runtime-seam interface** (§5.3), and that seam interface itself. **Not** here: `Reconciler`, `RenderContext`, `Factories`, `FuncElement`/`MemoElement`, `IV1HandlerEntry`/`V1HandlerAdapter`, the internal `Reg`/`ChangeEchoSuppressor` (§5.1–5.3). | `Microsoft.WindowsAppSDK.WinUI` |
+| **`Microsoft.UI.Reactor`** (core) | Reconciler, hooks, `RenderContext`, hosting (`ReactorApp` / windows / render loop), the built-in control catalog + DSL factories (`Factories`, `Dsl.cs`), Flex/Yoga. | `Reactor.Abstractions` |
+| **`Microsoft.UI.Reactor.Charting`** | The charting subsystem (`src/Reactor/Charting`). | `Reactor` |
+| **`Microsoft.UI.Reactor.DataGrid`** | The data grid (`src/Reactor/Controls/DataGrid`). | `Reactor` |
+| **`Microsoft.UI.Reactor.Docking`** | Docking windows (`src/Reactor/Docking`). | `Reactor` |
+| **`Microsoft.UI.Reactor.Advanced`** *(exists)* | Win2D canvas (spec 053). | `Reactor` + Win2D |
+| **`Microsoft.UI.Reactor.All`** *(metapackage)* | No code — references core + every feature package for a "batteries-included" experience. | all of the above |
+
+Notes:
+
+- **A third-party control library references `Reactor.Abstractions` only** (R1).
+  The existing `tests/external_proof` project is the acceptance shape: it should
+  compile and register against `Reactor.Abstractions` with no reference to the
+  core runtime.
+- **An app references `Microsoft.UI.Reactor`** (which brings the reconciler +
+  built-ins), plus whichever feature packages it wants — or `…Reactor.All` for
+  everything. Because feature packages self-register lazily (048), referencing a
+  feature package does **not** root its whole surface unless the app actually uses
+  it (R5).
+- **The split is a boundary move, not a rewrite.** `Reactor.Advanced` already
+  proves the "feature library as a separate package that references core" shape;
+  charting / data-grid / docking follow the same pattern (§11).
+- **`ControlRegistry` lives in Abstractions, not core.** Both the *definer* side
+  (a library calling `Register`) and the *consumer* side (the reconciler calling
+  `TryResolve`) need it, and the reconciler's dependency flows the correct
+  direction (core → abstractions). `TryResolve` / the base-derived cache are
+  `internal`; the reconciler in the core package reaches them via
+  `InternalsVisibleTo` (already the pattern between test assemblies).
+
+- **`ControlRegistry` lives in Abstractions, but its stored shape must be split
+  from core's dispatch adapter** (§5.2). Both the *definer* side (a library calling
+  `Register`) and the *consumer* side (the reconciler resolving) need the registry,
+  but the internal `IV1HandlerEntry`/`V1HandlerAdapter` that it currently constructs
+  name `Reconciler` and stay in core.
+
+**Open design point:** the exact contents of the Abstractions package are *defined*
+by §6's emitted-reference closure plus the hand-author surface **plus the §4.1
+runtime seam**, not chosen freely. Anything the generator or a hand-written handler
+*names* must resolve to Abstractions (directly, or via the seam interface that core
+implements); anything else stays in core. That closure is the acceptance criterion,
+and resolving it — §5.1 (`Element` carve-out), §5.2 (`ControlRegistry` split), §5.3
+(contexts/descriptors/`Reg`) — is the main engineering risk of Phase 1.
+
+### §5.1 `Element` carve-out
+
+"Move the `Element` base to Abstractions" is a carve-out, not a file move (§4.1):
+
+- `Element`'s implicit `string → Factories.TextBlock` conversion (`Element.cs:342`)
+  pulls the built-in catalog. **Resolution:** drop the implicit conversion from the
+  Abstractions `Element` and re-add it as an extension/convenience in core (it is a
+  DSL nicety, not part of the authoring contract), or have it call a seam hook the
+  core populates.
+- `FuncElement`/`MemoElement` (`Element.cs:1510-1516`) depend on `RenderContext`
+  (a core hooks-runtime type). **Resolution:** these are *composition primitives*,
+  not authoring contracts — leave them (and `ElementExtras`' animation/resource/
+  input conveniences) in **core**, and move only the pure `Element` record base +
+  the modifier/attribute contract to Abstractions.
+- Net: Abstractions gets the pure `Element` primitive and the handler/descriptor
+  contract; core keeps `Factories`, `RenderContext`, `FuncElement`/`MemoElement`,
+  and the composition sugar. The carve-out line is "does a *definer* of a custom
+  element need it?" — if not, it stays in core.
+
+### §5.2 `ControlRegistry` — split the stored shape from the dispatch adapter
+
+`ControlRegistry.Register<TElement,TControl>` currently wraps the handler factory
+in a `V1HandlerAdapter` implementing the **internal** `IV1HandlerEntry`, whose
+`Mount`/`Update` take a `Reconciler` (`V1HandlerRegistry.cs:30-40`,
+`ControlRegistry.cs:112-113`). Moving the registry as-is drags `Reconciler` into
+Abstractions. **Resolution (recommended):** split the two roles —
+
+- **Abstractions** holds `ControlRegistry` storing a *neutral* public registration
+  record — e.g. `Type → ReactorRegistration` where `ReactorRegistration` captures
+  the handler factory + kind (value / decorator / base-derived) with **no**
+  `Reconciler` in its signature.
+- **Core** materializes the `IV1HandlerEntry` dispatch adapter from that neutral
+  record *after* `TryResolve`, keeping `IV1HandlerEntry`/`V1HandlerAdapter`/
+  `V1DecoratorHandlerAdapter` (which name `Reconciler`) in core.
+
+This keeps the public `Register`/`RegisterDecorator`/`RegisterForDerivedTypes`
+surface (and the first-wins/base-derived semantics of 048 §8) in Abstractions while
+the runtime-typed adapter stays in core.
+
+### §5.3 Contexts, descriptors, `Reg` visibility, and the WinUI dependency
+
+- **Author contexts must stop exposing `Reconciler`.** `MountContext` exposes a
+  `Reconciler` escape hatch (`MountContext.cs:50-65`); `ControlDescriptor.OneWayBridged`
+  and `DescriptorHandler` use it. **Resolution:** replace the public `Reconciler`
+  member with the minimal **runtime-seam** the generated/hand-written code actually
+  needs — `MountChild`, `ReconcileChild`, `ApplySetters`, element-tag get/set,
+  `DetachReactorState`, a read-side suppress-check, lifecycle add, and
+  assembly-register (the union of §6's closure). Abstractions declares the seam
+  interface; core's `Reconciler` implements it (the seam's shape is **Q9**). Any
+  descriptor entry that genuinely needs the full `Reconciler` (rare) stays a
+  core-only API.
+- **`Reg`/`RegDecorator`/`RegBase` are `internal`** (`Reg.cs:66`), and 048 §8
+  deliberately steers 3P authors to the *public* `ControlRegistry.Register`. Feature
+  packages (§11) that want Pattern-B scale registration would need these.
+  **Decision required (Q7):** either (a) keep `Reg` internal and have feature
+  packages self-register via generated Pattern-A cctors (the 058 path), or (b)
+  promote a supported *public* bulk/factory registration primitive. Recommendation:
+  (a) — do not widen `Reg` to public; feature packages use the same generated
+  Pattern-A shape a 3P library uses, which is the dogfooding point.
+- **The Abstractions NuGet declares its own `Microsoft.WindowsAppSDK.WinUI`
+  dependency and TFM rules.** External consumers do **not** inherit this repo's
+  `Directory.Build.targets` injection rule, so the package's `.nuspec`/csproj must
+  carry the `.WinUI` sub-package reference and the `net10.0-windows…` TFM explicitly
+  (mirroring how `Reactor.Advanced` is packaged).
+
+## §6 Source generators, authoring attributes, and the Abstractions boundary
+
+This section answers the review question: *where do the generator and its
+attributes live, and should the wrappers be their own NuGet package?*
+
+### §6.1 What the generator emits — the closure that defines the boundary
+
+The wrapper generator (`src/Reactor.Wrappers.Generator/WrapperGenerator.cs`) emits
+source that references a broad set of `Reactor.Core` / `V1Protocol` types. A scan
+of the emit paths (line numbers verified against the current source) shows the
+closure is **larger than a v0 draft assumed** — it includes direct static calls
+into the runtime, not just type names:
+
+*Authoring-contract types (map cleanly to Abstractions):*
+
+- `Microsoft.UI.Reactor.Core.Element`
+- `…Core.V1Protocol.ControlRegistry` (`Register` / `RegisterDecorator`) — `1716`, `1262`
+- `…V1Protocol.Descriptor.ControlDescriptor<TElement,TControl>`, `DescriptorHandler<…>`
+- `…V1Protocol.SingleContent<…>`, `Panel<…>`, `ItemsHost<…>`, `Descriptor.PropEntry`
+- `…Core.ReactorBinding` / `ReactorBinding<TElement>`
+- `…V1Protocol.MountContext` / `UpdateContext` / `UnmountContext`
+
+*Runtime members (the real work — these must resolve through the §5.3 seam, not a move):*
+
+- `Reconciler.SetElementTag` — `1233`, `1243`, `1313`, `1327`, `1331`
+- `Reconciler.GetElementTag` — `1483`, `1498` (event trampolines)
+- `Reconciler.DetachReactorState` — `1253`
+- `Reconciler.ApplySetters` — `1314`, `1328`, `1332`
+- `ChangeEchoSuppressor.ShouldSuppress` — `1497` (**internal**, read-side)
+- `ReactorApp.TryRegisterControlAssembly` — `1716`
+- `ElementExtensions.OnMountAdd` / `OnUnmountAdd` — `1784`, `1786`
+
+**The acceptance criterion for the package split is: *this entire emitted-reference
+closure must resolve against `Reactor.Abstractions`*** — either because the type
+lives there (authoring-contract types) or because the call goes through the §5.3
+runtime-seam interface that core's `Reconciler` implements (runtime members). If any
+emitted symbol resolves only to `Reactor.dll`, generated wrapper code in a library
+that references only `Reactor.Abstractions` fails to compile — or transitively drags
+full Reactor — defeating R1.
+
+The runtime members are the sharp edge, and two need explicit correction from the
+v0 draft:
+
+- **`Reconciler.*` are direct `public static` calls, not "namespace anchors."**
+  `SetElementTag`/`GetElementTag`/`DetachReactorState`/`ApplySetters` are element-tag
+  and setter primitives the generated mount/update/trampoline code calls directly.
+  **Resolution:** put these on the Abstractions runtime seam (e.g. as methods on the
+  re-shaped `MountContext`/`UpdateContext`, or a static `ReactorElementState` helper
+  in Abstractions whose implementation core supplies). The generator then emits
+  `ctx.SetElementTag(...)` / `ctx.GetElementTag(...)` instead of naming `Reconciler`.
+- **`ChangeEchoSuppressor.ShouldSuppress` is a READ-side check** (`1497`), so the v0
+  "emit `WriteSuppressed` instead" idea is wrong — `WriteSuppressed` only *arms* the
+  token on the write; the generated event trampoline still needs a way to *consume*
+  it and early-return on the echo. **Resolution options:** (a) expose a public
+  read-side primitive in Abstractions (e.g. `ReactorBinding.IsEchoSuppressed(control)`)
+  that core's suppressor backs; (b) route generated deferred-controlled props
+  exclusively through the `.Controlled` descriptor entry (`1582-1611`), which already
+  avoids the direct suppressor reference, and **forbid** the raw-trampoline
+  deferred path in Abstractions-only wrappers; (c) a thin Abstractions shim the
+  suppressor implements. **Recommendation: (a)+(b)** — prefer `.Controlled`, and
+  provide the public read-side primitive for the cases that genuinely need the
+  deferred trampoline. `ShouldSuppress` being `internal` today is exactly why this
+  path does not yet compile for a true external assembly (§6.2).
+- **`ReactorApp.TryRegisterControlAssembly`, `OnMountAdd`/`OnUnmountAdd`** likewise
+  join the seam (assembly-register + lifecycle-add), so generated lifecycle/registration
+  code names Abstractions surface, not `ReactorApp`/`ElementExtensions` in core.
+
+Resolving this closure (i.e. designing the §5.3 seam and re-pointing the generator's
+emit at it) is **Phase 1 work** and is the gating dependency for §6.3 Shape B.
+
+### §6.2 What is already decoupled
+
+- **The generator** references neither `Reactor.dll` nor its attributes assembly at
+  build time (it emits strings, binds by metadata name). It ships today as an
+  analyzer asset (`OutputItemType="Analyzer"`, `ReferenceOutputAssembly="false"`).
+- **The attributes** (`Reactor.Wrappers.Abstractions` — `[GenerateReactorWrapper]`,
+  `[WrapControlled]`, `[WrapEvent]`, `[WrapElementSlot]`, `[WrapLifecycle]`, …)
+  are a standalone assembly with **no** reference to `Reactor.dll`. Today it is
+  `IsPackable=false` and bundled into the `Microsoft.UI.Reactor` package's `lib/`
+  via the `_BundleWrappersAbstractions` target (`PrivateAssets="all"` so NuGet
+  emits no phantom dependency).
+
+Net effect today: an author gets the generator + attributes **only** by referencing
+the full `Microsoft.UI.Reactor` package. Splitting them out is a real packaging
+change, not a rename.
+
+> **Latent gap worth noting.** Because the generator emits a call to the
+> **internal** `ChangeEchoSuppressor.ShouldSuppress` (§6.1), the deferred-controlled
+> trampoline path only compiles in assemblies granted `InternalsVisibleTo` from
+> Reactor core (tests, devtools) — *not* a true external library. So one generated
+> code path already fails the "public surface is sufficient" bar today; the §6.1
+> read-side-primitive work fixes it as a side effect.
+
+### §6.3 Three candidate shapes (evaluate, then decide)
+
+**Shape A — fold into Abstractions.** The attributes fold into
+`Reactor.Abstractions`; the generator ships as an analyzer asset *inside*
+`Reactor.Abstractions`. A single `<PackageReference Include="Microsoft.UI.Reactor.Abstractions">`
+gives an author the abstractions, the attributes, and the generator — covering both
+hand-authoring and generated authoring.
+- *Buys:* one reference for everything an author needs; nothing extra to publish.
+- *Costs:* bundles a build-only analyzer into a runtime-carrying package (minor —
+  analyzers are `PrivateAssets`/build-time and don't flow to the author's own
+  consumers); a hand-author who never uses the generator still *has* it available
+  (harmless, unused).
+
+**Shape B — standalone `Reactor.Wrappers` (the review proposal).**
+`Reactor.Abstractions` carries runtime types only; a separate `Reactor.Wrappers`
+package carries the attributes + generator and takes a normal (transitive)
+`PackageReference` on `Reactor.Abstractions`.
+- *Buys:* a hand-author (external_proof/Marquee style) references only
+  `Reactor.Abstractions` and never pulls the generator; a `[GenerateReactorWrapper]`
+  user adds exactly one package (`Reactor.Wrappers`) that transitively brings
+  Abstractions + attributes + generator; the generator/attributes can version
+  independently of the runtime and of Abstractions.
+- *Costs:* an extra package to build / sign / publish / version (spec 022 CI
+  surface). Its entire value is **contingent** on §6.1 — the emitted closure must
+  already be ⊆ Abstractions, else generated code forces a full-Reactor reference and
+  the split buys nothing.
+
+**Shape C — bundled in core (status-quo mechanics).** The attributes + generator
+stay bundled inside `Microsoft.UI.Reactor`, unchanged.
+- *Buys:* zero new packaging work; one obvious "batteries-included" reference for
+  app authors; no new versioning coordination.
+- *Costs:* an author who wants only to *define* a custom element still references
+  the full runtime — the exact friction #163 raises (R1). It also does not compose
+  with the Abstractions split unless the emitted closure is *also* reachable from
+  Abstractions; if it is, then Shape C is effectively "Shape A's contents, shipped
+  in the core package instead of the abstractions package," which re-imposes the
+  heavy dependency on definers.
+
+**Hybrid B+C.** Ship the attributes + generator standalone (`Reactor.Wrappers`,
+Shape B) *and* have the core `Microsoft.UI.Reactor` package transitively include
+them (so batteries-included app authors need not add a second reference). Costs the
+Shape B publishing surface but gives both the minimal-definer path and the
+one-reference app path.
+
+### §6.4 Recommendation
+
+The wrappers-packaging choice (A/B/C) is a **packaging decision that only becomes
+real once the §6.1 runtime closure is clean** — until generated code resolves fully
+against `Reactor.Abstractions`, *no* packaging arrangement lets a definer avoid the
+full-Reactor reference. So the recommendation is sequenced:
+
+1. **Phase 1 gate first:** design the §5.3 seam and re-point the generator's emit at
+   it (§6.1). This is the load-bearing work; packaging is downstream of it.
+2. **Then adopt Shape B, in the B+C hybrid form:** `Reactor.Abstractions` carries
+   the authoring types; a standalone `Reactor.Wrappers` (attributes + generator)
+   takes a transitive reference on it; the core `Microsoft.UI.Reactor` package also
+   includes `Reactor.Wrappers` so app authors keep a single reference. This is the
+   only shape that fully satisfies R1 for a *definer* (references `Reactor.Abstractions`
+   alone; adds `Reactor.Wrappers` only to opt into generation) while keeping the
+   app-author experience batteries-included.
+
+**Fallbacks, corrected from v0.1:**
+
+- If the §6.1 closure work is *not yet done*, **Shape A does not rescue it** — folding
+  the generator into `Reactor.Abstractions` does nothing if the emitted code still
+  names `Reactor.dll` types; the definer still transitively pulls full Reactor. So the
+  genuine interim fallback is **Shape C (status quo: everything in
+  `Microsoft.UI.Reactor`)** *or* a **reduced generator feature set** (emit only the
+  subset whose closure is already ⊆ Abstractions, e.g. one-way/leaf wrappers, and
+  defer controlled/deferred paths). Shape A is only meaningful *after* the closure is
+  clean, at which point Shape B is strictly better anyway.
+- Shape C long-term is not recommended (it does not move the definer off the full
+  runtime — the core R1 friction), but it is the correct *no-op* state if the split
+  is deferred entirely.
+
+## §7 Library registration API — `UseLibrary`
+
+Give Reactor a MAUI-style, one-call-per-library registration convention (R2).
+
+### §7.0 What `UseLibrary` is *for* — and what it deliberately is not
+
+The design review flagged a real tension: **per-control factory self-registration
+(spec 048 / Pattern A) is already the trim-safe default**, and it stays that way.
+Calling `Marquee.Of(...)` or a generated `SettingsCard(...)` factory registers *that
+one control* on first use, rooting nothing else. `UseLibrary` must **not** be
+positioned as the thing an app "has to call or the library won't work," because a
+`Register` body that news up every control would root the whole library — exactly
+the per-control trimming 048 fought to get, lost.
+
+So `UseLibrary` is scoped to what per-control factory registration *cannot* do:
+
+1. **Library-level initialization** that is not per control — XAML metadata provider
+   registration, resource dictionaries, one-time service setup.
+2. **Base-derived registrations** (`RegisterForDerivedTypes`) that intentionally
+   cover a family in one entry.
+3. **The direct-record idiom opt-in** — an app that builds element records directly
+   (`new FooElement(...)`) instead of via factories needs *something* to register;
+   `UseLibrary` is that opt-in, and — like `RegisterAllBuiltIns()` — it is
+   **explicitly documented as a bulk trim opt-out**, not the default path.
+4. **Discoverability + diagnostics** (§9) — a single call site the analyzer and the
+   runtime throw can point at.
+
+**The trim-safe default remains: reference the library, use its factories, pay only
+for the controls you touch.** `UseLibrary` is the convenience/robustness layer on
+top, with its rooting cost called out.
+
+### §7.1 The contract
+
+```csharp
+namespace Microsoft.UI.Reactor;
+
+/// <summary>One place a Reactor-enabled library wires up everything it needs:
+/// element/handler registration, generated metadata, initialization.</summary>
+public interface IReactorLibrary
+{
+    void Register(IReactorLibraryBuilder builder);
+}
+```
+
+`IReactorLibraryBuilder` is a thin façade over `ControlRegistry` (+ any future
+per-library metadata/init hooks) so a library never touches the registry directly
+and Reactor keeps a seam to add cross-cutting setup later:
+
+```csharp
+public interface IReactorLibraryBuilder
+{
+    IReactorLibraryBuilder Register<TElement, TControl>(Func<IElementHandler<TElement, TControl>> handler)
+        where TElement : Element where TControl : UIElement;
+    IReactorLibraryBuilder RegisterDecorator<TElement>(Func<IDecoratorElementHandler<TElement>> handler)
+        where TElement : Element;
+    // …RegisterForDerivedTypes, and future init hooks…
+}
+```
+
+### §7.2 The app-facing call
+
+Fold into the existing `ReactorApp` startup surface (`src/Reactor/Hosting/ReactorApp.cs`):
+
+```csharp
+ReactorApp.CreateBuilder()
+    .UseLibrary<MyControls.MyControlsLibrary>()   // one call per library
+    .UseLibrary(new AcmeCharts.AcmeChartsLibrary(options))
+    .Run(App);
+```
+
+`UseLibrary<T>()` news up `T` (parameterless) and calls `Register`; the instance
+overload supports libraries that need construction options. A library exposes a
+friendly extension so app authors get the MAUI feel:
+
+```csharp
+namespace MyControls;
+public static class MyControlsRegistration
+{
+    public static IReactorAppBuilder UseMyControls(this IReactorAppBuilder b)
+        => b.UseLibrary<MyControlsLibrary>();
+}
+```
+
+### §7.3 How built-ins and feature packages fold in
+
+The existing `ReactorApp.RegisterAllBuiltIns()` (spec 048 §3.4 option A) *is* the
+built-in library's `Register` body. Reframe it as the built-in `IReactorLibrary`
+so the whole model is uniform: `RegisterAllBuiltIns()` becomes `UseLibrary<BuiltInControlsLibrary>()`
+(the old method stays as a compatibility shim). Each feature package
+(`…Charting`, `…DataGrid`, `…Docking`) ships its own `UseCharting()` /
+`UseDataGrid()` / `UseDocking()` extension over the same interface. This directly
+dogfoods the third-party model with Reactor's own components (R4, §11).
+
+**Trim note (corrected).** `UseLibrary<T>()` names `T`, whose `Register` body names
+whatever it registers — so calling it roots exactly that surface. If `Register`
+bulk-registers every control, `UseLibrary` roots the whole library: that is the
+**same trim opt-out shape as `RegisterAllBuiltIns()`**, not the per-control default.
+Per §7.0, this is *intended* — `UseLibrary` is the convenience/direct-record path,
+and libraries should keep their per-control factories self-registering so an app
+that prefers the factory path (and never calls `UseLibrary`) still pays only for the
+controls it touches (R5). Two consequences the design must honor:
+
+- **The R3 "you forgot to register" diagnostic (§9) must NOT force an unconditional
+  `UseLibrary` call**, or it would push every app into rooting whole libraries. It
+  fires only when an element is *actually used via the direct-record idiom* with no
+  registration in reach — not merely because a `[ReactorLibrary]` package is
+  referenced.
+- **Finer-grained modules are allowed.** A large library may expose
+  `UseChartsCore()` / `UseChartsInteractive()` rather than one all-controls
+  `UseCharts()`, so an app roots only the sub-surface it needs. Recommended for the
+  feature packages in §11.
+
+## §8 Self-registration vs. explicit registration
+
+The issue asks whether custom element types can register themselves (static
+initialization / assembly discovery) instead of requiring an explicit setup call.
+Spec 048 already analyzed and **rejected the unconditional-eager forms** for the
+built-in catalog; that analysis carries over.
+
+- **`[ModuleInitializer]` / unconditional assembly-load registration is a trimmer
+  root.** It runs on first type-load of the assembly, so the trimmer can never
+  prove it dead, and its body names every handler + control → the whole library is
+  kept. This defeats R5. Spec 048 §3.4 deleted exactly this shape (the eager
+  `RegisterV1BuiltInHandlers` bootstrap) for that reason.
+
+- **Reflection-based assembly scanning** (enumerate loaded assemblies for
+  `[ReactorLibrary]` and invoke each) is AOT-hostile and startup-costly, and roots
+  types the trimmer would otherwise drop.
+
+**Recommendation:** keep *explicit* registration the norm over eager auto-discovery,
+and offer self-registration only as **opt-in**. "Explicit" here means the two
+trim-honest paths from §7: per-control factory self-registration (the trim-safe
+**default** — pay only for controls you touch) and `UseLibrary` (the bulk /
+direct-record opt-in, itself a documented trim opt-out per §7.0). Both are
+AOT-friendly and statically discoverable by the trimmer; neither relies on
+load-time or reflection-driven rooting. Layer *optional* discovery on top:
+
+1. **`[assembly: ReactorLibrary(typeof(MyControlsLibrary))]`** — a *marker*, not an
+   eager root. It does not register anything at load time. It exists so (a)
+   diagnostics (§9) can point a developer at the exact `UseX()` they forgot, and
+   (b) an *explicitly opted-in* discovery pass (for non-trimmed apps that value
+   convenience over binary size) can find libraries to auto-`UseLibrary`.
+
+2. **`ReactorApp…UseDiscoveredLibraries()`** — an explicit opt-out of the trim
+   story (mirrors `RegisterAllBuiltIns()`): an ordinary method the trimmer removes
+   when unreachable, that scans `[assembly: ReactorLibrary]` markers and registers
+   each. Apps that want zero ceremony and don't care about trimming call it; apps
+   that want a small binary do not. **It (and any reflection-based marker scan) is
+   annotated `[RequiresUnreferencedCode]`** so the trim/AOT analyzers — which this
+   repo treats as hard errors (`Directory.Build.targets`) — flag it at the call
+   site rather than letting it silently defeat trimming.
+
+This keeps the trim-safe default while giving the "I don't want to remember setup"
+crowd a documented, opt-in escape hatch — the same philosophy as 048's
+`RegisterAllBuiltIns()`.
+
+## §9 Diagnostics
+
+Layer library-scoped diagnostics on top of 048's existing runtime throw (R3).
+
+- **Keep and enrich the runtime throw.** `ThrowNoHandlerRegistered` already lists
+  four fixes. Enrich it: when the unregistered element's *assembly* carries
+  `[assembly: ReactorLibrary(typeof(X))]`, name the specific missing call — e.g.
+  *"`MarqueeElement` is defined in `MyControls`, which declares a Reactor library
+  but was never registered. Call `builder.UseMyControls()` (or
+  `UseLibrary<MyControls.MyControlsLibrary>()`) at startup."* This turns the most
+  common third-party failure from a generic message into an exact instruction.
+  **Keep this enrichment reflection-light and AOT-safe:** read the marker via the
+  already-loaded `element.GetType().Assembly` custom-attribute (the element type is
+  necessarily loaded at the throw site, so no extra assembly is force-loaded and no
+  scan runs), and guard it so a trimmed-away attribute simply falls back to the
+  generic message. Prefer the build-time analyzer below as the *primary* signal;
+  the runtime enrichment is the backstop.
+
+- **Add a build-time analyzer / `mur check` rule.** Flag the case where a project
+  references a library that declares `[ReactorLibrary]` but the app never calls the
+  corresponding `UseX()` / `UseLibrary<>()` — catching the whole class of "forgot
+  to register" up front rather than at first mount. This lives alongside the
+  existing analyzer suite (spec 060) and the `mur check` did-you-mean rules
+  (spec 038). *Caveat:* detecting "never registered anywhere in the app" reliably is
+  a whole-program question the analyzer can only approximate (registration can be
+  indirect); scope it to a high-confidence heuristic (a direct `UseX()` call
+  somewhere in the compilation) with a suppression, per the §4-core discipline in
+  spec 060.
+
+- **Direct-record construction guardrail.** Extend the analyzer to warn when an
+  element record from a `[ReactorLibrary]` assembly is constructed directly
+  (`new FooElement(...)`) rather than via its factory, mirroring the runtime
+  message's "most common cause."
+
+## §10 Trimming and AOT
+
+Every proposal above is constructed to preserve spec 048's reachability model (R5):
+
+- **Package split (§5) is trim-neutral.** Carving `Element` / `ControlRegistry`'s
+  stored shape / descriptors into `Reactor.Abstractions` — and routing runtime calls
+  through the §5.3 seam — does not change *what roots what*: the registration link
+  (factory → `Register` → handler → control) is unchanged; only the assembly the
+  link's endpoints live in changes, and the seam is an interface the trimmer follows
+  like any other. The trimmer follows references across assemblies exactly as within
+  one.
+
+- **`UseLibrary<T>()` (§7) roots per-library.** It names `T`; `T.Register` names
+  that library's controls. No `[ModuleInitializer]`, so an unreached `UseX()` is
+  removed with everything it names — identical to `RegisterAllBuiltIns()` today.
+
+- **Self-registration (§8) stays opt-in.** The `[ReactorLibrary]` marker roots
+  nothing; only the explicit `UseDiscoveredLibraries()` opt-out re-roots, and it is
+  an ordinary (removable) method.
+
+- **Abstractions package sets `IsAotCompatible=true`** (as the core library does),
+  so trim/AOT analyzers run on it; `ControlRegistry` already avoids reflection and
+  `MakeGenericType` (048 §8), which the move preserves.
+
+- **`Reactor.Abstractions` `IsTrimmable` / self-contained flags** follow the
+  existing library conventions (`WindowsAppSDKSelfContained=false`; only app exes
+  own self-contained packaging).
+
+The AOT-proof harness (`tests/aot_trim_proof`) is the regression gate: after the
+split it must still show the Hello-World app dropping every control it doesn't use,
+and the external-proof AOT publish (spec 048 §11) must still succeed with the
+library referencing only `Reactor.Abstractions`.
+
+## §11 Migration — dogfooding with charting / data-grid / docking
+
+Reactor's own optional features are the proving ground (R4). The `Reactor.Advanced`
+package (Win2D, spec 053) already demonstrates the shape: a feature library in a
+separate package/assembly that references core and self-registers lazily. The
+migration extracts charting, data grid, and docking the same way:
+
+1. Move `src/Reactor/Charting` → `src/Reactor.Charting` (new project, references
+   `Reactor`), ship as `Microsoft.UI.Reactor.Charting`. Expose `UseCharting()`.
+2. Repeat for `src/Reactor/Controls/DataGrid` → `Reactor.DataGrid` and
+   `src/Reactor/Docking` → `Reactor.Docking`.
+3. Provide `Microsoft.UI.Reactor.All` metapackage referencing core + all features
+   so existing "everything" consumers get a one-line migration.
+4. Update the ReactorGallery + samples to reference the specific feature packages
+   they use — proving the split from the consumer side and exercising the
+   `UseX()` convention end-to-end.
+
+Each extraction is gated on: no `internal` cross-boundary reach that
+`InternalsVisibleTo` can't cleanly express, no regression in the AOT-proof harness,
+and the feature's selftests/E2E still green.
+
+## §12 Open questions
+
+These are the decision surface for @azchohfi. Each states a recommendation but is
+`TBD`.
+
+| # | Question | Recommendation |
+|---|---|---|
+| Q1 | Wrappers packaging: Shape A (fold) / B (standalone `Reactor.Wrappers`) / C (bundled) / B+C hybrid? | B+C hybrid, gated on the §6.1 closure; if the closure slips, fall back to **Shape C or a reduced generator feature set** (not Shape A — §6.4). |
+| Q2 | Is the §6.1 emitted-reference closure cleanly hoistable into Abstractions, or does it force runtime types into the "abstractions" package? | Neither `Reconciler` nor `ChangeEchoSuppressor` move. Introduce the §5.3 runtime seam and re-point the generator's emit at it; expose a public **read-side** echo-suppress check (the current `ChangeEchoSuppressor.ShouldSuppress` is internal + read-side — the v0.1 "emit `WriteSuppressed`" idea was wrong, that primitive is write-side). Phase 1 spike. |
+| Q3 | Registration: explicit `UseLibrary` only, or also opt-in discovery? | Explicit default + opt-in `[ReactorLibrary]` marker + `UseDiscoveredLibraries()` escape hatch. |
+| Q4 | Package granularity: one `Reactor.Abstractions`, or split further (e.g. `…Abstractions` vs `…Authoring`)? | Single `Reactor.Abstractions`; revisit only if the closure proves it too heavy. |
+| Q5 | Feature-package boundaries: charting / data-grid / docking each their own package, or a single `…Extras`? | Per-feature packages (mirrors the 3P story more honestly). |
+| Q6 | Versioning across split packages — lockstep with the core version, or independent? Ties to spec 022 (versioning) and 057 (release channels). | Lockstep for core+features; the standalone `Reactor.Wrappers` may float. |
+| Q7 | `Reg`/`RegDecorator`/`RegBase` are `internal` today (048 §8 steers 3P authors to public `ControlRegistry.Register`). Keep them internal, or promote a public bulk primitive? | Keep internal; feature packages register via generated Pattern-A cctors. Revisit only if a public bulk API proves necessary. |
+| Q8 | Is the "define an element without any Reactor runtime" goal worth the packaging cost given the WinUI coupling (§4) is unavoidable anyway? | Yes for the runtime decoupling + smaller WinUI slice; but this is the strategic call. |
+| Q9 | **Runtime-seam design (§5.3).** What is the minimal interface Abstractions declares and core's `Reconciler` implements (child mount/reconcile, `ApplySetters`, tag get/set, detach, echo-suppress read, lifecycle-add, assembly-register)? Should `MountContext`/`UpdateContext` expose *it* instead of the concrete `Reconciler`? | Design a single `IReactorRuntime` (working name) seam; contexts expose the seam, not `Reconciler`. The load-bearing Phase-1 deliverable. |
+| Q10 | **Element carve-out (§5.1).** `Element` has an implicit `string → Factories.TextBlock` conversion and `FuncElement`/`MemoElement` depend on `RenderContext`. Which Element surface is the pure primitive that moves, and which convenience stays in core? | Move the pure `Element` primitive + handler/descriptor contract; keep `Factories`, `RenderContext`, `FuncElement`/`MemoElement`, and the implicit-conversion sugar in core. |
+| Q11 | **Deferred-controlled in Abstractions-only.** Generated deferred-controlled wrappers read the internal `ShouldSuppress`, so today they only compile under `InternalsVisibleTo`. Expose a public read-side primitive, route through `.Controlled`, or forbid the pattern in Abstractions-only libraries? | Expose a public read-side echo-suppress check on the seam (ties to Q2); `.Controlled` remains the higher-level path. |
+
+## §13 Phasing
+
+- **Phase 1 — Abstractions carve-out + runtime seam (the load-bearing phase).**
+  This is a *decoupling design task, not a file move.* Create
+  `Microsoft.UI.Reactor.Abstractions` and:
+  - Design the §5.3 runtime seam (Q9) — the minimal interface core's `Reconciler`
+    implements — and make `MountContext`/`UpdateContext` expose it instead of the
+    concrete `Reconciler`.
+  - Re-point the wrapper generator's emit (§6.1) at that seam + public primitives;
+    expose the public read-side echo-suppress check (Q2/Q11) so the deferred-controlled
+    path compiles without `InternalsVisibleTo`.
+  - Carve out the pure `Element` primitive + handler/descriptor/`PropEntry` contract
+    (Q10), leaving `Factories`/`RenderContext`/`FuncElement`/`MemoElement` in core.
+  - Split `ControlRegistry` into a neutral stored-registration shape (Abstractions)
+    vs. core's `V1HandlerAdapter` dispatch (§5.2), materialized after `TryResolve`.
+  - Gate: `tests/external_proof` compiles + registers against Abstractions only
+    (with no `InternalsVisibleTo` grant); the generator's full emitted closure
+    resolves against Abstractions; the AOT-proof harness stays green.
+- **Phase 2 — `UseLibrary` + diagnostics.** Add `IReactorLibrary` /
+  `IReactorLibraryBuilder` / `UseLibrary`; reframe `RegisterAllBuiltIns` as the
+  built-in library; add the `[ReactorLibrary]` marker + enriched runtime throw +
+  the analyzer/`mur check` rule (§9).
+- **Phase 3 — feature-package extraction.** Split charting / data-grid / docking
+  into packages with `UseX()` extensions; add the `…All` metapackage; migrate
+  samples/gallery (§11).
+- **Phase 4 — opt-in self-registration.** `UseDiscoveredLibraries()` + the
+  discovery pass over `[ReactorLibrary]` markers, documented as the trim opt-out.
+
+Phases 1–2 are the core of issue #163; Phase 3 is the dogfooding proof; Phase 4 is
+the convenience layer and can slip without blocking the rest.

--- a/docs/specs/062-third-party-registration-and-package-boundaries.md
+++ b/docs/specs/062-third-party-registration-and-package-boundaries.md
@@ -513,10 +513,16 @@ scoped to what per-control registration cannot do:
    registration, resource dictionaries, one-time setup).
 2. **Base-derived registrations** (`RegisterForDerivedTypes`) that intentionally cover
    a family in one entry.
-3. **The direct-record idiom opt-in** — an app that builds element records directly
-   (`new FooElement(...)`) instead of via factories needs *something* to register;
-   `UseLibrary` is that opt-in, and — like `RegisterAllBuiltIns()` — it is explicitly
-   a documented bulk trim opt-out, not the default path.
+3. **The direct-record idiom against *factory-carried* registration** — some registrations
+   live on a *factory*, not the element record: the built-in catalog (Pattern B, a `Reg<>`
+   static-field initializer in the `Factories` partial) and any library that follows that
+   shape. For those, an app that builds records directly (`new ButtonElement(...)`) instead
+   of via the factory bypasses registration and needs a bulk opt-in — `UseLibrary`, like
+   `RegisterAllBuiltIns()`, is that documented trim opt-out, not the default path.
+   *Generated wrappers (058) do **not** need this*: their Pattern-A registration static
+   constructor is emitted **on the element record itself** (`partial record {Elem}` +
+   `static {Elem}()`), so `new FooElement(...)` triggers the type initializer and
+   self-registers — identically to calling the factory.
 4. **A discoverability + diagnostics anchor** (§10) the analyzer and runtime throw can
    point at.
 
@@ -631,9 +637,11 @@ Layer library-scoped diagnostics on top of 048's runtime throw (R3).
   **not** force an unconditional `UseLibrary` call (that would push every app into
   rooting whole libraries, §8); it fires only when an element is actually used via the
   direct-record idiom with no registration in reach.
-- **Direct-record construction guardrail.** Warn when an element record from a
-  `[ReactorLibrary]` assembly is constructed directly (`new FooElement(...)`) rather
-  than via its factory, mirroring the runtime message's most common cause.
+- **Direct-record construction guardrail.** Warn when a *factory-registered* element record
+  (a built-in / Pattern-B-style control, where the registration link lives on the factory) is
+  constructed directly (`new FooElement(...)`) rather than via its factory, mirroring the
+  runtime message's most common cause. It must **not** fire on generated wrappers (058),
+  whose element-rooted Pattern-A cctor makes direct construction self-registering and safe.
 
 ## §11 Trimming and AOT
 

--- a/docs/specs/062-third-party-registration-and-package-boundaries.md
+++ b/docs/specs/062-third-party-registration-and-package-boundaries.md
@@ -287,11 +287,32 @@ element, the bound surface is enumerable and, as of this change, entirely public
 | `ElementExtensions.OnMountAdd` / `OnUnmountAdd` | `Elements` |
 | `ReactorApp.TryRegisterControlAssembly` | `Hosting` |
 
-**What is *not* part of the binary freeze:** the app-facing DSL — the ~200 factory
-methods, ~600 fluent modifiers, and the hooks — is bound by the **recompiling app**,
-not by a shipped wrapper binary. It carries a softer, source-level add-only
-compatibility expectation (don't gratuitously break `Text("x").Bold()`), but it is
-not part of the versioned binary ABI a wrapper rolls forward against.
+The freeze is **transitive**: every type that appears in a frozen member's signature — its
+generic arguments and constraints, base/interface contracts, and the `Element`-boundary
+types a wrapper hands back or receives (`Element`, `Optional<T>`, the `ChildrenStrategy`
+records) — is part of the ABI closure and is preserved along with the member. A frozen
+signature is only as stable as the transitive types it names.
+
+**What is *not* part of the binary freeze — and the scope of the guarantee.** The
+roll-forward ABI guarantee is scoped to **control-wrapper / handler binaries**: a shipped
+wrapper's metadata references only the frozen seam above, so it rolls forward across a
+same-major runtime (§6.3 R7). The app-facing DSL — the ~200 factory methods, ~600 fluent
+modifiers, and the hooks — is deliberately **out** of that binary freeze: it is far too
+large and churny to pin as ABI, and freezing it would forfeit evolving overloads and adding
+parameters without a major bump. The DSL instead carries a *best-effort source*
+compatibility policy (don't gratuitously break `Text("x").Bold()`) — **not** a binary
+promise. Two consequences to state plainly:
+
+- **Source-compatible is not binary-compatible.** Adding an optional parameter or otherwise
+  changing an existing DSL signature is a source-level non-event but a **binary** break for
+  an already-compiled caller; adding a *new* overload is normally binary-additive yet can
+  still break *recompilation* through overload ambiguity or changed inference. "Source
+  add-only" is a weaker, different contract than the seam's binary freeze.
+- **A binary that binds the DSL is not covered.** Applications recompile, so they never hit
+  this. But a *compiled* Reactor component/library binary (§8) whose `Render()` calls
+  `Text()` / `.Bold()` / `UseState()` bakes hard references to the DSL, so it is **outside**
+  the roll-forward guarantee — it must recompile against a newer Reactor, exactly like an
+  app. The ABI band protects the wrapper seam, not arbitrary DSL consumers.
 
 ### §6.2 Governance — three pieces that do not exist yet
 

--- a/docs/specs/062-third-party-registration-and-package-boundaries.md
+++ b/docs/specs/062-third-party-registration-and-package-boundaries.md
@@ -141,28 +141,39 @@ This spec is a *delta*, so it is worth being precise about what already exists.
   direct-record idiom; apps that want a small binary simply do not call it.
 
 - **Hand-authoring already works against the public surface only (047).**
-  `tests/external_proof/Reactor.External.TestControl` ships an element + control +
-  handler in a *separate assembly* with **no** `InternalsVisibleTo` — proving the
-  public V1 surface is sufficient.
+  `tests/external_proof/Reactor.External.TestControl` ships a hand-coded
+  `IElementHandler` control **and** a source-generated wrapper in a *separate assembly*
+  with **no** `InternalsVisibleTo`; it binds only the public V1 surface
+  (`MountContext` / `UpdateContext`, `ReactorBinding`, `ControlDescriptor`, the registry),
+  so the fact that it *compiles* is the empirical gate that the surface is
+  public-sufficient. It is a representative control, not an exhaustive exercise of every
+  frozen member — §6.1 enumerates the full public list.
 
 - **Generated authoring already works (058).** `[GenerateReactorWrapper]` on a
   partial record emits the init-props, child/items slots, `On{Event}` callbacks, the
-  `ControlDescriptor`, Pattern-A registration, and a factory. The generator is a
-  `netstandard2.0` Roslyn component that emits *strings* and binds attributes by
-  metadata name, so it references neither `Reactor.dll` nor its own attributes
-  assembly at build time.
+  `ControlDescriptor`, Pattern-A registration, and a factory. The generator *itself* is a
+  lean `netstandard2.0` Roslyn component that emits *strings* and binds attributes by
+  metadata name, so the *generator assembly* references neither `Reactor.dll` nor its own
+  attributes assembly. That decoupling stops at the generator, though: the strings it
+  emits are compiled **in the consumer** against Reactor's public runtime surface
+  (`ReactorBinding.ShouldSuppressEcho`, `Reconciler.GetElementTag`, `ControlDescriptor`,
+  …), so the *generated code* is tightly bound to that surface — which is exactly the ABI
+  §6 must freeze.
 
 - **The missing-handler failure already throws helpfully (048).**
   `Reconciler.ThrowNoHandlerRegistered` (`src/Reactor/Core/Reconciler.Mount.cs`)
   raises an `InvalidOperationException` naming the element type and listing concrete
   fixes.
 
-- **The last internal-symbol leak is closed (this change).**
-  `ReactorBinding.ShouldSuppressEcho(UIElement)` is now a **public** read-side echo
-  primitive, and the wrapper generator's deferred-controlled trampoline emits it
-  instead of the internal `ChangeEchoSuppressor.ShouldSuppress`. Every symbol the
-  generator bakes into external generated code is now public — the precondition for
-  Track A (§6).
+- **The last internal symbol the generated wrapper needed is now public (this
+  change).** `ReactorBinding.ShouldSuppressEcho(UIElement)` is now a **public** read-side
+  echo primitive, and the wrapper generator's deferred-controlled trampoline emits it
+  instead of the internal `ChangeEchoSuppressor.ShouldSuppress`. With that, every symbol
+  the generator bakes into external generated code is public — and every member the §6.1
+  seam enumerates is public (verified type-by-type), with `external_proof` compiling
+  IVT-free as the empirical gate. That is the precondition for Track A (§6). It is *not* a
+  claim that no Reactor internal could ever help a future hand-author — promoting a
+  not-yet-enumerated member is an additive §6.3 change, not a regression.
 
 What is **not** yet present, and is the subject of this spec: a *governed* stable
 authoring ABI (§6), a leaner core with the heavy subsystems in `Reactor.Advanced`

--- a/docs/specs/062-third-party-registration-and-package-boundaries.md
+++ b/docs/specs/062-third-party-registration-and-package-boundaries.md
@@ -116,12 +116,16 @@ recipe (spec 047, `tests/external_proof`) and the `[GenerateReactorWrapper]`
 generator (spec 058) keep working, ideally with a smaller footprint, never larger.
 
 **R7 — Cross-version library interop (stable ABI).** A control library built against
-Reactor version *N* must load and run, **without recompilation**, against a host that
-supplies a *newer* runtime version *M* ≥ *N* — the NuGet single-version unification and
-assembly roll-forward that .NET applies to any additive-compatible dependency. An app
-that transitively pulls `LibA` (built against *N*)
-and `LibB` (built against *M*) unifies to a **single** runtime, and both libraries'
-controls must mount, update, and echo correctly against it.
+Reactor version *N* loads and runs, **without recompilation**, against any host runtime
+*M* in the **same SemVer major** (*M* ≥ *N*) — the ABI compatibility band. Additive
+surface ships in **minor** releases (patch = compatible fixes only), and a compiled
+wrapper rolls forward across them because .NET binds a foreign assembly by type/member
+signature and NuGet resolves a **single** Reactor version into the graph. An app that
+transitively pulls `LibA` (built against *N*) and `LibB` (built against *M*, same major)
+unifies to that one runtime, and both libraries' controls must mount, update, and echo
+correctly against it. A deliberate break (§6.3) is confined to a **major** bump — the
+major number is the signal that the frozen surface may have moved. The binary guarantee
+begins at **1.0**; 0.x previews carry no durable ABI promise (Q3).
 
 ## §3 Current state — what 047 / 048 / 058 already deliver
 
@@ -301,7 +305,12 @@ not part of the versioned binary ABI a wrapper rolls forward against.
    and its assembly version tracks the package version, so default-`AssemblyLoadContext`
    unification lets an old wrapper bind a newer runtime. Make this a *decision*: pin an
    explicit assembly-version / strong-name policy and document that the guarantee holds
-   in the default load context with NuGet highest-wins unification. **Side-by-side**
+   in the default load context, where NuGet resolves a **single** Reactor version into the
+   graph. The same-major band is enforced at *restore*, not left to luck at load: a
+   generated library package declares a **bounded** Reactor dependency range — lower bound
+   its build version, upper bound the next major (e.g. `[1.2.0, 2.0.0)`) — so a graph that
+   mixes majors fails or warns during restore (NU1107/NU1608) instead of silently binding a
+   mismatched runtime and throwing `MissingMethodException` at mount time. **Side-by-side**
    (two runtimes in separate `AssemblyLoadContext`s) is **out of scope** — `Element`
    records from different contexts are different `Type`s a shared reconciler cannot
    process; custom/plugin ALCs break the guarantee by design.
@@ -313,7 +322,7 @@ not part of the versioned binary ABI a wrapper rolls forward against.
   handler/descriptor interfaces), never as edits to existing ones — a §6.1 signature is
   never removed or changed when an additive change would achieve the same result.
   Reactor still reserves the right to break the seam, but only as a genuine last resort
-  when no compatible change exists; every such break is a deliberate, versioned,
+  when no compatible change exists; every such break is a deliberate, **major-versioned**,
   release-noted exception — not routine churn (and, in preview, expected to grow rarer
   as the API settles).
 - **Records stay evolvable.** The reconciler dispatches by element `Type` → registered

--- a/src/Reactor.Wrappers.Abstractions/WrapperAttributes.cs
+++ b/src/Reactor.Wrappers.Abstractions/WrapperAttributes.cs
@@ -99,7 +99,7 @@ namespace Microsoft.UI.Reactor.Wrappers
         /// default synchronous value-diff <c>Controlled</c>. Required for controlled values whose change event is NOT a
         /// synchronous, exact-comparable round-trip — deferred / coercing string boxes such as
         /// <c>PasswordBox.Password</c>, <c>AutoSuggestBox.Text</c>, <c>RichEditBox</c>. The generated trampoline gates on
-        /// <c>ChangeEchoSuppressor.ShouldSuppress</c> and re-reads the control value. Single <see cref="ChangedEvent"/> only.</summary>
+        /// the public <c>ReactorBinding.ShouldSuppressEcho</c> primitive and re-reads the control value. Single <see cref="ChangedEvent"/> only.</summary>
         public bool Deferred { get; set; }
     }
 

--- a/src/Reactor.Wrappers.Generator/WrapperGenerator.cs
+++ b/src/Reactor.Wrappers.Generator/WrapperGenerator.cs
@@ -1492,15 +1492,16 @@ public sealed class WrapperGenerator : IIncrementalGenerator
             // and fire the user callback. Using the public primitive (not the
             // internal ChangeEchoSuppressor) keeps the emitted code compilable
             // against Reactor's public surface alone — spec 062 §14. The trampoline
-            // null-guards the sender before the strict public call so a control that
-            // raises its change event with a null sender stays a no-op, preserving
-            // the pre-existing tolerant behavior of the internal read-side check
-            // (which returned false for null / non-FrameworkElement senders).
+            // uses an `as`-cast and null-guards the sender before the strict public
+            // call so a control that raises its change event with a null or
+            // unexpected-type sender stays a no-op, preserving the pre-existing
+            // tolerant behavior of the internal read-side check (which returned
+            // false for null / non-FrameworkElement senders).
             foreach (var p in deferredProps)
             {
                 sb.AppendLine($"    private static readonly {p.ControlledDelegate} __{p.Name}ControlledTrampoline = static (s, _) =>");
                 sb.AppendLine("    {");
-                sb.AppendLine($"        var __c = ({controlFqn})s!;");
+                sb.AppendLine($"        var __c = s as {controlFqn};");
                 sb.AppendLine("        if (__c is null) return;");
                 sb.AppendLine("        if (global::Microsoft.UI.Reactor.Core.ReactorBinding.ShouldSuppressEcho(__c)) return;");
                 sb.AppendLine($"        ({Reconciler}.GetElementTag(__c) as {elementName})?.On{p.Name}Changed?.Invoke(__c.{p.ControlProp});");

--- a/src/Reactor.Wrappers.Generator/WrapperGenerator.cs
+++ b/src/Reactor.Wrappers.Generator/WrapperGenerator.cs
@@ -1491,12 +1491,13 @@ public sealed class WrapperGenerator : IIncrementalGenerator
             // echoed change event is dropped), then re-read the live control value
             // and fire the user callback. Using the public primitive (not the
             // internal ChangeEchoSuppressor) keeps the emitted code compilable
-            // against Reactor's public surface alone — spec 062 §14. The trampoline
-            // uses an `as`-cast and null-guards the sender before the strict public
-            // call so a control that raises its change event with a null or
-            // unexpected-type sender stays a no-op, preserving the pre-existing
-            // tolerant behavior of the internal read-side check (which returned
-            // false for null / non-FrameworkElement senders).
+            // against Reactor's public surface alone — spec 062 §14. The public
+            // primitive is strict (it throws on a null argument), so the trampoline
+            // defends the sender itself: an `as`-cast plus null-check make it a no-op
+            // for a null or unexpected-type sender. This *restores* the tolerance the
+            // internal read-side check had (it returned false for null /
+            // non-FrameworkElement senders) — the earlier direct cast would instead
+            // have thrown on such a sender before reaching the suppression check.
             foreach (var p in deferredProps)
             {
                 sb.AppendLine($"    private static readonly {p.ControlledDelegate} __{p.Name}ControlledTrampoline = static (s, _) =>");

--- a/src/Reactor.Wrappers.Generator/WrapperGenerator.cs
+++ b/src/Reactor.Wrappers.Generator/WrapperGenerator.cs
@@ -1486,15 +1486,18 @@ public sealed class WrapperGenerator : IIncrementalGenerator
                 sb.AppendLine();
             }
             // Deferred (suppress-counter) controlled trampolines: gate on the
-            // ChangeEchoSuppressor (a programmatic Update write begins a suppress
-            // token via WriteSuppressed, so its echoed change event is dropped),
-            // then re-read the live control value and fire the user callback.
+            // public ReactorBinding.ShouldSuppressEcho primitive (a programmatic
+            // Update write begins a suppress token via WriteSuppressed, so its
+            // echoed change event is dropped), then re-read the live control value
+            // and fire the user callback. Using the public primitive (not the
+            // internal ChangeEchoSuppressor) keeps the emitted code compilable
+            // against Reactor's public surface alone — spec 062 §14.
             foreach (var p in deferredProps)
             {
                 sb.AppendLine($"    private static readonly {p.ControlledDelegate} __{p.Name}ControlledTrampoline = static (s, _) =>");
                 sb.AppendLine("    {");
                 sb.AppendLine($"        var __c = ({controlFqn})s!;");
-                sb.AppendLine("        if (global::Microsoft.UI.Reactor.Core.ChangeEchoSuppressor.ShouldSuppress(__c)) return;");
+                sb.AppendLine("        if (global::Microsoft.UI.Reactor.Core.ReactorBinding.ShouldSuppressEcho(__c)) return;");
                 sb.AppendLine($"        ({Reconciler}.GetElementTag(__c) as {elementName})?.On{p.Name}Changed?.Invoke(__c.{p.ControlProp});");
                 sb.AppendLine("    };");
                 sb.AppendLine();
@@ -1566,8 +1569,9 @@ public sealed class WrapperGenerator : IIncrementalGenerator
             if (p.Controlled && p.Deferred)
             {
                 // Deferred (suppress-counter) two-way via HandCodedControlled: the
-                // generated trampoline (above) gates on ChangeEchoSuppressor and
-                // re-reads the control value. The set is wrapped in WriteSuppressed
+                // generated trampoline (above) gates on the public
+                // ReactorBinding.ShouldSuppressEcho primitive and re-reads the
+                // control value. The set is wrapped in WriteSuppressed
                 // by the entry, so a programmatic Update write doesn't echo back.
                 sb.AppendLine($"        .HandCodedControlled<__EventPayload, {p.ValueType}, {p.ControlledDelegate}>(");
                 sb.AppendLine($"            get:         static e => e.{p.Name},");

--- a/src/Reactor.Wrappers.Generator/WrapperGenerator.cs
+++ b/src/Reactor.Wrappers.Generator/WrapperGenerator.cs
@@ -1491,12 +1491,17 @@ public sealed class WrapperGenerator : IIncrementalGenerator
             // echoed change event is dropped), then re-read the live control value
             // and fire the user callback. Using the public primitive (not the
             // internal ChangeEchoSuppressor) keeps the emitted code compilable
-            // against Reactor's public surface alone — spec 062 §14.
+            // against Reactor's public surface alone — spec 062 §14. The trampoline
+            // null-guards the sender before the strict public call so a control that
+            // raises its change event with a null sender stays a no-op, preserving
+            // the pre-existing tolerant behavior of the internal read-side check
+            // (which returned false for null / non-FrameworkElement senders).
             foreach (var p in deferredProps)
             {
                 sb.AppendLine($"    private static readonly {p.ControlledDelegate} __{p.Name}ControlledTrampoline = static (s, _) =>");
                 sb.AppendLine("    {");
                 sb.AppendLine($"        var __c = ({controlFqn})s!;");
+                sb.AppendLine("        if (__c is null) return;");
                 sb.AppendLine("        if (global::Microsoft.UI.Reactor.Core.ReactorBinding.ShouldSuppressEcho(__c)) return;");
                 sb.AppendLine($"        ({Reconciler}.GetElementTag(__c) as {elementName})?.On{p.Name}Changed?.Invoke(__c.{p.ControlProp});");
                 sb.AppendLine("    };");

--- a/src/Reactor/Core/ReactorBinding.cs
+++ b/src/Reactor/Core/ReactorBinding.cs
@@ -38,6 +38,7 @@ public static class ReactorBinding
     /// Typed overload — saves a cast at the call site for the common case
     /// where the handler already has a strongly-typed control reference.
     /// </summary>
+    /// <exception cref="ArgumentNullException"><paramref name="target"/> or <paramref name="mutate"/> is <see langword="null"/>.</exception>
     public static void WriteSuppressed<T>(T target, Action<T> mutate) where T : UIElement
     {
         ArgumentNullException.ThrowIfNull(target);
@@ -48,14 +49,16 @@ public static class ReactorBinding
 
     /// <summary>
     /// Read-side counterpart of <see cref="WriteSuppressed(UIElement, Action)"/>.
-    /// Call as the first line of a change-event handler: returns <c>true</c> — and
-    /// consumes one suppression token — when the current fire is the
-    /// engine-synthesized echo of a prior <c>WriteSuppressed</c> write against
-    /// <paramref name="target"/>, so the handler should return early before
-    /// invoking the user's callback. Also honors the non-consuming
-    /// <c>ApplySetters</c> suppression scope. Returns <c>false</c> for a genuine
-    /// user interaction (no outstanding token/scope), for a target that is not a
-    /// <see cref="FrameworkElement"/>, or when the target carries no Reactor state.
+    /// Call as the first line of a change-event handler: returns <c>true</c> when
+    /// the current fire is the engine-synthesized echo of a prior
+    /// <c>WriteSuppressed</c> write against <paramref name="target"/> —
+    /// <b>consuming one suppression token</b> on that counter-based path — so the
+    /// handler should return early before invoking the user's callback. It also
+    /// returns <c>true</c> <i>without</i> consuming a token while inside the
+    /// non-consuming <c>ApplySetters</c> suppression scope. Returns <c>false</c>
+    /// for a genuine user interaction (no outstanding token/scope), for a target
+    /// that is not a <see cref="FrameworkElement"/>, or when the target carries no
+    /// Reactor state.
     ///
     /// <para>This is the public primitive the wrapper generator emits for a
     /// <c>[WrapControlled(Deferred = true)]</c> prop, so a deferred-controlled
@@ -64,6 +67,7 @@ public static class ReactorBinding
     /// It maps to the counter/scope channel (paired with <c>WriteSuppressed</c>),
     /// not the synchronous value-diff channel.</para>
     /// </summary>
+    /// <exception cref="ArgumentNullException"><paramref name="target"/> is <see langword="null"/>.</exception>
     public static bool ShouldSuppressEcho(UIElement target)
     {
         ArgumentNullException.ThrowIfNull(target);

--- a/src/Reactor/Core/ReactorBinding.cs
+++ b/src/Reactor/Core/ReactorBinding.cs
@@ -45,4 +45,28 @@ public static class ReactorBinding
         ChangeEchoSuppressor.BeginSuppress(target);
         mutate(target);
     }
+
+    /// <summary>
+    /// Read-side counterpart of <see cref="WriteSuppressed(UIElement, Action)"/>.
+    /// Call as the first line of a change-event handler: returns <c>true</c> — and
+    /// consumes one suppression token — when the current fire is the
+    /// engine-synthesized echo of a prior <c>WriteSuppressed</c> write against
+    /// <paramref name="target"/>, so the handler should return early before
+    /// invoking the user's callback. Also honors the non-consuming
+    /// <c>ApplySetters</c> suppression scope. Returns <c>false</c> for a genuine
+    /// user interaction (no outstanding token/scope), for a target that is not a
+    /// <see cref="FrameworkElement"/>, or when the target carries no Reactor state.
+    ///
+    /// <para>This is the public primitive the wrapper generator emits for a
+    /// <c>[WrapControlled(Deferred = true)]</c> prop, so a deferred-controlled
+    /// generated wrapper compiles against Reactor's public surface alone (no
+    /// <c>InternalsVisibleTo</c>) — the read-side gap called out in spec 062 §14.
+    /// It maps to the counter/scope channel (paired with <c>WriteSuppressed</c>),
+    /// not the synchronous value-diff channel.</para>
+    /// </summary>
+    public static bool ShouldSuppressEcho(UIElement target)
+    {
+        ArgumentNullException.ThrowIfNull(target);
+        return ChangeEchoSuppressor.ShouldSuppress(target);
+    }
 }

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/Spec062DeferredControlledFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/Spec062DeferredControlledFixtures.cs
@@ -1,0 +1,85 @@
+using System.Threading.Tasks;
+using Microsoft.UI.Reactor;
+using Microsoft.UI.Reactor.Core;
+using Reactor.External.TestControl;
+using static Microsoft.UI.Reactor.Factories;
+
+namespace Microsoft.UI.Reactor.AppTests.Host.SelfTest.Fixtures;
+
+/// <summary>
+/// Spec 062 §14 — live-WinUI proof that a source-generated
+/// <c>[WrapControlled(Deferred = true)]</c> wrapper authored in an EXTERNAL
+/// assembly (no <c>InternalsVisibleTo</c> from Reactor.dll) round-trips its
+/// two-way value through the suppress-counter echo channel using only Reactor's
+/// PUBLIC surface.
+///
+/// <para><see cref="ExternalEchoTextBoxElement"/> (over
+/// <see cref="EchoTextBox"/>) is filled in by <c>Reactor.Wrappers.Generator</c>;
+/// its deferred-controlled trampoline gates the echo on the public
+/// <c>ReactorBinding.ShouldSuppressEcho</c> primitive. This fixture exercises that
+/// exact generated code path end-to-end:</para>
+/// <list type="bullet">
+///   <item>a framework-driven reconcile write (the generated Update wraps the set
+///         in <c>WriteSuppressed</c>) does NOT fire the user's OnTextChanged; and</item>
+///   <item>a genuine user edit (direct setter, outside the suppression scope) DOES
+///         fire it — exactly once, with no stranded token on the coincident
+///         re-render the callback triggers.</item>
+/// </list>
+/// The hermetic no-dispatcher half (registration + no-IVT audit) lives in
+/// <c>tests/external_proof/Reactor.External.TestControl.Tests</c> as
+/// <c>ExternalEchoBoxWrapperSelftests</c>.
+/// </summary>
+internal static class Spec062DeferredControlledFixtures
+{
+    internal class Echo(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            int fireCount = 0;
+            var host = H.CreateHost();
+
+            host.Mount(ctx =>
+            {
+                var (text, setText) = ctx.UseState("a");
+                return VStack(
+                    ExternalEchoTextBoxElement.EchoTextBox(text, t => { fireCount++; setText(t); }),
+                    Button("Reconcile", () => setText("b"))
+                );
+            });
+
+            await Harness.Render();
+            var ec = H.FindControl<EchoTextBox>(_ => true);
+            H.Check("Spec062_Deferred_Mounted", ec is not null);
+            H.Check("Spec062_Deferred_InitialText", ec?.Text == "a");
+
+            // Framework-driven reconcile — the generated deferred Update writes Text
+            // via WriteSuppressed; the trampoline's ShouldSuppressEcho drops the
+            // echo. The user callback must NOT fire.
+            int beforeReconcile = fireCount;
+            H.ClickButton("Reconcile");
+            await Harness.Render();
+            H.Check("Spec062_Deferred_NoEchoOnReconcile", fireCount == beforeReconcile);
+            ec = H.FindControl<EchoTextBox>(_ => true);
+            H.Check("Spec062_Deferred_ReconcileApplied", ec?.Text == "b");
+
+            // Genuine user edit — direct write OUTSIDE the suppression scope. The
+            // callback must fire exactly once. Its setText drives a coincident
+            // re-render where newEl.Text == ctrl.Text already, so the readback-gated
+            // Update performs NO write and arms NO suppression token.
+            int beforeUser = fireCount;
+            if (ec is not null) ec.Text = "user";
+            await Harness.Render();
+            H.Check("Spec062_Deferred_FiresOnUserEdit", fireCount == beforeUser + 1);
+
+            // Token-stranding pin — if the coincident reconcile had armed a stray
+            // token, the NEXT real user edit would be swallowed. Assert it still
+            // fires exactly once.
+            int beforeSecond = fireCount;
+            ec = H.FindControl<EchoTextBox>(_ => true);
+            if (ec is not null) ec.Text = "user2";
+            await Harness.Render();
+            H.Check("Spec062_Deferred_NoStrandedTokenAfterCoincident",
+                fireCount == beforeSecond + 1);
+        }
+    }
+}

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/Spec062DeferredControlledFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/Spec062DeferredControlledFixtures.cs
@@ -43,7 +43,7 @@ internal static class Spec062DeferredControlledFixtures
             // primitive must report false. This pins the false-return branch that the
             // mounted round-trip below only exercises implicitly.
             H.Check("Spec062_Deferred_FreshControlNotSuppressed",
-                ReactorBinding.ShouldSuppressEcho(new EchoTextBox()) == false);
+                !ReactorBinding.ShouldSuppressEcho(new EchoTextBox()));
 
             host.Mount(ctx =>
             {

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/Spec062DeferredControlledFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/Spec062DeferredControlledFixtures.cs
@@ -38,6 +38,13 @@ internal static class Spec062DeferredControlledFixtures
             int fireCount = 0;
             var host = H.CreateHost();
 
+            // No-Reactor-state path: a fresh, unmounted control carries no attached
+            // ReactorState and no pending suppress token, so the public read-side
+            // primitive must report false. This pins the false-return branch that the
+            // mounted round-trip below only exercises implicitly.
+            H.Check("Spec062_Deferred_FreshControlNotSuppressed",
+                ReactorBinding.ShouldSuppressEcho(new EchoTextBox()) == false);
+
             host.Mount(ctx =>
             {
                 var (text, setText) = ctx.UseState("a");

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -1413,6 +1413,12 @@ internal static class SelfTestFixtureRegistry
         "Spec047ExternalProof_Marquee_PoolRent",
         "Spec047ExternalProof_Marquee_PoolResetContract",
 
+        // Spec 062 §14 — stable-ABI proof: an EXTERNAL (no-IVT) source-generated
+        // [WrapControlled(Deferred = true)] wrapper round-trips its two-way value
+        // through the suppress-counter echo channel via the PUBLIC
+        // ReactorBinding.ShouldSuppressEcho primitive.
+        "Spec062DeferredControlled_Echo",
+
         // Spec 058 §14 — source-generated wrapper parity smoke test.
         "ToggleSwitchWrapper_Parity",
         "SliderWrapper_Parity",
@@ -2905,6 +2911,9 @@ internal static class SelfTestFixtureRegistry
         "Spec047ExternalProof_Marquee_SetterChain" => new Spec047ExternalProofFixtures.MarqueeSetterChain(harness),
         "Spec047ExternalProof_Marquee_PoolRent" => new Spec047ExternalProofFixtures.MarqueePoolRentReturn(harness),
         "Spec047ExternalProof_Marquee_PoolResetContract" => new Spec047ExternalProofFixtures.MarqueePoolResetContract(harness),
+
+        // Spec 062 §14 — external no-IVT generated deferred-controlled echo proof.
+        "Spec062DeferredControlled_Echo" => new Spec062DeferredControlledFixtures.Echo(harness),
 
         // Spec 058 §14 — source-generated wrapper parity smoke test.
         "ToggleSwitchWrapper_Parity" => new ToggleSwitchWrapperParityFixture.Execution(harness),

--- a/tests/Reactor.Tests/Spec047/V1Protocol/ShouldSuppressEchoTests.cs
+++ b/tests/Reactor.Tests/Spec047/V1Protocol/ShouldSuppressEchoTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Linq;
 using System.Reflection;
 using Microsoft.UI.Reactor.Core;
 using Microsoft.UI.Xaml;
@@ -45,7 +44,10 @@ public class ShouldSuppressEchoTests
     private static MethodInfo ShouldSuppressEchoMethod =>
         typeof(ReactorBinding).GetMethod(
             nameof(ReactorBinding.ShouldSuppressEcho),
-            BindingFlags.Public | BindingFlags.Static)
+            BindingFlags.Public | BindingFlags.Static,
+            binder: null,
+            types: new[] { typeof(UIElement) },
+            modifiers: null)
         ?? throw new InvalidOperationException(
             "ReactorBinding.ShouldSuppressEcho(UIElement) must remain a public static method (spec 062 §14 frozen ABI).");
 

--- a/tests/Reactor.Tests/Spec047/V1Protocol/ShouldSuppressEchoTests.cs
+++ b/tests/Reactor.Tests/Spec047/V1Protocol/ShouldSuppressEchoTests.cs
@@ -71,6 +71,8 @@ public class ShouldSuppressEchoTests
         var ps = ShouldSuppressEchoMethod.GetParameters();
         var p = Assert.Single(ps);
         Assert.Equal(typeof(UIElement), p.ParameterType);
-        Assert.Equal("target", p.Name);
+        // Parameter *name* is deliberately not asserted: it is not part of the CLR
+        // binary contract (renaming it doesn't break external generated wrappers) —
+        // only the arity and parameter type are ABI-load-bearing here.
     }
 }

--- a/tests/Reactor.Tests/Spec047/V1Protocol/ShouldSuppressEchoTests.cs
+++ b/tests/Reactor.Tests/Spec047/V1Protocol/ShouldSuppressEchoTests.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using Microsoft.UI.Reactor.Core;
+using Microsoft.UI.Xaml;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests.Spec047.V1Protocol;
+
+/// <summary>
+/// Spec 062 §14 — <see cref="ReactorBinding.ShouldSuppressEcho(UIElement)"/>
+/// API-contract tests. This is the public read-side counterpart of
+/// <see cref="ReactorBinding.WriteSuppressed(UIElement, Action)"/>, emitted by
+/// the wrapper generator for a <c>[WrapControlled(Deferred = true)]</c> prop so a
+/// deferred-controlled generated wrapper compiles against Reactor's public
+/// surface alone (no <c>InternalsVisibleTo</c>).
+///
+/// <para>The runtime token/scope semantics (consume-once counter, non-consuming
+/// setter scope) require a live WinUI control off the STA dispatcher, so they are
+/// pinned headlessly on the internal <see cref="Reconciler.ReactorState"/> overload
+/// by <c>ChangeEchoSuppressorStateTests</c> — which the public UIElement method
+/// delegates to after a single attached-DP read — and end-to-end by the
+/// <c>Spec062DeferredControlledFixtures</c> selftest against the external
+/// generated wrapper. These unit tests cover the argument-null contract and the
+/// frozen public ABI shape (§14 additive-only discipline).</para>
+/// </summary>
+public class ShouldSuppressEchoTests
+{
+    [Fact]
+    public void ShouldSuppressEcho_Throws_When_Target_Is_Null()
+    {
+        var ex = Assert.Throws<ArgumentNullException>(
+            () => ReactorBinding.ShouldSuppressEcho((UIElement)null!));
+        Assert.Equal("target", ex.ParamName);
+    }
+
+    // ── Stable-ABI guard (spec 062 §14) ──────────────────────────────────
+    // The method is part of the frozen contract the wrapper generator's emitted
+    // code binds to. If its visibility, static-ness, return type, or single
+    // UIElement parameter ever change, generated deferred-controlled wrappers in
+    // external assemblies break at compile time — pin the shape here so a
+    // signature change is caught in Reactor's own unit suite first. (typeof does
+    // not construct a WinUI object, so this stays headless-safe.)
+
+    private static MethodInfo ShouldSuppressEchoMethod =>
+        typeof(ReactorBinding).GetMethod(
+            nameof(ReactorBinding.ShouldSuppressEcho),
+            BindingFlags.Public | BindingFlags.Static)
+        ?? throw new InvalidOperationException(
+            "ReactorBinding.ShouldSuppressEcho(UIElement) must remain a public static method (spec 062 §14 frozen ABI).");
+
+    [Fact]
+    public void ShouldSuppressEcho_Is_Public_Static()
+    {
+        var m = ShouldSuppressEchoMethod;
+        Assert.True(m.IsPublic, "ShouldSuppressEcho must be public (frozen ABI).");
+        Assert.True(m.IsStatic, "ShouldSuppressEcho must be static (frozen ABI).");
+    }
+
+    [Fact]
+    public void ShouldSuppressEcho_Returns_Bool()
+    {
+        Assert.Equal(typeof(bool), ShouldSuppressEchoMethod.ReturnType);
+    }
+
+    [Fact]
+    public void ShouldSuppressEcho_Takes_Single_UIElement_Parameter()
+    {
+        var ps = ShouldSuppressEchoMethod.GetParameters();
+        var p = Assert.Single(ps);
+        Assert.Equal(typeof(UIElement), p.ParameterType);
+        Assert.Equal("target", p.Name);
+    }
+}

--- a/tests/external_proof/Reactor.External.TestControl.Tests/ExternalEchoBoxWrapperSelftests.cs
+++ b/tests/external_proof/Reactor.External.TestControl.Tests/ExternalEchoBoxWrapperSelftests.cs
@@ -1,3 +1,6 @@
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
 using Microsoft.UI.Reactor;
 using Microsoft.UI.Reactor.Core;
 using Xunit;
@@ -55,5 +58,15 @@ public class ExternalEchoBoxWrapperSelftests
         // proof is vacuous. (typeof does not construct a WinUI object.)
         var asm = typeof(ExternalEchoTextBoxElement).Assembly.GetName().Name;
         Assert.Equal("Reactor.External.TestControl", asm);
+
+        // And pin the ABI contract itself: Reactor.dll must NOT grant this assembly
+        // InternalsVisibleTo. Without this guard the compile-proof could silently go
+        // vacuous — a future IVT grant would let the generator emit internal symbols
+        // again yet everything would still build green. ReactorBinding anchors the
+        // Reactor core assembly.
+        var reactorIvtTargets = typeof(ReactorBinding).Assembly
+            .GetCustomAttributes<InternalsVisibleToAttribute>()
+            .Select(a => a.AssemblyName.Split(',')[0].Trim());
+        Assert.DoesNotContain("Reactor.External.TestControl", reactorIvtTargets);
     }
 }

--- a/tests/external_proof/Reactor.External.TestControl.Tests/ExternalEchoBoxWrapperSelftests.cs
+++ b/tests/external_proof/Reactor.External.TestControl.Tests/ExternalEchoBoxWrapperSelftests.cs
@@ -1,0 +1,59 @@
+using Microsoft.UI.Reactor;
+using Microsoft.UI.Reactor.Core;
+using Xunit;
+
+namespace Reactor.External.TestControl.Tests;
+
+/// <summary>
+/// Spec 062 §14 — stable-ABI proof for issue #163, from a genuinely EXTERNAL
+/// assembly. <see cref="ExternalEchoTextBoxElement"/> is a source-generated
+/// <c>[GenerateReactorWrapper]</c> + <c>[WrapControlled("Text", Deferred = true)]</c>
+/// wrapper whose generated deferred-controlled trampoline gates the echo on the
+/// PUBLIC <c>ReactorBinding.ShouldSuppressEcho</c> primitive.
+///
+/// <para>The very fact that this assembly compiles — the wrapper generator runs
+/// here against <see cref="EchoTextBox"/> with NO <c>InternalsVisibleTo</c> from
+/// Reactor.dll — is the proof the read-side echo primitive is public: before it
+/// was, the generated code named the internal <c>ChangeEchoSuppressor</c> and this
+/// project failed with CS0122. The live echo round-trip (framework write is
+/// suppressed, user edit fires) needs a WinUI dispatcher and lives in
+/// <c>Reactor.AppTests.Host</c> as <c>Spec062DeferredControlled_Echo</c>.</para>
+/// </summary>
+public class ExternalEchoBoxWrapperSelftests
+{
+    [Fact]
+    public void GeneratedFactory_SurfacesControlledValue_AndCallback()
+    {
+        // The generated factory + init props exist and carry the controlled
+        // Optional<string> value and its On{Prop}Changed callback. Constructing the
+        // record is headless-safe (no WinUI control is created until mount) and
+        // triggers the generated Pattern-A registration static cctor.
+        var el = ExternalEchoTextBoxElement.EchoTextBox("hi", _ => { });
+
+        Assert.IsAssignableFrom<Element>(el);
+        Assert.True(el.Text.HasValue);
+        Assert.Equal("hi", el.Text.Value);
+        Assert.NotNull(el.OnTextChanged);
+    }
+
+    [Fact]
+    public void GeneratedControlledValue_DefaultsToUnset()
+    {
+        // Controlled props default to Optional.Unset so the control owns the value
+        // and user input survives re-renders unless an explicit value is provided.
+        var el = ExternalEchoTextBoxElement.EchoTextBox();
+
+        Assert.False(el.Text.HasValue);
+        Assert.Null(el.OnTextChanged);
+    }
+
+    [Fact]
+    public void GeneratedWrapper_LivesInExternalAssembly_NoInternalsVisibleTo()
+    {
+        // Guard the "external" in external-proof: the generated element must be
+        // compiled into THIS assembly, not Reactor.dll — otherwise the no-IVT ABI
+        // proof is vacuous. (typeof does not construct a WinUI object.)
+        var asm = typeof(ExternalEchoTextBoxElement).Assembly.GetName().Name;
+        Assert.Equal("Reactor.External.TestControl", asm);
+    }
+}

--- a/tests/external_proof/Reactor.External.TestControl/EchoTextBox.cs
+++ b/tests/external_proof/Reactor.External.TestControl/EchoTextBox.cs
@@ -1,0 +1,55 @@
+using System;
+using Microsoft.UI.Xaml.Controls;
+
+namespace Reactor.External.TestControl;
+
+/// <summary>
+/// Spec 062 §14 — a value-bearing external string control wrapped by a
+/// source-generated <c>[GenerateReactorWrapper]</c> +
+/// <c>[WrapControlled("Text", Deferred = true)]</c> record
+/// (<see cref="ExternalEchoTextBoxElement"/>), authored OUTSIDE Reactor.dll with
+/// NO <c>InternalsVisibleTo</c>.
+///
+/// <para><c>Deferred = true</c> selects the <b>suppress-counter</b> echo channel —
+/// the channel the deferred / coercing value boxes (<c>PasswordBox.Password</c>,
+/// <c>AutoSuggestBox.Text</c>, <c>RichEditBox</c>) require because their change
+/// event is not a synchronous, exact-comparable round-trip that the value-diff arm
+/// can use. The generated trampoline for that channel gates the echo on the
+/// <b>public</b> <c>ReactorBinding.ShouldSuppressEcho</c> primitive. Before that
+/// primitive was public the generator emitted the <i>internal</i>
+/// <c>ChangeEchoSuppressor.ShouldSuppress</c>, and this assembly (no
+/// <c>InternalsVisibleTo</c> from Reactor.dll) would fail to compile with CS0122.
+/// The very fact that this project compiles is the stable-ABI proof for issue #163
+/// / spec 062 §14.</para>
+///
+/// <para>The setter notifies on a genuine change only (mirroring the trusted
+/// <see cref="GaugeControl"/> shape), so the live echo round-trip fixture is
+/// deterministic: a framework reconcile write happens inside <c>WriteSuppressed</c>
+/// and is dropped by <c>ShouldSuppressEcho</c>; a direct user edit outside that
+/// scope fires the callback exactly once.</para>
+/// </summary>
+public sealed partial class EchoTextBox : Control
+{
+    private string _text = string.Empty;
+
+    /// <summary>Value-bearing property. Fires <see cref="TextChanged"/> only when
+    /// the value actually changes (user-initiated or programmatic), so a no-op
+    /// programmatic write never echoes and the suppression token is always
+    /// consumed by a real change.</summary>
+    public string Text
+    {
+        get => _text;
+        set
+        {
+            var next = value ?? string.Empty;
+            if (string.Equals(_text, next, StringComparison.Ordinal)) return;
+            _text = next;
+            TextChanged?.Invoke(this, EventArgs.Empty);
+        }
+    }
+
+    /// <summary>Fires whenever <see cref="Text"/> actually changes. The generated
+    /// deferred-controlled trampoline subscribes here and gates the echo on
+    /// <c>ReactorBinding.ShouldSuppressEcho</c>.</summary>
+    public event EventHandler? TextChanged;
+}

--- a/tests/external_proof/Reactor.External.TestControl/ExternalEchoTextBoxElement.cs
+++ b/tests/external_proof/Reactor.External.TestControl/ExternalEchoTextBoxElement.cs
@@ -1,0 +1,26 @@
+using Microsoft.UI.Reactor.Wrappers;
+
+namespace Reactor.External.TestControl;
+
+// Spec 062 §14 — the stable-ABI proof for issue #163.
+//
+// This partial record is filled in by Reactor.Wrappers.Generator: it emits the
+// Optional<string> Text init-prop, the OnTextChanged callback, the deferred
+// (suppress-counter) HandCodedControlled descriptor entry + trampoline, the
+// Pattern-A self-registration cctor, and the EchoTextBox(...) factory.
+//
+//   * AutoDiscover = false + Include = { "Text" }  →  surface EXACTLY the one
+//     coercing value prop (line 665 of the generator drops any prop that is
+//     neither auto-discovered nor explicitly Included, so [WrapControlled] alone
+//     is not enough to surface it — Include is required).
+//   * [WrapControlled("Text", Deferred = true)]    →  route it through the
+//     DEFERRED echo channel, whose generated trampoline gates on the PUBLIC
+//     ReactorBinding.ShouldSuppressEcho primitive. If that primitive were still
+//     internal, THIS assembly (no InternalsVisibleTo from Reactor.dll) would not
+//     compile — so a green build is the proof the read-side ABI gap is closed.
+//   * RegisterAssembly = false                     →  EchoTextBox is a pure-code
+//     control with no IXamlMetadataProvider; skip the RegisterControlAssembly
+//     call (issue #142) that only third-party XAML control libraries need.
+[GenerateReactorWrapper(typeof(EchoTextBox), AutoDiscover = false, Include = new[] { "Text" }, RegisterAssembly = false)]
+[WrapControlled("Text", Deferred = true)]
+public partial record ExternalEchoTextBoxElement;

--- a/tests/external_proof/Reactor.External.TestControl/Reactor.External.TestControl.csproj
+++ b/tests/external_proof/Reactor.External.TestControl/Reactor.External.TestControl.csproj
@@ -53,6 +53,17 @@
     <!-- Regular project reference — NOT InternalsVisibleTo. Reactor.dll's
          public surface alone must be sufficient. -->
     <ProjectReference Include="..\..\..\src\Reactor\Reactor.csproj" />
+
+    <!-- Spec 062 §14 — the wrapper generator + its authoring attributes do NOT
+         flow transitively from Reactor (Reactor references them with
+         PrivateAssets="all"), so an external author must reference them directly,
+         exactly as samples/apps/wct-controls does. Reactor.Wrappers.Abstractions
+         is the net10.0 attributes-only assembly ([GenerateReactorWrapper] /
+         [WrapControlled] / …); Reactor.Wrappers.Generator is the Roslyn source
+         generator, consumed as an analyzer (no runtime reference). -->
+    <ProjectReference Include="..\..\..\src\Reactor.Wrappers.Abstractions\Reactor.Wrappers.Abstractions.csproj" />
+    <ProjectReference Include="..\..\..\src\Reactor.Wrappers.Generator\Reactor.Wrappers.Generator.csproj"
+                      OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

Adds `ReactorBinding.ShouldSuppressEcho(UIElement)` — the public read-side counterpart of the existing `WriteSuppressed` primitive — and re-points the wrapper source-generator to emit it instead of the internal `ChangeEchoSuppressor.ShouldSuppress`. This closes the one place the generator emitted an **internal** Reactor symbol into **externally**-generated code, so a source-generated `[WrapControlled(Deferred = true)]` wrapper now compiles against Reactor's **public surface alone** (no `InternalsVisibleTo`). This is increment 1 of the spec-062 stable-ABI work and the first enforcement of the §14 cross-version-interop contract.

Audit result backing this increment: every other symbol the generator emits into external code (`Reconciler.SetElementTag/GetElementTag/DetachReactorState/ApplySetters`, `ReactorApp.TryRegisterControlAssembly`, `ElementExtensions.On{Mount,Unmount}Add`, descriptors/registry) is already `public` — `ChangeEchoSuppressor.ShouldSuppress` was the only leak, so this closes the internal-symbol violation across the whole emit surface.

## Linked issue / spec

Part of #163. Implements `docs/specs/062-third-party-registration-and-package-boundaries.md` §14 (stable-ABI cross-version interop, requirement R7) — increment 1. The larger `Reactor.Abstractions` package carve-out is deliberately deferred to follow-up PRs.

## Test plan

- [x] **Unit** (`tests/Reactor.Tests/Spec047/V1Protocol/ShouldSuppressEchoTests.cs`) — null-arg contract + frozen-ABI reflection guards (public/static, returns `bool`, single `UIElement` param).
- [x] **Hermetic external no-IVT proof** (`tests/external_proof/…`) — a genuinely external assembly (no `InternalsVisibleTo` from Reactor.dll) source-generates a `[WrapControlled(Deferred = true)]` wrapper; the fact it compiles is the ABI proof. Adds a reflection guard that Reactor.dll grants the external assembly no IVT, so the proof can't silently go vacuous.
- [x] **Selftest** (`tests/Reactor.AppTests.Host/SelfTest/Fixtures/Spec062DeferredControlledFixtures.cs`) — live WinUI deferred-controlled echo round-trip: reconcile write is suppressed, genuine user edit fires exactly once, no stranded token, and a fresh (no-state) control reports `false`.
- [x] `dotnet build Reactor.slnx` → 0 warnings / 0 errors.
- [x] External proof: 9 passed / 0 failed. Spec062 selftest: 7/7.

## Risk / breaking changes

- **New public API** `ReactorBinding.ShouldSuppressEcho(UIElement)` — purely additive.
- The generated deferred-controlled trampoline now null-guards the sender (`if (__c is null) return;`) before the strict public call, preserving the pre-existing tolerant behavior of the internal read-side check (returned `false` for null / non-`FrameworkElement`). Behavior-preserving; also protects the built-in `PasswordBox` trampoline emitted from the same path.
- No breaking changes; no change to `reactor.api.txt` (the static class is excluded from the index by design).

Reviewed via the repo's `pr-review` skill (7 dimensions + a gpt-5.4 multi-model cross-check); all findings addressed.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>

Fixes: #163