### PR TITLE
Add syntax highlighting to ReactorGallery source-code panels

### DIFF
--- a/samples/ReactorGallery/UserControls/CodeHighlighter.cs
+++ b/samples/ReactorGallery/UserControls/CodeHighlighter.cs
@@ -113,7 +113,7 @@ internal static class CodeHighlighter
                     // Whitespace is invisible, so it inherits the block foreground.
                     inlines[t] = tk.Kind == Kind.Whitespace
                         ? Run(tk.Text)
-                        : Run(tk.Text).Foreground(ColorFor(tk.Kind, palette));
+                        : Run(tk.Text).Foreground(BrushFor(ColorFor(tk.Kind, palette)));
                 }
             }
             paragraphs[li] = Paragraph(inlines);
@@ -136,7 +136,7 @@ internal static class CodeHighlighter
             string num = (i + 1)
                 .ToString(global::System.Globalization.CultureInfo.InvariantCulture)
                 .PadLeft(width);
-            paragraphs[i] = Paragraph(Run(num).Foreground(palette.LineNumber));
+            paragraphs[i] = Paragraph(Run(num).Foreground(BrushFor(palette.LineNumber)));
         }
         return paragraphs;
     }
@@ -149,6 +149,32 @@ internal static class CodeHighlighter
         Kind.Number  => p.Number,
         _            => p.PlainText,
     };
