### PR TITLE
Add NavigationView pane-open change notification (#916)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,14 @@ Conventions for contributors:
 
 ### Added
 
+- **`NavigationView` pane-open change notification (issue #916).**
+  `NavigationViewElement.OnPaneOpenChanged` plus the `.PaneOpenChanged(handler)`
+  and paired `.IsPaneOpen(value, handler)` fluents report every `IsPaneOpen`
+  change on the realized control, so pane state can be driven from component
+  state. `SplitViewElement` gains the matching `.IsPaneOpen(value, handler)`
+  overload. `ControlDescriptor.Immediate` now accepts a `null` `loadedHook` for
+  DP observations that have no template part to walk.
+
 ### Changed
 
 ### Deprecated
@@ -35,6 +43,13 @@ Conventions for contributors:
 ### Removed
 
 ### Fixed
+
+- **`NavigationView` pane state no longer desyncs when the control moves its own
+  pane (issue #916).** `IsPaneOpen` could be written but had no change
+  notification, so a light dismiss or an adaptive display-mode change on resize
+  left the app's state stale — the next toggle wrote a value the control already
+  held and the pane appeared to need two clicks. Wire `.IsPaneOpen(value,
+  handler)` (or `.PaneOpenChanged(handler)`) to keep the two in sync.
 
 ### Security
 

--- a/docs/_pipeline/apps/navigation/App.cs
+++ b/docs/_pipeline/apps/navigation/App.cs
@@ -436,6 +436,29 @@ class PaneOpenChangedDemo : Component
 }
 // </snippet:nav-pane-open-changed>
 
+// <snippet:nav-pane-controlled>
+class ControlledPaneDemo : Component
+{
+    public override Element Render()
+    {
+        var (isPaneOpen, setIsPaneOpen) = UseState(true);
+
+        return NavigationView(
+            [
+                NavItem("Home", icon: "Home", tag: "Home"),
+                NavItem("Settings", icon: "Setting", tag: "Settings")
+            ],
+            content: Button(isPaneOpen ? "Close pane" : "Open pane",
+                () => setIsPaneOpen(!isPaneOpen)).Padding(24)
+        )
+        // One call sets the pane state and wires the change handler, so the two
+        // cannot drift apart.
+        .IsPaneOpen(isPaneOpen, setIsPaneOpen)
+        .Height(320);
+    }
+}
+// </snippet:nav-pane-controlled>
+
 
 // <snippet:frame-events>
 class FrameEventsDemo : Component
@@ -477,7 +500,8 @@ class NavigationApp : Component
                 Component<TabNavDemo>(),
                 Component<FrameEventsDemo>(),
                 Component<SelectedTagChangedDemo>(),
-                Component<PaneOpenChangedDemo>()
+                Component<PaneOpenChangedDemo>(),
+                Component<ControlledPaneDemo>()
             ).Padding(24)
         );
     }

--- a/docs/_pipeline/apps/navigation/App.cs
+++ b/docs/_pipeline/apps/navigation/App.cs
@@ -406,6 +406,37 @@ class SelectedTagChangedDemo : Component
 }
 // </snippet:nav-selected-tag-changed>
 
+// <snippet:nav-pane-open-changed>
+class PaneOpenChangedDemo : Component
+{
+    public override Element Render()
+    {
+        var (isPaneOpen, setIsPaneOpen) = UseState(true);
+
+        return (NavigationView(
+            [
+                NavItem("Home", icon: "Home", tag: "Home"),
+                NavItem("Settings", icon: "Setting", tag: "Settings")
+            ],
+            content: VStack(12,
+                Heading("Pane state"),
+                TextBlock(isPaneOpen ? "Pane is open" : "Pane is closed").Opacity(0.6),
+                Button(isPaneOpen ? "Close pane" : "Open pane",
+                    () => setIsPaneOpen(!isPaneOpen))
+            ).Padding(24)
+        ) with
+        {
+            IsPaneOpen = isPaneOpen,
+        })
+        // Light dismiss and adaptive display-mode changes move the pane without
+        // asking the app — push the new state back so the toggle stays truthful.
+        .PaneOpenChanged(setIsPaneOpen)
+        .Height(320);
+    }
+}
+// </snippet:nav-pane-open-changed>
+
+
 // <snippet:frame-events>
 class FrameEventsDemo : Component
 {
@@ -445,7 +476,8 @@ class NavigationApp : Component
                 Component<PageCachingDemo>(),
                 Component<TabNavDemo>(),
                 Component<FrameEventsDemo>(),
-                Component<SelectedTagChangedDemo>()
+                Component<SelectedTagChangedDemo>(),
+                Component<PaneOpenChangedDemo>()
             ).Padding(24)
         );
     }

--- a/docs/_pipeline/templates/navigation.md.dt
+++ b/docs/_pipeline/templates/navigation.md.dt
@@ -79,7 +79,7 @@ Here is what each piece does:
 | `UseNavigationLifecycle(...)` | hook | Page-side `onNavigatedTo` / `onNavigatingFrom` / `onNavigatedFrom`. The `from` callback receives a context with `.Cancel()`. |
 | `UseSystemBackButton(nav, window)` | hook | Wire the title-bar / hardware Back button to `nav.GoBack`. |
 | `NavigationHost(nav, routeMap)` | element | Renders the current route. Set `Transition`, `CacheMode`, `CacheSize`. |
-| `NavigationView(items, content)` | element | Sidebar shell. Use `.SelectedTagChanged(handler)` for selection events. |
+| `NavigationView(items, content)` | element | Sidebar shell. Use `.SelectedTagChanged(handler)` for selection events and `.PaneOpenChanged(handler)` to track the pane. |
 | `TabView(tabs)` | element | Parallel workspaces; tabs keep their own state. |
 | `BreadcrumbBar(items)` | element | Trail of ancestor routes for drill-down nav. |
 | `Frame(...)` | element | Raw WinUI Frame for XAML-page interop; `.Navigating`, `.Navigated`, `.NavigationFailed`. |
@@ -305,6 +305,23 @@ fires whenever the user picks a different `NavItem`:
 
 `SelectedTagChanged` receives the tag string (or `null` if no item is
 selected). Passing `null` to the fluent clears any previously-set handler.
+
+## NavigationView.PaneOpenChanged
+
+`IsPaneOpen` is controlled state, so it needs a matching change notification:
+`NavigationView` opens and closes its own pane in response to things your app
+never sees — a light dismiss tap in the content area, or an adaptive
+display-mode change as the window is resized. Wire `.PaneOpenChanged(handler)`
+and feed the value straight back into the state that drives `IsPaneOpen`:
+
+```csharp snippet="navigation/nav-pane-open-changed"
+```
+
+Without it the component state keeps the stale value, so the next toggle
+writes a value the control is already at and appears to do nothing — the pane
+takes two clicks to reopen. The callback also fires as the echo of your own
+`IsPaneOpen` write, which is a harmless no-op state update. Passing `null`
+clears the handler; `SplitView` exposes the same fluent.
 
 ## Navigation Diagnostics
 

--- a/docs/_pipeline/templates/navigation.md.dt
+++ b/docs/_pipeline/templates/navigation.md.dt
@@ -79,7 +79,7 @@ Here is what each piece does:
 | `UseNavigationLifecycle(...)` | hook | Page-side `onNavigatedTo` / `onNavigatingFrom` / `onNavigatedFrom`. The `from` callback receives a context with `.Cancel()`. |
 | `UseSystemBackButton(nav, window)` | hook | Wire the title-bar / hardware Back button to `nav.GoBack`. |
 | `NavigationHost(nav, routeMap)` | element | Renders the current route. Set `Transition`, `CacheMode`, `CacheSize`. |
-| `NavigationView(items, content)` | element | Sidebar shell. Use `.SelectedTagChanged(handler)` for selection events and `.PaneOpenChanged(handler)` to track the pane. |
+| `NavigationView(items, content)` | element | Sidebar shell. Use `.SelectedTagChanged(handler)` for selection events and `.IsPaneOpen(value, handler)` to drive the pane from state. |
 | `TabView(tabs)` | element | Parallel workspaces; tabs keep their own state. |
 | `BreadcrumbBar(items)` | element | Trail of ancestor routes for drill-down nav. |
 | `Frame(...)` | element | Raw WinUI Frame for XAML-page interop; `.Navigating`, `.Navigated`, `.NavigationFailed`. |
@@ -321,7 +321,17 @@ Without it the component state keeps the stale value, so the next toggle
 writes a value the control is already at and appears to do nothing — the pane
 takes two clicks to reopen. The callback also fires as the echo of your own
 `IsPaneOpen` write, which is a harmless no-op state update. Passing `null`
-clears the handler; `SplitView` exposes the same fluent.
+clears the handler.
+
+Because the two always belong together, there is a paired overload that sets
+the state and wires the handler in one call — reach for it whenever the pane
+is driven from state:
+
+```csharp snippet="navigation/nav-pane-controlled"
+```
+
+`SplitView` exposes the same `.PaneOpenChanged(handler)` and
+`.IsPaneOpen(value, handler)` pair.
 
 ## Navigation Diagnostics
 

--- a/docs/guide/navigation.md
+++ b/docs/guide/navigation.md
@@ -91,7 +91,7 @@ Here is what each piece does:
 | `UseNavigationLifecycle(...)` | hook | Page-side `onNavigatedTo` / `onNavigatingFrom` / `onNavigatedFrom`. The `from` callback receives a context with `.Cancel()`. |
 | `UseSystemBackButton(nav, window)` | hook | Wire the title-bar / hardware Back button to `nav.GoBack`. |
 | `NavigationHost(nav, routeMap)` | element | Renders the current route. Set `Transition`, `CacheMode`, `CacheSize`. |
-| `NavigationView(items, content)` | element | Sidebar shell. Use `.SelectedTagChanged(handler)` for selection events and `.PaneOpenChanged(handler)` to track the pane. |
+| `NavigationView(items, content)` | element | Sidebar shell. Use `.SelectedTagChanged(handler)` for selection events and `.IsPaneOpen(value, handler)` to drive the pane from state. |
 | `TabView(tabs)` | element | Parallel workspaces; tabs keep their own state. |
 | `BreadcrumbBar(items)` | element | Trail of ancestor routes for drill-down nav. |
 | `Frame(...)` | element | Raw WinUI Frame for XAML-page interop; `.Navigating`, `.Navigated`, `.NavigationFailed`. |
