### PR TITLE
docs(spec-062): document the explicit-registration escape hatch (E2), defer E1b on evidence

### DIFF
--- a/docs/_pipeline/templates/extending-reactor-controls.md.dt
+++ b/docs/_pipeline/templates/extending-reactor-controls.md.dt
@@ -385,6 +385,86 @@ the resulting binary for your custom handler class name. If
 references it, the name is gone. That round-trip is the only
 authoritative test that Pattern A is wired correctly.
 
+## Explicit registration — the narrow escape hatch
+
+Everything above self-registers: the holder's static constructor runs
+on the only path that can produce the element, so there is nothing to
+"wire up" at startup and no `UseMyLibrary()` step. A Reactor app builds
+its element tree *before* it reconciles, so construction always
+precedes dispatch.
+
+**Two cases genuinely need an explicit call**, because no element
+construction triggers them:
+
+1. **A handler for an element you never construct** — typically an
+   *override* for a built-in. Constructing a `ButtonElement` runs the
+   *owner's* registration, never yours, and registration is
+   **first-wins**: whoever gets there first keeps the entry and later
+   calls are silently dropped. So an override has to register at
+   startup, before that element is first mounted.
+2. **Eager global initialization** — for example merging a XAML
+   `ResourceDictionary` into `Application.Current.Resources`. That is
+   ordinary WinUI startup work rather than control registration, and
+   it is usually too late if deferred to a render pass.
+
+Two paths already exist for this. Pick by scope, not by taste:
+
+| | Global — `ControlRegistry.Register*` | Per-host — `reconciler.RegisterType` / `RegisterHandler` |
+|---|---|---|
+| Scope | Whole process | One host's reconciler |
+| Capture | Must be `static` — captures nothing | May capture host-local state |
+| Two implementations of one element | No (first-wins) | Yes — different hosts may differ |
+| Compatibility | Part of the frozen protocol seam, so a *shipped* control library rolls forward | Outside the frozen seam — apps recompile anyway |
+| Reach for it when | A library-level override, or a reusable control library | A bespoke, app-local control |
+
+**Global.** Registers process-wide, and is the path a redistributable
+library should prefer:
+
+```csharp
+ControlRegistry.Register<ButtonElement, Microsoft.UI.Xaml.Controls.Button>(
+    static () => new MyButtonHandler());
+```
+
+`Register` takes a handler **factory**, not an instance, so the handler
+is constructed lazily and once. The `static` on the lambda is the same
+mandate as Step 6 — a capturing lambda allocates a closure and blunts
+the trimmer, and `REACTOR_DESC_001` flags it. The sibling entry points
+are `RegisterDecorator<TElement>` for decorator elements and
+`RegisterForDerivedTypes<TBase, TControl>` for a whole element family.
+
+**Per-host.** Registers on one host's reconciler, from the `configure`
+callback that runs before the first render:
+
+```csharp
+ReactorApp.Run<EditorApp>("Monaco Editor", configure: host =>
+{
+    host.Reconciler.RegisterType<MonacoEditorElement, MonacoEditor>(
+        mount: static (r, el, requestRerender) => new MonacoEditor { Text = el.Text },
+        update: static (r, oldEl, newEl, editor, requestRerender) =>
+        {
+            if (newEl.Text != oldEl.Text) editor.Text = newEl.Text;
+            return null;   // null = the same control was patched in place
+        },
+        unmount: static (r, editor) => editor.Dispose());
+});
+```
+
+`RegisterType` takes **inline** mount/update/unmount delegates, so a
+one-off control needs no `IElementHandler` class at all; `unmount` is
+optional. Returning `null` from `update` means "I patched the existing
+control" — return a different `UIElement` only when you genuinely
+replaced it. If you *do* have a handler class, `RegisterHandler` takes
+an **instance** of it instead. This is the shape Reactor's own docking
+natives and the Monaco sample use.
+
+A library that wants eager setup ships an ordinary
+`public static void UseAcme(Reconciler reconciler)` over one of these —
+Reactor deliberately adds no `IReactorLibrary` interface or
+marker-driven discovery scan. Assembly scanning is AOT-hostile, and a
+`[ModuleInitializer]` names every handler on first type-load, so the
+trimmer can never prove any of it dead — both would forfeit the
+pay-for-what-you-use trimming that Step 6 exists to preserve.
+
 ## Patterns
 
 A few recurring shapes turn up across most custom-control ports:

--- a/docs/_pipeline/templates/extending-reactor-controls.md.dt
+++ b/docs/_pipeline/templates/extending-reactor-controls.md.dt
@@ -400,8 +400,10 @@ construction triggers them:
    *override* for a built-in. Constructing a `ButtonElement` runs the
    *owner's* registration, never yours, and registration is
    **first-wins**: whoever gets there first keeps the entry and later
-   calls are silently dropped. So an override has to register at
-   startup, before that element is first mounted.
+   calls are silently dropped. Register at startup, before the first
+   render builds a tree containing that element — the built-in claims
+   the entry on the factory call that *constructs* it, so waiting until
+   just before the first mount is already too late.
 2. **Eager global initialization** — for example merging a XAML
    `ResourceDictionary` into `Application.Current.Resources`. That is
    ordinary WinUI startup work rather than control registration, and

--- a/docs/_pipeline/templates/extending-reactor-controls.md.dt
+++ b/docs/_pipeline/templates/extending-reactor-controls.md.dt
@@ -425,12 +425,17 @@ ControlRegistry.Register<ButtonElement, Microsoft.UI.Xaml.Controls.Button>(
     static () => new MyButtonHandler());
 ```
 
-`Register` takes a handler **factory**, not an instance, so the handler
-is constructed lazily and once. The `static` on the lambda is the same
-mandate as Step 6 — a capturing lambda allocates a closure and blunts
-the trimmer, and `REACTOR_DESC_001` flags it. The sibling entry points
-are `RegisterDecorator<TElement>` for decorator elements and
-`RegisterForDerivedTypes<TBase, TControl>` for a whole element family.
+`Register` takes a handler **factory**, not an instance. The registration
+itself is process-wide, but the factory runs lazily *per reconciler* —
+each host that mounts the element builds its own handler instance and
+caches it — so a handler must not assume it is a process-wide singleton.
+The `static` on the lambda is the same mandate as Step 6 — a capturing
+lambda allocates a closure and blunts the trimmer, and
+`REACTOR_DESC_001` flags it. The sibling entry points are
+`RegisterDecorator<TElement>` for decorator elements, and
+`RegisterForDerivedTypes<TBase, TControl>` /
+`RegisterDecoratorForDerivedTypes<TBase>` to cover a whole element
+family through its base type.
 
 **Per-host.** Registers on one host's reconciler, from the `configure`
 callback that runs before the first render:

--- a/docs/guide/extending-reactor-controls.md
+++ b/docs/guide/extending-reactor-controls.md
@@ -502,6 +502,86 @@ the resulting binary for your custom handler class name. If
 references it, the name is gone. That round-trip is the only
 authoritative test that Pattern A is wired correctly.
 
+## Explicit registration — the narrow escape hatch
+
+Everything above self-registers: the holder's static constructor runs
+on the only path that can produce the element, so there is nothing to
+"wire up" at startup and no `UseMyLibrary()` step. A Reactor app builds
+its element tree *before* it reconciles, so construction always
+precedes dispatch.
+
+**Two cases genuinely need an explicit call**, because no element
+construction triggers them:
+
+1. **A handler for an element you never construct** — typically an
+   *override* for a built-in. Constructing a `ButtonElement` runs the
+   *owner's* registration, never yours, and registration is
+   **first-wins**: whoever gets there first keeps the entry and later
+   calls are silently dropped. So an override has to register at
+   startup, before that element is first mounted.
+2. **Eager global initialization** — for example merging a XAML
+   `ResourceDictionary` into `Application.Current.Resources`. That is
+   ordinary WinUI startup work rather than control registration, and
+   it is usually too late if deferred to a render pass.
+
+Two paths already exist for this. Pick by scope, not by taste:
+
+| | Global — `ControlRegistry.Register*` | Per-host — `reconciler.RegisterType` / `RegisterHandler` |
+|---|---|---|
+| Scope | Whole process | One host's reconciler |
+| Capture | Must be `static` — captures nothing | May capture host-local state |
+| Two implementations of one element | No (first-wins) | Yes — different hosts may differ |
+| Compatibility | Part of the frozen protocol seam, so a *shipped* control library rolls forward | Outside the frozen seam — apps recompile anyway |
+| Reach for it when | A library-level override, or a reusable control library | A bespoke, app-local control |
+
+**Global.** Registers process-wide, and is the path a redistributable
+library should prefer:
+
+```csharp
+ControlRegistry.Register<ButtonElement, Microsoft.UI.Xaml.Controls.Button>(
+    static () => new MyButtonHandler());
+```
+
+`Register` takes a handler **factory**, not an instance, so the handler
+is constructed lazily and once. The `static` on the lambda is the same
+mandate as Step 6 — a capturing lambda allocates a closure and blunts
+the trimmer, and `REACTOR_DESC_001` flags it. The sibling entry points
+are `RegisterDecorator<TElement>` for decorator elements and
+`RegisterForDerivedTypes<TBase, TControl>` for a whole element family.
+
+**Per-host.** Registers on one host's reconciler, from the `configure`
+callback that runs before the first render:
+
+```csharp
+ReactorApp.Run<EditorApp>("Monaco Editor", configure: host =>
+{
+    host.Reconciler.RegisterType<MonacoEditorElement, MonacoEditor>(
+        mount: static (r, el, requestRerender) => new MonacoEditor { Text = el.Text },
+        update: static (r, oldEl, newEl, editor, requestRerender) =>
+        {
+            if (newEl.Text != oldEl.Text) editor.Text = newEl.Text;
+            return null;   // null = the same control was patched in place
+        },
+        unmount: static (r, editor) => editor.Dispose());
+});
+```
+
+`RegisterType` takes **inline** mount/update/unmount delegates, so a
+one-off control needs no `IElementHandler` class at all; `unmount` is
+optional. Returning `null` from `update` means "I patched the existing
+control" — return a different `UIElement` only when you genuinely
+replaced it. If you *do* have a handler class, `RegisterHandler` takes
+an **instance** of it instead. This is the shape Reactor's own docking
+natives and the Monaco sample use.
+
+A library that wants eager setup ships an ordinary
+`public static void UseAcme(Reconciler reconciler)` over one of these —
+Reactor deliberately adds no `IReactorLibrary` interface or
+marker-driven discovery scan. Assembly scanning is AOT-hostile, and a
+`[ModuleInitializer]` names every handler on first type-load, so the
+trimmer can never prove any of it dead — both would forfeit the
+pay-for-what-you-use trimming that Step 6 exists to preserve.
+
 ## Patterns
 
 A few recurring shapes turn up across most custom-control ports:

--- a/docs/guide/extending-reactor-controls.md
+++ b/docs/guide/extending-reactor-controls.md
@@ -517,8 +517,10 @@ construction triggers them:
    *override* for a built-in. Constructing a `ButtonElement` runs the
    *owner's* registration, never yours, and registration is
    **first-wins**: whoever gets there first keeps the entry and later
-   calls are silently dropped. So an override has to register at
-   startup, before that element is first mounted.
+   calls are silently dropped. Register at startup, before the first
+   render builds a tree containing that element — the built-in claims
+   the entry on the factory call that *constructs* it, so waiting until
+   just before the first mount is already too late.
 2. **Eager global initialization** — for example merging a XAML
    `ResourceDictionary` into `Application.Current.Resources`. That is
    ordinary WinUI startup work rather than control registration, and

--- a/docs/guide/extending-reactor-controls.md
+++ b/docs/guide/extending-reactor-controls.md
@@ -542,12 +542,17 @@ ControlRegistry.Register<ButtonElement, Microsoft.UI.Xaml.Controls.Button>(
     static () => new MyButtonHandler());
 ```
 
