### PR TITLE
deps: bump NuGet packages missed by (Linux) Dependabot

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -47,7 +47,7 @@
          (PrivateAssets=all) — never shipped in the `mur` tool output. Version tracks
          YamlDotNet's major (18.x). -->
     <PackageVersion Include="Vecc.YamlDotNet.Analyzers.StaticGenerator" Version="18.1.0" />
-    <PackageVersion Include="GitHub.Copilot.SDK" Version="1.0.7" />
+    <PackageVersion Include="GitHub.Copilot.SDK" Version="1.0.8" />
     <PackageVersion Include="MessagePack" Version="2.5.301" />
   </ItemGroup>
 


### PR DESCRIPTION
<!--
Thanks for contributing to Reactor! A few notes before you open this PR:

- Link the issue or spec this PR addresses (Fixes #..., Implements docs/specs/0XX-...).
- Keep the change focused. Smaller, well-scoped PRs land faster.
- Include tests. See CONTRIBUTING.md for the unit / selftest / e2e split.
- Run `dotnet build Reactor.slnx` and `dotnet test tests/Reactor.Tests` locally.
- First-time contributors: the Microsoft CLA bot will comment automatically; sign once and you're set.
-->

## Summary

<!-- One or two sentences: what changes, and why. -->

## Linked issue / spec

Fixes #913 

## Test plan

<!-- Bulleted list of how this was verified. Examples:
- [ ] Added unit tests in tests/Reactor.Tests/...
- [ ] Added selftest fixture in tests/Reactor.AppTests.Host/SelfTest/Fixtures/...
- [ ] Ran `dotnet test tests/Reactor.Tests`
- [ ] Manually ran `dotnet run --project samples/Reactor.TestApp`
-->

## Risk / breaking changes

<!-- Any public-API change, behavior shift, or perf-sensitive path? Flag it here. -->
