### PR TITLE
spec-062 E1a: reframe the unregistered-mount throw around what actually causes it

### DIFF
--- a/src/Reactor/Core/Reconciler.Mount.cs
+++ b/src/Reactor/Core/Reconciler.Mount.cs
@@ -225,52 +225,52 @@ public sealed partial class Reconciler
     /// Reactor bugs to diagnose.
     /// </summary>
     /// <remarks>
-    /// The most common cause (after spec-048 §3.4 deletes
-    /// <c>RegisterV1BuiltInHandlers</c>) is that the caller bypassed the
-    /// factory method (e.g. <c>Factories.TextBlock(...)</c>) and constructed
-    /// the element record directly (<c>new TextBlockElement(...)</c>). The
-    /// factory body contains the <c>Reg&lt;TElement, TControl, THandler&gt;.Done</c>
-    /// touch that registers the handler on first call; direct-record
-    /// construction skips that touch. See issue
+    /// Spec 062 §10 — with lazy self-registration the norm, this is reframed around
+    /// what actually causes it rather than around a registration call most apps never
+    /// make. A "mounted but unregistered" element is nearly unreachable for generated
+    /// wrappers (spec 058: constructing the element self-registers it); it survives for
+    /// a factory-carried control constructed by raw <c>new</c> that bypassed the factory
+    /// trigger, a wrapper assembly that is referenced but never touched, or a
+    /// third-party override that was never registered. See issue
     /// <see href="https://github.com/microsoft/microsoft-ui-reactor/issues/486"/>
-    /// for the full discussion of the trade-off.
+    /// for the original trade-off discussion.
     /// </remarks>
     [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
     private static UIElement? ThrowNoHandlerRegistered(Element element)
     {
-        var elementTypeName = element.GetType().FullName ?? element.GetType().Name;
+        // Reflection-light and AOT-safe by construction: the message names only
+        // element.GetType(), never a member walk or an assembly scan.
+        var elementType = element.GetType();
+        var elementTypeName = elementType.FullName ?? elementType.Name;
         throw new InvalidOperationException(
-            $"No handler is registered for element type '{elementTypeName}'. " +
-            "The reconciler tried all four dispatch arms (per-host _v1Handlers, " +
-            "per-host _typeRegistry, global ControlRegistry, and the composition-" +
-            "primitive switch) and none of them knew how to mount this element.\n\n" +
-            "Most common cause: the element record was constructed directly " +
-            $"(e.g. `new {element.GetType().Name}(...)`) instead of through its " +
-            "factory method. Factory methods carry the registration touch (a " +
-            "`_ = Reg<TElement, TControl, THandler>.Done;` statement) that " +
-            "registers the handler on first call; bypassing the factory skips " +
-            "that touch.\n\n" +
-            "Fixes:\n" +
-            $"  (1) Call the factory method at least once before mounting (e.g. " +
-            "`Factories.TextBlock(\"\")` for built-ins) so the handler registers, " +
-            "then continue using the direct-record idiom for the hot path.\n" +
-            "  (2) Opt into the whole built-in catalog at startup with " +
-            "`Microsoft.UI.Reactor.ReactorApp.RegisterAllBuiltIns()` (spec-048 " +
-            "§3.4 option A) so every built-in element record mounts regardless " +
-            "of how it was constructed.\n" +
-            "  (3) Register the handler explicitly up front. For a control-backed " +
-            "element with its own WinUI control, use " +
+            $"No handler is registered for element type '{elementTypeName}', so the " +
+            "reconciler does not know how to mount it.\n\n" +
+            "Registration is lazy: an element becomes mountable as a side effect of " +
+            "the code that introduces it. One of these is missing:\n\n" +
+            $"  (1) Create it through its factory. Built-in and Pattern-B controls " +
+            $"self-register on the factory call, so `new {elementType.Name}(...)` on " +
+            "its own never registers anything. Call the factory (e.g. " +
+            "`Factories.TextBlock(\"\")`) at least once, then the direct-record idiom " +
+            "is safe for the hot path.\n" +
+            "  (2) If it comes from a [GenerateReactorWrapper] library, make sure that " +
+            "assembly is actually referenced and reached — its generated element " +
+            "carries the self-registration, so an unreferenced or fully-trimmed " +
+            "wrapper never runs it.\n" +
+            "  (3) To register a third-party control or override a built-in handler " +
+            "globally at startup, use " +
             $"`Microsoft.UI.Reactor.Core.V1Protocol.ControlRegistry.Register" +
-            $"<{element.GetType().Name}, TControl>(static () => new YourHandler())`; " +
-            "for a decorator-backed element (one that wraps/forwards to a child " +
-            "rather than owning a leaf control) use " +
-            $"`Microsoft.UI.Reactor.Core.V1Protocol.ControlRegistry.RegisterDecorator" +
-            $"<{element.GetType().Name}>(static () => new YourDecoratorHandler())`.\n" +
-            "  (4) For custom controls authored by your project, follow the " +
-            "Pattern A factory-as-registration recipe in " +
-            "docs/guide/extending-reactor-controls.md.\n\n" +
-            "See https://github.com/microsoft/microsoft-ui-reactor/issues/486 " +
-            "for background.");
+            $"<{elementType.Name}, TControl>(static () => new YourHandler())` — or " +
+            $"`ControlRegistry.RegisterDecorator<{elementType.Name}>(...)` for a " +
+            "decorator-backed element that wraps a child instead of owning a leaf " +
+            "control.\n" +
+            "  (4) For a bespoke app-local control, register it on the host's " +
+            $"reconciler before first mount: `reconciler.RegisterHandler<{elementType.Name}, " +
+            "TControl>(new YourHandler())` (or `RegisterType`).\n" +
+            "  (5) As a blunt opt-in for the whole built-in catalog, call " +
+            "`Microsoft.UI.Reactor.ReactorApp.RegisterAllBuiltIns()` at startup — this " +
+            "makes every built-in element record mountable regardless of how it was " +
+            "constructed, at the cost of rooting the catalog for the trimmer.\n\n" +
+            "Authoring guide: docs/guide/extending-reactor-controls.md");
     }
 
     // Spec 047 §14 Phase 3-final Batch B — widened to internal static so