+
+    // Cache one brush per color string. The palette uses a small fixed set of
+    // colors, so a highlighted panel reuses ~7 brushes instead of allocating a
+    // new SolidColorBrush per token (which .Foreground(string) / BrushHelper.Parse
+    // would do). Only touched on the UI thread during Render.
+    static readonly Dictionary<string, Microsoft.UI.Xaml.Media.SolidColorBrush> BrushCache = new();
+
+    static Microsoft.UI.Xaml.Media.SolidColorBrush BrushFor(string hex)
+    {
+        if (BrushCache.TryGetValue(hex, out var brush)) return brush;
+        brush = new Microsoft.UI.Xaml.Media.SolidColorBrush(ParseHexColor(hex));
+        BrushCache[hex] = brush;
+        return brush;
+    }
+
+    static global::Windows.UI.Color ParseHexColor(string hex)
+    {
+        hex = hex.TrimStart('#');
+        byte a = 0xFF;
+        int o = 0;
+        if (hex.Length == 8) { a = Convert.ToByte(hex.Substring(0, 2), 16); o = 2; }
+        byte r = Convert.ToByte(hex.Substring(o, 2), 16);
+        byte g = Convert.ToByte(hex.Substring(o + 2, 2), 16);
+        byte b = Convert.ToByte(hex.Substring(o + 4, 2), 16);
+        return global::Windows.UI.Color.FromArgb(a, r, g, b);
+    }
 
     static List<List<Tok>> Tokenize(string src)
     {

--- a/samples/ReactorGallery/UserControls/CodeHighlighter.cs
+++ b/samples/ReactorGallery/UserControls/CodeHighlighter.cs
@@ -1,0 +1,307 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.UI.Reactor;
+using Microsoft.UI.Reactor.Core;
+using static Microsoft.UI.Reactor.Factories;
+
+namespace WinUIGalleryReactor;
+
+/// <summary>
+/// A theme color palette for a code block. Values are hex color strings.
+/// </summary>
+internal readonly record struct CodePalette(
+    string Background,
+    string PlainText,
+    string Comment,
+    string Keyword,
+    string Str,
+    string Number,
+    string GutterBackground,
+    string LineNumber);
+
+/// <summary>
+/// A small C# syntax highlighter that reproduces the same coloring rules the
+/// official WinUI Gallery uses for C# code — i.e. the <c>ColorCode</c> library's
+/// C# grammar and its Default Light / Default Dark themes.
+///
+/// <para>ColorCode's C# grammar is intentionally minimal: it colors comments,
+/// string / char literals, a fixed keyword set, and integer literals. Type names,
+/// method calls and member accesses are deliberately left as plain text (the
+/// grammar's class-name rule is disabled upstream). All keywords — including
+/// control-flow ones — share a single color. This highlighter mirrors those
+/// exact rules, palette values, and light/dark split; the line-number gutter is
+/// the only local addition.</para>
+/// </summary>
+internal static class CodeHighlighter
+{
+    internal const string CodeFontFamily = "Cascadia Code, Cascadia Mono, Consolas";
+    internal const double CodeFontSize = 13;
+    internal const double CodeLineHeight = 20;
+
+    // ColorCode "Default Dark" (VS dark). Gutter colors are a local addition.
+    internal static readonly CodePalette Dark = new(
+        Background: "#1E1E1E",       // VSDarkBackground
+        PlainText:  "#DADADA",       // VSDarkPlainText
+        Comment:    "#57A64A",       // VSDarkComment
+        Keyword:    "#569CD6",       // VSDarkKeyword
+        Str:        "#D69D85",       // VSDarkString
+        Number:     "#B5CEA8",       // VSDarkNumber
+        GutterBackground: "#252526",
+        LineNumber: "#858585");
+
+    // ColorCode "Default Light" (VS light). ColorCode does not assign the Number
+    // scope a color in its light theme, so numbers fall back to plain text.
+    internal static readonly CodePalette Light = new(
+        Background: "#FFFFFF",        // White
+        PlainText:  "#000000",        // Black
+        Comment:    "#008000",        // Green
+        Keyword:    "#0000FF",        // Blue
+        Str:        "#A31515",        // DullRed
+        Number:     "#000000",        // (uncolored -> plain text)
+        GutterBackground: "#F3F3F3",
+        LineNumber: "#9AA0A6");
+
+    enum Kind { Default, Keyword, Str, Comment, Number, Whitespace }
+
+    readonly record struct Tok(string Text, Kind Kind);
+
+    // ColorCode's exact C# keyword list (ColorCode.Core CSharp grammar). All of
+    // these map to the single Keyword color — ColorCode does not split out a
+    // separate control-flow keyword color for C#.
+    static readonly HashSet<string> Keywords = new(StringComparer.Ordinal)
+    {
+        "abstract", "as", "ascending", "base", "bool", "break", "by", "byte", "case",
+        "catch", "char", "checked", "class", "const", "continue", "decimal", "default",
+        "delegate", "descending", "do", "double", "dynamic", "else", "enum", "equals",
+        "event", "explicit", "extern", "false", "finally", "fixed", "float", "for",
+        "foreach", "from", "get", "goto", "group", "if", "implicit", "in", "int",
+        "into", "interface", "internal", "is", "join", "let", "lock", "long",
+        "namespace", "new", "null", "object", "on", "operator", "orderby", "out",
+        "override", "params", "partial", "private", "protected", "public", "readonly",
+        "ref", "return", "sbyte", "sealed", "select", "set", "short", "sizeof",
+        "stackalloc", "static", "string", "struct", "switch", "this", "throw", "true",
+        "try", "typeof", "uint", "ulong", "unchecked", "unsafe", "ushort", "using",
+        "var", "virtual", "void", "volatile", "where", "while", "yield", "async",
+        "await", "warning", "disable",
+    };
+
+    /// <summary>
+    /// Lexes <paramref name="code"/> into one <see cref="RichTextParagraph"/> per
+    /// line, colored per <paramref name="palette"/>. <paramref name="lineCount"/>
+    /// is the number of lines produced (used to build a matching gutter).
+    /// </summary>
+    public static RichTextParagraph[] Highlight(string? code, in CodePalette palette, out int lineCount)
+    {
+        var lines = Tokenize(code ?? string.Empty);
+        var paragraphs = new RichTextParagraph[lines.Count];
+        for (int li = 0; li < lines.Count; li++)
+        {
+            var toks = lines[li];
+            RichTextInline[] inlines;
+            if (toks.Count == 0)
+            {
+                // Preserve the height of blank lines so the gutter stays aligned.
+                inlines = new RichTextInline[] { Run(" ") };
+            }
+            else
+            {
+                inlines = new RichTextInline[toks.Count];
+                for (int t = 0; t < toks.Count; t++)
+                {
+                    var tk = toks[t];
+                    // Whitespace is invisible, so it inherits the block foreground.
+                    inlines[t] = tk.Kind == Kind.Whitespace
+                        ? Run(tk.Text)
+                        : Run(tk.Text).Foreground(ColorFor(tk.Kind, palette));
+                }
+            }
+            paragraphs[li] = Paragraph(inlines);
+        }
+
+        lineCount = lines.Count;
+        return paragraphs;
+    }
+
+    /// <summary>
+    /// Builds the right-aligned line-number gutter for <paramref name="lineCount"/>
+    /// lines. Numbers are left-padded (monospace) so they align on the right.
+    /// </summary>
+    public static RichTextParagraph[] Gutter(int lineCount, in CodePalette palette)
+    {
+        int width = lineCount.ToString(global::System.Globalization.CultureInfo.InvariantCulture).Length;
+        var paragraphs = new RichTextParagraph[Math.Max(lineCount, 0)];
+        for (int i = 0; i < lineCount; i++)
+        {
+            string num = (i + 1)
+                .ToString(global::System.Globalization.CultureInfo.InvariantCulture)
+                .PadLeft(width);
+            paragraphs[i] = Paragraph(Run(num).Foreground(palette.LineNumber));
+        }
+        return paragraphs;
+    }
+
+    static string ColorFor(Kind kind, in CodePalette p) => kind switch
+    {
+        Kind.Keyword => p.Keyword,
+        Kind.Str     => p.Str,
+        Kind.Comment => p.Comment,
+        Kind.Number  => p.Number,
+        _            => p.PlainText,
+    };
+
+    static List<List<Tok>> Tokenize(string src)
+    {
+        src = src.Replace("\r\n", "\n").Replace("\r", "\n").Replace("\t", "    ");
+
+        var lines = new List<List<Tok>>();
+        var current = new List<Tok>();
+        lines.Add(current);
+
+        void Emit(string text, Kind kind) => current.Add(new Tok(text, kind));
+        void NewLine()
+        {
+            current = new List<Tok>();
+            lines.Add(current);
+        }
+
+        int i = 0;
+        int n = src.Length;
+        while (i < n)
+        {
+            char c = src[i];
+
+            if (c == '\n') { i++; NewLine(); continue; }
+
+            if (c == ' ')
+            {
+                int s = i;
+                while (i < n && src[i] == ' ') i++;
+                Emit(src.Substring(s, i - s), Kind.Whitespace);
+                continue;
+            }
+
+            // Line comment (also covers /// doc comments).
+            if (c == '/' && i + 1 < n && src[i + 1] == '/')
+            {
+                int s = i;
+                while (i < n && src[i] != '\n') i++;
+                Emit(src.Substring(s, i - s), Kind.Comment);
+                continue;
+            }
+
+            // Block comment (may span lines).
+            if (c == '/' && i + 1 < n && src[i + 1] == '*')
+            {
+                var sb = new StringBuilder("/*");
+                i += 2;
+                while (i < n)
+                {
+                    if (src[i] == '\n') { Emit(sb.ToString(), Kind.Comment); sb.Clear(); NewLine(); i++; continue; }
+                    if (src[i] == '*' && i + 1 < n && src[i + 1] == '/') { sb.Append("*/"); i += 2; break; }
+                    sb.Append(src[i]); i++;
+                }
+                if (sb.Length > 0) Emit(sb.ToString(), Kind.Comment);
+                continue;
+            }
+
+            // Char literal, verbatim string, or regular string. ColorCode has no
+            // rule for the '$' of an interpolated string, so it is left plain and
+            // only the quoted part is colored (handled by falling through to the
+            // '"' case on the next iteration).
+            if (c == '\'' || c == '"' || (c == '@' && i + 1 < n && src[i + 1] == '"'))
+            {
+                ScanString(src, ref i, Emit, NewLine);
+                continue;
+            }
+
+            // Numbers: ColorCode colors only integer digit runs (\b[0-9]+\b).
+            if (char.IsDigit(c))
+            {
+                int s = i;
+                while (i < n && char.IsDigit(src[i])) i++;
+                // A trailing letter/underscore means the digits are part of a
+                // larger token (e.g. 0xFF, 200f) — not a standalone number.
+                bool wordBoundary = i >= n || !(char.IsLetter(src[i]) || src[i] == '_');
+                Emit(src.Substring(s, i - s), wordBoundary ? Kind.Number : Kind.Default);
+                continue;
+            }
+
+            // Identifiers / keywords.
+            if (char.IsLetter(c) || c == '_')
+            {
+                int s = i;
+                while (i < n && (char.IsLetterOrDigit(src[i]) || src[i] == '_')) i++;
+                string word = src.Substring(s, i - s);
+                Emit(word, Keywords.Contains(word) ? Kind.Keyword : Kind.Default);
+                continue;
+            }
+
+            // Punctuation / operators (including '$', '.', etc.) — plain text.
+            Emit(c.ToString(), Kind.Default);
+            i++;
+        }
+
+        return lines;
+    }
+
+    static void ScanString(string src, ref int i, Action<string, Kind> emit, Action newLine)
+    {
+        int n = src.Length;
+        var sb = new StringBuilder();
+
+        bool verbatim = false;
+        if (src[i] == '@') { verbatim = true; sb.Append('@'); i++; }
+
+        char quote = src[i]; // '"' or '\''
+        sb.Append(quote);
+        i++;
+
+        while (i < n)
+        {
+            char c = src[i];
+
+            if (c == '\n')
+            {
+                if (verbatim)
+                {
+                    // Verbatim strings can span lines.
+                    emit(sb.ToString(), Kind.Str);
+                    sb.Clear();
+                    newLine();
+                    i++;
+                    continue;
+                }
+                break; // unterminated on this line — stop before the newline
+            }
+
+            if (!verbatim && c == '\\' && i + 1 < n)
+            {
+                sb.Append(c);
+                sb.Append(src[i + 1]);
+                i += 2;
+                continue;
+            }
+
+            if (verbatim && c == quote && i + 1 < n && src[i + 1] == quote)
+            {
+                sb.Append(quote);
+                sb.Append(quote);
+                i += 2;
+                continue;
+            }
+
+            if (c == quote)
+            {
+                sb.Append(quote);
+                i++;
+                break;
+            }
+
+            sb.Append(c);
+            i++;
+        }
+
+        emit(sb.ToString(), Kind.Str);
+    }
+}

--- a/samples/ReactorGallery/UserControls/CodeHighlighter.cs
+++ b/samples/ReactorGallery/UserControls/CodeHighlighter.cs
@@ -152,7 +152,10 @@ internal static class CodeHighlighter
 
     static List<List<Tok>> Tokenize(string src)
     {
-        src = src.Replace("\r\n", "\n").Replace("\r", "\n").Replace("\t", "    ");
+        // Normalize line endings only. Tabs are preserved verbatim so the
+        // rendered/selectable text matches the original source (and the Copy
+        // button); they are treated as whitespace by the lexer below.
+        src = src.Replace("\r\n", "\n").Replace("\r", "\n");
 
         var lines = new List<List<Tok>>();
         var current = new List<Tok>();
@@ -173,10 +176,10 @@ internal static class CodeHighlighter
 
             if (c == '\n') { i++; NewLine(); continue; }
 
-            if (c == ' ')
+            if (c == ' ' || c == '\t')
             {
                 int s = i;
-                while (i < n && src[i] == ' ') i++;
+                while (i < n && (src[i] == ' ' || src[i] == '\t')) i++;
                 Emit(src.Substring(s, i - s), Kind.Whitespace);
                 continue;
             }

--- a/samples/ReactorGallery/UserControls/CodeHighlighter.cs
+++ b/samples/ReactorGallery/UserControls/CodeHighlighter.cs
@@ -220,10 +220,12 @@ internal static class CodeHighlighter
             {
                 int s = i;
                 while (i < n && char.IsDigit(src[i])) i++;
-                // A trailing letter/underscore means the digits are part of a
-                // larger token (e.g. 0xFF, 200f) — not a standalone number.
-                bool wordBoundary = i >= n || !(char.IsLetter(src[i]) || src[i] == '_');
-                Emit(src.Substring(s, i - s), wordBoundary ? Kind.Number : Kind.Default);
+                // Require a word boundary on BOTH sides (mirrors \b[0-9]+\b): a
+                // letter/digit/underscore on either edge means the digits belong
+                // to a larger token (e.g. 0xFF, 200f, 1_000) and are not colored.
+                bool leadingBoundary = s == 0 || !(char.IsLetterOrDigit(src[s - 1]) || src[s - 1] == '_');
+                bool trailingBoundary = i >= n || !(char.IsLetterOrDigit(src[i]) || src[i] == '_');
+                Emit(src.Substring(s, i - s), leadingBoundary && trailingBoundary ? Kind.Number : Kind.Default);
                 continue;
             }
 

--- a/samples/ReactorGallery/UserControls/CodeHighlighter.cs
+++ b/samples/ReactorGallery/UserControls/CodeHighlighter.cs
@@ -153,16 +153,12 @@ internal static class CodeHighlighter
     // Cache one brush per color string. The palette uses a small fixed set of
     // colors, so a highlighted panel reuses ~7 brushes instead of allocating a
     // new SolidColorBrush per token (which .Foreground(string) / BrushHelper.Parse
-    // would do). Only touched on the UI thread during Render.
-    static readonly Dictionary<string, Microsoft.UI.Xaml.Media.SolidColorBrush> BrushCache = new();
+    // would do). ConcurrentDictionary keeps the shared static cache safe even
+    // though it is only expected to be touched on the UI thread during Render.
+    static readonly global::System.Collections.Concurrent.ConcurrentDictionary<string, Microsoft.UI.Xaml.Media.SolidColorBrush> BrushCache = new();
 
     static Microsoft.UI.Xaml.Media.SolidColorBrush BrushFor(string hex)
-    {
-        if (BrushCache.TryGetValue(hex, out var brush)) return brush;
-        brush = new Microsoft.UI.Xaml.Media.SolidColorBrush(ParseHexColor(hex));
-        BrushCache[hex] = brush;
-        return brush;
-    }
+        => BrushCache.GetOrAdd(hex, static h => new Microsoft.UI.Xaml.Media.SolidColorBrush(ParseHexColor(h)));
 
     static global::Windows.UI.Color ParseHexColor(string hex)
     {

--- a/samples/ReactorGallery/UserControls/GalleryControls.cs
+++ b/samples/ReactorGallery/UserControls/GalleryControls.cs
@@ -1,6 +1,7 @@
 using System.Threading.Tasks;
 using Microsoft.UI.Reactor;
 using Microsoft.UI.Reactor.Core;
+using Microsoft.UI.Reactor.Hooks;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
@@ -59,7 +60,116 @@ internal sealed class CopyToClipboardButton : Component<string>
                     // than crash the gallery. Anything else propagates.
                 }
             })
