### PR TITLE
Add TabView.FillContentArea opt-in for full-height tab content (#914)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,17 @@ Conventions for contributors:
 
 ### Added
 
+- **`TabView.FillContentArea` — opt-in full-height tab body (issue #914).**
+  WinUI's `DefaultTabViewStyle` sets `VerticalAlignment="Top"` on the `TabView`
+  control itself, so the `*` content row in its template never receives leftover
+  space and tab content collapses to its natural height instead of filling the
+  tab body. Reactor keeps the WinUI default; set
+  `TabView([...]) with { FillContentArea = true }` or call `.FillContentArea()`
+  to stretch the control so its content area fills the available space. An
+  explicit `.VAlign(...)` on the `TabView` element still wins. Apps working
+  around this with `UseWindowSize()` + `.MinHeight(...)` (including the Windows
+  App SDK `reactor-tabview` template) can drop that workaround.
+
 - **`NavigationView` pane-open change notification (issue #916).**
   `NavigationViewElement.OnPaneOpenChanged` plus the `.PaneOpenChanged(handler)`
   and paired `.IsPaneOpen(value, handler)` fluents report every `IsPaneOpen`

--- a/docs/_pipeline/templates/navigation.md.dt
+++ b/docs/_pipeline/templates/navigation.md.dt
@@ -252,6 +252,33 @@ own content independently:
 Unlike stack-based navigation, tabs keep all their content alive simultaneously.
 Use tabs when users need to switch freely between parallel workspaces.
 
+### Filling the tab content area
+
+WinUI's `DefaultTabViewStyle` ships `VerticalAlignment="Top"` on the `TabView`
+control itself. A top-aligned control is arranged at its *desired* height, so
+the `*` content row in the control template never receives any leftover space
+and the tab body collapses to the natural height of the selected tab's content.
+A tab child with a background paints only a band behind its own text.
+
+Reactor keeps that WinUI default. Opt in to a full-height tab body with
+`FillContentArea`:
+
+```csharp
+TabView([
+    Tab("Editor", Border(Text("Editor")).Background(Colors.CornflowerBlue)),
+    Tab("Preview", Text("Preview")),
+]).FillContentArea()
+```
+
+The init property is available for record-construction syntax too:
+
+```csharp
+TabView([...]) with { FillContentArea = true }
+```
+
+An explicit `.VAlign(...)` on the `TabView` element always wins over the opt-in,
+so you can still pin a tab strip to the top of a tall container.
+
 ## State Serialization
 
 `NavigationHandle` can capture and restore the full navigation state —

--- a/docs/_pipeline/templates/navigation.md.dt
+++ b/docs/_pipeline/templates/navigation.md.dt
@@ -265,8 +265,8 @@ Reactor keeps that WinUI default. Opt in to a full-height tab body with
 
 ```csharp
 TabView([
-    Tab("Editor", Border(Text("Editor")).Background(Colors.CornflowerBlue)),
-    Tab("Preview", Text("Preview")),
+    Tab("Editor", Border(TextBlock("Editor")).Background(Theme.CardBackground)),
+    Tab("Preview", TextBlock("Preview")),
 ]).FillContentArea()
 ```
 

--- a/docs/guide/navigation.md
+++ b/docs/guide/navigation.md
@@ -502,8 +502,8 @@ Reactor keeps that WinUI default. Opt in to a full-height tab body with
 
 ```csharp
 TabView([
-    Tab("Editor", Border(Text("Editor")).Background(Colors.CornflowerBlue)),
-    Tab("Preview", Text("Preview")),
+    Tab("Editor", Border(TextBlock("Editor")).Background(Theme.CardBackground)),
+    Tab("Preview", TextBlock("Preview")),
 ]).FillContentArea()
 ```
 

--- a/docs/guide/navigation.md
+++ b/docs/guide/navigation.md
@@ -489,6 +489,33 @@ class TabNavDemo : Component
 Unlike stack-based navigation, tabs keep all their content alive simultaneously.
 Use tabs when users need to switch freely between parallel workspaces.
 
+### Filling the tab content area
+
+WinUI's `DefaultTabViewStyle` ships `VerticalAlignment="Top"` on the `TabView`
+control itself. A top-aligned control is arranged at its *desired* height, so
+the `*` content row in the control template never receives any leftover space
+and the tab body collapses to the natural height of the selected tab's content.
+A tab child with a background paints only a band behind its own text.
+
+Reactor keeps that WinUI default. Opt in to a full-height tab body with
+`FillContentArea`:
+
+```csharp
+TabView([
+    Tab("Editor", Border(Text("Editor")).Background(Colors.CornflowerBlue)),
+    Tab("Preview", Text("Preview")),
+]).FillContentArea()
+```
+
+The init property is available for record-construction syntax too:
+
+```csharp
+TabView([...]) with { FillContentArea = true }
+```
+
+An explicit `.VAlign(...)` on the `TabView` element always wins over the opt-in,
+so you can still pin a tab strip to the top of a tall container.
+
 ## State Serialization
 
 `NavigationHandle` can capture and restore the full navigation state —

--- a/plugins/reactor/skills/reactor-dsl/references/reactor.api.txt
+++ b/plugins/reactor/skills/reactor-dsl/references/reactor.api.txt
@@ -745,6 +745,7 @@ TabViewElement.AllowDropTabs(bool allow = true) → TabViewElement
 TabViewElement.CanDragTabs(bool canDrag = true) → TabViewElement
 TabViewElement.CanReorderTabs(bool canReorder = true) → TabViewElement
 TabViewElement.CloseButtonOverlayMode(TabViewCloseButtonOverlayMode mode) → TabViewElement
+TabViewElement.FillContentArea(bool fill = true) → TabViewElement
 TabViewElement.IsAddTabButtonVisible(bool visible = true) → TabViewElement
 TabViewElement.SelectedIndexChanged(Action<int> handler) → TabViewElement
 TabViewElement.Set(Action<TabView> configure) → TabViewElement
@@ -6526,6 +6527,7 @@ TabViewWidthMode TabWidthMode { get; init; }
 bool AllowDropTabs { get; init; }
 bool CanDragTabs { get; init; }
 bool CanReorderTabs { get; init; }
+bool FillContentArea { get; init; }
 bool IsAddTabButtonVisible { get; init; }
 Deconstruct(ref TabViewItemData[] Tabs) → void
 Equals(Element other) → bool

--- a/skills/reactor.api.txt
+++ b/skills/reactor.api.txt
@@ -745,6 +745,7 @@ TabViewElement.AllowDropTabs(bool allow = true) → TabViewElement
 TabViewElement.CanDragTabs(bool canDrag = true) → TabViewElement
 TabViewElement.CanReorderTabs(bool canReorder = true) → TabViewElement
 TabViewElement.CloseButtonOverlayMode(TabViewCloseButtonOverlayMode mode) → TabViewElement
+TabViewElement.FillContentArea(bool fill = true) → TabViewElement
 TabViewElement.IsAddTabButtonVisible(bool visible = true) → TabViewElement
 TabViewElement.SelectedIndexChanged(Action<int> handler) → TabViewElement
 TabViewElement.Set(Action<TabView> configure) → TabViewElement
@@ -6526,6 +6527,7 @@ TabViewWidthMode TabWidthMode { get; init; }
 bool AllowDropTabs { get; init; }
 bool CanDragTabs { get; init; }
 bool CanReorderTabs { get; init; }
+bool FillContentArea { get; init; }
 bool IsAddTabButtonVisible { get; init; }
 Deconstruct(ref TabViewItemData[] Tabs) → void
 Equals(Element other) → bool

--- a/src/Reactor/Core/Element.TabView.cs
+++ b/src/Reactor/Core/Element.TabView.cs
@@ -54,6 +54,38 @@ public partial record TabViewElement
             el.OnTabDragCompleted(idx, wasOutside);
         };
 
+    /// <summary>
+    /// Issue #914 — WinUI's <c>DefaultTabViewStyle</c> sets
+    /// <c>VerticalAlignment="Top"</c> on the TabView itself, so the control is arranged at
+    /// its desired height and the <c>*</c> content row of its template never receives the
+    /// leftover space: tab content collapses to its own height and the rest of the tab body
+    /// stays unpainted. Opting in via <see cref="TabViewElement.FillContentArea"/> writes
+    /// <c>Stretch</c> on the control, which is what the XAML TabView templates do by hand.
+    ///
+    /// <para>An explicit <c>.VAlign(…)</c> always wins, so the opt-in stands down entirely
+    /// when one is present. Deferring to <c>ApplyModifiers</c> (which runs after the
+    /// descriptor entries) is NOT enough: it only re-writes the alignment when the modifier
+    /// *changed*, so an unchanged explicit alignment would be clobbered by this write on
+    /// every subsequent re-render.</para>
+    ///
+    /// <para>Turning the opt-in back off releases the local value so WinUI's style default
+    /// (<c>Top</c>) applies again; the control is not pooled, so mount always starts from
+    /// the style value and only the on→off transition needs the release.</para>
+    /// </summary>
+    private static void ApplyFillContentArea(WinUI.TabView control, TabViewElement element, TabViewElement? old)
+    {
+        if (WritesFill(element)) control.VerticalAlignment = VerticalAlignment.Stretch;
+        else if (old is not null && WritesFill(old) && element.Modifiers?.Layout?.VerticalAlignment is null)
+            control.ClearValue(FrameworkElement.VerticalAlignmentProperty);
+    }
+
+    /// <summary>
+    /// True when the opt-in owns the control's vertical alignment: it is on and the author
+    /// did not pin the alignment themselves.
+    /// </summary>
+    private static bool WritesFill(TabViewElement element)
+        => element.FillContentArea && element.Modifiers?.Layout?.VerticalAlignment is null;
+
     private static partial Desc.ControlDescriptor<TabViewElement, WinUI.TabView> Customize(
         Desc.ControlDescriptor<TabViewElement, WinUI.TabView> d)
     {
@@ -102,6 +134,9 @@ public partial record TabViewElement
         // dedicated control property therefore ride the imperative bridge (see
         // docs/guide/extensibility-preview.md — secondary-slot decision).
         return d
+            .ImperativeBridged(
+                mount:  static (ctx, c, e) => ApplyFillContentArea(c, e, old: null),
+                update: static (ctx, c, o, n) => ApplyFillContentArea(c, n, o))
             .HandCodedControlled<V1.TabViewEventPayload, int, WinUI.SelectionChangedEventHandler>(
                 get:         static e => e.SelectedIndex,
                 set:         static (c, v) => c.SelectedIndex = v,

--- a/src/Reactor/Core/Element.TabView.cs
+++ b/src/Reactor/Core/Element.TabView.cs
@@ -59,32 +59,30 @@ public partial record TabViewElement
     /// <c>VerticalAlignment="Top"</c> on the TabView itself, so the control is arranged at
     /// its desired height and the <c>*</c> content row of its template never receives the
     /// leftover space: tab content collapses to its own height and the rest of the tab body
-    /// stays unpainted. Opting in via <see cref="TabViewElement.FillContentArea"/> writes
-    /// <c>Stretch</c> on the control, which is what the XAML TabView templates do by hand.
+    /// stays unpainted. Opting in via <see cref="TabViewElement.FillContentArea"/> resolves
+    /// to <c>Stretch</c>, which is what the XAML TabView templates do by hand.
     ///
-    /// <para>An explicit <c>.VAlign(…)</c> always wins, so the opt-in stands down entirely
-    /// when one is present. Deferring to <c>ApplyModifiers</c> (which runs after the
-    /// descriptor entries) is NOT enough: it only re-writes the alignment when the modifier
-    /// *changed*, so an unchanged explicit alignment would be clobbered by this write on
-    /// every subsequent re-render.</para>
+    /// <para>An explicit <c>.VAlign(…)</c> always wins, so the opt-in resolves to
+    /// <see cref="Optional{T}.Unset"/> when one is present. Deferring to
+    /// <c>ApplyModifiers</c> (which runs after the descriptor entries) is NOT enough: it
+    /// only re-writes the alignment when the modifier <em>changed</em>. With an unchanged
+    /// explicit alignment it is skipped entirely, so an unguarded opt-in would overwrite the
+    /// author's value with <c>Stretch</c> as it switched on, and <c>ClearValue</c> it away
+    /// to the style's <c>Top</c> as it switched off — with nothing left to restore it.</para>
     ///
-    /// <para>Turning the opt-in back off releases the local value so WinUI's style default
-    /// (<c>Top</c>) applies again; the control is not pooled, so mount always starts from
-    /// the style value and only the on→off transition needs the release.</para>
+    /// <para>Unset resolves to <c>ClearValue</c> on the descriptor's
+    /// <see cref="FrameworkElement.VerticalAlignmentProperty"/>, releasing the local value
+    /// so WinUI's style default (<c>Top</c>) applies again.</para>
+    ///
+    /// <para>Ownership is decided from the element's own modifiers. An alignment supplied
+    /// through a hand-built <see cref="ModifiedElement"/> wrapper is not visible here (the
+    /// reconciler unwraps those into a separate merged bag before dispatch), so pair the
+    /// opt-in with the fluent <c>.VAlign(…)</c> on the TabView element itself.</para>
     /// </summary>
-    private static void ApplyFillContentArea(WinUI.TabView control, TabViewElement element, TabViewElement? old)
-    {
-        if (WritesFill(element)) control.VerticalAlignment = VerticalAlignment.Stretch;
-        else if (old is not null && WritesFill(old) && element.Modifiers?.Layout?.VerticalAlignment is null)
-            control.ClearValue(FrameworkElement.VerticalAlignmentProperty);
-    }
-
-    /// <summary>
-    /// True when the opt-in owns the control's vertical alignment: it is on and the author
-    /// did not pin the alignment themselves.
-    /// </summary>
-    private static bool WritesFill(TabViewElement element)
-        => element.FillContentArea && element.Modifiers?.Layout?.VerticalAlignment is null;
+    private static Optional<VerticalAlignment> ResolveFillAlignment(TabViewElement element)
+        => element.FillContentArea && element.Modifiers?.Layout?.VerticalAlignment is null
+            ? VerticalAlignment.Stretch
+            : Optional<VerticalAlignment>.Unset;
 
     private static partial Desc.ControlDescriptor<TabViewElement, WinUI.TabView> Customize(
         Desc.ControlDescriptor<TabViewElement, WinUI.TabView> d)
@@ -134,9 +132,10 @@ public partial record TabViewElement
         // dedicated control property therefore ride the imperative bridge (see
         // docs/guide/extensibility-preview.md — secondary-slot decision).
         return d
-            .ImperativeBridged(
-                mount:  static (ctx, c, e) => ApplyFillContentArea(c, e, old: null),
-                update: static (ctx, c, o, n) => ApplyFillContentArea(c, n, o))
+            .OneWay(
+                get: static e => ResolveFillAlignment(e),
+                set: static (c, v) => c.VerticalAlignment = v,
+                dp:  FrameworkElement.VerticalAlignmentProperty)
             .HandCodedControlled<V1.TabViewEventPayload, int, WinUI.SelectionChangedEventHandler>(
                 get:         static e => e.SelectedIndex,
                 set:         static (c, v) => c.SelectedIndex = v,

--- a/src/Reactor/Core/Element.cs
+++ b/src/Reactor/Core/Element.cs
@@ -902,6 +902,7 @@ public abstract record Element
             (TabViewElement ta, TabViewElement tb) =>
                 ta.SelectedIndex == tb.SelectedIndex
                 && ta.IsAddTabButtonVisible == tb.IsAddTabButtonVisible
+                && ta.FillContentArea == tb.FillContentArea
                 && SettersEqual(ta.Setters, tb.Setters),
 
             (TreeViewElement ta, TreeViewElement tb) =>
@@ -4776,6 +4777,22 @@ public partial record TabViewElement(
     public Element? TabStripHeader { get; init; }
     /// <summary>Element rendered at the trailing edge of the tab strip.</summary>
     public Element? TabStripFooter { get; init; }
+    /// <summary>
+    /// Opt in to having the tab content area fill the space the TabView is given
+    /// by its parent (issue #914).
+    /// </summary>
+    /// <remarks>
+    /// WinUI's <c>DefaultTabViewStyle</c> ships
+    /// <c>&lt;Setter Property="VerticalAlignment" Value="Top" /&gt;</c>, so a TabView is
+    /// arranged at its <em>desired</em> height and the <c>*</c> content row in its template
+    /// never receives any leftover space — tab content is sized to content and the rest of
+    /// the tab body stays unpainted. Setting this to <c>true</c> writes
+    /// <see cref="Microsoft.UI.Xaml.VerticalAlignment.Stretch"/> on the control, which is
+    /// what the XAML TabView templates do by hand. An explicit <c>.VAlign(…)</c> on this
+    /// element always wins over the opt-in.
+    /// <para>Defaults to <c>false</c> so the WinUI style default is preserved.</para>
+    /// </remarks>
+    public bool FillContentArea { get; init; }
     /// <summary>
     /// Fires when the user starts dragging a tab. <c>tabIndex</c> is the index
     /// of the dragged tab in <see cref="Tabs"/>. Used by spec 045 §2.4 docking

--- a/src/Reactor/Elements/ElementExtensions.cs
+++ b/src/Reactor/Elements/ElementExtensions.cs
@@ -1920,7 +1920,8 @@ public static partial class ElementExtensions
     /// <remarks>
     /// WinUI's default TabView style sets <c>VerticalAlignment="Top"</c> on the control, so
     /// by default the tab body is sized to its content and a tab child with its own
-    /// background paints only a band. See <see cref="TabViewElement.FillContentArea"/>.
+    /// background paints only a band. An explicit <c>.VAlign(…)</c> on the TabView element
+    /// always wins over this opt-in. See <see cref="TabViewElement.FillContentArea"/>.
     /// </remarks>
     public static TabViewElement FillContentArea(this TabViewElement el, bool fill = true) =>
         el with { FillContentArea = fill };

--- a/src/Reactor/Elements/ElementExtensions.cs
+++ b/src/Reactor/Elements/ElementExtensions.cs
@@ -1913,6 +1913,18 @@ public static partial class ElementExtensions
     public static TabViewElement TabStripFooter(this TabViewElement el, Element footer) =>
         el with { TabStripFooter = footer };
 
+    /// <summary>
+    /// Makes the tab content area fill the space the parent gives the TabView, instead of
+    /// collapsing to the content's own height (issue #914).
+    /// </summary>
+    /// <remarks>
+    /// WinUI's default TabView style sets <c>VerticalAlignment="Top"</c> on the control, so
+    /// by default the tab body is sized to its content and a tab child with its own
+    /// background paints only a band. See <see cref="TabViewElement.FillContentArea"/>.
+    /// </remarks>
+    public static TabViewElement FillContentArea(this TabViewElement el, bool fill = true) =>
+        el with { FillContentArea = fill };
+
     /// <inheritdoc cref="IsAddTabButtonVisible"/>
     [Obsolete("Use IsAddTabButtonVisible() — aligns with WinUI naming (see #268).")]
     public static TabViewElement IsAddButtonVisible(this TabViewElement el, bool visible = true) =>

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/TabViewFillContentAreaFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/TabViewFillContentAreaFixtures.cs
@@ -106,15 +106,17 @@ internal static class TabViewFillContentAreaFixtures
     }
 
     /// <summary>
-    /// An explicit <c>.VAlign(…)</c> wins over the opt-in, on mount AND on every subsequent
-    /// re-render. <c>Center</c> is deliberately chosen because it is neither WinUI's style
-    /// default (<c>Top</c>) nor the value the opt-in writes (<c>Stretch</c>), so each check
-    /// fails if either the modifier or the opt-in misbehaves.
+    /// An explicit <c>.VAlign(…)</c> wins over the opt-in, on mount AND across every
+    /// subsequent transition of the opt-in. <c>Center</c> is deliberately chosen because it
+    /// is neither WinUI's style default (<c>Top</c>) nor the value the opt-in resolves to
+    /// (<c>Stretch</c>), so each check fails if either the modifier or the opt-in misbehaves.
     ///
-    /// <para>The re-render phases are the real oracle: <c>ApplyModifiers</c> only re-writes
-    /// the alignment when the modifier <em>changed</em>, so an opt-in that wrote
-    /// unconditionally would clobber an unchanged explicit alignment on the second render,
-    /// and the on→off release would clobber it on the third.</para>
+    /// <para>The transition phases are the real oracle. <c>ApplyModifiers</c> only re-writes
+    /// the alignment when the modifier <em>changed</em>, and it is skipped here on every
+    /// re-render because the author's <c>Center</c> never changes. So if the opt-in did not
+    /// stand down, the off→on edge would overwrite <c>Center</c> with <c>Stretch</c> and the
+    /// on→off edge would <c>ClearValue</c> it away to the style's <c>Top</c> — with nothing
+    /// left to restore it.</para>
     /// </summary>
     internal class ExplicitAlignmentWins(Harness h) : SelfTestFixtureBase(h)
     {
@@ -128,8 +130,9 @@ internal static class TabViewFillContentAreaFixtures
                     () => phase,
                     () => set(phase + 1),
                     // Phase 0/1: opt-in ON with an explicit alignment, unchanged across the
-                    // re-render. Phase 2: opt-in flipped OFF, alignment still unchanged.
-                    static (p, tab) => p <= 1
+                    // re-render. Phase 2: opt-in flipped OFF. Phase 3: opt-in flipped back
+                    // ON. The explicit alignment is identical in all four phases.
+                    static (p, tab) => p <= 1 || p >= 3
                         ? tab.FillContentArea().VAlign(VerticalAlignment.Center)
                         : tab.VAlign(VerticalAlignment.Center));
             });
@@ -159,6 +162,15 @@ internal static class TabViewFillContentAreaFixtures
             await Harness.Render();
             H.Check("TabViewFill_ExplicitSurvivesOptOut",
                 tabView.VerticalAlignment == VerticalAlignment.Center);
+
+            // Phase 3 — opt-in turned back on, alignment still unchanged. This is the edge
+            // where an unguarded opt-in would newly resolve to Stretch and overwrite Center.
+            H.ClickButton("Advance");
+            await Harness.Render();
+            H.Check("TabViewFill_ExplicitSurvivesOptIn",
+                tabView.VerticalAlignment == VerticalAlignment.Center);
+            H.Check("TabViewFill_ExplicitBodyStillContentSizedAfterOptIn",
+                Body(H)!.ActualHeight < FilledBodyFloor);
         }
     }
 }

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/TabViewFillContentAreaFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/TabViewFillContentAreaFixtures.cs
@@ -1,0 +1,164 @@
+using Microsoft.UI.Reactor;
+using Microsoft.UI.Reactor.Core;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation;
+using Microsoft.UI.Xaml.Controls;
+using static Microsoft.UI.Reactor.Factories;
+
+namespace Microsoft.UI.Reactor.AppTests.Host.SelfTest.Fixtures;
+
+/// <summary>
+/// Issue #914 — WinUI's <c>DefaultTabViewStyle</c> sets <c>VerticalAlignment="Top"</c> on
+/// the TabView itself, so the control is arranged at its desired height and the <c>*</c>
+/// content row of its template never receives the leftover space. Tab content therefore
+/// collapses to its own height and a tab child with a background paints only a band.
+///
+/// <para>These fixtures pin the <c>FillContentArea</c> opt-in against a live control: the
+/// WinUI default must be preserved when the flag is off, the tab body must actually grow
+/// to the remaining height when it is on, the transition must work in both directions, and
+/// an explicit <c>.VAlign(…)</c> must still win.</para>
+/// </summary>
+internal static class TabViewFillContentAreaFixtures
+{
+    // The host Grid is 400 px tall with an Auto button row on top, so the TabView's slot is
+    // ~350 px. The tab strip eats ~40 px, leaving ~310 px of content area; an unstretched
+    // body is a single line of text (~20 px). The 150 px threshold sits far outside both.
+    private const double HostHeight = 400;
+    private const double FilledBodyFloor = 150;
+
+    private static Element BuildHost(
+        Func<int> getPhase,
+        Action advance,
+        Func<int, TabViewElement, TabViewElement> configure)
+    {
+        var tab = configure(
+            getPhase(),
+            TabView(new TabViewItemData("Tab1", Border(TextBlock("body")).AutomationId("tab-body"))));
+
+        return Grid([GridSize.Star()], [GridSize.Auto, GridSize.Star()],
+                Button("Advance", advance).Grid(row: 0, column: 0),
+                tab.Grid(row: 1, column: 0))
+            .Width(600).Height(HostHeight);
+    }
+
+    private static Border? Body(Harness h) =>
+        h.FindControl<Border>(b => AutomationProperties.GetAutomationId(b) == "tab-body");
+
+    /// <summary>
+    /// Off → on → off. Asserts the opt-out keeps WinUI's <c>Top</c> AND a content-sized
+    /// body, that opting in both flips the alignment and makes the body actually fill the
+    /// remaining height, and that opting back out releases the local value so the style
+    /// default applies again.
+    /// </summary>
+    internal class ToggleFillContentArea(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                var (phase, set) = ctx.UseState(0);
+                return BuildHost(
+                    () => phase,
+                    () => set(phase + 1),
+                    static (p, tab) => p == 1 ? tab.FillContentArea() : tab);
+            });
+
+            await Harness.Render();
+            var tabView = H.FindControl<TabView>(_ => true);
+            H.Check("TabViewFill_Mounted", tabView is not null && Body(H) is not null);
+            if (tabView is null) throw new InvalidOperationException("TabView was not mounted.");
+
+            // Phase 0 — opt-out: WinUI's style default is untouched and the body is
+            // content-sized (this is the pre-fix behaviour, deliberately preserved).
+            double bodyOff = Body(H)!.ActualHeight;
+            H.Check("TabViewFill_OffKeepsWinUIDefault",
+                tabView.VerticalAlignment == VerticalAlignment.Top);
+            H.Check("TabViewFill_OffBodyIsContentSized",
+                bodyOff > 0 && bodyOff < FilledBodyFloor);
+
+            // Phase 1 — opt-in: alignment flips AND the body genuinely fills the slot. The
+            // height assertions are the real oracle: deleting the descriptor entry leaves
+            // bodyOn == bodyOff.
+            H.ClickButton("Advance");
+            await Harness.Render();
+            double bodyOn = Body(H)!.ActualHeight;
+            H.Check("TabViewFill_OnStretchesControl",
+                tabView.VerticalAlignment == VerticalAlignment.Stretch);
+            H.Check("TabViewFill_OnBodyFillsContentArea", bodyOn > FilledBodyFloor);
+            H.Check("TabViewFill_OnBodyGrewOverOff", bodyOn > bodyOff * 3);
+            // The TabView now fills its ~350 px slot, and the tab body reaches its bottom
+            // minus only the tab strip.
+            H.Check("TabViewFill_OnBodyReachesTabViewBottom",
+                tabView.ActualHeight > FilledBodyFloor * 2
+                && tabView.ActualHeight - bodyOn < 60);
+
+            // Phase 2 — back off: the local Stretch is released, so WinUI's style default
+            // takes over again and the body re-collapses.
+            H.ClickButton("Advance");
+            await Harness.Render();
+            double bodyOffAgain = Body(H)!.ActualHeight;
+            H.Check("TabViewFill_ToggledOffRestoresWinUIDefault",
+                tabView.VerticalAlignment == VerticalAlignment.Top);
+            H.Check("TabViewFill_ToggledOffBodyCollapsesAgain",
+                bodyOffAgain < FilledBodyFloor && Math.Abs(bodyOffAgain - bodyOff) < 2);
+        }
+    }
+
+    /// <summary>
+    /// An explicit <c>.VAlign(…)</c> wins over the opt-in, on mount AND on every subsequent
+    /// re-render. <c>Center</c> is deliberately chosen because it is neither WinUI's style
+    /// default (<c>Top</c>) nor the value the opt-in writes (<c>Stretch</c>), so each check
+    /// fails if either the modifier or the opt-in misbehaves.
+    ///
+    /// <para>The re-render phases are the real oracle: <c>ApplyModifiers</c> only re-writes
+    /// the alignment when the modifier <em>changed</em>, so an opt-in that wrote
+    /// unconditionally would clobber an unchanged explicit alignment on the second render,
+    /// and the on→off release would clobber it on the third.</para>
+    /// </summary>
+    internal class ExplicitAlignmentWins(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                var (phase, set) = ctx.UseState(0);
+                return BuildHost(
+                    () => phase,
+                    () => set(phase + 1),
+                    // Phase 0/1: opt-in ON with an explicit alignment, unchanged across the
+                    // re-render. Phase 2: opt-in flipped OFF, alignment still unchanged.
+                    static (p, tab) => p <= 1
+                        ? tab.FillContentArea().VAlign(VerticalAlignment.Center)
+                        : tab.VAlign(VerticalAlignment.Center));
+            });
+
+            await Harness.Render();
+            var tabView = H.FindControl<TabView>(_ => true);
+            if (tabView is null) throw new InvalidOperationException("TabView was not mounted.");
+
+            double bodyPinned = Body(H)!.ActualHeight;
+            H.Check("TabViewFill_ExplicitCenterBeatsOptIn",
+                tabView.VerticalAlignment == VerticalAlignment.Center);
+            H.Check("TabViewFill_ExplicitBodyStaysContentSized",
+                bodyPinned > 0 && bodyPinned < FilledBodyFloor);
+
+            // Phase 1 — re-render with the SAME explicit alignment. ApplyModifiers skips
+            // unchanged values, so nothing but the opt-in could move this.
+            H.ClickButton("Advance");
+            await Harness.Render();
+            H.Check("TabViewFill_ExplicitSurvivesRerender",
+                tabView.VerticalAlignment == VerticalAlignment.Center);
+            H.Check("TabViewFill_ExplicitBodyStillContentSizedAfterRerender",
+                Body(H)!.ActualHeight < FilledBodyFloor);
+
+            // Phase 2 — opt-in turned off while the explicit alignment stays put: the
+            // release must not steal the author's value either.
+            H.ClickButton("Advance");
+            await Harness.Render();
+            H.Check("TabViewFill_ExplicitSurvivesOptOut",
+                tabView.VerticalAlignment == VerticalAlignment.Center);
+        }
+    }
+}

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -353,6 +353,8 @@ internal static class SelfTestFixtureRegistry
         "ControlUpdate2_RichEditBox",
         "ControlUpdate2_AutoSuggestBox",
         "WrapElementSlot_TabStripHeaderMountUpdateRemove",