@@ -667,7 +667,37 @@ Without it the component state keeps the stale value, so the next toggle
 writes a value the control is already at and appears to do nothing — the pane
 takes two clicks to reopen. The callback also fires as the echo of your own
 `IsPaneOpen` write, which is a harmless no-op state update. Passing `null`
-clears the handler; `SplitView` exposes the same fluent.
+clears the handler.
+
+Because the two always belong together, there is a paired overload that sets
+the state and wires the handler in one call — reach for it whenever the pane
+is driven from state:
+
+```csharp
+class ControlledPaneDemo : Component
+{
+    public override Element Render()
+    {
+        var (isPaneOpen, setIsPaneOpen) = UseState(true);
+
+        return NavigationView(
+            [
+                NavItem("Home", icon: "Home", tag: "Home"),
+                NavItem("Settings", icon: "Setting", tag: "Settings")
+            ],
+            content: Button(isPaneOpen ? "Close pane" : "Open pane",
+                () => setIsPaneOpen(!isPaneOpen)).Padding(24)
+        )
+        // One call sets the pane state and wires the change handler, so the two
+        // cannot drift apart.
+        .IsPaneOpen(isPaneOpen, setIsPaneOpen)
+        .Height(320);
+    }
+}
+```
+
+`SplitView` exposes the same `.PaneOpenChanged(handler)` and
+`.IsPaneOpen(value, handler)` pair.
 
 ## Navigation Diagnostics
 

--- a/docs/guide/navigation.md
+++ b/docs/guide/navigation.md
@@ -91,7 +91,7 @@ Here is what each piece does:
 | `UseNavigationLifecycle(...)` | hook | Page-side `onNavigatedTo` / `onNavigatingFrom` / `onNavigatedFrom`. The `from` callback receives a context with `.Cancel()`. |
 | `UseSystemBackButton(nav, window)` | hook | Wire the title-bar / hardware Back button to `nav.GoBack`. |
 | `NavigationHost(nav, routeMap)` | element | Renders the current route. Set `Transition`, `CacheMode`, `CacheSize`. |
-| `NavigationView(items, content)` | element | Sidebar shell. Use `.SelectedTagChanged(handler)` for selection events. |
+| `NavigationView(items, content)` | element | Sidebar shell. Use `.SelectedTagChanged(handler)` for selection events and `.PaneOpenChanged(handler)` to track the pane. |
 | `TabView(tabs)` | element | Parallel workspaces; tabs keep their own state. |
 | `BreadcrumbBar(items)` | element | Trail of ancestor routes for drill-down nav. |
 | `Frame(...)` | element | Raw WinUI Frame for XAML-page interop; `.Navigating`, `.Navigated`, `.NavigationFailed`. |
@@ -624,6 +624,50 @@ class SelectedTagChangedDemo : Component
 
 `SelectedTagChanged` receives the tag string (or `null` if no item is
 selected). Passing `null` to the fluent clears any previously-set handler.
+
+## NavigationView.PaneOpenChanged
+
+`IsPaneOpen` is controlled state, so it needs a matching change notification:
+`NavigationView` opens and closes its own pane in response to things your app
+never sees — a light dismiss tap in the content area, or an adaptive
+display-mode change as the window is resized. Wire `.PaneOpenChanged(handler)`
+and feed the value straight back into the state that drives `IsPaneOpen`:
+
+```csharp
+class PaneOpenChangedDemo : Component
+{
+    public override Element Render()
+    {
+        var (isPaneOpen, setIsPaneOpen) = UseState(true);
+
+        return (NavigationView(
+            [
+                NavItem("Home", icon: "Home", tag: "Home"),
+                NavItem("Settings", icon: "Setting", tag: "Settings")
+            ],
+            content: VStack(12,
+                Heading("Pane state"),
+                TextBlock(isPaneOpen ? "Pane is open" : "Pane is closed").Opacity(0.6),
+                Button(isPaneOpen ? "Close pane" : "Open pane",
+                    () => setIsPaneOpen(!isPaneOpen))
+            ).Padding(24)
+        ) with
+        {
+            IsPaneOpen = isPaneOpen,
+        })
+        // Light dismiss and adaptive display-mode changes move the pane without
+        // asking the app — push the new state back so the toggle stays truthful.
+        .PaneOpenChanged(setIsPaneOpen)
+        .Height(320);
+    }
+}
+```
+
+Without it the component state keeps the stale value, so the next toggle
+writes a value the control is already at and appears to do nothing — the pane
+takes two clicks to reopen. The callback also fires as the echo of your own
+`IsPaneOpen` write, which is a harmless no-op state update. Passing `null`
+clears the handler; `SplitView` exposes the same fluent.
 
 ## Navigation Diagnostics
 

--- a/plugins/reactor/skills/reactor-dsl/references/reactor.api.txt
+++ b/plugins/reactor/skills/reactor-dsl/references/reactor.api.txt
@@ -406,6 +406,7 @@ NavigationViewElement.AutoSuggestBox(AutoSuggestBoxElement box) → NavigationVi
 NavigationViewElement.BackRequested(Action handler) → NavigationViewElement
 NavigationViewElement.CompactModeThresholdWidth(double width) → NavigationViewElement
 NavigationViewElement.ExpandedModeThresholdWidth(double width) → NavigationViewElement
+NavigationViewElement.IsPaneOpen(bool isPaneOpen, Action<bool> onPaneOpenChanged) → NavigationViewElement
 NavigationViewElement.OpenPaneLength(double length) → NavigationViewElement
 NavigationViewElement.PaneCustomContent(Element content) → NavigationViewElement
 NavigationViewElement.PaneDisplayMode(NavigationViewPaneDisplayMode mode) → NavigationViewElement
@@ -550,6 +551,7 @@ SplitButtonElement.AccentButton() → SplitButtonElement
 SplitButtonElement.Click(Action handler) → SplitButtonElement
 SplitButtonElement.Set(Action<SplitButton> configure) → SplitButtonElement
 SplitButtonElement.SubtleButton() → SplitButtonElement
+SplitViewElement.IsPaneOpen(bool isPaneOpen, Action<bool> onPaneOpenChanged) → SplitViewElement
 SplitViewElement.LightDismissOverlayMode(LightDismissOverlayMode mode) → SplitViewElement
 SplitViewElement.PaneBackground(Brush brush) → SplitViewElement
 SplitViewElement.PaneBackground(ThemeRef theme) → SplitViewElement

--- a/plugins/reactor/skills/reactor-dsl/references/reactor.api.txt
+++ b/plugins/reactor/skills/reactor-dsl/references/reactor.api.txt
@@ -410,6 +410,7 @@ NavigationViewElement.OpenPaneLength(double length) → NavigationViewElement
 NavigationViewElement.PaneCustomContent(Element content) → NavigationViewElement
 NavigationViewElement.PaneDisplayMode(NavigationViewPaneDisplayMode mode) → NavigationViewElement
 NavigationViewElement.PaneFooter(Element footer) → NavigationViewElement
+NavigationViewElement.PaneOpenChanged(Action<bool> handler) → NavigationViewElement
 NavigationViewElement.PaneTitle(string title) → NavigationViewElement
 NavigationViewElement.SelectedTagChanged(Action<string> handler) → NavigationViewElement
 NavigationViewElement.Set(Action<NavigationView> configure) → NavigationViewElement
@@ -4749,6 +4750,7 @@ ToString() → string
 ### record NavigationViewElement
 new(NavigationViewItemData[] MenuItems, Element Content = null)
 Action OnBackRequested { get; init; }
+Action<bool> OnPaneOpenChanged { get; init; }
 Action<string> OnSelectedTagChanged { get; init; }
 AutoSuggestBoxElement AutoSuggestBox { get; init; }
 Element Content { get; init; }

--- a/skills/reactor.api.txt
+++ b/skills/reactor.api.txt
@@ -406,6 +406,7 @@ NavigationViewElement.AutoSuggestBox(AutoSuggestBoxElement box) → NavigationVi
 NavigationViewElement.BackRequested(Action handler) → NavigationViewElement
 NavigationViewElement.CompactModeThresholdWidth(double width) → NavigationViewElement
 NavigationViewElement.ExpandedModeThresholdWidth(double width) → NavigationViewElement
+NavigationViewElement.IsPaneOpen(bool isPaneOpen, Action<bool> onPaneOpenChanged) → NavigationViewElement
 NavigationViewElement.OpenPaneLength(double length) → NavigationViewElement
 NavigationViewElement.PaneCustomContent(Element content) → NavigationViewElement
 NavigationViewElement.PaneDisplayMode(NavigationViewPaneDisplayMode mode) → NavigationViewElement
@@ -550,6 +551,7 @@ SplitButtonElement.AccentButton() → SplitButtonElement
 SplitButtonElement.Click(Action handler) → SplitButtonElement
 SplitButtonElement.Set(Action<SplitButton> configure) → SplitButtonElement
 SplitButtonElement.SubtleButton() → SplitButtonElement
+SplitViewElement.IsPaneOpen(bool isPaneOpen, Action<bool> onPaneOpenChanged) → SplitViewElement
 SplitViewElement.LightDismissOverlayMode(LightDismissOverlayMode mode) → SplitViewElement
 SplitViewElement.PaneBackground(Brush brush) → SplitViewElement
 SplitViewElement.PaneBackground(ThemeRef theme) → SplitViewElement

--- a/skills/reactor.api.txt
+++ b/skills/reactor.api.txt
@@ -410,6 +410,7 @@ NavigationViewElement.OpenPaneLength(double length) → NavigationViewElement
 NavigationViewElement.PaneCustomContent(Element content) → NavigationViewElement
 NavigationViewElement.PaneDisplayMode(NavigationViewPaneDisplayMode mode) → NavigationViewElement
 NavigationViewElement.PaneFooter(Element footer) → NavigationViewElement
+NavigationViewElement.PaneOpenChanged(Action<bool> handler) → NavigationViewElement
 NavigationViewElement.PaneTitle(string title) → NavigationViewElement
 NavigationViewElement.SelectedTagChanged(Action<string> handler) → NavigationViewElement
 NavigationViewElement.Set(Action<NavigationView> configure) → NavigationViewElement
@@ -4749,6 +4750,7 @@ ToString() → string
 ### record NavigationViewElement
 new(NavigationViewItemData[] MenuItems, Element Content = null)
 Action OnBackRequested { get; init; }