-            .SubtleButton();
+            // Overlay chip that adapts to the current theme (matches the WinUI
+            // Gallery's copy button, which sits on top of the code surface).
+            .FontSize(12)
+            .Foreground(Theme.PrimaryText)
+            .Background(Theme.Ref("ControlOnImageFillColorDefaultBrush"))
+            .CornerRadius(4)
+            .Padding(10, 4, 10, 4);
+    }
+}
+
+/// <summary>
+/// The collapsible "Source code" panel body: a rounded, theme-aware editor
+/// surface with C# syntax highlighting (matching the WinUI Gallery / ColorCode
+/// coloring rules), a line-number gutter, and an overlay copy button. Rendered
+/// as a Component so it can react to <see cref="FrameworkElement.ActualThemeChanged"/>
+/// and swap between the Light and Dark ColorCode palettes when the app theme toggles.
+/// </summary>
+internal sealed class SourceCodeView : Component<string>
+{
+    const double MaxPanelHeight = 420;
+
+    // Resolve the effective theme by walking up the visual tree for the nearest
+    // explicit RequestedTheme. This is reliable during reconcile, unlike
+    // FrameworkElement.ActualTheme which can lag a synchronous update pass.
+    static bool ResolveIsDark(FrameworkElement? start)
+    {
+        var cur = start;
+        while (cur is not null)
+        {
+            if (cur.RequestedTheme != ElementTheme.Default)
+                return cur.RequestedTheme == ElementTheme.Dark;
+            cur = VisualTreeHelper.GetParent(cur) as FrameworkElement;
+        }
+        return Application.Current?.RequestedTheme == ApplicationTheme.Dark;
+    }
+
+    public override Element Render()
+    {
+        var sourceCode = Props;
+
+        // The gallery toggles theme via a per-element RequestedTheme, so resolve
+        // the effective theme from the *connected* panel (via OnMount / the
+        // ActualThemeChanged sender) and re-render on change. Reading a stored ref
+        // or ActualTheme during reconcile is unreliable; walking up RequestedTheme
+        // from the live element is what ThemeRef itself does.
+        var (isDark, setIsDark) = UseState(
+            Application.Current?.RequestedTheme == ApplicationTheme.Dark,
+            threadSafe: true);
+
+        var palette = isDark ? CodeHighlighter.Dark : CodeHighlighter.Light;
+
+        var codeParagraphs = CodeHighlighter.Highlight(sourceCode, palette, out int lineCount);
+        var gutterParagraphs = CodeHighlighter.Gutter(lineCount, palette);
+
+        var code = (RichTextBlock(codeParagraphs) with
+            {
+                IsTextSelectionEnabled = true,
+                TextWrapping = TextWrapping.NoWrap,
+                FontSize = CodeHighlighter.CodeFontSize,
+                LineHeight = CodeHighlighter.CodeLineHeight,
+                LineStackingStrategy = LineStackingStrategy.BlockLineHeight,
+            })
+            .FontFamily(CodeHighlighter.CodeFontFamily)
+            .Padding(16, 12, 20, 12);
+
+        var gutter = Border(
+                (RichTextBlock(gutterParagraphs) with
+                {
+                    TextWrapping = TextWrapping.NoWrap,
+                    FontSize = CodeHighlighter.CodeFontSize,
+                    LineHeight = CodeHighlighter.CodeLineHeight,
+                    LineStackingStrategy = LineStackingStrategy.BlockLineHeight,
+                })
+                .FontFamily(CodeHighlighter.CodeFontFamily))
+            .Background(palette.GutterBackground)
+            .Padding(14, 12, 12, 12);
+
+        // Fixed gutter | horizontally scrollable code. A single Auto row keeps
+        // both columns the same height so their rows line up.
+        var body = Grid(
+            columns: [GridSize.Auto, GridSize.Star()], rows: [GridSize.Auto],
+            gutter.Grid(row: 0, column: 0),
+            (ScrollView(code) with { ContentOrientation = ScrollingContentOrientation.Horizontal })
+                .Grid(row: 0, column: 1)
+        );
+
+        // Size to content, capped so long snippets scroll instead of pushing the page.
+        double panelHeight = global::System.Math.Min(lineCount * CodeHighlighter.CodeLineHeight + 24, MaxPanelHeight);
+
+        var panel = Border(
+                (ScrollView(body) with { ContentOrientation = ScrollingContentOrientation.Vertical })
+                    .Height(panelHeight))
+            .Background(palette.Background)
+            .WithBorder(Theme.CardStroke)
+            .CornerRadius(6)
+            .OnMount(el =>
+            {
+                setIsDark(ResolveIsDark(el));
+                el.ActualThemeChanged += (sender, _) => setIsDark(ResolveIsDark((FrameworkElement)sender));
+            });
+
+        return Grid(
+            columns: [GridSize.Star()], rows: [GridSize.Star()],
+            panel.Grid(row: 0, column: 0),
+            Component<CopyToClipboardButton, string>(sourceCode)
+                .HAlign(HorizontalAlignment.Right)
+                .VAlign(VerticalAlignment.Top)
+                .Margin(0, 8, 12, 0)
+                .Grid(row: 0, column: 0)
+        );
     }
 }
 