--- a/src/Reactor/Core/Reconciler.Mount.cs
+++ b/src/Reactor/Core/Reconciler.Mount.cs
@@ -296,25 +296,47 @@ public sealed partial class Reconciler
     /// </summary>
     private static string FriendlyTypeName(Type type)
     {
-        var name = type.Name;
-        var tick = name.IndexOf('`');
-        if (tick >= 0) name = name.Substring(0, tick);
+        var sb = new global::System.Text.StringBuilder();
+        var args = type.GetGenericArguments();
+        AppendFriendlyTypeName(sb, type, args, args.Length);
+        return sb.ToString();
+    }
 
-        if (type.IsGenericType)
+    /// <remarks>
+    /// <paramref name="args"/> is the flat generic-argument list of the type being printed,
+    /// which for a nested type is the whole chain outermost-first — so
+    /// <c>Outer&lt;int&gt;.Inner&lt;string&gt;</c> reports <c>[int, string]</c> on the inner
+    /// type. Each level therefore renders only <c>args[start..end]</c>: the declaring chain
+    /// consumes its own prefix, and the arguments are not duplicated onto the nested name.
+    /// </remarks>
+    private static void AppendFriendlyTypeName(
+        global::System.Text.StringBuilder sb, Type type, Type[] args, int end)
+    {
+        var declaring = type.IsNested ? type.DeclaringType : null;
+        var start = declaring is { IsGenericType: true }
+            ? declaring.GetGenericArguments().Length
+            : 0;
+
+        if (declaring is not null)
         {
-            var args = type.GetGenericArguments();
-            var sb = new global::System.Text.StringBuilder(name).Append('<');
-            for (int i = 0; i < args.Length; i++)
-            {
-                if (i > 0) sb.Append(", ");
-                sb.Append(FriendlyTypeName(args[i]));
-            }
-            name = sb.Append('>').ToString();
+            AppendFriendlyTypeName(sb, declaring, args, start);
+            sb.Append('.');
         }
 
-        return type.IsNested && type.DeclaringType is { } declaring
-            ? FriendlyTypeName(declaring) + "." + name
-            : name;
+        var name = type.Name;
+        var tick = name.IndexOf('`');
+        sb.Append(tick >= 0 ? name.Substring(0, tick) : name);
+
+        if (end <= start) return;
+
+        sb.Append('<');
+        for (int i = start; i < end; i++)
+        {
+            if (i > start) sb.Append(", ");
+            var nested = args[i].GetGenericArguments();
+            AppendFriendlyTypeName(sb, args[i], nested, nested.Length);
+        }
+        sb.Append('>');
     }
 
     // Spec 047 §14 Phase 3-final Batch B — widened to internal static so