-`Register` takes a handler **factory**, not an instance, so the handler
-is constructed lazily and once. The `static` on the lambda is the same
-mandate as Step 6 — a capturing lambda allocates a closure and blunts
-the trimmer, and `REACTOR_DESC_001` flags it. The sibling entry points
-are `RegisterDecorator<TElement>` for decorator elements and
-`RegisterForDerivedTypes<TBase, TControl>` for a whole element family.
+`Register` takes a handler **factory**, not an instance. The registration
+itself is process-wide, but the factory runs lazily *per reconciler* —
+each host that mounts the element builds its own handler instance and
+caches it — so a handler must not assume it is a process-wide singleton.
+The `static` on the lambda is the same mandate as Step 6 — a capturing
+lambda allocates a closure and blunts the trimmer, and
+`REACTOR_DESC_001` flags it. The sibling entry points are
+`RegisterDecorator<TElement>` for decorator elements, and
+`RegisterForDerivedTypes<TBase, TControl>` /
+`RegisterDecoratorForDerivedTypes<TBase>` to cover a whole element
+family through its base type.
 
 **Per-host.** Registers on one host's reconciler, from the `configure`
 callback that runs before the first render:

--- a/docs/specs/062-third-party-registration-and-package-boundaries.md
+++ b/docs/specs/062-third-party-registration-and-package-boundaries.md
@@ -617,15 +617,16 @@ trigger, or a third-party override that was never registered.
   `ControlRegistry.Register…`, or — for a bespoke app-local control — register it on the
   host's reconciler via `Reconciler.RegisterType`/`RegisterHandler` before first mount
   (§8)."* Reflection-light and AOT-safe: it names only `element.GetType()`.