@@ -206,30 +316,7 @@ public static class GalleryControls
 
         children.Add(
             Expander("Source code",
-                Grid(
-                    columns: [GridSize.Star()], rows: [GridSize.Star()],
-                    (ScrollView(
-                        TextBlock(sourceCode.Trim())
-                            .FontFamily("Consolas, 'Cascadia Code', monospace")
-                            .FontSize(13)
-                            .Padding(12)
-                            .Set(tb =>
-                            {
-                                tb.IsTextSelectionEnabled = true;
-                                tb.TextWrapping = TextWrapping.NoWrap;
-                            })
-                    ) with { ContentOrientation = Microsoft.UI.Xaml.Controls.ScrollingContentOrientation.Both })
-                    .Height(200)
-                    .Background(Theme.SubtleFill)
-                    .Grid(row: 0, column: 0),
-
-                    Component<CopyToClipboardButton, string>(sourceCode.Trim())
-                        .HAlign(HorizontalAlignment.Right)
-                        .VAlign(VerticalAlignment.Top)
-                        .Margin(0, 8, 12, 0)
-                        .Grid(row: 0, column: 0)
-                )
-            )
+                Component<SourceCodeView, string>(sourceCode.Trim()))
             .OnMount(el =>
             {
                 var exp = (Expander)el;

--- a/samples/ReactorGallery/UserControls/GalleryControls.cs
+++ b/samples/ReactorGallery/UserControls/GalleryControls.cs
@@ -84,6 +84,8 @@ internal sealed class SourceCodeView : Component<string>
     // Resolve the effective theme by walking up the visual tree for the nearest
     // explicit RequestedTheme. This is reliable during reconcile, unlike
     // FrameworkElement.ActualTheme which can lag a synchronous update pass.
+    // Mirrors src/Reactor/Core/Theme.cs GetEffectiveThemeName: RequestedTheme
+    // override → the element's own ActualTheme → the app theme.
     static bool ResolveIsDark(FrameworkElement? start)
     {
         var cur = start;
@@ -93,6 +95,8 @@ internal sealed class SourceCodeView : Component<string>
                 return cur.RequestedTheme == ElementTheme.Dark;
             cur = VisualTreeHelper.GetParent(cur) as FrameworkElement;
         }
+        if (start is not null && start.ActualTheme != ElementTheme.Default)
+            return start.ActualTheme == ElementTheme.Dark;
         return Application.Current?.RequestedTheme == ApplicationTheme.Dark;
     }
 

--- a/samples/ReactorGallery/UserControls/GalleryControls.cs
+++ b/samples/ReactorGallery/UserControls/GalleryControls.cs
@@ -109,6 +109,11 @@ internal sealed class SourceCodeView : Component<string>
             Application.Current?.RequestedTheme == ApplicationTheme.Dark,
             threadSafe: true);
 