--- a/src/Reactor/Core/Reconciler.Mount.cs
+++ b/src/Reactor/Core/Reconciler.Mount.cs
@@ -289,25 +289,32 @@ public sealed partial class Reconciler
 
     /// <summary>
     /// Formats a type for a copy-pasteable C# snippet: <c>DataGridElement`1</c> — the raw
-    /// metadata name — becomes <c>DataGridElement&lt;T&gt;</c>. Reflection-light (name +
-    /// generic arguments only), so it stays AOT- and trim-safe.
+    /// metadata name — becomes <c>DataGridElement&lt;T&gt;</c>, and a nested type keeps its
+    /// declaring chain in C# form (<c>Outer.Inner&lt;T&gt;</c>) so the name stays
+    /// unambiguous. Reflection-light (name, generic arguments, declaring type), so it stays
+    /// AOT- and trim-safe.
     /// </summary>
     private static string FriendlyTypeName(Type type)
     {
-        if (!type.IsGenericType) return type.Name;
-
         var name = type.Name;
         var tick = name.IndexOf('`');
         if (tick >= 0) name = name.Substring(0, tick);
 
-        var args = type.GetGenericArguments();
-        var sb = new global::System.Text.StringBuilder(name).Append('<');
-        for (int i = 0; i < args.Length; i++)
+        if (type.IsGenericType)
         {
-            if (i > 0) sb.Append(", ");
-            sb.Append(FriendlyTypeName(args[i]));
+            var args = type.GetGenericArguments();
+            var sb = new global::System.Text.StringBuilder(name).Append('<');
+            for (int i = 0; i < args.Length; i++)
+            {
+                if (i > 0) sb.Append(", ");
+                sb.Append(FriendlyTypeName(args[i]));
+            }
+            name = sb.Append('>').ToString();
         }
-        return sb.Append('>').ToString();
+
+        return type.IsNested && type.DeclaringType is { } declaring
+            ? FriendlyTypeName(declaring) + "." + name
+            : name;
     }
 
     // Spec 047 §14 Phase 3-final Batch B — widened to internal static so

--- a/src/Reactor/Core/Reconciler.Mount.cs
+++ b/src/Reactor/Core/Reconciler.Mount.cs
@@ -230,8 +230,11 @@ public sealed partial class Reconciler
     /// make. A "mounted but unregistered" element is nearly unreachable for generated
     /// wrappers (spec 058: constructing the element self-registers it); it survives for
     /// a factory-carried control constructed by raw <c>new</c> that bypassed the factory