+Action<bool> OnPaneOpenChanged { get; init; }
 Action<string> OnSelectedTagChanged { get; init; }
 AutoSuggestBoxElement AutoSuggestBox { get; init; }
 Element Content { get; init; }

--- a/src/Reactor/Core/Element.NavigationView.cs
+++ b/src/Reactor/Core/Element.NavigationView.cs
@@ -10,7 +10,7 @@ namespace Microsoft.UI.Reactor.Core;
 
 // Spec 058 §15 (P5.23) — NavigationView's bespoke surface: 5 NamedSlots, the MenuItems +
 // SelectedTag menu reconciler (.Imperative), and the SelectionChanged/BackRequested events.
-// Issue #916 added the PaneOpening/PaneClosing pair behind OnPaneOpenChanged.
+// Issue #916 added an IsPaneOpen DP observation behind OnPaneOpenChanged.
 // IsPaneOpen/PaneDisplayMode/IsBackEnabled/IsSettingsVisible/PaneTitle auto-map (in Element.cs).
 // All reproduced verbatim from the deleted NavigationViewDescriptor.
 public partial record NavigationViewElement
@@ -29,18 +29,23 @@ public partial record NavigationViewElement
             (Reconciler.GetElementTag(s) as NavigationViewElement)?.OnBackRequested?.Invoke();
 
     // Issue #916 — the pane can open/close without the app asking (light dismiss, adaptive
-    // display-mode changes). Without these, a controlled IsPaneOpen drifts out of sync and the
-    // next toggle writes a value the control already holds. PaneOpening/PaneClosing (not the
-    // …ed pair) so the app learns the new state immediately: PaneClosed only fires once the
-    // close transition finishes, which would leave a toggle pressed mid-animation stale.
-    // Mirrors SplitViewElement's twin trampolines.
-    private static readonly TypedEventHandler<WinUI.NavigationView, object>
-        __PaneOpeningTrampoline = (s, _) =>
-            (Reconciler.GetElementTag(s) as NavigationViewElement)?.OnPaneOpenChanged?.Invoke(true);
-
-    private static readonly TypedEventHandler<WinUI.NavigationView, WinUI.NavigationViewPaneClosingEventArgs>
-        __PaneClosingTrampoline = (s, _) =>
-            (Reconciler.GetElementTag(s) as NavigationViewElement)?.OnPaneOpenChanged?.Invoke(false);
+    // display-mode changes). Without a notification a controlled IsPaneOpen drifts out of sync
+    // and the next toggle writes a value the control already holds. We observe the IsPaneOpen
+    // DP rather than the PaneOpening/PaneClosing pair, because the DP is precisely what the
+    // reconciler diffs against: the reported bool can never disagree with the control (a
+    // cancelled PaneClosing still leaves the DP at the requested value, so an event-sourced
+    // callback would hand the app a value the next diff then treats as a no-op write). It also
+    // beats PaneOpened/PaneClosed, which only arrive once the pane transition finishes.
+    //
+    // A programmatic write echoes the app's own value straight back (a no-op setState). Like
+    // every trampoline here, the echo of a write performed during Update runs before the new
+    // element is tagged, so it dispatches through the previous render's callback.
+    private static readonly DependencyPropertyChangedCallback __IsPaneOpenObserver = (d, _) =>
+    {
+        if (d is not WinUI.NavigationView control) return;
+        (Reconciler.GetElementTag(control) as NavigationViewElement)?
+            .OnPaneOpenChanged?.Invoke(control.IsPaneOpen);
+    };
 
     private static partial Desc.ControlDescriptor<NavigationViewElement, WinUI.NavigationView> Customize(
         Desc.ControlDescriptor<NavigationViewElement, WinUI.NavigationView> d)
@@ -117,20 +122,13 @@ public partial record NavigationViewElement
                 trampoline:       __BackRequestedTrampoline,
                 slotIsNull:       static p => p.BackRequestedTrampoline is null,
                 setSlot:          static (p, h) => p.BackRequestedTrampoline = h)
-            .HandCodedEvent<V1.NavigationViewEventPayload,
-                TypedEventHandler<WinUI.NavigationView, object>>(
-                subscribe:        static (c, h) => c.PaneOpening += h,
-                callbackPresent:  static e => e.OnPaneOpenChanged,
-                trampoline:       __PaneOpeningTrampoline,
-                slotIsNull:       static p => p.PaneOpeningTrampoline is null,
-                setSlot:          static (p, h) => p.PaneOpeningTrampoline = h)
-            .HandCodedEvent<V1.NavigationViewEventPayload,
-                TypedEventHandler<WinUI.NavigationView, WinUI.NavigationViewPaneClosingEventArgs>>(
-                subscribe:        static (c, h) => c.PaneClosing += h,
-                callbackPresent:  static e => e.OnPaneOpenChanged,
-                trampoline:       __PaneClosingTrampoline,
-                slotIsNull:       static p => p.PaneClosingTrampoline is null,
-                setSlot:          static (p, h) => p.PaneClosingTrampoline = h);
+            .Immediate<V1.NavigationViewEventPayload>(
+                callbackGate:      static e => e.OnPaneOpenChanged,
+                observeProperty:   WinUI.NavigationView.IsPaneOpenProperty,
+                observeCallback:   __IsPaneOpenObserver,
+                observeSlotIsNull: static p => p.IsPaneOpenObserver is null,
+                setObserveSlot:    static (p, cb) => p.IsPaneOpenObserver = cb,
+                loadedHook:        null);
     }
 
     private static void ApplyMenuAndSelection(WinUI.NavigationView control, NavigationViewElement? oldElement, NavigationViewElement element)

--- a/src/Reactor/Core/Element.NavigationView.cs
+++ b/src/Reactor/Core/Element.NavigationView.cs
@@ -10,6 +10,7 @@ namespace Microsoft.UI.Reactor.Core;
 
 // Spec 058 §15 (P5.23) — NavigationView's bespoke surface: 5 NamedSlots, the MenuItems +
 // SelectedTag menu reconciler (.Imperative), and the SelectionChanged/BackRequested events.
+// Issue #916 added the PaneOpening/PaneClosing pair behind OnPaneOpenChanged.
 // IsPaneOpen/PaneDisplayMode/IsBackEnabled/IsSettingsVisible/PaneTitle auto-map (in Element.cs).
 // All reproduced verbatim from the deleted NavigationViewDescriptor.
 public partial record NavigationViewElement
@@ -26,6 +27,20 @@ public partial record NavigationViewElement
     private static readonly TypedEventHandler<WinUI.NavigationView, WinUI.NavigationViewBackRequestedEventArgs>
         __BackRequestedTrampoline = (s, _) =>
             (Reconciler.GetElementTag(s) as NavigationViewElement)?.OnBackRequested?.Invoke();
+
+    // Issue #916 — the pane can open/close without the app asking (light dismiss, adaptive
+    // display-mode changes). Without these, a controlled IsPaneOpen drifts out of sync and the
+    // next toggle writes a value the control already holds. PaneOpening/PaneClosing (not the
+    // …ed pair) so the app learns the new state immediately: PaneClosed only fires once the
+    // close transition finishes, which would leave a toggle pressed mid-animation stale.
+    // Mirrors SplitViewElement's twin trampolines.
+    private static readonly TypedEventHandler<WinUI.NavigationView, object>
+        __PaneOpeningTrampoline = (s, _) =>
+            (Reconciler.GetElementTag(s) as NavigationViewElement)?.OnPaneOpenChanged?.Invoke(true);
+
+    private static readonly TypedEventHandler<WinUI.NavigationView, WinUI.NavigationViewPaneClosingEventArgs>
+        __PaneClosingTrampoline = (s, _) =>
+            (Reconciler.GetElementTag(s) as NavigationViewElement)?.OnPaneOpenChanged?.Invoke(false);
 
     private static partial Desc.ControlDescriptor<NavigationViewElement, WinUI.NavigationView> Customize(
         Desc.ControlDescriptor<NavigationViewElement, WinUI.NavigationView> d)
@@ -101,7 +116,21 @@ public partial record NavigationViewElement
                 callbackPresent:  static e => e.OnBackRequested,
                 trampoline:       __BackRequestedTrampoline,
                 slotIsNull:       static p => p.BackRequestedTrampoline is null,
-                setSlot:          static (p, h) => p.BackRequestedTrampoline = h);
+                setSlot:          static (p, h) => p.BackRequestedTrampoline = h)
+            .HandCodedEvent<V1.NavigationViewEventPayload,
+                TypedEventHandler<WinUI.NavigationView, object>>(
+                subscribe:        static (c, h) => c.PaneOpening += h,
+                callbackPresent:  static e => e.OnPaneOpenChanged,
+                trampoline:       __PaneOpeningTrampoline,
+                slotIsNull:       static p => p.PaneOpeningTrampoline is null,
+                setSlot:          static (p, h) => p.PaneOpeningTrampoline = h)
+            .HandCodedEvent<V1.NavigationViewEventPayload,
+                TypedEventHandler<WinUI.NavigationView, WinUI.NavigationViewPaneClosingEventArgs>>(
+                subscribe:        static (c, h) => c.PaneClosing += h,
+                callbackPresent:  static e => e.OnPaneOpenChanged,
+                trampoline:       __PaneClosingTrampoline,
+                slotIsNull:       static p => p.PaneClosingTrampoline is null,
+                setSlot:          static (p, h) => p.PaneClosingTrampoline = h);
     }
 
     private static void ApplyMenuAndSelection(WinUI.NavigationView control, NavigationViewElement? oldElement, NavigationViewElement element)