+        // Border is poolable, and the pool's cleanup does not remove WinUI event
+        // subscriptions — so the ActualThemeChanged handler attached on mount must
+        // be detached on unmount (below) or it would leak across rent/return.
+        var themeHandlerRef = UseRef<global::Windows.Foundation.TypedEventHandler<FrameworkElement, object>?>(null);
+
         var palette = isDark ? CodeHighlighter.Dark : CodeHighlighter.Light;
 
         var codeParagraphs = CodeHighlighter.Highlight(sourceCode, palette, out int lineCount);
@@ -158,7 +163,18 @@ internal sealed class SourceCodeView : Component<string>
             .OnMount(el =>
             {
                 setIsDark(ResolveIsDark(el));
-                el.ActualThemeChanged += (sender, _) => setIsDark(ResolveIsDark((FrameworkElement)sender));
+                var handler = new global::Windows.Foundation.TypedEventHandler<FrameworkElement, object>(
+                    (sender, _) => setIsDark(ResolveIsDark((FrameworkElement)sender)));
+                themeHandlerRef.Current = handler;
+                el.ActualThemeChanged += handler;
+            })
+            .OnUnmount(el =>
+            {
+                if (themeHandlerRef.Current is not null)
+                {
+                    el.ActualThemeChanged -= themeHandlerRef.Current;
+                    themeHandlerRef.Current = null;
+                }
             });
 
         return Grid(


### PR DESCRIPTION
## What

The gallery's **Source code** blocks rendered as plain black-and-white monospace text. This replaces them with a rounded, theme-aware editor panel that reproduces the **same coloring rules the official WinUI Gallery uses** (the [`ColorCode`](https://github.com/CommunityToolkit/ColorCode-Universal) library), plus a line-number gutter and margins.

### Before → After
- Flat black-on-white text → syntax-colored code on a proper editor surface.
- No line numbers → right-aligned line-number gutter.
- Cramped → generous padding, rounded panel, theme-adaptive border.

## How

- **`CodeHighlighter.cs`** — a small C# lexer that mirrors ColorCode's C# grammar: only comments, string/char literals, ColorCode's exact keyword set, and integer literals are colored; types, method calls and members stay plain text (ColorCode's ClassName rule is disabled upstream, and all keywords share one color). Uses the exact ColorCode `DefaultLight` / `DefaultDark` palette values.
- **`SourceCodeView`** — a `Component` that swaps the Light/Dark palette to match the app theme. It resolves the effective theme by walking up `RequestedTheme` from the connected panel on `OnMount` + `ActualThemeChanged` (the same mechanism `ThemeRef` uses), mirroring how the WinUI Gallery regenerates its code on theme change.
- Line-number gutter kept in sync with the code (`BlockLineHeight`), fixed gutter with horizontally-scrollable code, and a theme-adaptive copy button (`ControlOnImageFillColorDefaultBrush`).

## Scope

Sample-only change (`samples/ReactorGallery`). Two files: `CodeHighlighter.cs` (new) and `GalleryControls.cs`. No product code or public API touched; the gallery search index is unaffected (regenerated → no diff).

## Verification

- Builds clean (`ReactorGallery`, x64).
- Headless lexer check: lossless reconstruction + ColorCode-faithful classification, including `\b[0-9]+\b` number boundaries (`0xFF`, `3.14f`, `1_000`) and `$"{x}"` leaving `$` plain.
- UI Automation: confirmed the panel renders (gutter line numbers, highlighted code, copy button) and that the Light/Dark palette flips correctly on the theme toggle — for the visible panel and for a collapsed-then-expanded card.