### PR TITLE
Let the OS pick the default window size instead of hardcoding 1024x768

### DIFF
--- a/docs/_pipeline/templates/windows.md.dt
+++ b/docs/_pipeline/templates/windows.md.dt
@@ -58,7 +58,10 @@ Caveats:
 
 ## Sizing & resizing
 
-Initial `Width` / `Height` are DIPs. Runtime size is controlled by `SetSize`,
+Initial `Width` / `Height` are DIPs, and both are optional — leave them unset
+(the default) to let the OS choose the initial window size, exactly as a plain
+XAML `Window` does. Setting only one axis applies that axis and leaves the other
+to the OS. Runtime size is controlled by `SetSize`,
 chrome resize policy by `ResizeMode`, interactive aspect locks by `AspectRatio`,
 and content-driven sizing by `SizeToContent`.
 
@@ -87,7 +90,8 @@ Caveats:
 - `AspectRatio` rejects `ResizeMode.NoResize`; no drag means no constraint to apply.
 - `AspectRatio` and `SizeToContent` are mutually exclusive layout drivers.
 - `SizeToContent` runs after layout, so the first frame can briefly use the
-  initial `Width` / `Height`; maximized windows ignore it and log a warning.
+  initial `Width` / `Height` (or the OS-chosen size when they are unset);
+  maximized windows ignore it and log a warning.
 - Min/max fields (`MinWidth`, `MaxHeight`, etc.) win over content and aspect sizing.
 
 ## Movement & placement

--- a/docs/guide/windows.md
+++ b/docs/guide/windows.md
@@ -50,7 +50,10 @@ Caveats:
 
 ## Sizing & resizing
 
-Initial `Width` / `Height` are DIPs. Runtime size is controlled by `SetSize`,
+Initial `Width` / `Height` are DIPs, and both are optional — leave them unset
+(the default) to let the OS choose the initial window size, exactly as a plain
+XAML `Window` does. Setting only one axis applies that axis and leaves the other
+to the OS. Runtime size is controlled by `SetSize`,
 chrome resize policy by `ResizeMode`, interactive aspect locks by `AspectRatio`,
 and content-driven sizing by `SizeToContent`.
 
@@ -79,7 +82,8 @@ Caveats:
 - `AspectRatio` rejects `ResizeMode.NoResize`; no drag means no constraint to apply.
 - `AspectRatio` and `SizeToContent` are mutually exclusive layout drivers.
 - `SizeToContent` runs after layout, so the first frame can briefly use the
-  initial `Width` / `Height`; maximized windows ignore it and log a warning.
+  initial `Width` / `Height` (or the OS-chosen size when they are unset);
+  maximized windows ignore it and log a warning.
 - Min/max fields (`MinWidth`, `MaxHeight`, etc.) win over content and aspect sizing.
 
 ## Movement & placement

--- a/docs/specs/036-window-design.md
+++ b/docs/specs/036-window-design.md
@@ -1017,9 +1017,18 @@ ReactorApp.Run<App>("Title", 1024, 768)             same call site
 
 `width` / `height` on both `Run` overloads became `double?` with a `null`
 default, and `WindowSpec.Width` / `Height` followed. Call sites that pass
-sizes explicitly are unaffected. Call sites that relied on the implicit
-1024 × 768 now open at the OS-chosen size instead; apps that want the old
-extent state it: `ReactorApp.Run<App>("Title", 1024, 768)`.
+sizes explicitly keep compiling unchanged. Call sites that relied on the
+implicit 1024 × 768 now open at the OS-chosen size instead; apps that want
+the old extent state it: `ReactorApp.Run<App>("Title", 1024, 768)`.
+
+This is source-compatible but **binary-breaking**: `double` → `double?`
+changes the signatures of both `Run` overloads, the `WindowSpec.Width` /
+`Height` accessors, and the `ReactorDevtoolsBootRequest` constructor /
+`Deconstruct`. Already-compiled consumers must recompile. We accept the
+break rather than ship `double` compat overloads — Reactor is pre-1.0, the
+package makes no ABI promise yet, and §12.1 already sets the precedent of
+taking a deliberate break here rather than carrying a shim. Release notes
+flag it alongside the DIP change.
 
 ### 12.3 Configure callback
 