+        "TabViewFill_ToggleFillContentArea",
+        "TabViewFill_ExplicitAlignmentWins",
         // Modifier and event handler tests
         "ModifierEvent_EventHandlers",
         "ModifierEvent_Brushes",
@@ -1877,6 +1879,8 @@ internal static class SelfTestFixtureRegistry
         "ControlUpdate2_RichEditBox" => new ControlUpdateFixtures2.RichEditBoxUpdate(harness),
         "ControlUpdate2_AutoSuggestBox" => new ControlUpdateFixtures2.AutoSuggestBoxUpdate(harness),
         "WrapElementSlot_TabStripHeaderMountUpdateRemove" => new WrapElementSlotFixtures.TabStripHeaderMountUpdateRemove(harness),
+        "TabViewFill_ToggleFillContentArea" => new TabViewFillContentAreaFixtures.ToggleFillContentArea(harness),
+        "TabViewFill_ExplicitAlignmentWins" => new TabViewFillContentAreaFixtures.ExplicitAlignmentWins(harness),
         // Modifier and event handler tests
         "ModifierEvent_EventHandlers" => new ModifierEventFixtures.EventHandlerModifiers(harness),
         "ModifierEvent_Brushes" => new ModifierEventFixtures.BrushModifiers(harness),

--- a/tests/Reactor.Tests/ElementExtensionsCoverageTests.cs
+++ b/tests/Reactor.Tests/ElementExtensionsCoverageTests.cs
@@ -471,6 +471,16 @@ public class ElementExtensionsCoverageTests
     }
 
     [Fact]
