### PR TITLE
docs: surface IsHitTestVisible(bool) in cheat sheet and skills

### DIFF
--- a/docs/_pipeline/templates/cheat-sheet.md.dt
+++ b/docs/_pipeline/templates/cheat-sheet.md.dt
@@ -93,7 +93,7 @@ Full coverage on [Controls](controls.md).
 | Text | `.FontSize(n)` `.Bold()` `.SemiBold()` `.Opacity(n)` |
 | Color | `.Background(token)` `.Foreground(token)` `.BorderBrush(token)` `.BorderThickness(...)` `.WithBorder(token, thickness?)` |
 | Shape | `.CornerRadius(n)` |
-| Behavior | `.IsEnabled(bool)` `.IsVisible(bool)` `.ToolTip(s)` |
+| Behavior | `.IsEnabled(bool)` `.IsVisible(bool)` `.IsHitTestVisible(bool)` `.ToolTip(s)` |
 | Keying | `.WithKey(s)` |
 | Flex | `.Flex(grow?, shrink?, basis?)` |
 | Themed | `.RequestedTheme(ElementTheme)` `.Backdrop(BackdropKind)` |

--- a/docs/guide/cheat-sheet.md
+++ b/docs/guide/cheat-sheet.md
@@ -112,7 +112,7 @@ Full coverage on [Controls](controls.md).
 | Text | `.FontSize(n)` `.Bold()` `.SemiBold()` `.Opacity(n)` |
 | Color | `.Background(token)` `.Foreground(token)` `.BorderBrush(token)` `.BorderThickness(...)` `.WithBorder(token, thickness?)` |
 | Shape | `.CornerRadius(n)` |
-| Behavior | `.IsEnabled(bool)` `.IsVisible(bool)` `.ToolTip(s)` |
+| Behavior | `.IsEnabled(bool)` `.IsVisible(bool)` `.IsHitTestVisible(bool)` `.ToolTip(s)` |
 | Keying | `.WithKey(s)` |
 | Flex | `.Flex(grow?, shrink?, basis?)` |
 | Themed | `.RequestedTheme(ElementTheme)` `.Backdrop(BackdropKind)` |

--- a/plugins/reactor/skills/reactor-input/SKILL.md
+++ b/plugins/reactor/skills/reactor-input/SKILL.md
@@ -21,6 +21,7 @@ etc.) when you attach a handler, so you never need to set those manually.
 | API | Purpose |
 |-----|---------|
 | `.OnPointerEntered/Exited/Pressed/Released/Moved` | Pointer events |
+| `.IsHitTestVisible(bool)` | Opt an element + its subtree out of hit-testing |
 | `.OnTapped()` / `.OnDoubleTapped()` / `.OnRightTapped()` | Tap events |
 | `.OnKeyDown()` / `.OnKeyUp()` | Keyboard events |
 | `.OnPan(...)` | Pan gesture (drag with inertia) |
@@ -49,6 +50,20 @@ Events: `OnPointerEntered`, `OnPointerExited`, `OnPointerPressed`,
 `OnPointerReleased`, `OnPointerMoved`, `OnPointerCanceled`.
 
 The `(s, e)` signature gives you the sender and `PointerRoutedEventArgs`.
+
+### Opting out of hit-testing
+
+`.IsHitTestVisible(false)` sets `UIElement.IsHitTestVisible` — the element
+**and its subtree** stop being pointer targets, so decorative or overlay
+layers let pointer events pass through to whatever is underneath.
+
+```csharp
+Border(overlayGlow).IsHitTestVisible(false)
+```
+
+Unlike `.IsEnabled(false)`, it does not grey the control out or block focus —
+reach for `.IsEnabled(false)` when you want a disabled affordance, and
+`.IsHitTestVisible(false)` when you only want clicks to fall through.
 
 ## 2. Tap events
 

--- a/skills/input.md
+++ b/skills/input.md
@@ -19,6 +19,7 @@ etc.) when you attach a handler, so you never need to set those manually.
 | API | Purpose |
 |-----|---------|
 | `.OnPointerEntered/Exited/Pressed/Released/Moved` | Pointer events |
+| `.IsHitTestVisible(bool)` | Opt an element + its subtree out of hit-testing |
 | `.OnTapped()` / `.OnDoubleTapped()` / `.OnRightTapped()` | Tap events |
 | `.OnKeyDown()` / `.OnKeyUp()` | Keyboard events |
 | `.OnPan(...)` | Pan gesture (drag with inertia) |
@@ -47,6 +48,20 @@ Events: `OnPointerEntered`, `OnPointerExited`, `OnPointerPressed`,
 `OnPointerReleased`, `OnPointerMoved`, `OnPointerCanceled`.
 
 The `(s, e)` signature gives you the sender and `PointerRoutedEventArgs`.
+
+### Opting out of hit-testing
+
+`.IsHitTestVisible(false)` sets `UIElement.IsHitTestVisible` — the element
+**and its subtree** stop being pointer targets, so decorative or overlay
+layers let pointer events pass through to whatever is underneath.
+
+```csharp
+Border(overlayGlow).IsHitTestVisible(false)
+```
+
+Unlike `.IsEnabled(false)`, it does not grey the control out or block focus —
+reach for `.IsEnabled(false)` when you want a disabled affordance, and
+`.IsHitTestVisible(false)` when you only want clicks to fall through.
 
 ## 2. Tap events
 


### PR DESCRIPTION
Follow-up to #810 (squash commit `d08fc786`), which added the `.IsHitTestVisible(bool)` common element modifier. A PR review found it shipped undiscoverable: it landed in the generated `reactor.api.txt` indexes but was never surfaced in any human-facing docs or agent-skill prose.

## Changes

**Cheat sheet (primary)** — added `.IsHitTestVisible(bool)` to the Behavior row of the modifier-chains table, next to the semantically adjacent `.IsVisible(bool)`.

Edited the template `docs/_pipeline/templates/cheat-sheet.md.dt` and regenerated the committed output with:

```
mur docs compile --topic cheat-sheet --no-screenshots --skip-diagrams --skip-reference
```

Both the template and `docs/guide/cheat-sheet.md` are committed together so the "Docs build" drift gate stays green. The regenerated page contains only the intended one-line change — no unrelated snippet churn.

**Input skill (secondary)** — added a short `### Opting out of hit-testing` subsection under *1. Pointer events*, plus a quick-reference row. It covers what the modifier maps to (`UIElement.IsHitTestVisible`), that it applies to the whole subtree, and how it differs from `.IsEnabled(false)` (which also greys the control out and blocks focus).

`skills/input.md` and `plugins/reactor/skills/reactor-input/SKILL.md` are near-identical hand-authored mirrors (they diverge only in frontmatter and a couple of generic type args), so the same prose was applied to both to keep them in sync.

## Scope

Docs and agent-skill prose only. No changes to `src/Reactor/**`, tests, or the `reactor.api.txt` indexes — those were already correct from #810.

## Validation

- `mur docs compile --topic cheat-sheet` succeeded; tier lint and cross-link lint reported 0 findings.
- `git diff` confirms the generated page changed by exactly the one templated line.

> Note: `dotnet run --project src/Reactor.Cli` initially failed in this environment with `MSB3923` while downloading `@github/copilot-win32-x64` (TLS handshake failure). Worked around locally with `-p:CopilotSkipCliDownload=true`, which doesn't affect the docs pipeline output. Not a repo issue.