--- a/docs/specs/036-window-design.md
+++ b/docs/specs/036-window-design.md
@@ -231,8 +231,8 @@ namespace Microsoft.UI.Reactor;
 
 public sealed record WindowSpec(
     string Title = "Reactor App",
-    double Width = 1024,                                          // DIPs
-    double Height = 768,                                          // DIPs
+    double? Width = null,                                          // DIPs; null = OS default
+    double? Height = null,                                         // DIPs; null = OS default
     double? MinWidth = null,
     double? MinHeight = null,
     double? MaxWidth = null,
@@ -257,6 +257,16 @@ public sealed record WindowSpec(
 All sizes / positions are DIPs. The record is immutable; `Update(spec)`
 on `ReactorWindow` diffs old vs. new and applies only the changed
 fields, in the same spirit as the reconciler.
+
+> **On the absent size default.** `Width` / `Height` are `double?` and
+> default to `null`, meaning *"don't call `AppWindow.Resize` at all"* — the
+> window opens at whatever size Windows picks for a new top-level window,
+> exactly like a plain XAML `Window`. Reactor originally inherited a
+> hardcoded 1024 × 768 from the pre-036 `Run<TRoot>` signature; that number
+> was never a design decision, and baking it in meant every app that didn't
+> care about size still fought the shell's own placement heuristics. Setting
+> one axis and leaving the other `null` applies the requested axis and keeps
+> the OS extent on the other.
 
 > **On `double` vs `float`.** DIPs are floating-point — the question is
 > single vs. double precision. We use `double` to match the rest of the
@@ -322,8 +332,8 @@ public static partial class ReactorApp
     // Implemented as: Run(ctx => ctx.OpenWindow(spec, () => new TRoot()));
     public static void Run<TRoot>(
         string title = "Reactor App",
-        double width = 1024,
-        double height = 768,
+        double? width = null,
+        double? height = null,
         bool fullScreen = false,
         bool devtools = false,
         Action<ReactorHost>? configure = null) where TRoot : Component, new();
@@ -1002,6 +1012,14 @@ Old (today):                                        New (no source change):
 ReactorApp.Run<App>("Title", 1024, 768)             same call site
                                                     width=1024, height=768 are now DIPs
 ```
+
+### 12.2a Dropping the size defaults
+
+`width` / `height` on both `Run` overloads became `double?` with a `null`
+default, and `WindowSpec.Width` / `Height` followed. Call sites that pass
+sizes explicitly are unaffected. Call sites that relied on the implicit
+1024 × 768 now open at the OS-chosen size instead; apps that want the old
+extent state it: `ReactorApp.Run<App>("Title", 1024, 768)`.
 
 ### 12.3 Configure callback
 

--- a/plugins/reactor/skills/reactor-dsl/references/reactor.api.txt
+++ b/plugins/reactor/skills/reactor-dsl/references/reactor.api.txt
@@ -5524,17 +5524,17 @@ ReferenceList<TTarget>(Func<TElement, IReadOnlyList<ElementRef<TTarget>>> get, A
 WriteSuppressed(Action mutate) → void
 
 ### record ReactorDevtoolsBootRequest
-new(DevtoolsCliOptions Options, string Title, double Width, double Height, bool FullScreen, Type HostRoot, Func<Component> HostRootFactory, Func<RenderContext, Element> RootRenderFunc, Action<ReactorHost> Configure)
+new(DevtoolsCliOptions Options, string Title, double? Width, double? Height, bool FullScreen, Type HostRoot, Func<Component> HostRootFactory, Func<RenderContext, Element> RootRenderFunc, Action<ReactorHost> Configure)
 Action<ReactorHost> Configure { get; init; }
 DevtoolsCliOptions Options { get; init; }
 Func<Component> HostRootFactory { get; init; }
 Func<RenderContext, Element> RootRenderFunc { get; init; }
 Type HostRoot { get; init; }
 bool FullScreen { get; init; }
-double Height { get; init; }
-double Width { get; init; }
+double? Height { get; init; }
+double? Width { get; init; }
 string Title { get; init; }
-Deconstruct(ref DevtoolsCliOptions Options, ref string Title, ref double Width, ref double Height, ref bool FullScreen, ref Type HostRoot, ref Func<Component> HostRootFactory, ref Func<RenderContext, Element> RootRenderFunc, ref Action<ReactorHost> Configure) → void
+Deconstruct(ref DevtoolsCliOptions Options, ref string Title, ref double? Width, ref double? Height, ref bool FullScreen, ref Type HostRoot, ref Func<Component> HostRootFactory, ref Func<RenderContext, Element> RootRenderFunc, ref Action<ReactorHost> Configure) → void
 Equals(ReactorDevtoolsBootRequest other) → bool
 Equals(object obj) → bool
 GetHashCode() → int
@@ -7344,14 +7344,14 @@ bool PersistPlacement { get; init; }
 bool ShowInSwitcher { get; init; }
 bool ShowInTaskbar { get; init; }
 bool? ExtendsContentIntoTitleBar { get; init; }
-double Height { get; init; }
 double Opacity { get; init; }
-double Width { get; init; }
 double? AspectRatio { get; init; }
+double? Height { get; init; }
 double? MaxHeight { get; init; }
 double? MaxWidth { get; init; }
 double? MinHeight { get; init; }
 double? MinWidth { get; init; }
+double? Width { get; init; }
 string PersistenceId { get; init; }
 string Title { get; init; }
 Equals(WindowSpec other) → bool

--- a/plugins/reactor/skills/reactor-getting-started/SKILL.md
+++ b/plugins/reactor/skills/reactor-getting-started/SKILL.md
@@ -115,7 +115,7 @@ Memo(ctx => TextBlock($"Hi, {name}"), name)    // re-render when deps change
 
 `Component` skips parent-triggered re-renders by default. `Component<TProps>` skips when `Equals(oldProps, newProps)`.
 
-**App entry point.** `ReactorApp.Run<MyRoot>("Title", width: W, height: H)` against a component class (the scaffolded form). For a tiny demo without a class, the inline form: `ReactorApp.Run("Title", ctx => { var (m, setM) = ctx.UseState("hi"); return TextBlock(m); })`.
+**App entry point.** `ReactorApp.Run<MyRoot>("Title", width: W, height: H)` against a component class (the scaffolded form). `width`/`height` are optional DIPs — omit them to let the OS choose the initial window size. For a tiny demo without a class, the inline form: `ReactorApp.Run("Title", ctx => { var (m, setM) = ctx.UseState("hi"); return TextBlock(m); })`.
 
 ## Hooks
 

--- a/samples/ReactorGallery/Program.cs
+++ b/samples/ReactorGallery/Program.cs
@@ -3,7 +3,11 @@ using Microsoft.UI.Reactor.Core;
 using Microsoft.UI.Reactor.Hosting;
 using static Microsoft.UI.Reactor.Factories;
 
-ReactorApp.Run<WinUIGalleryReactor.GalleryShell>("WinUI Gallery (Reactor)", width: 1400, height: 900,
+// No explicit width/height: the gallery is content-heavy and benefits from a
+// window proportional to the display, which is what the OS default gives
+// (~3/4 of the work area). This is also the sample that dogfoods the spec 036
+// §4.1 "unset size defers to the OS" path.
+ReactorApp.Run<WinUIGalleryReactor.GalleryShell>("WinUI Gallery (Reactor)",
     configure: host =>
     {
         XamlInterop.Register(host.Reconciler);

--- a/samples/apps/demo-script-tool/App/Resources/SystemPrompt.txt
+++ b/samples/apps/demo-script-tool/App/Resources/SystemPrompt.txt
@@ -96,6 +96,7 @@ Reactor essentials you may need:
 - Effects: `ctx.UseEffect(() => { /* mount */ return () => { /* cleanup */ }; }, deps)`.
 - App entry: `ReactorApp.Run("Title", ctx => element);` for inline, or
   `ReactorApp.Run<MyComponent>("Title", width: 1200, height: 800);`.
+  width/height are optional — omit them to let the OS size the window.
 
 When a demo introduces "WinUI 3 / XAML developers to Reactor", the goal
 is to show a Reactor app that matches what they would have written in

--- a/samples/apps/widget-creator/Resources/SystemPrompt.txt
+++ b/samples/apps/widget-creator/Resources/SystemPrompt.txt
@@ -131,7 +131,8 @@ static class WidgetSelfTest
 ```
 
 ## Reactor API you may use (this is the CORE surface — do not invent members)
-- Entry: `ReactorApp.Run<App>("Title", width: W, height: H);`
+- Entry: `ReactorApp.Run<App>("Title", width: W, height: H);` — width/height are
+  optional DIPs; omit them to let the OS pick the initial window size.
 - Startup: call `CrashReporter.Install();` immediately before `ReactorApp.Run<App>(...)`.
 - Component: `class App : Component { public override Element Render() => ErrorBoundary(Component<WidgetBody>(), CrashReporter.ReportAndExit); }`,
   then put the actual widget UI in `class WidgetBody : Component { ... }`.

--- a/skills/reactor.api.txt
+++ b/skills/reactor.api.txt
@@ -5524,17 +5524,17 @@ ReferenceList<TTarget>(Func<TElement, IReadOnlyList<ElementRef<TTarget>>> get, A
 WriteSuppressed(Action mutate) → void
 
 ### record ReactorDevtoolsBootRequest
-new(DevtoolsCliOptions Options, string Title, double Width, double Height, bool FullScreen, Type HostRoot, Func<Component> HostRootFactory, Func<RenderContext, Element> RootRenderFunc, Action<ReactorHost> Configure)
+new(DevtoolsCliOptions Options, string Title, double? Width, double? Height, bool FullScreen, Type HostRoot, Func<Component> HostRootFactory, Func<RenderContext, Element> RootRenderFunc, Action<ReactorHost> Configure)
 Action<ReactorHost> Configure { get; init; }
 DevtoolsCliOptions Options { get; init; }
 Func<Component> HostRootFactory { get; init; }
 Func<RenderContext, Element> RootRenderFunc { get; init; }
 Type HostRoot { get; init; }
 bool FullScreen { get; init; }
-double Height { get; init; }
-double Width { get; init; }
+double? Height { get; init; }
+double? Width { get; init; }
 string Title { get; init; }
-Deconstruct(ref DevtoolsCliOptions Options, ref string Title, ref double Width, ref double Height, ref bool FullScreen, ref Type HostRoot, ref Func<Component> HostRootFactory, ref Func<RenderContext, Element> RootRenderFunc, ref Action<ReactorHost> Configure) → void
+Deconstruct(ref DevtoolsCliOptions Options, ref string Title, ref double? Width, ref double? Height, ref bool FullScreen, ref Type HostRoot, ref Func<Component> HostRootFactory, ref Func<RenderContext, Element> RootRenderFunc, ref Action<ReactorHost> Configure) → void
 Equals(ReactorDevtoolsBootRequest other) → bool
 Equals(object obj) → bool
 GetHashCode() → int
@@ -7344,14 +7344,14 @@ bool PersistPlacement { get; init; }
 bool ShowInSwitcher { get; init; }
 bool ShowInTaskbar { get; init; }
 bool? ExtendsContentIntoTitleBar { get; init; }
-double Height { get; init; }
 double Opacity { get; init; }
-double Width { get; init; }
 double? AspectRatio { get; init; }
+double? Height { get; init; }
 double? MaxHeight { get; init; }
 double? MaxWidth { get; init; }
 double? MinHeight { get; init; }
 double? MinWidth { get; init; }
+double? Width { get; init; }
 string PersistenceId { get; init; }
 string Title { get; init; }
 Equals(WindowSpec other) → bool

--- a/src/Reactor.Devtools/DevtoolsHost.cs
+++ b/src/Reactor.Devtools/DevtoolsHost.cs
@@ -102,7 +102,7 @@ internal sealed class DevtoolsHost : IReactorDevtoolsHost
     }
 
     [RequiresUnreferencedCode("Devtools component discovery uses Assembly.GetTypes().")]
-    private static bool RunScreenshotSubverb(DevtoolsCliOptions options, double width, double height, Action<ReactorHost>? configure, Type? hostRoot = null)
+    private static bool RunScreenshotSubverb(DevtoolsCliOptions options, double? width, double? height, Action<ReactorHost>? configure, Type? hostRoot = null)
     {
         if (string.IsNullOrEmpty(options.ScreenshotOutputPath))
         {
@@ -181,7 +181,7 @@ internal sealed class DevtoolsHost : IReactorDevtoolsHost
     }
 
     [RequiresUnreferencedCode("Devtools component discovery uses Assembly.GetTypes() and Activator.CreateInstance.")]
-    private bool RunRunSubverb(DevtoolsCliOptions options, string title, double width, double height, bool fullScreen, Action<ReactorHost>? configure, Type? hostRoot = null, Func<Component>? hostRootFactory = null)
+    private bool RunRunSubverb(DevtoolsCliOptions options, string title, double? width, double? height, bool fullScreen, Action<ReactorHost>? configure, Type? hostRoot = null, Func<Component>? hostRootFactory = null)
     {
         string? componentName = options.ComponentName;
         Type? componentType = null;
@@ -397,7 +397,7 @@ internal sealed class DevtoolsHost : IReactorDevtoolsHost
     }
 
 
-    internal static WindowSpec BuildEmbedWindowSpec(DevtoolsCliOptions options, string baseTitle, double width, double height)
+    internal static WindowSpec BuildEmbedWindowSpec(DevtoolsCliOptions options, string baseTitle, double? width, double? height)
     {
         if (!options.EmbedRequested || options.EmbedHostPid is not { } hostPid)
             throw new ArgumentException("Embed options must include --embed and --embed-host-pid.", nameof(options));

--- a/src/Reactor.Devtools/DevtoolsTools.cs
+++ b/src/Reactor.Devtools/DevtoolsTools.cs
@@ -390,8 +390,8 @@ internal static class DevtoolsTools
                     new[] { "component" },
                     ("component", Schema.Str("Component class name (allowlisted).")),
                     ("title", Schema.Str()),
-                    ("width", Schema.Num("Initial DIP width (default 1024).")),
-                    ("height", Schema.Num("Initial DIP height (default 768).")),
+                    ("width", Schema.Num("Initial DIP width. Omit to let the OS choose.")),
+                    ("height", Schema.Num("Initial DIP height. Omit to let the OS choose.")),
                     ("key", Schema.Str("Optional WindowKey for FindWindow lookup.")))),
             @params =>
             {
@@ -418,8 +418,8 @@ internal static class DevtoolsTools
                 var spec = new WindowSpec
                 {
                     Title = titleArg ?? component,
-                    Width = widthArg ?? 1024,
-                    Height = heightArg ?? 768,
+                    Width = widthArg,
+                    Height = heightArg,
                     Key = string.IsNullOrEmpty(keyArg) ? (WindowKey?)null : WindowKey.Of(keyArg!),
                 };
                 try { spec.Validate(); }

--- a/src/Reactor/Docking/Native/DockFloatingWindow.cs
+++ b/src/Reactor/Docking/Native/DockFloatingWindow.cs
@@ -154,7 +154,7 @@ public static class DockFloatingWindow
             excludeFromShutdownPolicy: true);
         windowHolder[0] = window;
         DockFloatingTracker.Register(window);
-        DockFloatingTracker.RegisterEntry(window, pane, spec.Width, spec.Height);
+        DockFloatingTracker.RegisterEntry(window, pane, spec.Width ?? width, spec.Height ?? height);
         if (manager is not null) DockFloatingTracker.RegisterFor(manager, window);
         // Spec 045 §2.6 — fire OnFloatingWindowCreated so apps can
         // observe the new top-level for telemetry / persistence /

--- a/src/Reactor/Hosting/Devtools/Contract/ReactorDevtoolsBootRequest.cs
+++ b/src/Reactor/Hosting/Devtools/Contract/ReactorDevtoolsBootRequest.cs
@@ -5,8 +5,8 @@ namespace Microsoft.UI.Reactor.Hosting.Devtools;
 public sealed record ReactorDevtoolsBootRequest(
     DevtoolsCliOptions Options,
     string Title,
-    double Width,
-    double Height,
+    double? Width,
+    double? Height,
     bool FullScreen,
     Type? HostRoot,
     Func<Component>? HostRootFactory,

--- a/src/Reactor/Hosting/ReactorApp.cs
+++ b/src/Reactor/Hosting/ReactorApp.cs
@@ -21,8 +21,8 @@ internal record ReactorAppOptions(
     Func<RenderContext, Element>? RootRenderFunc = null,
     Action<ReactorHost>? Configure = null,
     string WindowTitle = "Reactor App",
-    double WindowWidth = 1024,
-    double WindowHeight = 768,
+    double? WindowWidth = null,
+    double? WindowHeight = null,
     bool FullScreen = false,
     Action<ReactorAppContext>? Startup = null,
     WindowSpec? InitialWindowSpec = null);
@@ -227,7 +227,7 @@ public static partial class ReactorApp
     /// XAML loader for this process. Required when a third-party control library
     /// is referenced from a Reactor app that has no XAML files of its own (and
     /// therefore no compiler-generated provider that would auto-chain to the
-    /// library). Call before <see cref="Run{TRoot}(string, double, double, bool, Action{ReactorHost}?)"/>.
+    /// library). Call before <see cref="Run{TRoot}(string, double?, double?, bool, Action{ReactorHost}?)"/>.
     /// Idempotent (same instance is added at most once) and thread-safe.
     /// See https://github.com/microsoft/microsoft-ui-reactor/issues/142.
     /// </summary>
@@ -334,15 +334,18 @@ public static partial class ReactorApp
     private static readonly nint DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2 = -4;
 
     /// <summary>
-    /// Launches the app. Enable the <c>Reactor.DevtoolsSupport</c> runtime host
+    /// Launches the app. <paramref name="width"/> / <paramref name="height"/> are
+    /// DIPs; leave them <c>null</c> (the default) to let the OS pick the initial
+    /// window size, exactly as a plain XAML <c>Window</c> does. Enable the
+    /// <c>Reactor.DevtoolsSupport</c> runtime host
     /// configuration switch in DEBUG builds to allow the <c>mur devtools</c> /
     /// <c>--devtools</c> surface: component switching via VS Code, MCP agent tools,
     /// and component listing.
     /// </summary>
     public static void Run<TRoot>(
         string title = "Reactor App",
-        double width = 1024,
-        double height = 768,
+        double? width = null,
+        double? height = null,
         bool fullScreen = false,
         Action<ReactorHost>? configure = null)
         where TRoot : Component, new()
@@ -372,13 +375,15 @@ public static partial class ReactorApp
 
     /// <summary>
     /// Launches the app with a render function instead of a Component subclass.
+    /// <paramref name="width"/> / <paramref name="height"/> are DIPs; leave them
+    /// <c>null</c> to let the OS pick the initial window size.
     /// See the generic overload for devtools activation semantics.
     /// </summary>
     public static void Run(
         string title,
         Func<RenderContext, Element> rootRender,
-        double width = 1024,
-        double height = 768,
+        double? width = null,
+        double? height = null,
         bool fullScreen = false,
         Action<ReactorHost>? configure = null)
     {
@@ -441,7 +446,7 @@ public static partial class ReactorApp
     /// Use it for pre-mount setup that needs the live <see cref="ReactorHost"/>
     /// (logger wiring, custom reconciler registrations, host-level event
     /// hooks). Mirror of the <c>configure</c> parameter on the legacy
-    /// <see cref="Run{TRoot}(string, double, double, bool, Action{ReactorHost}?)"/>
+    /// <see cref="Run{TRoot}(string, double?, double?, bool, Action{ReactorHost}?)"/>
     /// entry — secondary windows now have the same escape hatch as the
     /// primary.
     /// </param>
@@ -772,17 +777,17 @@ public static partial class ReactorApp
     /// With <c>--vscode</c>, starts the capture server for the VS Code preview panel. Devtools
     /// dispatch requires the build-time <c>Reactor.DevtoolsSupport</c> switch.
     /// </summary>
-    private static bool TryRunDevtools(string title, double width, double height, bool fullScreen, Action<ReactorHost>? configure, Type? hostRoot = null, Func<Component>? hostRootFactory = null, Func<RenderContext, Element>? rootRenderFunc = null)
+    private static bool TryRunDevtools(string title, double? width, double? height, bool fullScreen, Action<ReactorHost>? configure, Type? hostRoot = null, Func<Component>? hostRootFactory = null, Func<RenderContext, Element>? rootRenderFunc = null)
     {
         return TryRunDevtoolsCore(Environment.GetCommandLineArgs(), title, width, height, fullScreen, configure, hostRoot, hostRootFactory, rootRenderFunc, exitOnUnavailable: true);
     }
 
-    internal static bool TryRunDevtoolsForTest(string[] args, string title, double width, double height, Action<ReactorHost>? configure = null, Type? hostRoot = null)
+    internal static bool TryRunDevtoolsForTest(string[] args, string title, double? width, double? height, Action<ReactorHost>? configure = null, Type? hostRoot = null)
     {
         return TryRunDevtoolsCore(args, title, width, height, fullScreen: false, configure, hostRoot, hostRootFactory: null, rootRenderFunc: null, exitOnUnavailable: false);
     }
 
-    private static bool TryRunDevtoolsCore(string[] args, string title, double width, double height, bool fullScreen, Action<ReactorHost>? configure, Type? hostRoot = null, Func<Component>? hostRootFactory = null, Func<RenderContext, Element>? rootRenderFunc = null, bool exitOnUnavailable = false)
+    private static bool TryRunDevtoolsCore(string[] args, string title, double? width, double? height, bool fullScreen, Action<ReactorHost>? configure, Type? hostRoot = null, Func<Component>? hostRootFactory = null, Func<RenderContext, Element>? rootRenderFunc = null, bool exitOnUnavailable = false)
     {
         var options = DevtoolsCliParser.Parse(args);
 

--- a/src/Reactor/Hosting/ReactorApp.cs
+++ b/src/Reactor/Hosting/ReactorApp.cs
@@ -759,7 +759,8 @@ public static partial class ReactorApp
     /// <summary>
     /// Emit one stderr <c>[reactor]</c> info-line per process the first time
     /// any <c>Run</c> overload is invoked, describing the DIP-vs-pixel size
-    /// behavior change. (spec 036 §12.1) The Phase-2 layer adds the actual
+    /// behavior change (spec 036 §12.1) and the dropped 1024×768 size default
+    /// (spec 036 §12.2a). The Phase-2 layer adds the actual
     /// DIP→pixel conversion; the message is wired now so the diagnostic
     /// surface lands in the same release.
     /// </summary>
@@ -767,8 +768,10 @@ public static partial class ReactorApp
     {
         if (Interlocked.CompareExchange(ref _dipBehaviorChangeNoticeEmitted, 1, 0) != 0) return;
         Console.Error.WriteLine(
-            "[reactor] WindowSpec.Width / Height and ReactorApp.Run<T>(width, height) are now DIPs. " +
-            "On a 100% display this is unchanged; on 200% the window is twice as large in physical pixels. (spec 036 §12.1)");
+            "[reactor] WindowSpec.Width / Height and ReactorApp.Run<T>(width, height) are now DIPs, " +
+            "and both are optional. On a 100% display an explicit size is unchanged; on 200% the window " +
+            "is twice as large in physical pixels. Omitting width/height now lets the OS choose the " +
+            "initial size — pass width: 1024, height: 768 to keep the old default extent. (spec 036 §12.1 / §12.2a)");
     }
 
     /// <summary>

--- a/src/Reactor/Hosting/ReactorWindow.cs
+++ b/src/Reactor/Hosting/ReactorWindow.cs
@@ -927,7 +927,8 @@ public sealed class ReactorWindow : IDisposable
     /// Builds the physical-pixel size a spec asks for, or returns false when the
     /// spec declares neither axis — the "let the OS size the window" default.
     /// A half-specified spec keeps the current (OS-chosen) extent on the other
-    /// axis. (spec 036 §4.1 / §5.1)
+    /// axis, and is also skipped when that extent is not yet a real positive
+    /// value. (spec 036 §4.1 / §5.1)
     /// </summary>
     private bool TryBuildSpecSize(WindowSpec spec, out global::Windows.Graphics.SizeInt32 size)
     {
@@ -948,6 +949,13 @@ public sealed class ReactorWindow : IDisposable
                 DiagnosticLog.SwallowedError(LogCategory.Hosting, "ReactorWindow.TryBuildSpecSize", ex);
                 return false;
             }
+
+            // A non-positive current extent means there is no real OS extent to
+            // preserve yet. Resizing would drive that axis to 0, which is worse
+            // than leaving the window at whatever the OS gave it — skip, and let
+            // the first-DPI re-apply try again once the extent is real.
+            if ((spec.Width is null && currentWidth <= 0) || (spec.Height is null && currentHeight <= 0))
+                return false;
         }
 
         size = new global::Windows.Graphics.SizeInt32(

--- a/src/Reactor/Hosting/ReactorWindow.cs
+++ b/src/Reactor/Hosting/ReactorWindow.cs
@@ -995,11 +995,22 @@ public sealed class ReactorWindow : IDisposable
                     // leaves that axis to the OS).
                     if (_spec.Embed is null && !_userResized && !_firstDpiApplied)
                     {
-                        _firstDpiApplied = true;
                         try
                         {
                             if (TryBuildSpecSize(_spec, out var dpiSize))
+                            {
+                                // Latch only once the size really lands. If
+                                // TryBuildSpecSize declined because the extent to
+                                // preserve wasn't real yet, staying unlatched lets
+                                // a later DPI report apply the declared axis.
+                                _firstDpiApplied = true;
                                 _appWindow.Resize(dpiSize);
+                            }
+                            else if (_spec.Width is null && _spec.Height is null)
+                            {
+                                // Nothing to apply, ever — stop re-checking.
+                                _firstDpiApplied = true;
+                            }
                         }
                         catch (COMException ex) when (HResults.IsTeardownReentry(ex.HResult))
                         {

--- a/src/Reactor/Hosting/ReactorWindow.cs
+++ b/src/Reactor/Hosting/ReactorWindow.cs
@@ -551,8 +551,9 @@ public sealed class ReactorWindow : IDisposable
         }
 
         // Sizing — DIP -> physical at the current per-window DPI. (spec 036 §5.1)
-        // A null Width/Height means "let the OS pick": we skip Resize entirely
-        // on that axis so the window keeps the extent Windows chose at creation.
+        // Reactor only overrides the axes the spec declares: with both null it
+        // makes no Resize call at all, and with one set it resizes once, passing
+        // the current (OS-chosen) extent through on the other axis.
         if (spec.Embed is null && isInitial && spec.Presenter == PresenterKind.Overlapped
             && TryBuildSpecSize(spec, out var initialSize))
         {

--- a/src/Reactor/Hosting/ReactorWindow.cs
+++ b/src/Reactor/Hosting/ReactorWindow.cs
@@ -551,11 +551,14 @@ public sealed class ReactorWindow : IDisposable
         }
 
         // Sizing — DIP -> physical at the current per-window DPI. (spec 036 §5.1)
-        if (spec.Embed is null && isInitial && spec.Presenter == PresenterKind.Overlapped)
+        // A null Width/Height means "let the OS pick": we skip Resize entirely
+        // on that axis so the window keeps the extent Windows chose at creation.
+        if (spec.Embed is null && isInitial && spec.Presenter == PresenterKind.Overlapped
+            && TryBuildSpecSize(spec, out var initialSize))
         {
             try
             {
-                _appWindow.Resize(DipToPhysicalSize(spec.Width, spec.Height));
+                _appWindow.Resize(initialSize);
             }
             catch (COMException ex) when (HResults.IsTeardownReentry(ex.HResult))
             {
@@ -919,6 +922,39 @@ public sealed class ReactorWindow : IDisposable
             DipToPhysicalScalar(heightDip));
     }
 
+    /// <summary>
+    /// Builds the physical-pixel size a spec asks for, or returns false when the
+    /// spec declares neither axis — the "let the OS size the window" default.
+    /// A half-specified spec keeps the current (OS-chosen) extent on the other
+    /// axis. (spec 036 §4.1 / §5.1)
+    /// </summary>
+    private bool TryBuildSpecSize(WindowSpec spec, out global::Windows.Graphics.SizeInt32 size)
+    {
+        size = default;
+        if (spec.Width is null && spec.Height is null) return false;
+
+        int currentWidth = 0, currentHeight = 0;
+        if (spec.Width is null || spec.Height is null)
+        {
+            try
+            {
+                var current = _appWindow.Size;
+                currentWidth = current.Width;
+                currentHeight = current.Height;
+            }
+            catch (COMException ex) when (HResults.IsTeardownReentry(ex.HResult))
+            {
+                DiagnosticLog.SwallowedError(LogCategory.Hosting, "ReactorWindow.TryBuildSpecSize", ex);
+                return false;
+            }
+        }
+
+        size = new global::Windows.Graphics.SizeInt32(
+            spec.Width is { } w ? DipToPhysicalScalar(w) : currentWidth,
+            spec.Height is { } h ? DipToPhysicalScalar(h) : currentHeight);
+        return true;
+    }
+
     private global::Windows.Graphics.PointInt32 DipToPhysicalPoint(double xDip, double yDip)
     {
         var dpi = Dpi == 0 ? 96 : Dpi;
@@ -945,13 +981,16 @@ public sealed class ReactorWindow : IDisposable
 
                     // First DPI report after window creation: re-apply spec
                     // sizing against the now-known per-window DPI, but only if
-                    // the user hasn't already resized the window manually.
+                    // the user hasn't already resized the window manually and
+                    // the spec actually declares a size (a null Width/Height
+                    // leaves that axis to the OS).
                     if (_spec.Embed is null && !_userResized && !_firstDpiApplied)
                     {
                         _firstDpiApplied = true;
                         try
                         {
-                            _appWindow.Resize(DipToPhysicalSize(_spec.Width, _spec.Height));
+                            if (TryBuildSpecSize(_spec, out var dpiSize))
+                                _appWindow.Resize(dpiSize);
                         }
                         catch (COMException ex) when (HResults.IsTeardownReentry(ex.HResult))
                         {

--- a/src/Reactor/Hosting/WindowSpec.cs
+++ b/src/Reactor/Hosting/WindowSpec.cs
@@ -20,7 +20,8 @@ public sealed record EmbedRequest(WindowEmbedStyle Style, int HostPid, bool Init
 /// <para>All sizes and positions are <b>DIPs</b> (device-independent pixels) —
 /// no Win32 / no <c>SizeInt32</c> in user code. (spec 036 §4.1)</para>
 /// <para>Validation runs in the primary constructor: <c>Width</c>/<c>Height</c>
-/// must be positive, max ≥ min when both are set, and
+/// must be positive <i>when set</i> (<c>null</c> defers the initial extent to
+/// the OS), max ≥ min when both are set, and
 /// <see cref="ManualPosition"/> is required iff
 /// <see cref="StartPosition"/> is <see cref="WindowStartPosition.Manual"/>.</para>
 /// </remarks>
@@ -29,11 +30,20 @@ public sealed record WindowSpec
     /// <summary>Window caption text. Defaults to <c>"Reactor App"</c>.</summary>
     public string Title { get; init; } = "Reactor App";
 
-    /// <summary>Initial DIP width. Must be positive.</summary>
-    public double Width { get; init; } = 1024;
+    /// <summary>
+    /// Initial DIP width. Must be positive when set. <c>null</c> (the default)
+    /// leaves the initial width to the OS — Reactor never calls
+    /// <c>AppWindow.Resize</c> on that axis, so the window opens at the size
+    /// Windows picks for a new top-level window (the same behavior a plain
+    /// XAML <c>Window</c> gets).
+    /// </summary>
+    public double? Width { get; init; }
 
-    /// <summary>Initial DIP height. Must be positive.</summary>
-    public double Height { get; init; } = 768;
+    /// <summary>
+    /// Initial DIP height. Must be positive when set. <c>null</c> (the default)
+    /// leaves the initial height to the OS. See <see cref="Width"/>.
+    /// </summary>
+    public double? Height { get; init; }
 
     /// <summary>Optional minimum DIP width.</summary>
     public double? MinWidth { get; init; }
@@ -82,7 +92,8 @@ public sealed record WindowSpec
 
     /// <summary>
     /// Content-driven sizing mode. Size changes are applied after the first layout pass,
-    /// so apps may see one frame at the initial Width/Height before content settles.
+    /// so apps may see one frame at the initial Width/Height (or the OS-chosen size when
+    /// those are null) before content settles.
     /// </summary>
     public WindowSizeToContent SizeToContent { get; init; } = WindowSizeToContent.Manual;
 
@@ -228,10 +239,10 @@ public sealed record WindowSpec
     /// </summary>
     public void Validate()
     {
-        if (!(Width > 0))
-            throw new ArgumentException("WindowSpec.Width must be positive.", nameof(Width));
-        if (!(Height > 0))
-            throw new ArgumentException("WindowSpec.Height must be positive.", nameof(Height));
+        if (Width is { } w && !(w > 0))
+            throw new ArgumentException("WindowSpec.Width must be positive when set.", nameof(Width));
+        if (Height is { } h && !(h > 0))
+            throw new ArgumentException("WindowSpec.Height must be positive when set.", nameof(Height));
 
         if (MinWidth is { } minW && !(minW > 0))
             throw new ArgumentException("WindowSpec.MinWidth must be positive when set.", nameof(MinWidth));

--- a/src/Reactor/Hosting/WindowSpec.cs
+++ b/src/Reactor/Hosting/WindowSpec.cs
@@ -244,22 +244,25 @@ public sealed record WindowSpec
     /// </summary>
     public void Validate()
     {
-        // Non-finite values must be rejected too (NaN and ±Infinity both reach
-        // the DIP→pixel conversion and produce a garbage int), so the check is
-        // spelled out rather than written as !(w > 0).
+        // Every DIP size below reaches DipToPhysicalScalar / DipToPxScalar,
+        // where a non-finite double casts to a garbage int — +Infinity on
+        // MaxWidth, for instance, lands in ptMaxTrackSize as int.MinValue and
+        // makes the window unresizable. `null` is the way to say "unset" /
+        // "unbounded", so non-finite values are rejected on every axis. The
+        // comparison is spelled out rather than written as !(x > 0).
         if (Width is { } w && (w <= 0 || !double.IsFinite(w)))
             throw new ArgumentException("WindowSpec.Width must be positive and finite when set.", nameof(Width));
         if (Height is { } h && (h <= 0 || !double.IsFinite(h)))
             throw new ArgumentException("WindowSpec.Height must be positive and finite when set.", nameof(Height));
 
-        if (MinWidth is { } minW && !(minW > 0))
-            throw new ArgumentException("WindowSpec.MinWidth must be positive when set.", nameof(MinWidth));
-        if (MinHeight is { } minH && !(minH > 0))
-            throw new ArgumentException("WindowSpec.MinHeight must be positive when set.", nameof(MinHeight));
-        if (MaxWidth is { } maxW && !(maxW > 0))
-            throw new ArgumentException("WindowSpec.MaxWidth must be positive when set.", nameof(MaxWidth));
-        if (MaxHeight is { } maxH && !(maxH > 0))
-            throw new ArgumentException("WindowSpec.MaxHeight must be positive when set.", nameof(MaxHeight));
+        if (MinWidth is { } minW && (minW <= 0 || !double.IsFinite(minW)))
+            throw new ArgumentException("WindowSpec.MinWidth must be positive and finite when set.", nameof(MinWidth));
+        if (MinHeight is { } minH && (minH <= 0 || !double.IsFinite(minH)))
+            throw new ArgumentException("WindowSpec.MinHeight must be positive and finite when set.", nameof(MinHeight));
+        if (MaxWidth is { } maxW && (maxW <= 0 || !double.IsFinite(maxW)))
+            throw new ArgumentException("WindowSpec.MaxWidth must be positive and finite when set (use null for unbounded).", nameof(MaxWidth));
+        if (MaxHeight is { } maxH && (maxH <= 0 || !double.IsFinite(maxH)))
+            throw new ArgumentException("WindowSpec.MaxHeight must be positive and finite when set (use null for unbounded).", nameof(MaxHeight));
 
         if (MinWidth is { } a && MaxWidth is { } b && a > b)
             throw new ArgumentException(

--- a/src/Reactor/Hosting/WindowSpec.cs
+++ b/src/Reactor/Hosting/WindowSpec.cs
@@ -20,7 +20,8 @@ public sealed record EmbedRequest(WindowEmbedStyle Style, int HostPid, bool Init
 /// <para>All sizes and positions are <b>DIPs</b> (device-independent pixels) —
 /// no Win32 / no <c>SizeInt32</c> in user code. (spec 036 §4.1)</para>
 /// <para><see cref="Validate"/> enforces the cross-field invariants and is
-/// called by the hosting layer (<c>ReactorWindow.Apply</c>) before the spec is
+/// called by the hosting layer (the <see cref="ReactorWindow"/> constructor and
+/// <see cref="ReactorWindow.Update"/>) before the spec is
 /// used; tests may call it directly. It requires <c>Width</c>/<c>Height</c> to
 /// be positive <i>when set</i> (<c>null</c> defers the initial extent to
 /// the OS), max ≥ min when both are set, and
@@ -231,12 +232,14 @@ public sealed record WindowSpec
     {
         // Empty - validation deferred until field setters complete in the
         // record's init phase. The Validate() method is called explicitly
-        // by the hosting layer (ReactorWindow.Apply) before use.
+        // by the hosting layer (the ReactorWindow constructor and
+        // ReactorWindow.Update) before use.
     }
 
     /// <summary>
     /// Throws <see cref="ArgumentException"/> when any cross-field invariant is
-    /// violated. Called by <see cref="ReactorWindow"/> before the spec is
+    /// violated. Called by <see cref="ReactorWindow"/> (constructor and
+    /// <see cref="ReactorWindow.Update"/>) before the spec is
     /// applied; tests may also call this directly to verify a spec.
     /// </summary>
     public void Validate()

--- a/src/Reactor/Hosting/WindowSpec.cs
+++ b/src/Reactor/Hosting/WindowSpec.cs
@@ -19,10 +19,12 @@ public sealed record EmbedRequest(WindowEmbedStyle Style, int HostPid, bool Init
 /// <remarks>
 /// <para>All sizes and positions are <b>DIPs</b> (device-independent pixels) —
 /// no Win32 / no <c>SizeInt32</c> in user code. (spec 036 §4.1)</para>
-/// <para>Validation runs in the primary constructor: <c>Width</c>/<c>Height</c>
-/// must be positive <i>when set</i> (<c>null</c> defers the initial extent to
+/// <para><see cref="Validate"/> enforces the cross-field invariants and is
+/// called by the hosting layer (<c>ReactorWindow.Apply</c>) before the spec is
+/// used; tests may call it directly. It requires <c>Width</c>/<c>Height</c> to
+/// be positive <i>when set</i> (<c>null</c> defers the initial extent to
 /// the OS), max ≥ min when both are set, and
-/// <see cref="ManualPosition"/> is required iff
+/// <see cref="ManualPosition"/> iff
 /// <see cref="StartPosition"/> is <see cref="WindowStartPosition.Manual"/>.</para>
 /// </remarks>
 public sealed record WindowSpec
@@ -32,10 +34,10 @@ public sealed record WindowSpec
 
     /// <summary>
     /// Initial DIP width. Must be positive when set. <c>null</c> (the default)
-    /// leaves the initial width to the OS — Reactor never calls
-    /// <c>AppWindow.Resize</c> on that axis, so the window opens at the size
-    /// Windows picks for a new top-level window (the same behavior a plain
-    /// XAML <c>Window</c> gets).
+    /// leaves the initial width to the OS — Reactor does not override that
+    /// axis, so the window keeps the width Windows picks for a new top-level
+    /// window (the same behavior a plain XAML <c>Window</c> gets). When both
+    /// axes are <c>null</c> no <c>AppWindow.Resize</c> call is made at all.
     /// </summary>
     public double? Width { get; init; }
 
@@ -239,9 +241,11 @@ public sealed record WindowSpec
     /// </summary>
     public void Validate()
     {
-        if (Width is { } w && !(w > 0))
+        // NaN must be rejected too, so the NaN-aware comparison is spelled out
+        // rather than written as !(w > 0).
+        if (Width is { } w && (w <= 0 || double.IsNaN(w)))
             throw new ArgumentException("WindowSpec.Width must be positive when set.", nameof(Width));
-        if (Height is { } h && !(h > 0))
+        if (Height is { } h && (h <= 0 || double.IsNaN(h)))
             throw new ArgumentException("WindowSpec.Height must be positive when set.", nameof(Height));
 
         if (MinWidth is { } minW && !(minW > 0))

--- a/src/Reactor/Hosting/WindowSpec.cs
+++ b/src/Reactor/Hosting/WindowSpec.cs
@@ -244,12 +244,13 @@ public sealed record WindowSpec
     /// </summary>
     public void Validate()
     {
-        // NaN must be rejected too, so the NaN-aware comparison is spelled out
-        // rather than written as !(w > 0).
-        if (Width is { } w && (w <= 0 || double.IsNaN(w)))
-            throw new ArgumentException("WindowSpec.Width must be positive when set.", nameof(Width));
-        if (Height is { } h && (h <= 0 || double.IsNaN(h)))
-            throw new ArgumentException("WindowSpec.Height must be positive when set.", nameof(Height));
+        // Non-finite values must be rejected too (NaN and ±Infinity both reach
+        // the DIP→pixel conversion and produce a garbage int), so the check is
+        // spelled out rather than written as !(w > 0).
+        if (Width is { } w && (w <= 0 || !double.IsFinite(w)))
+            throw new ArgumentException("WindowSpec.Width must be positive and finite when set.", nameof(Width));
+        if (Height is { } h && (h <= 0 || !double.IsFinite(h)))
+            throw new ArgumentException("WindowSpec.Height must be positive and finite when set.", nameof(Height));
 
         if (MinWidth is { } minW && !(minW > 0))
             throw new ArgumentException("WindowSpec.MinWidth must be positive when set.", nameof(MinWidth));

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/WindowModelFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/WindowModelFixtures.cs
@@ -712,4 +712,62 @@ internal static class WindowModelFixtures
             }
         }
     }
+
+    /// <summary>
+    /// Spec 036 §4.1 — <see cref="WindowSpec.Width"/> / <see cref="WindowSpec.Height"/>
+    /// default to null, meaning "let the OS size the window". The oracle is a bare
+    /// WinUI <c>Window</c> that nobody resizes: a null-size Reactor window must land
+    /// on exactly that extent, while an explicitly sized spec must not. The
+    /// half-specified case proves the per-axis fallback (requested width, OS height).
+    /// </summary>
+    internal class WindowDefaultSizeDefersToOs(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            EnsureUIDispatcher();
+
+            // OS baseline — a plain WinUI window Reactor never touches.
+            var baseline = new Window();
+            var osSize = baseline.AppWindow.Size;
+
+            ReactorWindow? unsized = null, sized = null, widthOnly = null;
+            try
+            {
+                unsized = await OpenAndSettle(
+                    new WindowSpec { Title = "OS Default Size" },
+                    () => new StubComponent());
+                sized = await OpenAndSettle(
+                    new WindowSpec { Title = "Explicit Size", Width = 420, Height = 260 },
+                    () => new StubComponent());
+                widthOnly = await OpenAndSettle(
+                    new WindowSpec { Title = "Width Only", Width = 420 },
+                    () => new StubComponent());
+                await Harness.Render();
+
+                var unsizedSize = unsized.AppWindow.Size;
+                var sizedSize = sized.AppWindow.Size;
+                var widthOnlySize = widthOnly.AppWindow.Size;
+
+                H.Check("WindowSize_NullSpec_MatchesOsDefault",
+                    unsizedSize.Width == osSize.Width && unsizedSize.Height == osSize.Height);
+
+                // Differential isolation: if the resize path were skipped for
+                // *every* spec, this check fails.
+                H.Check("WindowSize_ExplicitSpec_OverridesOsDefault",
+                    sizedSize.Width != osSize.Width || sizedSize.Height != osSize.Height);
+
+                H.Check("WindowSize_WidthOnly_AppliesWidth",
+                    widthOnlySize.Width == sizedSize.Width);
+                H.Check("WindowSize_WidthOnly_KeepsOsHeight",
+                    widthOnlySize.Height == osSize.Height);
+            }
+            finally
+            {
+                if (unsized is not null) await CloseAndSettle(unsized);
+                if (sized is not null) await CloseAndSettle(sized);
+                if (widthOnly is not null) await CloseAndSettle(widthOnly);
+                try { baseline.Close(); } catch { }
+            }
+        }
+    }
 }

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/WindowModelFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/WindowModelFixtures.cs
@@ -726,9 +726,19 @@ internal static class WindowModelFixtures
         {
             EnsureUIDispatcher();
 
-            // OS baseline — a plain WinUI window Reactor never touches.
+            // OS baseline — a plain WinUI window Reactor never touches. It is
+            // activated and allowed to settle first so it goes through the same
+            // show path as the Reactor windows below (which activate by default
+            // via WindowSpec.ActivateOnOpen); reading AppWindow.Size on a window
+            // that was never shown could return a pre-show placeholder extent.
             var baseline = new Window();
+            baseline.Activate();
+            await Harness.Render(50);
             var osSize = baseline.AppWindow.Size;
+
+            // Guards the oracle itself: if the baseline reported 0x0, every
+            // comparison below would be comparing garbage.
+            H.Check("WindowSize_OsBaseline_IsRealExtent", osSize.Width > 0 && osSize.Height > 0);
 
             ReactorWindow? unsized = null, sized = null, widthOnly = null;
             try
@@ -766,7 +776,18 @@ internal static class WindowModelFixtures
                 if (unsized is not null) await CloseAndSettle(unsized);
                 if (sized is not null) await CloseAndSettle(sized);
                 if (widthOnly is not null) await CloseAndSettle(widthOnly);
-                try { baseline.Close(); } catch { }
+                try
+                {
+                    baseline.Close();
+                }
+                catch (COMException ex)
+                {
+                    // Teardown-only. Swallowed so a failed close on the throwaway
+                    // oracle window can't mask the real fixture result, but logged
+                    // so it is not silent.
+                    global::System.Diagnostics.Debug.WriteLine(
+                        $"[selftest] WindowDefaultSizeDefersToOs baseline close failed: {ex}");
+                }
             }
         }
     }

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -1090,6 +1090,7 @@ internal static class SelfTestFixtureRegistry
         "WindowModel_NoActivateRoundTrip",
         "WindowModel_IgnorePointerInputRoundTrip",
         "WindowModel_OpacityIgnorePointerInvariants",
+        "WindowModel_DefaultSizeDefersToOs",
         // Spec 054 Phase 1 — window position/z-order/display read-back.
         "Position_ReadBack",
         "PositionChanged_FiresOnMove",
@@ -2606,6 +2607,7 @@ internal static class SelfTestFixtureRegistry
         "WindowModel_NoActivateRoundTrip" => new WindowModelFixtures.WindowNoActivateRoundTrip(harness),
         "WindowModel_IgnorePointerInputRoundTrip" => new WindowModelFixtures.WindowIgnorePointerInputRoundTrip(harness),
         "WindowModel_OpacityIgnorePointerInvariants" => new WindowModelFixtures.WindowOpacityIgnorePointerInvariants(harness),
+        "WindowModel_DefaultSizeDefersToOs" => new WindowModelFixtures.WindowDefaultSizeDefersToOs(harness),
         // Spec 054 Phase 1 — window position/z-order/display read-back.
         "Position_ReadBack" => new Phase1WindowingFixtures.PositionReadBack(harness),
         "PositionChanged_FiresOnMove" => new Phase1WindowingFixtures.PositionChangedFiresOnMove(harness),

--- a/tests/Reactor.Tests/WindowSpecTests.cs
+++ b/tests/Reactor.Tests/WindowSpecTests.cs
@@ -53,6 +53,13 @@ public class WindowSpecTests
         Assert.Contains("Height", ex.Message, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void Validate_Rejects_NaN_Sizes()
+    {
+        Assert.Throws<ArgumentException>(() => new WindowSpec { Width = double.NaN }.Validate());
+        Assert.Throws<ArgumentException>(() => new WindowSpec { Height = double.NaN }.Validate());
+    }
+
     // Spec 036 §4.1 — a null Width/Height means "let the OS choose the initial
     // extent"; it must not be treated as an invalid (non-positive) size, and it
     // must survive a `with` round-trip independently per axis.

--- a/tests/Reactor.Tests/WindowSpecTests.cs
+++ b/tests/Reactor.Tests/WindowSpecTests.cs
@@ -14,8 +14,8 @@ public class WindowSpecTests
     {
         var spec = new WindowSpec();
         Assert.Equal("Reactor App", spec.Title);
-        Assert.Equal(1024, spec.Width);
-        Assert.Equal(768, spec.Height);
+        Assert.Null(spec.Width);
+        Assert.Null(spec.Height);
         Assert.Equal(WindowStartPosition.Default, spec.StartPosition);
         Assert.Equal(PresenterKind.Overlapped, spec.Presenter);
         Assert.Equal(WindowResizeMode.CanResize, spec.ResizeMode);
@@ -51,6 +51,33 @@ public class WindowSpecTests
         var spec = new WindowSpec { Width = 100, Height = -1 };
         var ex = Assert.Throws<ArgumentException>(() => spec.Validate());
         Assert.Contains("Height", ex.Message, StringComparison.Ordinal);
+    }
+
+    // Spec 036 §4.1 — a null Width/Height means "let the OS choose the initial
+    // extent"; it must not be treated as an invalid (non-positive) size, and it
+    // must survive a `with` round-trip independently per axis.
+    [Fact]
+    public void Validate_Accepts_Null_Sizes()
+    {
+        new WindowSpec { Width = null, Height = null }.Validate();
+        new WindowSpec { Width = 640, Height = null }.Validate();
+        new WindowSpec { Width = null, Height = 480 }.Validate();
+    }
+
+    [Fact]
+    public void Explicit_Sizes_Are_Preserved_Per_Axis()
+    {
+        var widthOnly = new WindowSpec { Width = 640 };
+        Assert.Equal(640, widthOnly.Width);
+        Assert.Null(widthOnly.Height);
+
+        var both = widthOnly with { Height = 480 };
+        Assert.Equal(640, both.Width);
+        Assert.Equal(480, both.Height);
+
+        var cleared = both with { Width = null };
+        Assert.Null(cleared.Width);
+        Assert.Equal(480, cleared.Height);
     }
 
     [Fact]

--- a/tests/Reactor.Tests/WindowSpecTests.cs
+++ b/tests/Reactor.Tests/WindowSpecTests.cs
@@ -54,10 +54,14 @@ public class WindowSpecTests
     }
 
     [Fact]
-    public void Validate_Rejects_NaN_Sizes()
+    public void Validate_Rejects_NonFinite_Sizes()
     {
         Assert.Throws<ArgumentException>(() => new WindowSpec { Width = double.NaN }.Validate());
         Assert.Throws<ArgumentException>(() => new WindowSpec { Height = double.NaN }.Validate());
+        Assert.Throws<ArgumentException>(() => new WindowSpec { Width = double.PositiveInfinity }.Validate());
+        Assert.Throws<ArgumentException>(() => new WindowSpec { Height = double.PositiveInfinity }.Validate());
+        Assert.Throws<ArgumentException>(() => new WindowSpec { Width = double.NegativeInfinity }.Validate());
+        Assert.Throws<ArgumentException>(() => new WindowSpec { Height = double.NegativeInfinity }.Validate());
     }
 
     // Spec 036 §4.1 — a null Width/Height means "let the OS choose the initial

--- a/tests/Reactor.Tests/WindowSpecTests.cs
+++ b/tests/Reactor.Tests/WindowSpecTests.cs
@@ -64,6 +64,21 @@ public class WindowSpecTests
         Assert.Throws<ArgumentException>(() => new WindowSpec { Height = double.NegativeInfinity }.Validate());
     }
 
+    // Min*/Max* land in ptMinTrackSize / ptMaxTrackSize via the same DIP→pixel
+    // cast, where +Infinity becomes int.MinValue and pins the window. `null`
+    // is the way to express "unbounded", so non-finite values are rejected.
+    [Fact]
+    public void Validate_Rejects_NonFinite_MinMax()
+    {
+        Assert.Throws<ArgumentException>(() => new WindowSpec { MinWidth = double.NaN }.Validate());
+        Assert.Throws<ArgumentException>(() => new WindowSpec { MinHeight = double.PositiveInfinity }.Validate());
+        Assert.Throws<ArgumentException>(() => new WindowSpec { MaxWidth = double.PositiveInfinity }.Validate());
+        Assert.Throws<ArgumentException>(() => new WindowSpec { MaxHeight = double.NaN }.Validate());
+
+        // Unbounded stays expressible.
+        new WindowSpec { MinWidth = 200, MaxWidth = null }.Validate();
+    }
+
     // Spec 036 §4.1 — a null Width/Height means "let the OS choose the initial
     // extent"; it must not be treated as an invalid (non-positive) size, and it
     // must survive a `with` round-trip independently per axis.


### PR DESCRIPTION
## Summary

`WindowSpec.Width` / `Height` and the `ReactorApp.Run(width, height)` parameters defaulted to a hardcoded 1024x768. That number was never a design decision: it was inherited from the pre-spec-036 `Run` signature, and spec 036 only ever discussed the units (pixels vs DIPs), never the value. The effect was that every app which did not care about window size still overrode the size Windows would have picked for a new top-level window, unlike a plain XAML `Window`.

Both are now `double?` defaulting to `null`, meaning "let the OS decide". `ReactorWindow` skips `AppWindow.Resize` entirely when neither axis is set, so the window opens at the shell-chosen extent. A half-specified spec (`new WindowSpec { Width = 800 }`) applies the requested axis and keeps the OS extent on the other, via a new `TryBuildSpecSize` helper used by both the initial apply and the first-DPI re-apply.

The nullable shape propagates through `ReactorAppOptions`, `ReactorDevtoolsBootRequest`, `DevtoolsHost`, and the `windows.open` MCP tool, which no longer substitutes 1024/768 for omitted arguments.

Docs and the shipped agent kit were updated to match: spec 036 section 4.1 now records why there is no size default, section 12.2a covers the migration, and the `windows` guide template plus the `reactor-getting-started` skill and the widget-creator / demo-script-tool system prompts note that width/height are optional.

### Picked up during review

Review rounds surfaced two adjacent bugs in the same validation and sizing paths, fixed here:

- `WindowSpec.Validate()` accepted non-finite sizes. `MaxWidth = double.PositiveInfinity` reaches `DipToPxScalar` in the `WM_GETMINMAXINFO` handler, where `(int)Math.Round(inf)` lands in `ptMaxTrackSize` as `int.MinValue` and pins the window so it cannot be resized. All six size fields (`Width`, `Height`, `Min*`, `Max*`) now require a positive finite value; `null` remains the way to say unset / unbounded.
- The first-DPI re-apply latched `_firstDpiApplied` before knowing whether the resize happened, which could permanently suppress a declared axis. It now latches on the successful resize (or when the spec declares no size at all).

## Linked issue / spec

Amends `docs/specs/036-window-design.md` (sections 4.1, 4.3, 12.2a).

## Test plan

- [x] Added unit tests in `tests/Reactor.Tests/WindowSpecTests.cs`: null-size defaults, `Validate` accepts null sizes, per-axis preservation across `with`, and non-finite rejection for both the size and the min/max fields.
- [x] Added selftest fixture `WindowModel_DefaultSizeDefersToOs` in `tests/Reactor.AppTests.Host/SelfTest/Fixtures/WindowModelFixtures.cs`, registered in both `AllFixtures` and the `Create()` switch. It activates a bare WinUI `Window` as the OS-default oracle, asserts that baseline is a real non-zero extent, then asserts the null-size Reactor window matches it exactly, an explicitly sized spec does not, and the width-only case applies the width while keeping the OS height.
- [x] `dotnet test tests/Reactor.Tests` - 12,458 passed, 0 failed.
- [x] Full selftest suite green (`dotnet run --project tests/Reactor.AppTests.Host -- --self-test`).
- [x] `dotnet build Reactor.slnx`.
- [x] Regenerated both `reactor.api.txt` copies and recompiled the `windows` guide topic.

## Risk / breaking changes

Three things worth a careful look:

- **Behavior change.** An app calling `ReactorApp.Run<App>("Title")` with no size now opens at the OS-chosen size instead of 1024x768. Every sample in this repo passes an explicit size, so none of them change. The one-time `[reactor]` startup notice was extended to announce this and to say how to keep the old extent.
- **Validation tightened.** A spec that previously passed with a non-finite size (most plausibly `MaxWidth = double.PositiveInfinity` used to mean "unbounded") now throws from `Validate()`. That input already produced a broken window, so this converts a silent misbehavior into an actionable error, but it is a behavior change for any code doing it.
- **Binary-breaking (source-compatible).** `double` to `double?` changes the signatures of both `Run` overloads, the `WindowSpec.Width` / `Height` accessors, and the `ReactorDevtoolsBootRequest` constructor / `Deconstruct`. Call sites that pass sizes keep compiling; already-compiled consumers must recompile. Taking the break rather than shipping `double` compat overloads is deliberate given the pre-1.0 posture, and is now written down in spec 036 section 12.2a.

Known follow-up, not addressed here: `mur devtools screenshot` inherits the app's nullable size, so a capture from an app that does not pass an explicit size is now machine/DPI dependent where it used to be a fixed 1024x768. Materializing the default at the devtools boundary is the likely fix if that matters.