--- a/src/Reactor/Core/Element.cs
+++ b/src/Reactor/Core/Element.cs
@@ -4574,8 +4574,8 @@ public record NavigationHostElement(
 // auto-map. The 5 NamedSlots (Header/AutoSuggestBox/PaneFooter/PaneCustomContent/Content), the
 // MenuItems+SelectedTag menu reconciler (.Imperative), the 3 NaN-sentinel pane widths, and the
 // SelectionChanged/BackRequested events are bespoke — in Element.NavigationView.cs. BackRequested
-// is Excluded (auto-surfaces). Issue #916 — the twin PaneOpening/PaneClosing events
-// (OnPaneOpenChanged) are bespoke too, so IsPaneOpen can be used as controlled state.
+// is Excluded (auto-surfaces). Issue #916 — an IsPaneOpen DP observation
+// (OnPaneOpenChanged) is bespoke too, so IsPaneOpen can be used as controlled state.
 // Replaces NavigationViewDescriptor.
 [global::Microsoft.UI.Reactor.Wrappers.GenerateReactorDescriptor(typeof(WinUI.NavigationView), Exclude = new[] { "BackRequested" })]
 [global::Microsoft.UI.Reactor.Wrappers.WrapManual("MenuItems")]
@@ -4597,11 +4597,11 @@ public partial record NavigationViewElement(
     public Action<string?>? OnSelectedTagChanged { get; init; }
     public bool IsPaneOpen { get; init; } = true;
     /// <summary>
-    /// Fires whenever the realized pane opens or closes — including changes the app never
-    /// requested (light dismiss, adaptive display-mode changes on resize) and the echo of a
-    /// programmatic <see cref="IsPaneOpen"/> write. Feed the value back into the state that
-    /// drives <see cref="IsPaneOpen"/> to keep controlled pane state in sync (issue #916).
-    /// Mirrors <c>SplitViewElement.OnPaneOpenChanged</c>.
+    /// Fires whenever the realized control's <c>IsPaneOpen</c> changes — including changes the
+    /// app never requested (light dismiss, adaptive display-mode changes on resize) and the
+    /// echo of a programmatic <see cref="IsPaneOpen"/> write. Feed the value back into the
+    /// state that drives <see cref="IsPaneOpen"/> to keep controlled pane state in sync
+    /// (issue #916). Same shape as <c>SplitViewElement.OnPaneOpenChanged</c>.
     /// </summary>
     public Action<bool>? OnPaneOpenChanged { get; init; }
     public NavigationViewPaneDisplayMode PaneDisplayMode { get; init; } = NavigationViewPaneDisplayMode.Auto;

--- a/src/Reactor/Core/Element.cs
+++ b/src/Reactor/Core/Element.cs
@@ -4574,7 +4574,9 @@ public record NavigationHostElement(
 // auto-map. The 5 NamedSlots (Header/AutoSuggestBox/PaneFooter/PaneCustomContent/Content), the
 // MenuItems+SelectedTag menu reconciler (.Imperative), the 3 NaN-sentinel pane widths, and the
 // SelectionChanged/BackRequested events are bespoke — in Element.NavigationView.cs. BackRequested
-// is Excluded (auto-surfaces). Replaces NavigationViewDescriptor.
+// is Excluded (auto-surfaces). Issue #916 — the twin PaneOpening/PaneClosing events
+// (OnPaneOpenChanged) are bespoke too, so IsPaneOpen can be used as controlled state.
+// Replaces NavigationViewDescriptor.
 [global::Microsoft.UI.Reactor.Wrappers.GenerateReactorDescriptor(typeof(WinUI.NavigationView), Exclude = new[] { "BackRequested" })]
 [global::Microsoft.UI.Reactor.Wrappers.WrapManual("MenuItems")]
 [global::Microsoft.UI.Reactor.Wrappers.WrapManual("SelectedTag")]
@@ -4594,6 +4596,14 @@ public partial record NavigationViewElement(
     public string? SelectedTag { get; init; }
     public Action<string?>? OnSelectedTagChanged { get; init; }
     public bool IsPaneOpen { get; init; } = true;
+    /// <summary>
+    /// Fires whenever the realized pane opens or closes — including changes the app never
+    /// requested (light dismiss, adaptive display-mode changes on resize) and the echo of a
+    /// programmatic <see cref="IsPaneOpen"/> write. Feed the value back into the state that
+    /// drives <see cref="IsPaneOpen"/> to keep controlled pane state in sync (issue #916).
+    /// Mirrors <c>SplitViewElement.OnPaneOpenChanged</c>.
+    /// </summary>
+    public Action<bool>? OnPaneOpenChanged { get; init; }
     public NavigationViewPaneDisplayMode PaneDisplayMode { get; init; } = NavigationViewPaneDisplayMode.Auto;
     public bool IsBackEnabled { get; init; }
     public Action? OnBackRequested { get; init; }
@@ -4613,7 +4623,8 @@ public partial record NavigationViewElement(
     /// <summary>Window width at which the pane auto-expands. <c>NaN</c> uses the WinUI default (1008).</summary>
     public double ExpandedModeThresholdWidth { get; init; } = double.NaN;
     internal Action<WinUI.NavigationView>[] Setters { get; init; } = [];
-    internal override bool HasCallbacks => OnSelectedTagChanged is not null || OnBackRequested is not null;
+    internal override bool HasCallbacks =>
+        OnSelectedTagChanged is not null || OnBackRequested is not null || OnPaneOpenChanged is not null;
 }
 
 // Spec 058 §15 (P5.23) — Title/Subtitle/IsBackButtonVisible/IsBackButtonEnabled/

--- a/src/Reactor/Core/V1Protocol/ControlEventPayloads.cs
+++ b/src/Reactor/Core/V1Protocol/ControlEventPayloads.cs
@@ -441,7 +441,13 @@ internal sealed class TitleBarEventPayload
     public global::Windows.Foundation.TypedEventHandler<Microsoft.UI.Xaml.Controls.TitleBar, object>? PaneToggleRequestedTrampoline;
 }
 
-/// <summary>Spec 047 §14 Phase 3 deferred controls — NavigationView event payload.</summary>
+/// <summary>Spec 047 §14 Phase 3 deferred controls — NavigationView event payload.
+/// <para>Issue #916 — <c>PaneOpening</c> / <c>PaneClosing</c> are fire-only
+/// <c>.HandCodedEvent</c> trampolines (mirrors <see cref="SplitViewEventPayload"/>);
+/// both invoke <c>OnPaneOpenChanged</c> with the corresponding bool. The
+/// <c>…ing</c> pair is used rather than <c>PaneOpened</c>/<c>PaneClosed</c>
+/// so the app sees the new state immediately instead of after the pane
+/// transition finishes.</para></summary>
 internal sealed class NavigationViewEventPayload
 {
     public global::Windows.Foundation.TypedEventHandler<
@@ -450,6 +456,11 @@ internal sealed class NavigationViewEventPayload
     public global::Windows.Foundation.TypedEventHandler<
         Microsoft.UI.Xaml.Controls.NavigationView,
         Microsoft.UI.Xaml.Controls.NavigationViewBackRequestedEventArgs>? BackRequestedTrampoline;
+    public global::Windows.Foundation.TypedEventHandler<
+        Microsoft.UI.Xaml.Controls.NavigationView, object>? PaneOpeningTrampoline;
+    public global::Windows.Foundation.TypedEventHandler<
+        Microsoft.UI.Xaml.Controls.NavigationView,
+        Microsoft.UI.Xaml.Controls.NavigationViewPaneClosingEventArgs>? PaneClosingTrampoline;
 }
 
 /// <summary>

--- a/src/Reactor/Core/V1Protocol/ControlEventPayloads.cs
+++ b/src/Reactor/Core/V1Protocol/ControlEventPayloads.cs
@@ -442,12 +442,12 @@ internal sealed class TitleBarEventPayload
 }
 
 /// <summary>Spec 047 §14 Phase 3 deferred controls — NavigationView event payload.
-/// <para>Issue #916 — <c>PaneOpening</c> / <c>PaneClosing</c> are fire-only
-/// <c>.HandCodedEvent</c> trampolines (mirrors <see cref="SplitViewEventPayload"/>);
-/// both invoke <c>OnPaneOpenChanged</c> with the corresponding bool. The
-/// <c>…ing</c> pair is used rather than <c>PaneOpened</c>/<c>PaneClosed</c>
-/// so the app sees the new state immediately instead of after the pane
-/// transition finishes.</para></summary>
+/// <para>Issue #916 — <c>IsPaneOpenObserver</c> is the <c>.Immediate</c> entry's
+/// <c>IsPaneOpen</c> DP-changed callback, which invokes <c>OnPaneOpenChanged</c>
+/// with the control's current value. Observing the DP (rather than the
+/// <c>PaneOpening</c>/<c>PaneClosing</c> pair <c>SplitViewEventPayload</c> uses)
+/// keeps the reported value identical to the property the reconciler diffs
+/// against, including when a pane close is cancelled.</para></summary>
 internal sealed class NavigationViewEventPayload
 {
     public global::Windows.Foundation.TypedEventHandler<
@@ -456,11 +456,7 @@ internal sealed class NavigationViewEventPayload
     public global::Windows.Foundation.TypedEventHandler<
         Microsoft.UI.Xaml.Controls.NavigationView,
         Microsoft.UI.Xaml.Controls.NavigationViewBackRequestedEventArgs>? BackRequestedTrampoline;
-    public global::Windows.Foundation.TypedEventHandler<
-        Microsoft.UI.Xaml.Controls.NavigationView, object>? PaneOpeningTrampoline;
-    public global::Windows.Foundation.TypedEventHandler<
-        Microsoft.UI.Xaml.Controls.NavigationView,
-        Microsoft.UI.Xaml.Controls.NavigationViewPaneClosingEventArgs>? PaneClosingTrampoline;
+    public Microsoft.UI.Xaml.DependencyPropertyChangedCallback? IsPaneOpenObserver;
 }
 
 /// <summary>

--- a/src/Reactor/Core/V1Protocol/Descriptor/ControlDescriptor.cs
+++ b/src/Reactor/Core/V1Protocol/Descriptor/ControlDescriptor.cs
@@ -406,14 +406,16 @@ public sealed class ControlDescriptor<TElement, TControl>
     /// trampoline" pattern. The control's primary DP round-trip stays on a
     /// sibling <c>.HandCodedControlled</c> entry. See
     /// <see cref="ImmediatePropEntry{TElement,TControl,TPayload}"/> for the
-    /// shape contract (NumberBox is the canonical proof point).</summary>
+    /// shape contract (NumberBox is the canonical proof point). Pass
+    /// <paramref name="loadedHook"/> as <c>null</c> when the DP observation is
+    /// the whole subscription and there is no template part to walk.</summary>
     public ControlDescriptor<TElement, TControl> Immediate<TPayload>(
         Func<TElement, Delegate?> callbackGate,
         Microsoft.UI.Xaml.DependencyProperty observeProperty,
         Microsoft.UI.Xaml.DependencyPropertyChangedCallback observeCallback,
         Func<TPayload, bool> observeSlotIsNull,
         Action<TPayload, Microsoft.UI.Xaml.DependencyPropertyChangedCallback> setObserveSlot,
-        Microsoft.UI.Xaml.RoutedEventHandler loadedHook)
+        Microsoft.UI.Xaml.RoutedEventHandler? loadedHook)
         where TPayload : class, new()
     {
         _properties.Add(new ImmediatePropEntry<TElement, TControl, TPayload>(

--- a/src/Reactor/Core/V1Protocol/Descriptor/PropEntry.cs
+++ b/src/Reactor/Core/V1Protocol/Descriptor/PropEntry.cs
@@ -1088,7 +1088,7 @@ internal sealed class ImmediatePropEntry<TElement, TControl, TPayload> : PropEnt
     private readonly Microsoft.UI.Xaml.DependencyPropertyChangedCallback _observeCallback;
     private readonly Func<TPayload, bool> _observeSlotIsNull;
     private readonly Action<TPayload, Microsoft.UI.Xaml.DependencyPropertyChangedCallback> _setObserveSlot;
-    private readonly Microsoft.UI.Xaml.RoutedEventHandler _loadedHook;
+    private readonly Microsoft.UI.Xaml.RoutedEventHandler? _loadedHook;
 
     public ImmediatePropEntry(
         Func<TElement, Delegate?> callbackGate,
@@ -1096,7 +1096,7 @@ internal sealed class ImmediatePropEntry<TElement, TControl, TPayload> : PropEnt
         Microsoft.UI.Xaml.DependencyPropertyChangedCallback observeCallback,
         Func<TPayload, bool> observeSlotIsNull,
         Action<TPayload, Microsoft.UI.Xaml.DependencyPropertyChangedCallback> setObserveSlot,
-        Microsoft.UI.Xaml.RoutedEventHandler loadedHook)
+        Microsoft.UI.Xaml.RoutedEventHandler? loadedHook)
     {
         _callbackGate = callbackGate;
         _observeProperty = observeProperty;
@@ -1121,8 +1121,11 @@ internal sealed class ImmediatePropEntry<TElement, TControl, TPayload> : PropEnt
         ctrl.RegisterPropertyChangedCallback(_observeProperty, _observeCallback);
         // Loaded fires on each attach; the author's hook is responsible for
         // its own idempotency (typically by flipping a flag on the payload
-        // and self-unsubscribing). The entry doesn't track that.
-        ctrl.Loaded += _loadedHook;
+        // and self-unsubscribing). The entry doesn't track that. A null hook
+        // means the DP observation is the whole subscription (issue #916 —
+        // NavigationView.IsPaneOpen has no inner template part to walk).
+        if (_loadedHook is not null)
+            ctrl.Loaded += _loadedHook;
     }
 }
 

--- a/src/Reactor/Elements/ElementExtensions.Events.cs
+++ b/src/Reactor/Elements/ElementExtensions.Events.cs
@@ -212,6 +212,15 @@ public static partial class ElementExtensions
     public static NavigationViewElement BackRequested(this NavigationViewElement el, Action? handler) =>
         el with { OnBackRequested = handler };
 
+    /// <summary>
+    /// Wires the pane-open-state-changed handler. Fires for pane changes the app never
+    /// requested (light dismiss, adaptive display-mode changes) as well as the echo of a
+    /// programmatic <c>IsPaneOpen</c> write — feed the value back into the state that drives
+    /// <c>IsPaneOpen</c> to keep controlled pane state in sync. Passing <c>null</c> clears.
+    /// </summary>
+    public static NavigationViewElement PaneOpenChanged(this NavigationViewElement el, Action<bool>? handler) =>
+        el with { OnPaneOpenChanged = handler };
+
     /// <summary>Wires the back-requested handler. Passing <c>null</c> clears.</summary>
     public static TitleBarElement BackRequested(this TitleBarElement el, Action? handler) =>
         el with { OnBackRequested = handler };

--- a/src/Reactor/Elements/ElementExtensions.cs
+++ b/src/Reactor/Elements/ElementExtensions.cs
@@ -1587,6 +1587,21 @@ public static partial class ElementExtensions
     public static SplitViewElement LightDismissOverlayMode(this SplitViewElement el, LightDismissOverlayMode mode) =>
         el with { LightDismissOverlayMode = mode };
 
+    /// <summary>
+    /// Controlled pane state: sets <c>IsPaneOpen</c> and wires the matching change
+    /// handler in one call. The handler is required because the control opens and
+    /// closes its own pane (light dismiss, adaptive display-mode changes) — driving
+    /// <c>IsPaneOpen</c> from state without feeding those changes back leaves the
+    /// state stale, so the next toggle writes a value the control already holds and
+    /// appears to do nothing (issue #916). Use the <c>IsPaneOpen</c> initializer
+    /// directly only for a pane whose state the app never changes.
+    /// </summary>
+    public static SplitViewElement IsPaneOpen(
+        this SplitViewElement el,
+        bool isPaneOpen,
+        Action<bool> onPaneOpenChanged) =>
+        el with { IsPaneOpen = isPaneOpen, OnPaneOpenChanged = onPaneOpenChanged };
+
     // ── ListView / GridView (spec §8 — incremental loading + container style) ──
 
     /// <summary>Style applied to each generated <c>ListViewItem</c> container.</summary>
@@ -1706,6 +1721,21 @@ public static partial class ElementExtensions
     /// <summary>Sets the width of the pane when expanded.</summary>
     public static NavigationViewElement OpenPaneLength(this NavigationViewElement el, double length) =>
         el with { OpenPaneLength = length };
+
+    /// <summary>
+    /// Controlled pane state: sets <c>IsPaneOpen</c> and wires the matching change
+    /// handler in one call. The handler is required because the control opens and
+    /// closes its own pane (light dismiss, adaptive display-mode changes on resize) —
+    /// driving <c>IsPaneOpen</c> from state without feeding those changes back leaves
+    /// the state stale, so the next toggle writes a value the control already holds
+    /// and appears to do nothing (issue #916). Use the <c>IsPaneOpen</c> initializer
+    /// directly only for a pane whose state the app never changes.
+    /// </summary>
+    public static NavigationViewElement IsPaneOpen(
+        this NavigationViewElement el,
+        bool isPaneOpen,
+        Action<bool> onPaneOpenChanged) =>
+        el with { IsPaneOpen = isPaneOpen, OnPaneOpenChanged = onPaneOpenChanged };
 
     /// <summary>Sets the window width below which the pane collapses to compact mode.</summary>
     public static NavigationViewElement CompactModeThresholdWidth(this NavigationViewElement el, double width) =>

--- a/src/Reactor/Elements/ElementExtensions.cs
+++ b/src/Reactor/Elements/ElementExtensions.cs
@@ -1589,8 +1589,8 @@ public static partial class ElementExtensions
 
     /// <summary>
     /// Controlled pane state: sets <c>IsPaneOpen</c> and wires the matching change
-    /// handler in one call. The handler is required because the control opens and
-    /// closes its own pane (light dismiss, adaptive display-mode changes) — driving
+    /// handler in one call. The handler is required because the control closes its own
+    /// pane (a light dismiss tap in <c>Overlay</c>/<c>CompactOverlay</c> mode) — driving
     /// <c>IsPaneOpen</c> from state without feeding those changes back leaves the
     /// state stale, so the next toggle writes a value the control already holds and
     /// appears to do nothing (issue #916). Use the <c>IsPaneOpen</c> initializer

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/NavigationViewPaneFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/NavigationViewPaneFixtures.cs
@@ -128,16 +128,96 @@ internal static class NavigationViewPaneFixtures
             var nv = H.FindControl<NavigationView>(n => n.Name == ControlName);
             H.Check("NavPaneCancel_Mounted", nv is not null);
 
-            if (nv is not null) nv.PaneClosing += (_, args) => args.Cancel = true;
+            bool closingSeen = false;
+            if (nv is not null) nv.PaneClosing += (_, args) => { closingSeen = true; args.Cancel = true; };
 
             last = null;
             if (nv is not null) nv.IsPaneOpen = false;
             await Harness.Render();
 
-            // Whatever the control settles on, the app was told the same thing — so the next
-            // render's diff (element vs control) can never be a no-op write.
+            // The cancellation path really ran (without this the fixture would pass
+            // identically with the Cancel handler removed)...
+            H.Check("NavPaneCancel_ClosingCancelled", closingSeen);
+            // ...and whatever the control settled on, the app was told the same thing — so
+            // the next render's diff (element vs control) can never be a no-op write.
             H.Check("NavPaneCancel_CallbackFired", last is not null);
-            H.Check("NavPaneCancel_AgreesWithControl", last == nv?.IsPaneOpen);
+            H.Check("NavPaneCancel_AgreesWithControl", nv is not null && last == nv.IsPaneOpen);
+        }
+    }
+
+    /// <summary>
+    /// The handler can be wired and cleared across renders. Covers the live
+    /// <c>null → callback</c> and <c>callback → null</c> transitions: the observer must
+    /// start reporting when a handler appears, and a cleared handler must never be
+    /// invoked afterwards (the element pointer the trampoline resolves has to keep up).
+    /// </summary>
+    internal class HandlerTransitionsAcrossRenders(Harness h) : SelfTestFixtureBase(h)
+    {
+        internal static int Count;
+        internal static bool? Last;
+        private const string PhaseButton = "NextPhase";
+
+        public override async Task RunAsync()
+        {
+            Count = 0; Last = null;
+
+            var host = H.CreateHost();
+            host.Mount(_ => Component<HandlerPhaseComponent>());
+            await Harness.Render();
+
+            var nv = H.FindControl<NavigationView>(n => n.Name == ControlName);
+            H.Check("NavPaneXition_Mounted", nv is not null);
+
+            // Phase 0 — no handler wired.
+            if (nv is not null) nv.IsPaneOpen = false;
+            await Harness.Render();
+            H.Check("NavPaneXition_NoHandlerDpMoved", nv?.IsPaneOpen == false);
+            H.Check("NavPaneXition_NoHandlerNoCallback", Count == 0);
+
+            // Phase 1 — handler wired on a later render, not at mount.
+            H.ClickButton(PhaseButton);
+            await Harness.Render();
+            if (nv is not null) nv.IsPaneOpen = true;
+            await Harness.Render();
+            H.Check("NavPaneXition_LateHandlerFires", Count == 1);
+            H.Check("NavPaneXition_LateHandlerPayload", Last == true);
+
+            // Phase 2 — handler cleared; the stale delegate must not be invoked.
+            H.ClickButton(PhaseButton);
+            await Harness.Render();
+            if (nv is not null) nv.IsPaneOpen = false;
+            await Harness.Render();
+            // The DP really moved, so "no callback" means silence, not a missing change.
+            H.Check("NavPaneXition_ClearedPhaseDpMoved", nv?.IsPaneOpen == false);
+            H.Check("NavPaneXition_ClearedHandlerSilent", Count == 1);
+            H.Check("NavPaneXition_ClearedHandlerPayloadUnchanged", Last == true);
+        }
+    }
+
+    private sealed class HandlerPhaseComponent : Component
+    {
+        public override Element Render()
+        {
+            var (phase, setPhase) = UseState(0);
+
+            Action<bool>? handler = phase == 1
+                ? open =>
+                {
+                    HandlerTransitionsAcrossRenders.Count++;
+                    HandlerTransitionsAcrossRenders.Last = open;
+                }
+                : null;
+
+            return VStack(
+                Button("NextPhase", () => setPhase(phase + 1)),
+                (NavigationView([NavItem("Home", tag: "home")], TextBlock("pane body")) with
+                {
+                    PaneDisplayMode = NavigationViewPaneDisplayMode.Left,
+                    IsSettingsVisible = false,
+                })
+                .PaneOpenChanged(handler)
+                .Set(n => n.Name = ControlName)
+            );
         }
     }
 

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/NavigationViewPaneFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/NavigationViewPaneFixtures.cs
@@ -100,6 +100,47 @@ internal static class NavigationViewPaneFixtures
         }
     }
 