-- **Add a direct-record construction guardrail.** Warn when a *factory-registered* element
-  record (a built-in / Pattern-B-style control, where the registration link lives on the
-  factory) is constructed directly (`new FooElement(...)`) rather than via its factory — the
-  most common cause of the throw above. It must **not** fire on generated wrappers (058),
+- **A direct-record construction guardrail — proposed, then dropped.** The original
+  proposal was to warn when a *factory-registered* element record (a built-in /
+  Pattern-B-style control, where the registration link lives on the factory) is
+  constructed directly (`new FooElement(...)`) rather than via its factory — the most
+  common cause of the throw above — while **not** firing on generated wrappers (058),
   whose element-rooted Pattern-A cctor makes direct construction self-registering and safe.
 
-  **Status: shipped as the reworded throw only (E1a). The analyzer (E1b) is NOT being
-  built — deferred on evidence.** A false-positive spike over the whole repo found the
-  rule is not implementable at warning severity:
+  **Status: not being built (E1b).** Only the reworded throw above shipped (E1a). A
+  false-positive spike over the whole repo found the analyzer is not implementable at
+  warning severity:
 
   - **It would contradict a documented supported idiom.** `advanced.md` teaches the direct
     record initializer as a deliberate allocation optimization ("use only when the

--- a/docs/specs/062-third-party-registration-and-package-boundaries.md
+++ b/docs/specs/062-third-party-registration-and-package-boundaries.md
@@ -623,6 +623,37 @@ trigger, or a third-party override that was never registered.
   most common cause of the throw above. It must **not** fire on generated wrappers (058),
   whose element-rooted Pattern-A cctor makes direct construction self-registering and safe.
 
+  **Status: shipped as the reworded throw only (E1a). The analyzer (E1b) is NOT being
+  built — deferred on evidence.** A false-positive spike over the whole repo found the
+  rule is not implementable at warning severity:
+
+  - **It would contradict a documented supported idiom.** `advanced.md` teaches the direct
+    record initializer as a deliberate allocation optimization ("use only when the
+    allocation cost shows up in profiles") and then lists the three ways to guarantee
+    registration. A warning would flag documented-correct code, and would break any
+    consumer building with `TreatWarningsAsErrors`.
+  - **The property is whole-program, ordered and cross-assembly.** Registration is
+    process-global and first-wins, so `new TextBlockElement(...)` is only wrong when *no*
+    `TextBlockElement` factory runs anywhere first. A per-compilation analyzer cannot
+    decide that. Collecting sites and gating on "this compilation also calls
+    `RegisterAllBuiltIns()`" is not a proof either — the call may be unreachable, may run
+    after the first mount, or (as in this repo's own tests) may only be safe because it is
+    a `[ModuleInitializer]`.
+  - **No discriminator survives contact.** `StaticConstructors.IsEmpty` distinguishes the
+    element-rooted cctor today only by accident: any ordinary static field initializer on
+    an element record also emits a `.cctor`, silently disabling the rule. The honest
+    discriminator would be explicit metadata naming the canonical factory, which does not
+    exist yet.
+  - **Zero demonstrated true positives.** Of ~1,450 direct-construction sites in the repo,
+    every one is either the framework's own test suite (safe — the tests register the full
+    catalog from a `[ModuleInitializer]`), an app-local bespoke element (the supported §8
+    shape), or text inside a documentation string literal. Real app code has none.
+
+  The reworded runtime throw already names this cause first and prints the pasteable
+  remediation, which is the proportionate fix. Revisit only if explicit
+  registration-intent metadata lands, and then as an **Info**-severity suggestion with a
+  code fix — never a warning.
+
 ## §11 Trimming and AOT
 
 Both tracks preserve spec 048's reachability model (R5):
@@ -660,12 +691,15 @@ Both tracks preserve spec 048's reachability model (R5):
 - **Track A — stabilize the ABI in place.** A1: enumerate and lock the §6.1 seam behind the
   API-compat gate (Q1/Q2). A2: build the binary-compat interop harness. A3: settle and
   document the loader/version policy (Q3).
-- **Track B — consolidate into Advanced.** B1: charting + docking → `Reactor.Advanced`.
+- **Track B — consolidate into Advanced. Done.** B1: charting + docking → `Reactor.Advanced`.
   B2: markdown (with the §7 factory note, Q4). B3: data grid (§7 factory note, Q4).
-- **Registration clean-ups — independent, small.** E1: reword the R3 runtime throw and
-  add the direct-record guardrail (§10). E2: document the §8 explicit-registration escape
-  hatch (overrides / eager init) against the existing `ControlRegistry.Register*`. No
-  `IReactorLibrary`, marker, or discovery pass ships.
+- **Registration clean-ups — independent, small. Done.** E1a: the R3 runtime throw is
+  reworded around what actually causes it (§10). E1b — the direct-record guardrail
+  analyzer — is **deferred on evidence**; see §10 for the false-positive spike and why it
+  cannot ship at warning severity. E2: the §8 explicit-registration escape hatch
+  (overrides / eager init, and the global-vs-per-host choice) is documented in the
+  *Extending Reactor with Native Controls* guide. No `IReactorLibrary`, marker, or
+  discovery pass ships.
 
 Tracks A and B share no dependency and can land in either order; the registration
 clean-ups can interleave with either.

--- a/docs/specs/062-third-party-registration-and-package-boundaries.md
+++ b/docs/specs/062-third-party-registration-and-package-boundaries.md
@@ -639,11 +639,12 @@ trigger, or a third-party override that was never registered.
     `RegisterAllBuiltIns()`" is not a proof either — the call may be unreachable, may run
     after the first mount, or (as in this repo's own tests) may only be safe because it is
     a `[ModuleInitializer]`.
-  - **No discriminator survives contact.** `StaticConstructors.IsEmpty` distinguishes the
-    element-rooted cctor today only by accident: any ordinary static field initializer on
-    an element record also emits a `.cctor`, silently disabling the rule. The honest
-    discriminator would be explicit metadata naming the canonical factory, which does not
-    exist yet.
+  - **No discriminator survives contact.** The only structural signal available to an
+    analyzer is whether the element type declares a static constructor (Roslyn's
+    `INamedTypeSymbol.StaticConstructors`), and that distinguishes the element-rooted
+    cctor today only by accident: any ordinary static field initializer on an element
+    record also emits a `.cctor`, silently disabling the rule. The honest discriminator
+    would be explicit metadata naming the canonical factory, which does not exist yet.
   - **Zero demonstrated true positives.** Of ~1,450 direct-construction sites in the repo,
     every one is either the framework's own test suite (safe — the tests register the full
     catalog from a `[ModuleInitializer]`), an app-local bespoke element (the supported §8


### PR DESCRIPTION
## Summary

Documents the §8 explicit-registration escape hatch in the native-controls authoring guide, and records E1's disposition in the spec. This is **E2** from spec-062 §13.

## Linked issue / spec

- Part of #163 — the last of the spec-062 registration clean-ups
- Implements `docs/specs/062-third-party-registration-and-package-boundaries.md` §8 / §13 (E2)

## Why

The guide's Step 6 teaches the self-registering factory holder, which is correct for the common case — a control self-registers the first time its element is constructed, so there is no `UseMyLibrary()` step. But §8 identifies two cases where that isn't enough, and the guide never covered them:

1. **A handler for an element you never construct** — an *override* for a built-in. Constructing a `ButtonElement` runs the owner's registration, never yours, and registration is first-wins, so an override has to register at startup.
2. **Eager global initialization** — merging a XAML `ResourceDictionary`, which is too late if deferred to a render pass.

`reconciler.RegisterType` — the documented shape for a bespoke app-local control, and what Reactor's own docking natives and the Monaco sample use — had **zero mentions** in the authoring guide.

## What's added

A new *Explicit registration — the narrow escape hatch* section between Step 6 and Patterns: the two cases above, then a comparison table and worked example for each of the two existing paths.

| | Global — `ControlRegistry.Register*` | Per-host — `reconciler.RegisterType` / `RegisterHandler` |
|---|---|---|
| Scope | Whole process | One host's reconciler |
| Capture | Must be `static` | May capture host-local state |
| Compatibility | Frozen protocol seam — a shipped library rolls forward | Outside the seam |
| Reach for it when | Library-level override, reusable library | Bespoke app-local control |

It closes with why Reactor ships no `IReactorLibrary` or discovery scan — assembly scanning is AOT-hostile and a `[ModuleInitializer]` is a trimmer root, so either would forfeit the pay-for-what-you-use trimming Step 6 exists to preserve.

**Every signature and behavioural claim is checked against source**, not paraphrased from the spec: `RegisterType`'s inline mount/update/unmount delegates and optional `unmount`; returning `null` from `update` meaning "patched in place"; `Register` taking a handler *factory* rather than an instance; and the `configure: host => …` hook the Monaco sample actually registers from. (`ReactorAppContext` exposes only `LaunchActivation`, so the docs deliberately do **not** claim you can register from the `ReactorApp.Run` startup delegate.)

## E1(b) is deferred on evidence, not built

The spec's §10 also asked for a direct-record construction guardrail analyzer. **It should not ship**, and §10 now records why:

- **It would contradict a documented supported idiom.** `advanced.md` teaches the direct record initializer as a deliberate allocation optimization — *"use only when the allocation cost shows up in profiles"* — and then lists the three ways to guarantee registration. A warning would flag documented-correct code and break any consumer building with `TreatWarningsAsErrors`.
- **The property is whole-program, ordered and cross-assembly.** Registration is process-global and first-wins, so `new TextBlockElement(…)` is only wrong when no `TextBlockElement` factory runs anywhere first. Gating on "this compilation also calls `RegisterAllBuiltIns()`" isn't a proof either — the call may be unreachable, may run after the first mount, or (as in this repo's own tests) may only be safe because it's a `[ModuleInitializer]`.
- **No discriminator survives contact.** `StaticConstructors.IsEmpty` separates the element-rooted wrapper cctor from factory-rooted built-ins only by accident: any ordinary static field initializer on an element record also emits a `.cctor`, silently disabling the rule.
- **Zero demonstrated true positives.** Of ~1,450 direct-construction sites in the repo, every one is the framework's own test suite (safe — it registers the full catalog from a `[ModuleInitializer]`), an app-local bespoke element (the supported §8 shape), or text inside a documentation string literal.

The reworded runtime throw from #933 already names this cause first and prints pasteable remediation, which is the proportionate fix. §10 notes it should only be revisited if explicit registration-intent metadata lands, and then as **Info** severity with a code fix — never a warning.

This design call was cross-checked with two other model families, which independently rejected both `StaticConstructors.IsEmpty` and the compilation-end gate.

## Test plan

- [x] `mur docs check-tier` → **0 errors** (27 pre-existing non-fatal `winui-ref` warnings, unchanged)
- [x] `mur docs compile --topic extending-reactor-controls --no-screenshots --ci` → succeeds, and the regenerated page is **byte-identical** (verified by hash) to the committed one, so the CI up-to-date gate will pass
- [x] Compile touched **only** the intended two files — no unrelated snippet churn
- [x] `dotnet test tests/Reactor.Tests` (the doc-reading tests: `VersionSingleSource`, `EffectCleanupAnalyzer`, `ImperativeContentDialogAnalyzer`) → **54 passed, 0 failed**

Note: a full `docs compile` across *all* topics fails locally while building the unrelated `recipe-search-with-suggestions` doc app with `PRI210: 0x80070003` — the known deep-path/MakePri issue in this worktree. Confirmed pre-existing: it reproduces identically on a stashed, clean tree.

## Risk / breaking changes

**None.** Documentation and spec prose only — no code, no API surface, no generated-index change.

## Follow-up found while doing this (not fixed here)

`skills/reactor.api.txt` claims to cover "every public type", but `tools/Reactor.SignaturesGen` indexes non-static types only — so the public static classes **`ControlRegistry`** and **`ReactorApp`** are absent from the shipped API index entirely, despite both being named in the #933 throw message and `ControlRegistry.Register*` being the frozen §6.1 seam. An agent reading the index cannot find either signature. Left out of this PR deliberately: the index has two byte-identical shipped copies plus a `Reactor.Tests` byte-compare gate, so it deserves its own change.

Fixes: #163