-    /// trigger, a wrapper assembly that is referenced but never touched, or a
-    /// third-party override that was never registered. See issue
+    /// trigger, a wrapper assembly that is referenced but never touched, a third-party
+    /// override that was never registered, or a bespoke app-local element that was never
+    /// registered on the host's reconciler via
+    /// <see cref="Reconciler.RegisterHandler{TElement,TControl}"/> /
+    /// <see cref="Reconciler.RegisterType{TElement,TControl}"/> (§8). See issue
     /// <see href="https://github.com/microsoft/microsoft-ui-reactor/issues/486"/>
     /// for the original trade-off discussion.
     /// </remarks>
@@ -260,7 +263,8 @@ public sealed partial class Reconciler
             "globally at startup, use " +
             $"`Microsoft.UI.Reactor.Core.V1Protocol.ControlRegistry.Register" +
             $"<{elementType.Name}, TControl>(static () => new YourHandler())` — or " +
-            $"`ControlRegistry.RegisterDecorator<{elementType.Name}>(...)` for a " +
+            $"`ControlRegistry.RegisterDecorator<{elementType.Name}>(static () => new " +
+            "YourDecoratorHandler())` for a " +
             "decorator-backed element that wraps a child instead of owning a leaf " +
             "control.\n" +
             "  (4) For a bespoke app-local control, register it on the host's " +

--- a/src/Reactor/Core/Reconciler.Mount.cs
+++ b/src/Reactor/Core/Reconciler.Mount.cs
@@ -227,14 +227,18 @@ public sealed partial class Reconciler
     /// <remarks>
     /// Spec 062 §10 — with lazy self-registration the norm, this is reframed around
     /// what actually causes it rather than around a registration call most apps never
-    /// make. A "mounted but unregistered" element is nearly unreachable for generated
-    /// wrappers (spec 058: constructing the element self-registers it); it survives for
-    /// a factory-carried control constructed by raw <c>new</c> that bypassed the factory
-    /// trigger, a wrapper assembly that is referenced but never touched, a third-party
-    /// override that was never registered, or a bespoke app-local element that was never
+    /// make. It survives for a factory-carried control constructed by raw <c>new</c>
+    /// that bypassed the factory trigger, a third-party control or handler override
+    /// that was never registered, or a bespoke app-local element that was never
     /// registered on the host's reconciler via
     /// <see cref="Reconciler.RegisterHandler{TElement,TControl}"/> /
-    /// <see cref="Reconciler.RegisterType{TElement,TControl}"/> (§8). See issue
+    /// <see cref="Reconciler.RegisterType{TElement,TControl}"/> (§8).
+    /// <para>A <c>[GenerateReactorWrapper]</c> element is deliberately NOT listed as a
+    /// cause: the generator emits a static constructor on the element type that calls
+    /// <c>ControlRegistry.Register</c> (spec 058), and constructing an instance runs it —
+    /// so by the time there is an instance to mount, registration has already happened.
+    /// Listing it would send a wrapper author chasing a cause that cannot produce this.</para>
+    /// See issue
     /// <see href="https://github.com/microsoft/microsoft-ui-reactor/issues/486"/>
     /// for the original trade-off discussion.
     /// </remarks>