+    /// <summary>
+    /// <c>PaneClosing</c> is cancellable, and WinUI leaves <c>IsPaneOpen</c> at the requested
+    /// value when a close is cancelled. Reporting off the event would hand the app a bool the
+    /// control's own property disagrees with; observing the DP guarantees element state and
+    /// control state stay identical — which is exactly what the reconciler diffs against.
+    /// </summary>
+    internal class CancelledCloseKeepsCallbackInSyncWithControl(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            bool? last = null;
+
+            var host = H.CreateHost();
+            host.Mount(_ =>
+                (NavigationView([NavItem("Home", tag: "home")], TextBlock("pane body")) with
+                {
+                    IsPaneOpen = true,
+                    PaneDisplayMode = NavigationViewPaneDisplayMode.Left,
+                    IsSettingsVisible = false,
+                })
+                .PaneOpenChanged(open => last = open)
+                .Set(n => n.Name = ControlName));
+
+            await Harness.Render();
+
+            var nv = H.FindControl<NavigationView>(n => n.Name == ControlName);
+            H.Check("NavPaneCancel_Mounted", nv is not null);
+
+            if (nv is not null) nv.PaneClosing += (_, args) => args.Cancel = true;
+
+            last = null;
+            if (nv is not null) nv.IsPaneOpen = false;
+            await Harness.Render();
+
+            // Whatever the control settles on, the app was told the same thing — so the next
+            // render's diff (element vs control) can never be a no-op write.
+            H.Check("NavPaneCancel_CallbackFired", last is not null);
+            H.Check("NavPaneCancel_AgreesWithControl", last == nv?.IsPaneOpen);
+        }
+    }
+
     private sealed class PaneSyncComponent : Component
     {
         public override Element Render()

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/NavigationViewPaneFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/NavigationViewPaneFixtures.cs
@@ -153,71 +153,54 @@ internal static class NavigationViewPaneFixtures
     /// </summary>
     internal class HandlerTransitionsAcrossRenders(Harness h) : SelfTestFixtureBase(h)
     {
-        internal static int Count;
-        internal static bool? Last;
-        private const string PhaseButton = "NextPhase";
-
         public override async Task RunAsync()
         {
-            Count = 0; Last = null;
+            int count = 0;
+            bool? last = null;
 
-            var host = H.CreateHost();
-            host.Mount(_ => Component<HandlerPhaseComponent>());
-            await Harness.Render();
-
-            var nv = H.FindControl<NavigationView>(n => n.Name == ControlName);
-            H.Check("NavPaneXition_Mounted", nv is not null);
-
-            // Phase 0 — no handler wired.
-            if (nv is not null) nv.IsPaneOpen = false;
-            await Harness.Render();
-            H.Check("NavPaneXition_NoHandlerDpMoved", nv?.IsPaneOpen == false);
-            H.Check("NavPaneXition_NoHandlerNoCallback", Count == 0);
-
-            // Phase 1 — handler wired on a later render, not at mount.
-            H.ClickButton(PhaseButton);
-            await Harness.Render();
-            if (nv is not null) nv.IsPaneOpen = true;
-            await Harness.Render();
-            H.Check("NavPaneXition_LateHandlerFires", Count == 1);
-            H.Check("NavPaneXition_LateHandlerPayload", Last == true);
-
-            // Phase 2 — handler cleared; the stale delegate must not be invoked.
-            H.ClickButton(PhaseButton);
-            await Harness.Render();
-            if (nv is not null) nv.IsPaneOpen = false;
-            await Harness.Render();
-            // The DP really moved, so "no callback" means silence, not a missing change.
-            H.Check("NavPaneXition_ClearedPhaseDpMoved", nv?.IsPaneOpen == false);
-            H.Check("NavPaneXition_ClearedHandlerSilent", Count == 1);
-            H.Check("NavPaneXition_ClearedHandlerPayloadUnchanged", Last == true);
-        }
-    }
-
-    private sealed class HandlerPhaseComponent : Component
-    {
-        public override Element Render()
-        {
-            var (phase, setPhase) = UseState(0);
-
-            Action<bool>? handler = phase == 1
-                ? open =>
-                {
-                    HandlerTransitionsAcrossRenders.Count++;
-                    HandlerTransitionsAcrossRenders.Last = open;
-                }
-                : null;
-
-            return VStack(
-                Button("NextPhase", () => setPhase(phase + 1)),
+            static Element Build(Action<bool>? handler) =>
                 (NavigationView([NavItem("Home", tag: "home")], TextBlock("pane body")) with
                 {
                     PaneDisplayMode = NavigationViewPaneDisplayMode.Left,
                     IsSettingsVisible = false,
                 })
                 .PaneOpenChanged(handler)
-                .Set(n => n.Name = ControlName)
-            );
+                .Set(n => n.Name = ControlName);
+
+            // Phase 0 — mounted with no handler wired.
+            var host = H.CreateHost();
+            host.Mount(_ => Build(null));
+            await Harness.Render();
+
+            var nv = H.FindControl<NavigationView>(n => n.Name == ControlName);
+            H.Check("NavPaneXition_Mounted", nv is not null);
+
+            if (nv is not null) nv.IsPaneOpen = false;
+            await Harness.Render();
+            H.Check("NavPaneXition_NoHandlerDpMoved", nv?.IsPaneOpen == false);
+            H.Check("NavPaneXition_NoHandlerNoCallback", count == 0);
+
+            // Phase 1 — the handler appears on a later render, not at mount. Re-mounting the
+            // same shape re-renders in place, so this is the update path.
+            host.Mount(_ => Build(open => { count++; last = open; }));
+            await Harness.Render();
+            H.Check("NavPaneXition_SameControlReused",
+                ReferenceEquals(nv, H.FindControl<NavigationView>(n => n.Name == ControlName)));
+
+            if (nv is not null) nv.IsPaneOpen = true;
+            await Harness.Render();
+            H.Check("NavPaneXition_LateHandlerFires", count == 1);
+            H.Check("NavPaneXition_LateHandlerPayload", last == true);
+
+            // Phase 2 — handler cleared; the stale delegate must not be invoked.
+            host.Mount(_ => Build(null));
+            await Harness.Render();
+            if (nv is not null) nv.IsPaneOpen = false;
+            await Harness.Render();
+            // The DP really moved, so "no callback" means silence, not a missing change.
+            H.Check("NavPaneXition_ClearedPhaseDpMoved", nv?.IsPaneOpen == false);
+            H.Check("NavPaneXition_ClearedHandlerSilent", count == 1);
+            H.Check("NavPaneXition_ClearedHandlerPayloadUnchanged", last == true);
         }
     }
 

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/NavigationViewPaneFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/NavigationViewPaneFixtures.cs
@@ -1,0 +1,122 @@
+using Microsoft.UI.Reactor;
+using Microsoft.UI.Reactor.Core;
+using Microsoft.UI.Reactor.AppTests.Host.SelfTest;
+using Microsoft.UI.Xaml.Controls;
+using static Microsoft.UI.Reactor.Factories;
+
+namespace Microsoft.UI.Reactor.AppTests.Host.SelfTest.Fixtures;
+
+/// <summary>
+/// Issue #916 — <c>NavigationViewElement.IsPaneOpen</c> could be written but never reported
+/// back, so a controlled pane state desynced the moment the control opened or closed its own
+/// pane (light dismiss, adaptive display-mode changes on resize). The app then wrote back the
+/// value the control already held and the pane toggle appeared to need two clicks.
+///
+/// These fixtures drive the realized <c>NavigationView</c> directly (standing in for the
+/// user-driven pane changes Reactor never sees) and assert both halves of the fix: the
+/// callback fires with the new state, and a controlled <c>IsPaneOpen</c> fed from that
+/// callback reopens the pane on a single toggle.
+/// </summary>
+internal static class NavigationViewPaneFixtures
+{
+    private const string ControlName = "navPaneSync";
+
+    internal class PaneOpenChangedFires(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            int count = 0;
+            bool? last = null;
+
+            var host = H.CreateHost();
+            host.Mount(_ =>
+                (NavigationView([NavItem("Home", tag: "home")], TextBlock("pane body")) with
+                {
+                    IsPaneOpen = true,
+                    PaneDisplayMode = NavigationViewPaneDisplayMode.Left,
+                    IsSettingsVisible = false,
+                })
+                .PaneOpenChanged(open => { count++; last = open; })
+                .Set(n => n.Name = ControlName));
+
+            await Harness.Render();
+
+            var nv = H.FindControl<NavigationView>(n => n.Name == ControlName);
+            H.Check("NavPane_Mounted", nv is not null);
+            H.Check("NavPane_MountedOpen", nv?.IsPaneOpen == true);
+
+            // The control closes its own pane (light dismiss / adaptive collapse).
+            count = 0; last = null;
+            if (nv is not null) nv.IsPaneOpen = false;
+            await Harness.Render();
+
+            H.Check("NavPane_CloseCallbackFired", count >= 1);
+            H.Check("NavPane_CloseCallbackPayload", last == false);
+
+            // ...and opens it again.
+            count = 0; last = null;
+            if (nv is not null) nv.IsPaneOpen = true;
+            await Harness.Render();
+
+            H.Check("NavPane_OpenCallbackFired", count >= 1);
+            H.Check("NavPane_OpenCallbackPayload", last == true);
+        }
+    }
+
+    /// <summary>
+    /// The issue's repro, minus the title bar: state drives <c>IsPaneOpen</c>, the control
+    /// closes the pane on its own, and ONE toggle must reopen it. Before the fix the state
+    /// still read <c>true</c> at that point, so the toggle wrote <c>false</c> — a value the
+    /// control already held — and the pane stayed shut.
+    /// </summary>
+    internal class ControlledPaneResyncsAfterControlDrivenClose(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var host = H.CreateHost();
+            host.Mount(_ => Component<PaneSyncComponent>());
+
+            await Harness.Render();
+
+            var nv = H.FindControl<NavigationView>(n => n.Name == ControlName);
+            H.Check("NavPaneSync_Mounted", nv is not null);
+            H.Check("NavPaneSync_StartsOpen", nv?.IsPaneOpen == true);
+
+            // Control-driven close — the app never asked for this.
+            if (nv is not null) nv.IsPaneOpen = false;
+            await Harness.Render();
+            H.Check("NavPaneSync_ClosedByControl", nv?.IsPaneOpen == false);
+
+            // A single toggle click must reopen it.
+            H.ClickButton("TogglePane");
+            await Harness.Render();
+            H.Check("NavPaneSync_OneClickReopens", nv?.IsPaneOpen == true);
+
+            // ...and the next click closes it again (state didn't run away in the other
+            // direction — a callback that reported the wrong bool would fail here).
+            H.ClickButton("TogglePane");
+            await Harness.Render();
+            H.Check("NavPaneSync_NextClickCloses", nv?.IsPaneOpen == false);
+        }
+    }
+
+    private sealed class PaneSyncComponent : Component
+    {
+        public override Element Render()
+        {
+            var (isPaneOpen, setIsPaneOpen) = UseState(true);
+
+            return VStack(
+                Button("TogglePane", () => setIsPaneOpen(!isPaneOpen)),
+                (NavigationView([NavItem("Home", tag: "home")], TextBlock("pane body")) with
+                {
+                    IsPaneOpen = isPaneOpen,
+                    PaneDisplayMode = NavigationViewPaneDisplayMode.Left,
+                    IsSettingsVisible = false,
+                })
+                .PaneOpenChanged(setIsPaneOpen)
+                .Set(n => n.Name = ControlName)
+            );
+        }
+    }
+}

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -966,6 +966,10 @@ internal static class SelfTestFixtureRegistry
         "SelectionEvt_Pivot",
         "SelectionEvt_NavigationView",
 