+    public void TabView_FillContentArea_DefaultsOffAndOptsIn()
+    {
+        // Default must stay off so WinUI's DefaultTabViewStyle (VerticalAlignment="Top")
+        // is preserved for existing apps — issue #914.
+        Assert.False(TabView([]).FillContentArea);
+        Assert.True(TabView([]).FillContentArea().FillContentArea);
+        Assert.False(TabView([]).FillContentArea().FillContentArea(false).FillContentArea);
+    }
+
+    [Fact]
     [Obsolete("Tests the deprecated IsAddButtonVisible shim")]
     public void TabView_IsAddButtonVisible_Shim()
     {

--- a/tests/Reactor.Tests/OwnPropsEqualTests.cs
+++ b/tests/Reactor.Tests/OwnPropsEqualTests.cs
@@ -607,6 +607,7 @@ public class OwnPropsEqualTests
     [Theory]
     [InlineData("selectedIndex")]
     [InlineData("addBtn")]
+    [InlineData("fillContentArea")]
     public void TabViewElement_DifferingProp_NotEqual(string which)
     {
         var tabs = new[] { new TabViewItemData("h", new EmptyElement()) };
@@ -615,6 +616,7 @@ public class OwnPropsEqualTests
         {
             "selectedIndex" => a with { SelectedIndex = 1 },
             "addBtn" => a with { IsAddTabButtonVisible = true },
+            "fillContentArea" => a with { FillContentArea = true },
             _ => throw new global::System.InvalidOperationException(),
         };
         Assert.False(Element.OwnPropsEqual(a, b));


### PR DESCRIPTION
Fixes #914.

## Root cause

WinUI's `DefaultTabViewStyle` ([`controls/dev/TabView/TabView.xaml`](https://github.com/microsoft/microsoft-ui-xaml/blob/winui3/main/controls/dev/TabView/TabView.xaml)) ships:

```xml
<Setter Property="VerticalAlignment" Value="Top" />
```

on the `TabView` **control itself**. The template is a Grid with rows `Auto` (tab strip) / `*` (content), and the `TabContentPresenter` in row 1 has no alignment attributes (it's already `Stretch` on both axes). Because a top-aligned control is arranged at its *desired* height, the `*` row never receives any leftover space — so tab content collapses to its own height and the rest of the tab body stays unpainted.

That also explains why the workarounds in the issue failed: `TabViewItem`'s template hard-codes `Content=""` and renders only the tab-strip chip, while `TabView.cpp` re-hosts the selected tab's content in `TabContentPresenter`. Neither `.VAlign(Stretch)` on the tab child nor walking up to the `TabViewItem` can reach the control that is actually top-aligned.

Measured on a live control before the fix (600×400 host):

```
default:            tv=(600.0x59.0)  va=Top  presenter=(600.0x19.0)  body=(600.0x19.0)
VAlign(Stretch):    tv=(600.0x368.0)         presenter=(600.0x328.0) body=(600.0x328.0)
```

## The fix — an opt-in, not a default change

Reactor keeps the WinUI default. Two equivalent surfaces:

```csharp
TabView([...]).FillContentArea()
TabView([...]) with { FillContentArea = true }
```

Implemented as a leading `.ImperativeBridged(mount, update)` entry on the existing TabView `ControlDescriptor`. When the opt-in owns the alignment it writes `VerticalAlignment.Stretch`; on the on→off transition it calls `ClearValue(FrameworkElement.VerticalAlignmentProperty)` so the style's `Top` applies again (`TabView` isn't pooled, so mount always starts from the style value).

**An explicit `.VAlign(...)` always wins** — the opt-in stands down entirely when one is present. Simply deferring to `ApplyModifiers` (which runs after descriptor dispatch) is *not* enough: it only re-writes alignment when the modifier **changed**, so an unchanged `.VAlign(Center)` would have been clobbered by the opt-in on every subsequent re-render. That bug was caught by the multi-model PR review and is now covered by three assertions that fail without the guard.

## Tests

New selftest fixtures (`TabViewFillContentAreaFixtures`) measure real WinUI layout — headless xUnit can't construct XAML objects:

| Fixture | Covers |
|---|---|
| `ToggleFillContentArea` | off → on → off; alignment **and** measured body height in every phase |
| `ExplicitAlignmentWins` | explicit `Center` (neither `Top` nor `Stretch`, so no assertion can pass vacuously) survives mount, an unchanged re-render, and the opt-out transition |

All three write arms were mutation-checked:

- no-op `if (WritesFill(element)) ... Stretch` → 3 assertions fail
- no-op the `ClearValue` arm → 2 assertions fail
- drop the explicit-alignment guard → 3 assertions fail

Plus headless coverage for the record surface (`ElementExtensionsCoverageTests`) and `Element.OwnPropsEqual`.

## Validation

- `dotnet build Reactor.slnx` — 0 warnings, 0 errors
- `tests/Reactor.Tests` — 12,460 passed, 0 failed
- full selftest suite — 0 failures (TabViewFill: 14/14 ok)
- both public API index copies regenerated via `Reactor.SignaturesGen`
- docs added to the `navigation.md.dt` template and recompiled; CHANGELOG entry added

## Downstream

The Windows App SDK `reactor-tabview` template can drop its `UseWindowSize()` + `.MinHeight(windowHeight)` workaround in favour of `.FillContentArea()`.