@@ -242,39 +246,68 @@ public sealed partial class Reconciler
     private static UIElement? ThrowNoHandlerRegistered(Element element)
     {
         // Reflection-light and AOT-safe by construction: the message names only
-        // element.GetType(), never a member walk or an assembly scan.
+        // element.GetType() (plus its generic arguments), never a member walk or an
+        // assembly scan.
         var elementType = element.GetType();
-        var elementTypeName = elementType.FullName ?? elementType.Name;
+        var friendlyName = FriendlyTypeName(elementType);
+        // FullName is the precise identifier (and keeps `Outer+Inner` nesting), but for a
+        // closed generic it is an assembly-qualified monster —
+        // `Foo`1[[System.Int32, System.Private.CoreLib, Version=…]]` — so generics use the
+        // readable C# form instead. Non-generic output is unchanged.
+        var elementTypeName = elementType.IsGenericType
+            ? (string.IsNullOrEmpty(elementType.Namespace)
+                ? friendlyName
+                : elementType.Namespace + "." + friendlyName)
+            : (elementType.FullName ?? elementType.Name);
         throw new InvalidOperationException(
             $"No handler is registered for element type '{elementTypeName}', so the " +
             "reconciler does not know how to mount it.\n\n" +
             "Registration is lazy: an element becomes mountable as a side effect of " +
             "the code that introduces it. One of these is missing:\n\n" +
-            $"  (1) Create it through its factory. Built-in and Pattern-B controls " +
-            $"self-register on the factory call, so `new {elementType.Name}(...)` on " +
-            "its own never registers anything. Call the factory (e.g. " +
+            $"  (1) Create it through its factory. Built-in and factory-registered " +
+            $"controls self-register on the factory call, so `new {friendlyName}(...)` " +
+            "on its own never registers anything. Call the factory (e.g. " +
             "`Factories.TextBlock(\"\")`) at least once, then the direct-record idiom " +
             "is safe for the hot path.\n" +
-            "  (2) If it comes from a [GenerateReactorWrapper] library, make sure that " +
-            "assembly is actually referenced and reached — its generated element " +
-            "carries the self-registration, so an unreferenced or fully-trimmed " +
-            "wrapper never runs it.\n" +
-            "  (3) To register a third-party control or override a built-in handler " +
+            "  (2) To register a third-party control or override a built-in handler " +
             "globally at startup, use (in Microsoft.UI.Reactor.Core.V1Protocol) " +
-            $"`ControlRegistry.Register<{elementType.Name}, TControl>(static () => " +
+            $"`ControlRegistry.Register<{friendlyName}, TControl>(static () => " +
             "new YourHandler())` — or " +
-            $"`ControlRegistry.RegisterDecorator<{elementType.Name}>(static () => new " +
+            $"`ControlRegistry.RegisterDecorator<{friendlyName}>(static () => new " +
             "YourDecoratorHandler())` for a " +
             "decorator-backed element that wraps a child instead of owning a leaf " +
             "control.\n" +
-            "  (4) For a bespoke app-local control, register it on the host's " +
-            $"reconciler before first mount: `reconciler.RegisterHandler<{elementType.Name}, " +
+            "  (3) For a bespoke app-local control, register it on the host's " +
+            $"reconciler before first mount: `reconciler.RegisterHandler<{friendlyName}, " +
             "TControl>(new YourHandler())` (or `RegisterType`).\n" +
-            "  (5) As a blunt opt-in for the whole built-in catalog, call " +
+            "  (4) As a blunt opt-in for the whole built-in catalog, call " +
             "`Microsoft.UI.Reactor.ReactorApp.RegisterAllBuiltIns()` at startup — this " +
             "makes every built-in element record mountable regardless of how it was " +
             "constructed, at the cost of rooting the catalog for the trimmer.\n\n" +
             "Authoring guide: docs/guide/extending-reactor-controls.md");
+    }
+
+    /// <summary>
+    /// Formats a type for a copy-pasteable C# snippet: <c>DataGridElement`1</c> — the raw
+    /// metadata name — becomes <c>DataGridElement&lt;T&gt;</c>. Reflection-light (name +
+    /// generic arguments only), so it stays AOT- and trim-safe.
+    /// </summary>
+    private static string FriendlyTypeName(Type type)
+    {
+        if (!type.IsGenericType) return type.Name;
+
+        var name = type.Name;
+        var tick = name.IndexOf('`');
+        if (tick >= 0) name = name.Substring(0, tick);
+
+        var args = type.GetGenericArguments();
+        var sb = new global::System.Text.StringBuilder(name).Append('<');
+        for (int i = 0; i < args.Length; i++)
+        {
+            if (i > 0) sb.Append(", ");
+            sb.Append(FriendlyTypeName(args[i]));
+        }
+        return sb.Append('>').ToString();
     }
 
     // Spec 047 §14 Phase 3-final Batch B — widened to internal static so