+        // NavigationView pane-state round-trip (issue #916)
+        "NavPane_OpenChangedFires",
+        "NavPane_ControlledResync",
+
         // Value-change / toggle event wiring (Tier 2 gap closure)
         "ValueEvt_CheckBox",
         "ValueEvt_RadioButton",
@@ -2490,6 +2494,10 @@ internal static class SelfTestFixtureRegistry
         "SelectionEvt_TabView" => new SelectionEventFixtures.TabViewSelectionFires(harness),
         "SelectionEvt_Pivot" => new SelectionEventFixtures.PivotSelectionFires(harness),
         "SelectionEvt_NavigationView" => new SelectionEventFixtures.NavigationViewSelectionFires(harness),
+
+        // NavigationView pane-state round-trip (issue #916)
+        "NavPane_OpenChangedFires" => new NavigationViewPaneFixtures.PaneOpenChangedFires(harness),
+        "NavPane_ControlledResync" => new NavigationViewPaneFixtures.ControlledPaneResyncsAfterControlDrivenClose(harness),
 
         // Value-change / toggle event wiring
         "ValueEvt_CheckBox" => new ValueChangeEventFixtures.CheckBoxToggleFires(harness),

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -969,6 +969,7 @@ internal static class SelfTestFixtureRegistry
         // NavigationView pane-state round-trip (issue #916)
         "NavPane_OpenChangedFires",
         "NavPane_ControlledResync",
+        "NavPane_CancelledClose",
 
         // Value-change / toggle event wiring (Tier 2 gap closure)
         "ValueEvt_CheckBox",
@@ -2498,6 +2499,7 @@ internal static class SelfTestFixtureRegistry
         // NavigationView pane-state round-trip (issue #916)
         "NavPane_OpenChangedFires" => new NavigationViewPaneFixtures.PaneOpenChangedFires(harness),
         "NavPane_ControlledResync" => new NavigationViewPaneFixtures.ControlledPaneResyncsAfterControlDrivenClose(harness),
+        "NavPane_CancelledClose" => new NavigationViewPaneFixtures.CancelledCloseKeepsCallbackInSyncWithControl(harness),
 
         // Value-change / toggle event wiring
         "ValueEvt_CheckBox" => new ValueChangeEventFixtures.CheckBoxToggleFires(harness),

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -970,6 +970,7 @@ internal static class SelfTestFixtureRegistry
         "NavPane_OpenChangedFires",
         "NavPane_ControlledResync",
         "NavPane_CancelledClose",
+        "NavPane_HandlerTransitions",
 
         // Value-change / toggle event wiring (Tier 2 gap closure)
         "ValueEvt_CheckBox",
@@ -2500,6 +2501,7 @@ internal static class SelfTestFixtureRegistry
         "NavPane_OpenChangedFires" => new NavigationViewPaneFixtures.PaneOpenChangedFires(harness),
         "NavPane_ControlledResync" => new NavigationViewPaneFixtures.ControlledPaneResyncsAfterControlDrivenClose(harness),
         "NavPane_CancelledClose" => new NavigationViewPaneFixtures.CancelledCloseKeepsCallbackInSyncWithControl(harness),
+        "NavPane_HandlerTransitions" => new NavigationViewPaneFixtures.HandlerTransitionsAcrossRenders(harness),
 
         // Value-change / toggle event wiring
         "ValueEvt_CheckBox" => new ValueChangeEventFixtures.CheckBoxToggleFires(harness),

--- a/tests/Reactor.SelfTests/Fixtures/event-fluent-inventory.csv
+++ b/tests/Reactor.SelfTests/Fixtures/event-fluent-inventory.csv
@@ -44,6 +44,7 @@
 "MediaPlayerElementElement","OnMediaFailed","Action<string>?","?",".\src\Reactor\Core\Element.cs"
 "MediaPlayerElementElement","OnMediaOpened","Action?","?",".\src\Reactor\Core\Element.cs"
 "NavigationViewElement","OnBackRequested","Action?","§7.2",".\src\Reactor\Core\Element.cs"
+"NavigationViewElement","OnPaneOpenChanged","Action<bool>?","§7.2",".\src\Reactor\Core\Element.cs"
 "NavigationViewElement","OnSelectedTagChanged","Action<string?>?","§7.2",".\src\Reactor\Core\Element.cs"
 "NumberBoxElement","OnValueChanged","Action<double>?","§0.1",".\src\Reactor\Core\Element.cs"
 "PasswordBoxElement","OnPasswordChanged","Action<string>?","§3.2",".\src\Reactor\Core\Element.cs"

--- a/tests/Reactor.Tests/Elements/EventFluentNullClearTests.cs
+++ b/tests/Reactor.Tests/Elements/EventFluentNullClearTests.cs
@@ -483,6 +483,17 @@ public class EventFluentNullClearTests
         Assert.Null(el.BackRequested(null).OnBackRequested);
     }
 
+    // Issue #916 — NavigationView pane state must round-trip so a controlled
+    // IsPaneOpen can follow light dismiss / adaptive display-mode changes.
+    [Fact]
+    public void NavigationView_PaneOpenChanged_NullClears()
+    {
+        var el = NavigationView(Array.Empty<NavigationViewItemData>()).PaneOpenChanged(SentinelBool);
+        Assert.Same(SentinelBool, el.OnPaneOpenChanged);
+        Assert.Null(el.PaneOpenChanged(null).OnPaneOpenChanged);
+        Assert.Same(SentinelBool, el.PaneOpenChanged(null).PaneOpenChanged(SentinelBool).OnPaneOpenChanged);
+    }
+
     [Fact]
     public void TitleBar_BackRequested_NullClears()
     {

--- a/tests/Reactor.Tests/Elements/NavigationViewPaneOpenChangedTests.cs
+++ b/tests/Reactor.Tests/Elements/NavigationViewPaneOpenChangedTests.cs
@@ -9,8 +9,8 @@ namespace Microsoft.UI.Reactor.Tests.Elements;
 /// Issue #916 — <c>NavigationViewElement.IsPaneOpen</c> could be written but never
 /// reported back, so a controlled pane state desynced whenever the control opened or
 /// closed the pane itself (light dismiss, adaptive display-mode changes). These cover the
-/// record-level half of the fix; the live event wiring is proved by the
-/// <c>NavigationViewPaneOpenChanged*</c> selftest fixtures.
+/// record-level half of the fix; the live wiring — the callback actually firing when the
+/// realized control moves its pane — is proved by the <c>NavPane_*</c> selftest fixtures.
 /// </summary>
 public class NavigationViewPaneOpenChangedTests
 {
@@ -52,31 +52,27 @@ public class NavigationViewPaneOpenChangedTests
     }
 
     [Fact]
-    public void Callback_Value_Feeds_Back_Into_A_Controlled_IsPaneOpen()
+    public void IsPaneOpen_Pair_Sets_Both_State_And_Handler()
     {
-        // Models the issue's repro without WinUI. Each `with { IsPaneOpen = state }` is one
-        // render; the reconciler only writes the DP when consecutive elements differ, so the
-        // oracle is the sign of that diff after the control closed its own pane.
-        bool state = true;
-        var render1 = EmptyNav() with { IsPaneOpen = state };
+        // The paired overload exists so the two halves can't drift apart — issue #916 is
+        // exactly what happens when IsPaneOpen is set without the companion handler.
+        Action<bool> handler = _ => { };
 
-        // ── With the fix: the control's close is pushed back into state.
-        var wired = render1.PaneOpenChanged(open => state = open);
-        wired.OnPaneOpenChanged!(false);                       // light dismiss closed the pane
-        Assert.False(state);
-        var render2 = wired with { IsPaneOpen = state };
-        state = !state;                                        // one title-bar toggle click
-        var render3 = render2 with { IsPaneOpen = state };
-        Assert.False(render2.IsPaneOpen);
-        Assert.True(render3.IsPaneOpen);                       // false → true: the pane reopens
+        var closed = EmptyNav().IsPaneOpen(false, handler);
+        Assert.False(closed.IsPaneOpen);
+        Assert.Same(handler, closed.OnPaneOpenChanged);
+        Assert.True(closed.HasCallbacks);
 
-        // ── Pre-fix control: no callback, so state never learns about the close and the
-        // single toggle writes the value the control is already at.
-        bool stale = true;
-        var staleRender1 = EmptyNav() with { IsPaneOpen = stale };
-        stale = !stale;                                        // same single toggle click
-        var staleRender2 = staleRender1 with { IsPaneOpen = stale };
-        Assert.False(staleRender2.IsPaneOpen);                 // true → false: pane stays closed
-        Assert.NotEqual(staleRender2.IsPaneOpen, render3.IsPaneOpen);
+        // Both halves track the argument independently (a pair that ignored either
+        // argument, or aliased one to the other, fails here).
+        Assert.True(EmptyNav().IsPaneOpen(true, handler).IsPaneOpen);
+        Assert.NotEqual(
+            EmptyNav().IsPaneOpen(true, handler).IsPaneOpen,
+            EmptyNav().IsPaneOpen(false, handler).IsPaneOpen);
+
+        // Same shape on SplitView, so authors can move between the two controls.
+        var split = SplitView().IsPaneOpen(false, handler);
+        Assert.False(split.IsPaneOpen);
+        Assert.Same(handler, split.OnPaneOpenChanged);
     }
 }