--- a/src/Reactor/Core/Reconciler.Mount.cs
+++ b/src/Reactor/Core/Reconciler.Mount.cs
@@ -260,9 +260,9 @@ public sealed partial class Reconciler
             "carries the self-registration, so an unreferenced or fully-trimmed " +
             "wrapper never runs it.\n" +
             "  (3) To register a third-party control or override a built-in handler " +
-            "globally at startup, use " +
-            $"`Microsoft.UI.Reactor.Core.V1Protocol.ControlRegistry.Register" +
-            $"<{elementType.Name}, TControl>(static () => new YourHandler())` — or " +
+            "globally at startup, use (in Microsoft.UI.Reactor.Core.V1Protocol) " +
+            $"`ControlRegistry.Register<{elementType.Name}, TControl>(static () => " +
+            "new YourHandler())` — or " +
             $"`ControlRegistry.RegisterDecorator<{elementType.Name}>(static () => new " +
             "YourDecoratorHandler())` for a " +
             "decorator-backed element that wraps a child instead of owning a leaf " +

--- a/tests/Reactor.Tests/Spec048/UnregisteredHandlerAndRegisterAllBuiltInsTests.cs
+++ b/tests/Reactor.Tests/Spec048/UnregisteredHandlerAndRegisterAllBuiltInsTests.cs
@@ -84,6 +84,27 @@ public sealed class UnregisteredHandlerAndRegisterAllBuiltInsTests
             ex.Message);
     }
 
+    private static class GenericHolder<TOuter>
+    {
+        internal sealed record NestedProbeElement<TInner>(TOuter A, TInner B) : Element;
+    }
+
+    [Fact]
+    public void Nested_Inside_A_Generic_Type_Does_Not_Duplicate_The_Outer_Type_Arguments()
+    {
+        var reconciler = new Reconciler();
+
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => reconciler.Mount(new GenericHolder<int>.NestedProbeElement<string>(1, "x"), NoOp));
+
+        // Reflection reports the generic arguments of a nested type as the whole chain
+        // flattened outermost-first, so a naive render repeats the outer arguments on the
+        // inner name (`GenericHolder<Int32>.NestedProbeElement<Int32, String>`) — which is
+        // not the type and does not compile.
+        Assert.Contains("GenericHolder<Int32>.NestedProbeElement<String>", ex.Message);
+        Assert.DoesNotContain("NestedProbeElement<Int32, String>", ex.Message);
+    }
+
     [Fact]
     public void Mount_Of_EmptyElement_Does_Not_Throw()
     {

--- a/tests/Reactor.Tests/Spec048/UnregisteredHandlerAndRegisterAllBuiltInsTests.cs
+++ b/tests/Reactor.Tests/Spec048/UnregisteredHandlerAndRegisterAllBuiltInsTests.cs
@@ -45,6 +45,17 @@ public sealed class UnregisteredHandlerAndRegisterAllBuiltInsTests
         Assert.Contains("factory", ex.Message);
         Assert.Contains("RegisterAllBuiltIns", ex.Message);
         Assert.Contains("ControlRegistry.Register", ex.Message);
+
+        // Spec 062 §10 — with lazy self-registration the norm, the message must also
+        // name the two causes that 048's wording left out, or it sends an author
+        // hunting for a registration call they were never supposed to write.
+        Assert.Contains("GenerateReactorWrapper", ex.Message);   // referenced-but-unreached wrapper (058)
+        Assert.Contains("RegisterHandler", ex.Message);          // per-host, app-local bespoke control (§8)
+
+        // …and must NOT lead with the reconciler's internal dispatch-arm mechanics,
+        // which name private fields an app author cannot act on.
+        Assert.DoesNotContain("_v1Handlers", ex.Message);
+        Assert.DoesNotContain("_typeRegistry", ex.Message);
     }
 
     [Fact]