--- a/tests/Reactor.Tests/Elements/NavigationViewPaneOpenChangedTests.cs
+++ b/tests/Reactor.Tests/Elements/NavigationViewPaneOpenChangedTests.cs
@@ -1,0 +1,74 @@
+using System;
+using Microsoft.UI.Reactor.Core;
+using Xunit;
+using static Microsoft.UI.Reactor.Factories;
+
+namespace Microsoft.UI.Reactor.Tests.Elements;
+
+/// <summary>
+/// Issue #916 — <c>NavigationViewElement.IsPaneOpen</c> could be written but never
+/// reported back, so a controlled pane state desynced whenever the control opened or
+/// closed the pane itself (light dismiss, adaptive display-mode changes). These cover the
+/// record-level half of the fix; the live event wiring is proved by the
+/// <c>NavigationViewPaneOpenChanged*</c> selftest fixtures.
+/// </summary>
+public class NavigationViewPaneOpenChangedTests
+{
+    private static NavigationViewElement EmptyNav() =>
+        NavigationView(Array.Empty<NavigationViewItemData>());
+
+    [Fact]
+    public void OnPaneOpenChanged_Alone_Flips_HasCallbacks()
+    {
+        // The subscription gate (and the #153 Tag-refresh fast path) keys off HasCallbacks:
+        // if OnPaneOpenChanged is missing from the disjunct, a NavigationView wired ONLY for
+        // pane changes never gets its element pointer refreshed and the callback goes stale.
+        Assert.False(EmptyNav().HasCallbacks);
+        Assert.True(EmptyNav().PaneOpenChanged(_ => { }).HasCallbacks);
+        Assert.False(EmptyNav().PaneOpenChanged(_ => { }).PaneOpenChanged(null).HasCallbacks);
+    }
+
+    [Fact]
+    public void PaneOpenChanged_Leaves_Sibling_Callbacks_And_IsPaneOpen_Untouched()
+    {
+        Action<string?> tagHandler = _ => { };
+        Action backHandler = () => { };
+        var el = (EmptyNav() with { IsPaneOpen = false })
+            .SelectedTagChanged(tagHandler)
+            .BackRequested(backHandler)
+            .PaneOpenChanged(_ => { });
+
+        Assert.Same(tagHandler, el.OnSelectedTagChanged);
+        Assert.Same(backHandler, el.OnBackRequested);
+        Assert.False(el.IsPaneOpen);
+    }
+
+    [Fact]
+    public void Callback_Value_Feeds_Back_Into_A_Controlled_IsPaneOpen()
+    {
+        // Models the issue's repro without WinUI. Each `with { IsPaneOpen = state }` is one
+        // render; the reconciler only writes the DP when consecutive elements differ, so the
+        // oracle is the sign of that diff after the control closed its own pane.
+        bool state = true;
+        var render1 = EmptyNav() with { IsPaneOpen = state };
+
+        // ── With the fix: the control's close is pushed back into state.
+        var wired = render1.PaneOpenChanged(open => state = open);
+        wired.OnPaneOpenChanged!(false);                       // light dismiss closed the pane
+        Assert.False(state);
+        var render2 = wired with { IsPaneOpen = state };
+        state = !state;                                        // one title-bar toggle click
+        var render3 = render2 with { IsPaneOpen = state };
+        Assert.False(render2.IsPaneOpen);
+        Assert.True(render3.IsPaneOpen);                       // false → true: the pane reopens
+
+        // ── Pre-fix control: no callback, so state never learns about the close and the
+        // single toggle writes the value the control is already at.
+        bool stale = true;
+        var staleRender1 = EmptyNav() with { IsPaneOpen = stale };
+        stale = !stale;                                        // same single toggle click
+        var staleRender2 = staleRender1 with { IsPaneOpen = stale };
+        Assert.False(staleRender2.IsPaneOpen);                 // true → false: pane stays closed
+        Assert.NotEqual(staleRender2.IsPaneOpen, render3.IsPaneOpen);
+    }
+}

--- a/tests/Reactor.Tests/Elements/NavigationViewPaneOpenChangedTests.cs
+++ b/tests/Reactor.Tests/Elements/NavigationViewPaneOpenChangedTests.cs
@@ -26,6 +26,14 @@ public class NavigationViewPaneOpenChangedTests
         Assert.False(EmptyNav().HasCallbacks);
         Assert.True(EmptyNav().PaneOpenChanged(_ => { }).HasCallbacks);
         Assert.False(EmptyNav().PaneOpenChanged(_ => { }).PaneOpenChanged(null).HasCallbacks);
+
+        // …and the sibling callbacks must stay in the disjunct: clearing only the pane
+        // callback while SelectedTagChanged/BackRequested are still wired must keep
+        // HasCallbacks true (fails if the disjunct is narrowed to OnPaneOpenChanged alone).
+        var siblings = EmptyNav().SelectedTagChanged(_ => { }).BackRequested(() => { });
+        Assert.True(siblings.PaneOpenChanged(_ => { }).PaneOpenChanged(null).HasCallbacks);
+        Assert.True(EmptyNav().SelectedTagChanged(_ => { }).HasCallbacks);
+        Assert.True(EmptyNav().BackRequested(() => { }).HasCallbacks);
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #916.

`NavigationViewElement.IsPaneOpen` could be written but never reported back, so controlled pane state desynced whenever the control moved the pane on its own (light dismiss, adaptive display-mode change on resize). State kept the stale value, the next diff was a no-op, and a title-bar toggle appeared to need two clicks.

## What changed

- `NavigationViewElement.OnPaneOpenChanged` (`Action<bool>?`) + the `.PaneOpenChanged(handler)` fluent — same shape as `SplitViewElement`.
- A paired `.IsPaneOpen(value, handler)` fluent on **both** `NavigationViewElement` and `SplitViewElement`. The handler is non-nullable, so a controlled pane and its change notification are set in one call and can't drift apart — which is exactly the mistake this issue is.
- Wired as an `.Immediate` observation of `NavigationView.IsPaneOpenProperty` rather than the `PaneOpening`/`PaneClosing` pair. The DP is exactly what the reconciler diffs against, so the reported bool can never disagree with the control — `PaneClosing` is cancellable and WinUI leaves `IsPaneOpen` at the requested value when a close is cancelled, which an event-sourced callback would misreport. It also beats `PaneOpened`/`PaneClosed`, which only arrive after the pane transition finishes.
- `ControlDescriptor.Immediate` / `ImmediatePropEntry` now accept a `null` `loadedHook`, for observations with no template part to walk.

`IsPaneOpen` deliberately stays a one-way prop rather than becoming a live-diff controlled prop: the element default is `true`, so drift-healing every render would fight NavigationView's adaptive auto-collapse for apps that never set the prop. The callback alone restores correct controlled behaviour.

## Tests

- Unit (`NavigationViewPaneOpenChangedTests`): `HasCallbacks` gating (including that sibling callbacks stay in the disjunct), fluent set/null-clear, and coverage of the paired `.IsPaneOpen(value, handler)` overload on both elements.
- Selftests — the live oracles, since headless tests can't construct WinUI controls:
  - `NavPane_OpenChangedFires` — the callback fires with the right bool when the control moves its own pane.
  - `NavPane_ControlledResync` — the issue's repro: after a control-driven close, **one** toggle reopens the pane (and the next one closes it, so state can't run away in the other direction).
  - `NavPane_CancelledClose` — asserts the `PaneClosing` cancellation actually ran, then that the reported value still agrees with the control's `IsPaneOpen`.
  - `NavPane_HandlerTransitions` — live `null → handler → null` transitions: no callback before one is wired, it fires once wired on a later render, and the cleared handler is never invoked afterwards. Asserts the same `NavigationView` instance across phases, so the transitions provably run through the update path, and asserts the DP actually moved in each phase so "no callback" means silence rather than a missing change.
  - Mutation check: disabling the observer turns 8 checks red.
- Full unit suite 12462 passed / 0 failed; full selftest suite 0 failures (the 3 failures seen locally reproduce on a clean `main` build and are environmental).
- Docs: new `PaneOpenChanged` section plus a controlled-pane snippet in the navigation guide (regenerated via `mur docs compile --topic navigation`).
- `CHANGELOG.md` entries under `Unreleased`.