--- a/tests/Reactor.Tests/Spec048/UnregisteredHandlerAndRegisterAllBuiltInsTests.cs
+++ b/tests/Reactor.Tests/Spec048/UnregisteredHandlerAndRegisterAllBuiltInsTests.cs
@@ -76,6 +76,12 @@ public sealed class UnregisteredHandlerAndRegisterAllBuiltInsTests
         // render as C# (`Foo<Int32>`), never as the raw metadata name (``Foo`1``).
         Assert.Contains("UnregisteredGenericProbeElement<Int32>", ex.Message);
         Assert.DoesNotContain("UnregisteredGenericProbeElement`1", ex.Message);
+
+        // A nested type must keep its declaring chain, or the printed name is ambiguous
+        // (and the snippet still wouldn't compile).
+        Assert.Contains(
+            nameof(UnregisteredHandlerAndRegisterAllBuiltInsTests) + ".UnregisteredGenericProbeElement<Int32>",
+            ex.Message);
     }
 
     [Fact]

--- a/tests/Reactor.Tests/Spec048/UnregisteredHandlerAndRegisterAllBuiltInsTests.cs
+++ b/tests/Reactor.Tests/Spec048/UnregisteredHandlerAndRegisterAllBuiltInsTests.cs
@@ -47,15 +47,35 @@ public sealed class UnregisteredHandlerAndRegisterAllBuiltInsTests
         Assert.Contains("ControlRegistry.Register", ex.Message);
 
         // Spec 062 §10 — with lazy self-registration the norm, the message must also
-        // name the two causes that 048's wording left out, or it sends an author
+        // name the per-host path that 048's wording left out, or it sends an author
         // hunting for a registration call they were never supposed to write.
-        Assert.Contains("GenerateReactorWrapper", ex.Message);   // referenced-but-unreached wrapper (058)
         Assert.Contains("RegisterHandler", ex.Message);          // per-host, app-local bespoke control (§8)
+
+        // A [GenerateReactorWrapper] element registers in its generated static ctor, so
+        // having an instance means registration already ran — it cannot be the cause and
+        // must not be advertised as one (it would send wrapper authors down a dead end).
+        Assert.DoesNotContain("GenerateReactorWrapper", ex.Message);
 
         // …and must NOT lead with the reconciler's internal dispatch-arm mechanics,
         // which name private fields an app author cannot act on.
         Assert.DoesNotContain("_v1Handlers", ex.Message);
         Assert.DoesNotContain("_typeRegistry", ex.Message);
+    }
+
+    private sealed record UnregisteredGenericProbeElement<T>(T Value) : Element;
+
+    [Fact]
+    public void Unregistered_Generic_Element_Prints_A_Pasteable_Type_Name()
+    {
+        var reconciler = new Reconciler();
+
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => reconciler.Mount(new UnregisteredGenericProbeElement<int>(1), NoOp));
+
+        // The remediation snippets are meant to be copy-pasted, so a closed generic must
+        // render as C# (`Foo<Int32>`), never as the raw metadata name (``Foo`1``).
+        Assert.Contains("UnregisteredGenericProbeElement<Int32>", ex.Message);
+        Assert.DoesNotContain("UnregisteredGenericProbeElement`1", ex.Message);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Rewords the runtime throw that fires when an element is mounted with no registered handler, so it names the causes that actually produce it instead of a registration call most apps never make. This is **E1(a)** from spec-062 §13, sourced from §10 Diagnostics.

## Linked issue / spec

- Part of #163 — closes the fourth of its four frustrations, *"missing registration can still fail quietly"*
- Implements `docs/specs/062-third-party-registration-and-package-boundaries.md` §10 (E1a)

## Why

Spec 048 added this throw when lazy self-registration was new, and the wording still assumes the reader forgot to make a registration call. Now that self-registration is the norm, that blames the wrong thing — and the message opened by naming the reconciler's **private** dispatch fields:

> The reconciler tried all four dispatch arms (per-host `_v1Handlers`, per-host `_typeRegistry`, global `ControlRegistry`, and the composition-primitive switch)…

Those are mechanics an app author cannot act on. It also omitted two of the real causes entirely.

## What the message now says

| Cause | Status |
|---|---|
| Factory bypassed by direct-record construction (built-in / factory-registered controls self-register on the factory call) | kept, clarified |
| A third-party control / handler override never registered globally (`ControlRegistry.Register` / `RegisterDecorator`) | kept |
| A bespoke app-local control not registered on the host's reconciler (`Reconciler.RegisterHandler` / `RegisterType`, §8) | **new** |
| `RegisterAllBuiltIns()` as the blunt catalog opt-in | kept, now notes the trimmer cost so it doesn't read as the cheap default |

### One deliberate divergence from spec §10

§10's prescribed text lists *"a `[GenerateReactorWrapper]` assembly referenced but never reached"* as a cause. **That state is unreachable, so it is not in the message.** `WrapperGenerator.cs:1716` emits the `static {elementName}()` registration cctor on the **element type** itself, so constructing the element runs it — by the time there is an instance to mount, registration has already happened. §10's own prose concedes this (*"almost unreachable … constructing the element self-registers it"*). Listing it would send a wrapper author chasing a cause that cannot produce the throw. The reasoning is recorded in `<remarks>` above the method, and the test asserts the message does **not** mention it.

### Copy-pasteable type names

The message interpolates the element type into remediation snippets, so the printed name has to be real C#. Added a reflection-light `FriendlyTypeName` (name + generic arguments + declaring chain — no member walk, no assembly scan, AOT- and trim-safe) so that:

- a closed generic renders `DataGridElement<Int32>`, not the raw metadata name ``DataGridElement`1``;
- a nested type keeps its declaring chain (`Outer.Inner<T>`) instead of being printed ambiguously;
- a type nested inside a *generic* type does not duplicate the outer arguments — reflection reports the chain flattened outermost-first, so the naive render produces `GenericHolder<Int32>.NestedProbeElement<Int32, String>`, which is not the type and does not compile.

**Non-generic output is byte-identical to before.** The message as a whole stays reflection-light and AOT-safe: it names only `element.GetType()`.

I verified the three API forms the message prints match the real signatures: `ControlRegistry.Register<TElement,TControl>` takes a handler *factory*, `RegisterDecorator<TElement>` is single-arity and also takes a factory, and `Reconciler.RegisterHandler<TElement,TControl>` takes an *instance*. A copy-pasteable error message that doesn't compile is worse than none.

## Test plan

- [x] `dotnet test tests/Reactor.Tests` → **12,524 passed, 0 failed** (clean rebuild); `src/Reactor` builds 0 warnings / 0 errors
- [x] **Strengthened the existing assertion.** It checked only three substrings, so it would not have noticed a cause being dropped again. It now pins the per-host path, asserts the message does **not** name the private dispatch fields, and asserts it does **not** advertise the unreachable wrapper cause.
- [x] **Two new tests** for the pasteability contract: closed generics render as C#, and a type nested in a generic type does not duplicate the outer type arguments.
- [x] **Mutation-checked** — each new oracle was verified to fail when its target code is reverted (dropping the declaring-chain arm, and zeroing the outer-argument offset), so the assertions aren't vacuous.

## Risk / breaking changes

**None.** No API change — one exception message plus tests. The exception type (`InvalidOperationException`) and the throw condition are unchanged, and the three substrings the pre-existing test relied on (`factory`, `RegisterAllBuiltIns`, `ControlRegistry.Register`) are all still present.

## Not in this PR

**E1(b)** — the direct-record construction analyzer that would catch this at compile time rather than at mount. That's a new `REACTOR_*` diagnostic with the netstandard2.0 constraints, an `AnalyzerReleases.Unshipped.md` row, `mur check` parity and docs sync, and its delicate part is *not* firing on generated wrappers (where direct construction is safe). Deliberately split so this small, no-risk improvement can land on its own.
