### PR TITLE
fix(api-index): index public static classes so ControlRegistry and ReactorApp are discoverable

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -65,7 +65,7 @@ The `mur` CLI ships these embedded — works from any directory:
 | Command | What it prints | Source |
 |---|---|---|
 | `mur --skill` | This SKILL.md | embedded in `mur` |
-| `mur --api`   | The signatures index (≈12K tokens, every factory/modifier/hook/Theme token/enum) | embedded in `mur` |
+| `mur --api`   | The signatures index (≈70K tokens: every factory/modifier/hook/Theme token/enum, plus ctors/properties/methods/events on every public type — including static classes like `ControlRegistry` and `ReactorApp`) | embedded in `mur` |
 | `mur --regen-api` | Rebuilds `skills/reactor.api.txt` from a freshly-built `Reactor.dll` (selfhost only) | rebuilds `tools/Reactor.SignaturesGen` |
 | `mur check <path>` | **Is** the build (same exit code as `dotnet build`); adds one-line diagnostics with skill pointers for known REACTOR_* IDs and `→ try:` did-you-mean suggestions | wraps MSBuild |
 

--- a/plugins/reactor/skills/reactor-dsl/SKILL.md
+++ b/plugins/reactor/skills/reactor-dsl/SKILL.md
@@ -5,11 +5,19 @@ description: "Pointer to the full Reactor API signatures index (`references/reac
 
 ## What this skill carries
 
-The full alphabetized signatures index — every public factory, modifier, hook, theme token, and enum — lives at:
+The full alphabetized signatures index lives at:
 
 ```
-references/reactor.api.txt    (~12K tokens, ~650 lines)
+references/reactor.api.txt    (~70K tokens, ~6.3K lines)
 ```
+
+It covers every public factory, modifier, hook, theme token and enum, plus a
+`## Public types` section carrying the constructors, properties, methods and
+events of every other public type — including public **static** classes, so
+process-wide entry points such as `ControlRegistry.Register` and
+`ReactorApp.Run` are listed there too.
+
+It is large: grep it for the symbol you need rather than reading it end to end.
 
 It is the source of truth for the public API surface, regenerated from `Reactor.dll` by `mur --regen-api`.
 

--- a/plugins/reactor/skills/reactor-dsl/references/reactor.api.txt
+++ b/plugins/reactor/skills/reactor-dsl/references/reactor.api.txt
@@ -8,8 +8,9 @@
 # including public *static* classes — so process-wide entry points such as
 # ControlRegistry.Register and ReactorApp.Run are listed there, alongside
 # instance members like WindowSpec.Opacity and ReactorWindow.SetPosition.
-# Extension methods are listed under Modifiers/Hooks in the fluent form you
-# call them, not again under their declaring static class.
+# Extension methods with an Element receiver are listed under Modifiers, and
+# RenderContext/Component ones under Hooks, in the fluent form you call them;
+# any other extension is listed under its declaring class.
 
 ## Factories
 # All in `Microsoft.UI.Reactor.Factories` — `using static Microsoft.UI.Reactor.Factories;`
@@ -23,7 +24,7 @@ AppBarButton(Command command) → AppBarButtonData
 AppBarButton(string label, Action onClick = null, string icon = null) → AppBarButtonData
 AppBarSeparator() → AppBarSeparatorData
 AppBarToggleButton(string label, bool isChecked = false, Action<bool> onIsCheckedChanged = null, string icon = null) → AppBarToggleButtonData
-AutoSuggestBox(Optional<string> text = null, Action<string> onTextChanged = null, Action<string> onQuerySubmitted = null) → AutoSuggestBoxElement
+AutoSuggestBox(Optional<string> text = default, Action<string> onTextChanged = null, Action<string> onQuerySubmitted = null) → AutoSuggestBoxElement
 BitmapIcon(Uri source, bool showAsMonochrome = true) → BitmapIconData
 Body(string content) → TextBlockElement
 BodyLarge(string content) → TextBlockElement
@@ -34,15 +35,15 @@ BreadcrumbBar(BreadcrumbBarItemData[] items, Action<BreadcrumbBarItemData> onIte
 Button(Command command) → ButtonElement
 Button(Element content, Action onClick = null) → ButtonElement
 Button(string label, Action onClick = null) → ButtonElement
-CalendarDatePicker(Optional<DateTimeOffset?> date = null, Action<DateTimeOffset?> onDateChanged = null) → CalendarDatePickerElement
+CalendarDatePicker(Optional<DateTimeOffset?> date = default, Action<DateTimeOffset?> onDateChanged = null) → CalendarDatePickerElement
 CalendarView() → CalendarViewElement
 Canvas(Element[] children) → CanvasElement
 Caption(string content) → TextBlockElement
 Card(Element child) → BorderElement
-CheckBox(Optional<bool?> isChecked = null, Action<bool> onIsCheckedChanged = null, string label = null) → CheckBoxElement
-ColorPicker(Optional<Color> color = null, Action<Color> onColorChanged = null) → ColorPickerElement
+CheckBox(Optional<bool?> isChecked = default, Action<bool> onIsCheckedChanged = null, string label = null) → CheckBoxElement
+ColorPicker(Optional<Color> color = default, Action<Color> onColorChanged = null) → ColorPickerElement
 ComboBox(Element[] itemElements, Optional<int> selectedIndex, Action<int> onSelectedIndexChanged) → ComboBoxElement
-ComboBox(string[] items, Optional<int> selectedIndex = null, Action<int> onSelectedIndexChanged = null) → ComboBoxElement
+ComboBox(string[] items, Optional<int> selectedIndex = default, Action<int> onSelectedIndexChanged = null) → ComboBoxElement
 CommandBar(AppBarItemBase[] primaryCommands = null, AppBarItemBase[] secondaryCommands = null) → CommandBarElement
 CommandBarFlyout(Element target, AppBarItemBase[] primaryCommands = null, AppBarItemBase[] secondaryCommands = null) → CommandBarFlyoutElement
 CommandHost(Command[] commands, Element child) → CommandHostElement
@@ -50,14 +51,14 @@ Component<T, TProps>(TProps props) → ComponentElement<TProps>
 Component<T>() → ComponentElement
 ContentDialog(string title, Element content, string primaryButtonText = "OK") → ContentDialogElement
 ContentFlyout(Element content, FlyoutPlacementMode placement = FlyoutPlacementMode.Auto) → ContentFlyoutElement
-DatePicker(Optional<DateTimeOffset> date = null, Action<DateTimeOffset> onDateChanged = null) → DatePickerElement
+DatePicker(Optional<DateTimeOffset> date = default, Action<DateTimeOffset> onDateChanged = null) → DatePickerElement
 DevtoolsMenu(Func<IEnumerable<MenuFlyoutItemBase>> items = null, string glyph = "⚡", string toolTip = "Devtools", string automationId = null) → Element
 DropDownButton(string label, Element flyout = null) → DropDownButtonElement
 Ellipse() → EllipseElement
 Empty() → Element
 ErrorBoundary(Element child, Element fallback) → ErrorBoundaryElement
 ErrorBoundary(Element child, Func<Exception, Element> fallback) → ErrorBoundaryElement
-Expander(string header, Element content, Optional<bool> isExpanded = null, Action<bool> onIsExpandedChanged = null) → ExpanderElement
+Expander(string header, Element content, Optional<bool> isExpanded = default, Action<bool> onIsExpandedChanged = null) → ExpanderElement
 Expr(Func<Element> render) → Element
 Flex(Element[] children) → FlexElement
 Flex(FlexDirection direction, Element[] children) → FlexElement
@@ -108,7 +109,7 @@ LazyHStack<T>(IReadOnlyList<T> items, Func<T, string> keySelector, Func<T, int, 
 LazyVStack<T>(IReadOnlyList<T> items, Func<T, int, Element> viewBuilder) → LazyVStackElement<T>
 LazyVStack<T>(IReadOnlyList<T> items, Func<T, string> keySelector, Func<T, int, Element> viewBuilder) → LazyVStackElement<T>
 Line(double x1, double y1, double x2, double y2) → LineElement
-ListBox(string[] items, Optional<int> selectedIndex = null, Action<int> onSelectedIndexChanged = null) → ListBoxElement
+ListBox(string[] items, Optional<int> selectedIndex = default, Action<int> onSelectedIndexChanged = null) → ListBoxElement
 ListView(Element[] items) → ListViewElement
 ListView(Optional<int> selectedIndex, Action<int> onSelectedIndexChanged = null, Element[] items) → ListViewElement
 ListView(int? selectedIndex, Action<int> onSelectedIndexChanged = null, Element[] items) → ListViewElement
@@ -133,14 +134,14 @@ NavItem(string content, string icon = null, string tag = null) → NavigationVie
 NavItemHeader(string content) → NavigationViewItemData
 NavigationHost<TRoute>(NavigationHandle<TRoute> nav, Func<TRoute, Element> routeMap) → NavigationHostElement
 NavigationView(NavigationViewItemData[] menuItems, Element content = null) → NavigationViewElement
-NumberBox(Optional<double> value = null, Action<double> onValueChanged = null, string header = null) → NumberBoxElement
+NumberBox(Optional<double> value = default, Action<double> onValueChanged = null, string header = null) → NumberBoxElement
 Paragraph(RichTextInline[] inlines) → RichTextParagraph
 ParallaxView(Element child, double verticalShift = 0, double horizontalShift = 0) → ParallaxViewElement
-PasswordBox(Optional<string> password = null, Action<string> onPasswordChanged = null, string placeholderText = null) → PasswordBoxElement
+PasswordBox(Optional<string> password = default, Action<string> onPasswordChanged = null, string placeholderText = null) → PasswordBoxElement
 Path2D() → PathElement
 PathIcon(string data) → PathIconData
 PersonPicture() → PersonPictureElement
-PipsPager(int numberOfPages, Optional<int> selectedPageIndex = null, Action<int> onSelectedPageIndexChanged = null) → PipsPagerElement
+PipsPager(int numberOfPages, Optional<int> selectedPageIndex = default, Action<int> onSelectedPageIndexChanged = null) → PipsPagerElement
 Pivot(Optional<int> selectedIndex, Action<int> onSelectedIndexChanged = null, PivotItemData[] items) → PivotElement
 Pivot(PivotItemData[] items) → PivotElement
 Pivot(int? selectedIndex, Action<int> onSelectedIndexChanged = null, PivotItemData[] items) → PivotElement
@@ -151,26 +152,26 @@ ProgressIndeterminate() → ProgressElement
 ProgressRing() → ProgressRingElement
 ProgressRing(double value) → ProgressRingElement
 PropertyGrid(object target, TypeRegistry registry, Action<object> onRootChanged = null) → ComponentElement<PropertyGridElement>
-RadioButton(string label, Optional<bool> isChecked = null, Action<bool> onIsCheckedChanged = null, string groupName = null) → RadioButtonElement
-RadioButtons(string[] items, Optional<int> selectedIndex = null, Action<int> onSelectedIndexChanged = null) → RadioButtonsElement
+RadioButton(string label, Optional<bool> isChecked = default, Action<bool> onIsCheckedChanged = null, string groupName = null) → RadioButtonElement
+RadioButtons(string[] items, Optional<int> selectedIndex = default, Action<int> onSelectedIndexChanged = null) → RadioButtonsElement
 RadioMenuItem(string text, string groupName, bool isChecked = false, Action onClick = null, string icon = null) → RadioMenuFlyoutItemData
-RatingControl(Optional<double> value = null, Action<double> onValueChanged = null) → RatingControlElement
+RatingControl(Optional<double> value = default, Action<double> onValueChanged = null) → RatingControlElement
 Rectangle() → RectangleElement
 RefreshContainer(Element content, Action onRefreshRequested = null) → RefreshContainerElement
 RelativePanel(Element[] children) → RelativePanelElement
 RenderEachTime(Func<RenderContext, Element> render) → FuncElement
 RepeatButton(Command command) → RepeatButtonElement
 RepeatButton(string label, Action onClick = null) → RepeatButtonElement
-RichEditBox(Optional<string> text = null, Action<string> onTextChanged = null) → RichEditBoxElement
+RichEditBox(Optional<string> text = default, Action<string> onTextChanged = null) → RichEditBoxElement
 RichTextBlock(RichTextParagraph[] paragraphs) → RichTextBlockElement
 RichTextBlock(string text) → RichTextBlockElement
 Run(string text) → RichTextRun
 ScrollView(Element child) → ScrollViewElement
 ScrollViewer(Element child) → ScrollViewerElement
-SelectorBar(SelectorBarItemData[] items, Optional<int> selectedIndex = null, Action<int> onSelectedIndexChanged = null) → SelectorBarElement
+SelectorBar(SelectorBarItemData[] items, Optional<int> selectedIndex = default, Action<int> onSelectedIndexChanged = null) → SelectorBarElement
 SelectorBarItem(string text, string icon = null) → SelectorBarItemData
 SemanticZoom(Element zoomedInView, Element zoomedOutView) → SemanticZoomElement
-Slider(Optional<double> value = null, double min = 0, double max = 100, Action<double> onValueChanged = null) → SliderElement
+Slider(Optional<double> value = default, double min = 0, double max = 100, Action<double> onValueChanged = null) → SliderElement
 SplitButton(Command command, Element flyout = null) → SplitButtonElement
 SplitButton(string label, Action onClick = null, Element flyout = null) → SplitButtonElement
 SplitView(Element pane = null, Element content = null) → SplitViewElement
@@ -184,21 +185,21 @@ TabView(TabViewItemData[] tabs) → TabViewElement
 TabView(int? selectedIndex, Action<int> onSelectedIndexChanged = null, TabViewItemData[] tabs) → TabViewElement
 TeachingTip(string title, string subtitle = null, ElementRef target = null) → TeachingTipElement
 TextBlock(string content) → TextBlockElement
-TextBox(Optional<string> value = null, Action<string> onChanged = null, string placeholderText = null, string header = null) → TextBoxElement
+TextBox(Optional<string> value = default, Action<string> onChanged = null, string placeholderText = null, string header = null) → TextBoxElement
 Thick(double horizontal, double vertical) → Thickness
 Thick(double left, double top, double right, double bottom) → Thickness
 Thick(double uniform) → Thickness
-ThreeStateCheckBox(Optional<bool?> checkedState = null, Action<bool?> onCheckedStateChanged = null, string label = null) → CheckBoxElement
+ThreeStateCheckBox(Optional<bool?> checkedState = default, Action<bool?> onCheckedStateChanged = null, string label = null) → CheckBoxElement
 ThreeStateToggleButton(string label, bool? checkedState = null, Action<bool?> onCheckedStateChanged = null) → ToggleButtonElement
-TimePicker(Optional<TimeSpan> time = null, Action<TimeSpan> onTimeChanged = null) → TimePickerElement
+TimePicker(Optional<TimeSpan> time = default, Action<TimeSpan> onTimeChanged = null) → TimePickerElement
 Title(string content) → TextBlockElement
 TitleBar(string title) → TitleBarElement
 ToggleButton(Command command, bool isChecked = false) → ToggleButtonElement
 ToggleButton(string label, bool isChecked = false, Action<bool> onIsCheckedChanged = null) → ToggleButtonElement
 ToggleMenuItem(string text, bool isChecked = false, Action<bool> onIsCheckedChanged = null, string icon = null) → ToggleMenuFlyoutItemData
-ToggleSplitButton(Command command, Optional<bool> isChecked = null, Element flyout = null) → ToggleSplitButtonElement
-ToggleSplitButton(string label, Optional<bool> isChecked = null, Action<bool> onIsCheckedChanged = null, Element flyout = null) → ToggleSplitButtonElement
-ToggleSwitch(Optional<bool> isOn = null, Action<bool> onIsOnChanged = null, string onContent = null, string offContent = null, string header = null) → ToggleSwitchElement
+ToggleSplitButton(Command command, Optional<bool> isChecked = default, Element flyout = null) → ToggleSplitButtonElement
+ToggleSplitButton(string label, Optional<bool> isChecked = default, Action<bool> onIsCheckedChanged = null, Element flyout = null) → ToggleSplitButtonElement
+ToggleSwitch(Optional<bool> isOn = default, Action<bool> onIsOnChanged = null, string onContent = null, string offContent = null, string header = null) → ToggleSwitchElement
 TreeNode(string content, TreeViewNodeData[] children) → TreeViewNodeData
 TreeView(TreeViewNodeData[] nodes) → TreeViewElement
 TreeView<T>(IReadOnlyList<T> items, Func<T, IReadOnlyList<T>> childrenSelector, Func<T, Element> viewBuilder) → TemplatedTreeViewElement<T>
@@ -703,7 +704,7 @@ T.Semantics<T>(string role = null, string value = null, double? rangeMin = null,
 T.ShowErrors<T>(ShowWhen showWhen = ShowWhen.Always) → ValidationVisualizerElement
 T.Size<T>(double width, double height) → T
 T.SoundMode<T>(ElementSoundMode mode) → T
-T.SpringLayoutAnimation<T>(float dampingRatio = 0.6, float period = 0.08) → T
+T.SpringLayoutAnimation<T>(float dampingRatio = 0.6f, float period = 0.08f) → T
 T.Stagger<T>(TimeSpan delay, Curve curve = null) → T
 T.TabIndex<T>(int index) → T
 T.TabNavigation<T>(KeyboardNavigationMode mode) → T
@@ -840,7 +841,7 @@ TreeViewElement.Expanding(Action<TreeViewNodeData> handler) → TreeViewElement
 TreeViewElement.ItemInvoked(Action<TreeViewNodeData> handler) → TreeViewElement
 TreeViewElement.Set(Action<TreeView> configure) → TreeViewElement
 ValidationRuleElement.Evaluate(ValidationContext ctx) → void
-ValidationRuleElement.EvaluateAsync(ValidationContext ctx, CancellationToken cancellationToken = null) → Task
+ValidationRuleElement.EvaluateAsync(ValidationContext ctx, CancellationToken cancellationToken = default) → Task
 ViewboxElement.Set(Action<Viewbox> configure) → ViewboxElement
 ViewboxElement.Stretch(Stretch stretch) → ViewboxElement
 ViewboxElement.StretchDirection(StretchDirection direction) → ViewboxElement
@@ -929,7 +930,7 @@ RenderContext.UsePersisted<T>(string key, T initialValue, PersistedScope scope) 
 RenderContext.UseReducedMotion() → bool
 RenderContext.UseReducer<T>(T initialValue, bool threadSafe = false) → ValueTuple<T, Action<Func<T, T>>>
 RenderContext.UseReducer<TState, TAction>(Func<TState, TAction, TState> reducer, TState initialValue, bool threadSafe = false) → ValueTuple<TState, Action<TAction>>
-RenderContext.UseRef<T>(T initialValue = null) → Ref<T>
+RenderContext.UseRef<T>(T initialValue = default) → Ref<T>
 RenderContext.UseResource<T>(Func<CancellationToken, Task<T>> fetcher, QueryCache cache, object[] deps, ResourceOptions options = null, IHookDispatcher dispatcher = null) → AsyncValue<T>
 RenderContext.UseResource<T>(Func<CancellationToken, Task<T>> fetcher, object[] deps, ResourceOptions options = null, IHookDispatcher dispatcher = null) → AsyncValue<T>
 RenderContext.UseState<T>(T initialValue, bool threadSafe = false) → ValueTuple<T, Action<T>>
@@ -1298,7 +1299,7 @@ GetHashCode() → int
 ToString() → string
 
 ### record AutoSuggestBoxElement
-new(Optional<string> Text = null, Action<string> OnTextChanged = null, Action<string> OnQuerySubmitted = null, Action<string> OnSuggestionChosen = null)
+new(Optional<string> Text = default, Action<string> OnTextChanged = null, Action<string> OnQuerySubmitted = null, Action<string> OnSuggestionChosen = null)
 Action<string> OnQuerySubmitted { get; init; }
 Action<string> OnSuggestionChosen { get; init; }
 Action<string> OnTextChanged { get; init; }
@@ -1440,7 +1441,7 @@ GetHashCode() → int
 ToString() → string
 
 ### record CalendarDatePickerElement
-new(Optional<DateTimeOffset?> Date = null, Action<DateTimeOffset?> OnDateChanged = null)
+new(Optional<DateTimeOffset?> Date = default, Action<DateTimeOffset?> OnDateChanged = null)
 Action<DateTimeOffset?> OnDateChanged { get; init; }
 DateTimeOffset? MaxDate { get; init; }
 DateTimeOffset? MinDate { get; init; }
@@ -1524,7 +1525,7 @@ Time(string format = "t") → Func<object, Element>
 ToggleIndicator() → Func<object, Element>
 
 ### record CheckBoxElement
-new(Optional<bool?> IsChecked = null, Action<bool> OnIsCheckedChanged = null, string Label = null)
+new(Optional<bool?> IsChecked = default, Action<bool> OnIsCheckedChanged = null, string Label = null)
 Action<bool> OnIsCheckedChanged { get; init; }
 Action<bool?> OnCheckedStateChanged { get; init; }
 Optional<bool?> IsChecked { get; init; }
@@ -1545,7 +1546,7 @@ GetHashCode() → int
 ToString() → string
 
 ### record ColorPickerElement
-new(Optional<Color> Color = null, Action<Color> OnColorChanged = null)
+new(Optional<Color> Color = default, Action<Color> OnColorChanged = null)
 Action<Color> OnColorChanged { get; init; }
 ColorSpectrumShape ColorSpectrumShape { get; init; }
 Optional<Color> Color { get; init; }
@@ -1590,7 +1591,7 @@ GetHashCode() → int
 ToString() → string
 
 ### record ComboBoxElement
-new(string[] Items, Optional<int> SelectedIndex = null, Action<int> OnSelectedIndexChanged = null)
+new(string[] Items, Optional<int> SelectedIndex = default, Action<int> OnSelectedIndexChanged = null)
 Action OnDropDownClosed { get; init; }
 Action OnDropDownOpened { get; init; }
 Action<int> OnSelectedIndexChanged { get; init; }
@@ -1713,6 +1714,11 @@ Equals(object obj) → bool
 GetHashCode() → int
 ToString() → string
 
+### static class ComponentUseMemoCellsExtensions
+Component.UseMemoCells<T>(IReadOnlyList<T> items, Func<T, int, Element> builder, object[] dependencies) → Element[]
+Component.UseMemoCellsByIndex<T>(IReadOnlyList<T> items, IReadOnlyList<int> changedIndices, Func<T, int, Element> builder, object[] dependencies) → Element[]
+Component.UseMemoCellsByKey<T, TKey>(IReadOnlyList<T> items, Func<T, TKey> keySelector, Func<T, int, Element> builder, object[] dependencies) → Element[]
+
 ### static class CompositorProvider
 Compositor Current { get; set; }
 EnsureCompositor(UIElement element) → Compositor
@@ -1793,12 +1799,12 @@ RegisterDecoratorForDerivedTypes<TBase>(Func<IDecoratorElementHandler<TBase>> ha
 RegisterForDerivedTypes<TBase, TControl>(Func<IElementHandler<TBase, TControl>> handlerFactory) → void
 
 ### record Curve
-Ease(int durationMs, Easing easing = null) → Curve
+Ease(int durationMs, Easing easing = default) → Curve
 Equals(Curve other) → bool
 Equals(object obj) → bool
 GetHashCode() → int
 Linear(int durationMs) → Curve
-Spring(float dampingRatio = 0.8, float period = 0.05) → Curve
+Spring(float dampingRatio = 0.8f, float period = 0.05f) → Curve
 ToString() → string
 
 ### record DataPage<T>
@@ -1820,7 +1826,7 @@ int CachedBlockCount { get; }
 int MaxBlocks { get; }
 int? TotalCount { get; }
 GetBlock(int blockIndex) → CacheBlock<T>
-GetBlockAsync(int blockIndex, CancellationToken cancellationToken = null) → ValueTask<CacheBlock<T>>
+GetBlockAsync(int blockIndex, CancellationToken cancellationToken = default) → ValueTask<CacheBlock<T>>
 GetBlockStatus(int blockIndex) → BlockStatus
 GetItem(int rowIndex) → T
 Invalidate() → void
@@ -1848,7 +1854,7 @@ new()
 DateStyle Style { get; init; }
 
 ### record DatePickerElement
-new(Optional<DateTimeOffset> Date = null, Action<DateTimeOffset> OnDateChanged = null)
+new(Optional<DateTimeOffset> Date = default, Action<DateTimeOffset> OnDateChanged = null)
 Action<DateTimeOffset> OnDateChanged { get; init; }
 DateTimeOffset? MaxYear { get; init; }
 DateTimeOffset? MinYear { get; init; }
@@ -1955,13 +1961,13 @@ ToString() → string
 new()
 IReadOnlyCollection<string> AvailableFormats { get; }
 int OriginProcessId { get; }
-GetBitmapAsync(CancellationToken cancellationToken = null) → Task<RandomAccessStreamReference>
-GetCustomFormatAsync<T>(string formatId, CancellationToken cancellationToken = null) → Task<T>
-GetFilesAsync(CancellationToken cancellationToken = null) → Task<IReadOnlyList<IStorageItem>>
-GetHtmlAsync(CancellationToken cancellationToken = null) → Task<string>
-GetRtfAsync(CancellationToken cancellationToken = null) → Task<string>
-GetTextAsync(CancellationToken cancellationToken = null) → Task<string>
-GetUriAsync(CancellationToken cancellationToken = null) → Task<Uri>
+GetBitmapAsync(CancellationToken cancellationToken = default) → Task<RandomAccessStreamReference>
+GetCustomFormatAsync<T>(string formatId, CancellationToken cancellationToken = default) → Task<T>
+GetFilesAsync(CancellationToken cancellationToken = default) → Task<IReadOnlyList<IStorageItem>>
+GetHtmlAsync(CancellationToken cancellationToken = default) → Task<string>
+GetRtfAsync(CancellationToken cancellationToken = default) → Task<string>
+GetTextAsync(CancellationToken cancellationToken = default) → Task<string>
+GetUriAsync(CancellationToken cancellationToken = default) → Task<Uri>
 HasFormat(string formatId) → bool
 Text(string text) → DragData
 TryGetBitmap(ref RandomAccessStreamReference value) → bool
@@ -2143,6 +2149,54 @@ Equals(Element other) → bool
 Equals(object obj) → bool
 GetHashCode() → int
 ToString() → string
+
+### static class ElementExtensions
+AppBarButtonData.Command(Command command) → AppBarButtonData
+RichTextHyperlink.CharacterSpacing(int spacing) → RichTextHyperlink
+RichTextHyperlink.FontFamily(string family) → RichTextHyperlink
+RichTextHyperlink.FontSize(double size) → RichTextHyperlink
+RichTextHyperlink.FontStretch(FontStretch stretch) → RichTextHyperlink
+RichTextHyperlink.FontStyle(FontStyle style) → RichTextHyperlink
+RichTextHyperlink.FontWeight(FontWeight weight) → RichTextHyperlink
+RichTextHyperlink.Foreground(Brush brush) → RichTextHyperlink
+RichTextHyperlink.Foreground(string color) → RichTextHyperlink
+RichTextHyperlink.IsTabStop(bool isTabStop = true) → RichTextHyperlink
+RichTextHyperlink.IsTextScaleFactorEnabled(bool enabled = true) → RichTextHyperlink
+RichTextHyperlink.Language(string language) → RichTextHyperlink
+RichTextHyperlink.TabIndex(int tabIndex) → RichTextHyperlink
+RichTextHyperlink.TextDecorations(TextDecorations decorations) → RichTextHyperlink
+RichTextHyperlink.UnderlineStyle(UnderlineStyle style) → RichTextHyperlink
+RichTextParagraph.CharacterSpacing(int spacing) → RichTextParagraph
+RichTextParagraph.FontFamily(string family) → RichTextParagraph
+RichTextParagraph.FontSize(double size) → RichTextParagraph
+RichTextParagraph.FontStretch(FontStretch stretch) → RichTextParagraph
+RichTextParagraph.FontStyle(FontStyle style) → RichTextParagraph
+RichTextParagraph.FontWeight(FontWeight weight) → RichTextParagraph
+RichTextParagraph.Foreground(Brush brush) → RichTextParagraph
+RichTextParagraph.Foreground(string color) → RichTextParagraph
+RichTextParagraph.HorizontalTextAlignment(TextAlignment alignment) → RichTextParagraph
+RichTextParagraph.IsTextScaleFactorEnabled(bool enabled = true) → RichTextParagraph
+RichTextParagraph.Language(string language) → RichTextParagraph
+RichTextParagraph.LineHeight(double height) → RichTextParagraph
+RichTextParagraph.LineStackingStrategy(LineStackingStrategy strategy) → RichTextParagraph
+RichTextParagraph.Margin(double horizontal, double vertical) → RichTextParagraph
+RichTextParagraph.Margin(double left = 0, double top = 0, double right = 0, double bottom = 0) → RichTextParagraph
+RichTextParagraph.Margin(double uniform) → RichTextParagraph
+RichTextParagraph.TextAlignment(TextAlignment alignment) → RichTextParagraph
+RichTextParagraph.TextDecorations(TextDecorations decorations) → RichTextParagraph
+RichTextParagraph.TextIndent(double indent) → RichTextParagraph
+RichTextRun.CharacterSpacing(int spacing) → RichTextRun
+RichTextRun.FlowDirection(FlowDirection direction) → RichTextRun
+RichTextRun.FontFamily(string family) → RichTextRun
+RichTextRun.FontSize(double size) → RichTextRun
+RichTextRun.FontStretch(FontStretch stretch) → RichTextRun
+RichTextRun.FontStyle(FontStyle style) → RichTextRun
+RichTextRun.FontWeight(FontWeight weight) → RichTextRun
+RichTextRun.Foreground(Brush brush) → RichTextRun
+RichTextRun.Foreground(string color) → RichTextRun
+RichTextRun.IsTextScaleFactorEnabled(bool enabled = true) → RichTextRun
+RichTextRun.Language(string language) → RichTextRun
+RichTextRun.TextDecorations(TextDecorations decorations) → RichTextRun
 
 ### record ElementExtras
 new()
@@ -2353,7 +2407,7 @@ GetHashCode() → int
 ToString() → string
 
 ### record ExpanderElement
-new(string Header, Element Content, Optional<bool> IsExpanded = null, Action<bool> OnIsExpandedChanged = null)
+new(string Header, Element Content, Optional<bool> IsExpanded = default, Action<bool> OnIsExpandedChanged = null)
 Action<bool> OnIsExpandedChanged { get; init; }
 Element Content { get; init; }
 Element HeaderTemplate { get; init; }
@@ -2760,11 +2814,11 @@ GetHashCode() → int
 ToString() → string
 
 ### interface IAsyncValidator
-ValidateAsync(object value, string field, CancellationToken cancellationToken = null) → Task<ValidationMessage>
+ValidateAsync(object value, string field, CancellationToken cancellationToken = default) → Task<ValidationMessage>
 
 ### interface IDataSource<T>
 DataSourceCapabilities Capabilities { get; }
-GetPageAsync(DataRequest request, CancellationToken cancellationToken = null) → Task<DataPage<T>>
+GetPageAsync(DataRequest request, CancellationToken cancellationToken = default) → Task<DataPage<T>>
 GetRowKey(T item) → RowKey
 
 ### interface IDecoratorElementHandler<TElement>
@@ -2789,16 +2843,16 @@ int ItemCount { get; }
 BuildItemView(int index) → Element
 
 ### interface IKeyedDataSource<T>
-GetByKeyAsync(RowKey key, CancellationToken cancellationToken = null) → Task<T>
-GetByKeysAsync(IEnumerable<RowKey> keys, CancellationToken cancellationToken = null) → Task<IReadOnlyList<T>>
+GetByKeyAsync(RowKey key, CancellationToken cancellationToken = default) → Task<T>
+GetByKeysAsync(IEnumerable<RowKey> keys, CancellationToken cancellationToken = default) → Task<IReadOnlyList<T>>
 
 ### interface IKeyedItemSource
 GetKeyAt(int index) → string
 
 ### interface IMutableDataSource<T>
-CreateAsync(T item, CancellationToken cancellationToken = null) → Task<T>
-DeleteAsync(RowKey key, CancellationToken cancellationToken = null) → Task
-UpdateAsync(RowKey key, T item, CancellationToken cancellationToken = null) → Task<T>
+CreateAsync(T item, CancellationToken cancellationToken = default) → Task<T>
+DeleteAsync(RowKey key, CancellationToken cancellationToken = default) → Task
+UpdateAsync(RowKey key, T item, CancellationToken cancellationToken = default) → Task<T>
 
 ### interface IObservableDataSource<T>
 event EventHandler DataChanged
@@ -3364,11 +3418,11 @@ ToString() → string
 ### class ListDataSource<T>
 new(IEnumerable<T> items, Func<T, RowKey> getRowKey)
 DataSourceCapabilities Capabilities { get; }
-CreateAsync(T item, CancellationToken cancellationToken = null) → Task<T>
-DeleteAsync(RowKey key, CancellationToken cancellationToken = null) → Task
-GetPageAsync(DataRequest request, CancellationToken cancellationToken = null) → Task<DataPage<T>>
+CreateAsync(T item, CancellationToken cancellationToken = default) → Task<T>
+DeleteAsync(RowKey key, CancellationToken cancellationToken = default) → Task
+GetPageAsync(DataRequest request, CancellationToken cancellationToken = default) → Task<DataPage<T>>
 GetRowKey(T item) → RowKey
-UpdateAsync(RowKey key, T item, CancellationToken cancellationToken = null) → Task<T>
+UpdateAsync(RowKey key, T item, CancellationToken cancellationToken = default) → Task<T>
 
 ### record ListViewElement
 new(Element[] Items)
@@ -3799,7 +3853,7 @@ Equals(object obj) → bool
 Fade(TimeSpan? duration = null) → NavigationTransition
 GetHashCode() → int
 Slide(SlideDirection direction = SlideDirection.FromRight, TimeSpan? duration = null, CompositionEasingFunction easing = null, float? distance = null) → NavigationTransition
-Spring(float dampingRatio = 0.6, float period = 0.08, SlideDirection direction = SlideDirection.FromRight) → NavigationTransition
+Spring(float dampingRatio = 0.6f, float period = 0.08f, SlideDirection direction = SlideDirection.FromRight) → NavigationTransition
 ToString() → string
 
 ### record NavigationViewElement
@@ -3878,7 +3932,7 @@ new()
 new()
 
 ### record NumberBoxElement
-new(Optional<double> Value = null, Action<double> OnValueChanged = null, string Header = null)
+new(Optional<double> Value = default, Action<double> OnValueChanged = null, string Header = null)
 Action<double> OnValueChanged { get; init; }
 INumberFormatter2 NumberFormatter { get; init; }
 NumberBoxSpinButtonPlacementMode SpinButtonPlacement { get; init; }
@@ -4010,7 +4064,7 @@ GetHashCode() → int
 ToString() → string
 
 ### record PasswordBoxElement
-new(Optional<string> Password = null, Action<string> OnPasswordChanged = null, string PlaceholderText = null)
+new(Optional<string> Password = default, Action<string> OnPasswordChanged = null, string PlaceholderText = null)
 Action<string> OnPasswordChanged { get; init; }
 Optional<string> Password { get; init; }
 PasswordRevealMode PasswordRevealMode { get; init; }
@@ -4307,7 +4361,7 @@ Unsubscribe(string key) → int
 event Action<string> EntryChanged
 
 ### record RadioButtonElement
-new(string Label, Optional<bool> IsChecked = null, Action<bool> OnIsCheckedChanged = null, string GroupName = null)
+new(string Label, Optional<bool> IsChecked = default, Action<bool> OnIsCheckedChanged = null, string GroupName = null)
 Action<bool> OnIsCheckedChanged { get; init; }
 Optional<bool> IsChecked { get; init; }
 string GroupName { get; init; }
@@ -4320,7 +4374,7 @@ GetHashCode() → int
 ToString() → string
 
 ### record RadioButtonsElement
-new(string[] Items, Optional<int> SelectedIndex = null, Action<int> OnSelectedIndexChanged = null)
+new(string[] Items, Optional<int> SelectedIndex = default, Action<int> OnSelectedIndexChanged = null)
 Action<int> OnSelectedIndexChanged { get; init; }
 Optional<int> SelectedIndex { get; init; }
 string Header { get; init; }
@@ -4348,7 +4402,7 @@ GetHashCode() → int
 ToString() → string
 
 ### record RatingControlElement
-new(Optional<double> Value = null, Action<double> OnValueChanged = null)
+new(Optional<double> Value = default, Action<double> OnValueChanged = null)
 Action<double> OnValueChanged { get; init; }
 Optional<double> Value { get; init; }
 bool IsReadOnly { get; init; }
@@ -4720,7 +4774,7 @@ UsePersisted<T>(string key, T initialValue, PersistedScope scope) → ValueTuple
 UseReducedMotion() → bool
 UseReducer<T>(T initialValue, bool threadSafe = false) → ValueTuple<T, Action<Func<T, T>>>
 UseReducer<TState, TAction>(Func<TState, TAction, TState> reducer, TState initialValue, bool threadSafe = false) → ValueTuple<TState, Action<TAction>>
-UseRef<T>(T initialValue = null) → Ref<T>
+UseRef<T>(T initialValue = default) → Ref<T>
 UseState<T>(T initialValue, bool threadSafe = false) → ValueTuple<T, Action<T>>
 UseSystemBackButton<TRoute>(NavigationHandle<TRoute> nav, Window window) → void
 UseTrayIcon(TrayIconSpec spec) → ReactorTrayIcon
@@ -4796,7 +4850,7 @@ new(string defaultLocale = "en-US", string stringsBasePath = null)
 GetString(string locale, string ns, string key) → string
 
 ### record RichEditBoxElement
-new(Optional<string> Text = null)
+new(Optional<string> Text = default)
 Action<string> OnTextChanged { get; init; }
 Optional<string> Text { get; init; }
 SolidColorBrush SelectionHighlightColor { get; init; }
@@ -4964,10 +5018,10 @@ ToString() → string
 
 ### class RouteArgs
 Get<T>(string name) → T
-GetOrDefault<T>(string name, T defaultValue = null) → T
+GetOrDefault<T>(string name, T defaultValue = default) → T
 GetString(string name) → string
 GetWildcard() → string
-Query<T>(string name, T defaultValue = null) → T
+Query<T>(string name, T defaultValue = default) → T
 QueryString(string name) → string
 
 ### struct RowKey
@@ -5181,7 +5235,7 @@ GetHashCode() → int
 ToString() → string
 
 ### record SliderElement
-new(Optional<double> Value = null, double Min = 0, double Max = 100, Action<double> OnValueChanged = null)
+new(Optional<double> Value = default, double Min = 0, double Max = 100, Action<double> OnValueChanged = null)
 Action<double> OnValueChanged { get; init; }
 Optional<double> Value { get; init; }
 Orientation Orientation { get; init; }
@@ -5676,7 +5730,7 @@ GetHashCode() → int
 ToString() → string
 
 ### record TextBoxElement
-new(Optional<string> Value = null, Action<string> OnChanged = null, string PlaceholderText = null)
+new(Optional<string> Value = default, Action<string> OnChanged = null, string PlaceholderText = null)
 Action<string, int, int> OnSelectionChanged { get; init; }
 Action<string> OnChanged { get; init; }
 CharacterCasing CharacterCasing { get; init; }
@@ -5716,7 +5770,7 @@ ToString() → string
 Brush(string key) → Brush
 CornerRadius(string key) → CornerRadius
 Double(string key) → double
-Get<T>(string key, T defaultValue = null) → T
+Get<T>(string key, T defaultValue = default) → T
 Thickness(string key) → Thickness
 
 ### record ThemeTransitions
@@ -5744,7 +5798,7 @@ GetHashCode() → int
 ToString() → string
 
 ### record TimePickerElement
-new(Optional<TimeSpan> Time = null, Action<TimeSpan> OnTimeChanged = null)
+new(Optional<TimeSpan> Time = default, Action<TimeSpan> OnTimeChanged = null)
 Action<TimeSpan> OnTimeChanged { get; init; }
 Optional<TimeSpan> Time { get; init; }
 int ClockIdentifier { get; init; }
@@ -5809,7 +5863,7 @@ GetHashCode() → int
 ToString() → string
 
 ### record ToggleSplitButtonElement
-new(string Label, Optional<bool> IsChecked = null, Action<bool> OnIsCheckedChanged = null, Element Flyout = null)
+new(string Label, Optional<bool> IsChecked = default, Action<bool> OnIsCheckedChanged = null, Element Flyout = null)
 Action<bool> OnIsCheckedChanged { get; init; }
 Command Command { get; init; }
 Element Flyout { get; init; }
@@ -5823,7 +5877,7 @@ GetHashCode() → int
 ToString() → string
 
 ### record ToggleSwitchElement
-new(Optional<bool> IsOn = null, Action<bool> OnIsOnChanged = null, string OnContent = null, string OffContent = null)
+new(Optional<bool> IsOn = default, Action<bool> OnIsOnChanged = null, string OnContent = null, string OffContent = null)
 Action<bool> OnIsOnChanged { get; init; }
 Optional<bool> IsOn { get; init; }
 string Header { get; init; }
@@ -5842,7 +5896,7 @@ Equals(Transition other) → bool
 Equals(object obj) → bool
 Exit(Transition exit) → Transition
 GetHashCode() → int
-Scale(float from = 0.85) → Transition
+Scale(float from = 0.85f) → Transition
 Slide(Edge edge = Edge.Bottom) → Transition
 ToString() → string
 
@@ -5929,6 +5983,21 @@ Create<T>() → ElementRef<T>
 ### class UIThreadOnlyAttribute
 new()
 
+### static class UseAnnounceExtensions
+Component.UseAnnounce() → AnnounceHandle
+
+### static class UseElementFocusExtensions
+Component.UseElementFocus(FocusState state = FocusState.Programmatic) → ValueTuple<ElementRef, Action>
+
+### static class UseElementRefExtensions
+Component.UseElementRef<T>() → ElementRef<T>
+
+### static class UseFocusExtensions
+Component.UseFocus() → FocusManager
+
+### static class UseFocusTrapExtensions
+Component.UseFocusTrap(bool isActive) → FocusTrapHandle
+
 ### static class Validate
 Email(string message = null) → IValidator
 EqualTo<T>(T otherValue, string message = null) → IValidator
@@ -5941,6 +6010,10 @@ MustBeTrue(string message = null) → IValidator
 Range(double min, double max, string message = null) → IValidator
 Required(string message = null) → IValidator
 Url(string message = null) → IValidator
+
+### static class ValidateExtensions
+ValidationAttached.RunAsyncValidators(object value, CancellationToken cancellationToken = default) → Task<IReadOnlyList<ValidationMessage>>
+ValidationAttached.RunValidators(object value) → IReadOnlyList<ValidationMessage>
 
 ### record ValidationAttached
 new(string FieldName, IValidator[] Validators, IAsyncValidator[] AsyncValidators)
@@ -5983,6 +6056,10 @@ Reset(string field) → object
 ResetAll() → IReadOnlyDictionary<string, object>
 SetInitialValue(string field, object value) → void
 
+### static class ValidationContextComponentExtensions
+Component.UseChildValidationContext() → ValueTuple<ValidationContext, ValidationContext>
+Component.UseValidationContext() → ValidationContext
+
 ### record ValidationMessage
 new(string Field, string Text, Severity Severity = Severity.Error, string Code = null)
 Severity Severity { get; init; }
@@ -5999,7 +6076,7 @@ ToString() → string
 EvaluateRules(ValidationContext ctx, ValidationRuleElement[] rules) → void
 ValidateAttached(ValidationContext ctx, ValidationAttached attached, object value) → void
 ValidateField(ValidationContext ctx, string fieldName, object value, IValidator[] validators) → void
-ValidateFieldAsync(ValidationContext ctx, string fieldName, object value, IAsyncValidator[] asyncValidators, CancellationToken cancellationToken = null) → Task
+ValidateFieldAsync(ValidationContext ctx, string fieldName, object value, IAsyncValidator[] asyncValidators, CancellationToken cancellationToken = default) → Task
 
 ### static class ValidationRuleDsl
 ValidationRule(Func<bool> predicate, string message, string field, Severity severity = Severity.Error) → ValidationRuleElement

--- a/plugins/reactor/skills/reactor-dsl/references/reactor.api.txt
+++ b/plugins/reactor/skills/reactor-dsl/references/reactor.api.txt
@@ -4,8 +4,12 @@
 #             AfterBuild target rewrites this file).
 # Format: one symbol per line. No prose. Alphabetized within each section.
 # Sections: Factories, Modifiers, Reference builders, Hooks, Theme, Enums, Public types.
-# Public types now ARE covered — ctors/properties/methods/events on every
-# public type (e.g. WindowSpec.Opacity, ReactorWindow.SetPosition).
+# Public types covers ctors/properties/methods/events on every public type,
+# including public *static* classes — so process-wide entry points such as
+# ControlRegistry.Register and ReactorApp.Run are listed there, alongside
+# instance members like WindowSpec.Opacity and ReactorWindow.SetPosition.
+# Extension methods are listed under Modifiers/Hooks in the fluent form you
+# call them, not again under their declaring static class.
 
 ## Factories
 # All in `Microsoft.UI.Reactor.Factories` — `using static Microsoft.UI.Reactor.Factories;`
@@ -1105,6 +1109,10 @@ GetHashCode() → int
 Merge(AccessibilityModifiers other) → AccessibilityModifiers
 ToString() → string
 
+### static class AccessibilityScanner
+ExportJson(List<A11yDiagnostic> diagnostics, string filePath) → void
+Scan(Element root) → List<A11yDiagnostic>
+
 ### record AnimatedIconElement
 new()
 IconSource FallbackIconSource { get; init; }
@@ -1133,6 +1141,16 @@ Equals(AnimationConfig other) → bool
 Equals(object obj) → bool
 GetHashCode() → int
 ToString() → string
+
+### static class AnimationScope
+Curve Current { get; }
+bool HasScope { get; }
+WithAnimation(Curve curve, Action action) → void
+WithAnimationAsync(Curve curve, Action action) → Task
+
+### static class Animations
+Animate(AnimationKind kind, Action action) → void
+Animate<T>(AnimationKind kind, Func<T> func) → T
 
 ### record AnnotatedScrollBarElement
 new()
@@ -1297,6 +1315,9 @@ Equals(object obj) → bool
 GetHashCode() → int
 ToString() → string
 
+### static class AutoSuggestDsl
+AutoSuggest<T>(T selected, Action<T> onSelected = null, Func<string, CancellationToken, Task<IReadOnlyList<T>>> search = null, Func<T, string> displayText = null, string placeholderText = null, int debounceMs = 300, Func<T, Element> template = null) → AutoSuggestElement<T>
+
 ### record AutoSuggestElement<T>
 new(T Selected, Action<T> OnSelected = null, Func<string, CancellationToken, Task<IReadOnlyList<T>>> Search = null, Func<T, string> DisplayText = null, string PlaceholderText = null)
 Action<T> OnSelected { get; init; }
@@ -1370,6 +1391,9 @@ Equals(BreadcrumbBarItemData other) → bool
 Equals(object obj) → bool
 GetHashCode() → int
 ToString() → string
+
+### static class BrushHelper
+Parse(string color) → SolidColorBrush
 
 ### record ButtonElement
 new(string Label, Action OnClick = null)
@@ -1487,6 +1511,17 @@ Equals(Element other) → bool
 Equals(object obj) → bool
 GetHashCode() → int
 ToString() → string
+
+### static class CellRenderers
+CheckMark() → Func<object, Element>
+ColorSwatch() → Func<object, Element>
+Date(string format = "d") → Func<object, Element>
+Enum() → Func<object, Element>
+Hyperlink(string displayTextFormat = null) → Func<object, Element>
+Number(string format = null) → Func<object, Element>
+Text(string format = null) → Func<object, Element>
+Time(string format = "t") → Func<object, Element>
+ToggleIndicator() → Func<object, Element>
 
 ### record CheckBoxElement
 new(Optional<bool?> IsChecked = null, Action<bool> OnIsCheckedChanged = null, string Label = null)
@@ -1648,6 +1683,10 @@ Equals(object obj) → bool
 GetHashCode() → int
 ToString() → string
 
+### static class CommandInterop
+FromCommand(ICommand command, string label, IconData icon = null, string description = null, KeyboardAcceleratorData accelerator = null, object parameter = null) → Command
+FromCommand<T>(ICommand command, string label, IconData icon = null, string description = null, KeyboardAcceleratorData accelerator = null) → Command<T>
+
 ### class Component
 Render() → Element
 
@@ -1673,6 +1712,10 @@ Equals(ComponentElement<TProps> other) → bool
 Equals(object obj) → bool
 GetHashCode() → int
 ToString() → string
+
+### static class CompositorProvider
+Compositor Current { get; set; }
+EnsureCompositor(UIElement element) → Compositor
 
 ### record ConnectedTransition
 string AnimationKey { get; init; }
@@ -1742,6 +1785,12 @@ OneWayConditional<TValue>(Func<TElement, TValue> get, Action<TControl, TValue> s
 Reference(Func<TElement, ElementRef> get, Action<TControl, FrameworkElement> set) → ControlDescriptor<TElement, TControl>
 Reference<TTarget>(Func<TElement, ElementRef<TTarget>> get, Action<TControl, TTarget> set) → ControlDescriptor<TElement, TControl>
 ReferenceList<TTarget>(Func<TElement, IReadOnlyList<ElementRef<TTarget>>> get, Action<TControl, IReadOnlyList<TTarget>> apply) → ControlDescriptor<TElement, TControl>
+
+### static class ControlRegistry
+Register<TElement, TControl>(Func<IElementHandler<TElement, TControl>> handlerFactory) → void
+RegisterDecorator<TElement>(Func<IDecoratorElementHandler<TElement>> handlerFactory) → void
+RegisterDecoratorForDerivedTypes<TBase>(Func<IDecoratorElementHandler<TBase>> handlerFactory) → void
+RegisterForDerivedTypes<TBase, TControl>(Func<IElementHandler<TBase, TControl>> handlerFactory) → void
 
 ### record Curve
 Ease(int durationMs, Easing easing = null) → Curve
@@ -1959,6 +2008,9 @@ Equals(object obj) → bool
 GetHashCode() → int
 ToString() → string
 
+### static class DragOperationNegotiation
+Negotiate(DragOperations source, DragOperations target) → DragOperations
+
 ### record DragSourceConfig
 new(Func<DragData> GetData)
 Action<DragEndContext> OnEnd { get; init; }
@@ -2044,6 +2096,28 @@ Equals(Easing other) → bool
 Equals(object obj) → bool
 GetHashCode() → int
 ToString() → string
+
+### static class Editors
+CheckBox() → Func<object, Action<object>, Element>
+Color() → Func<object, Action<object>, Element>
+ColorCompact() → Func<object, Action<object>, Element>
+Combo<TValue>(IReadOnlyList<TValue> choices) → Func<object, Action<object>, Element>
+Date() → Func<object, Action<object>, Element>
+DateOffset() → Func<object, Action<object>, Element>
+DateOnly() → Func<object, Action<object>, Element>
+Decimal(Decimal? min = null, Decimal? max = null) → Func<object, Action<object>, Element>
+Double(double? min = null, double? max = null) → Func<object, Action<object>, Element>
+EnumCombo(Type enumType) → Func<object, Action<object>, Element>
+Float(float? min = null, float? max = null) → Func<object, Action<object>, Element>
+Int(int? min = null, int? max = null) → Func<object, Action<object>, Element>
+Long(long? min = null, long? max = null) → Func<object, Action<object>, Element>
+Number(Type numberType, double? min = null, double? max = null, double smallChange = 1) → Func<object, Action<object>, Element>
+Text(string placeholderText = null, int? maxLength = null) → Func<object, Action<object>, Element>
+TimeOfDay() → Func<object, Action<object>, Element>
+TimeOnlyEditor() → Func<object, Action<object>, Element>
+TimeSpanEditor() → Func<object, Action<object>, Element>
+Toggle(string onContent = null, string offContent = null) → Func<object, Action<object>, Element>
+Uri() → Func<object, Action<object>, Element>
 
 ### record Element
 AnimationConfig AnimationConfig { get; init; }
@@ -2259,6 +2333,15 @@ Equals(object obj) → bool
 GetHashCode() → int
 ToString() → string
 
+### static class ErrorBubbling
+FilterMessages(IReadOnlyList<ValidationMessage> messages, Severity? severityFilter) → ValueTuple<IReadOnlyList<ValidationMessage>, IReadOnlyList<ValidationMessage>>
+HighestSeverity(IReadOnlyList<ValidationMessage> messages) → Severity?
+ShouldDisplay(IReadOnlyList<ValidationMessage> messages, ShowWhen showWhen, ValidationContext ctx = null, bool submitAttempted = false) → bool
+
+### static class ErrorStyling
+GetBrushKey(Severity severity) → string
+ShouldShowErrors(ValidationContext ctx, string fieldName, ShowWhen showWhen, bool submitAttempted = false) → bool
+
 ### record ErrorStylingAttached
 new(Func<Element, Element> OnErrorTransform = null, Func<Element, Element> OnWarningTransform = null)
 Func<Element, Element> OnErrorTransform { get; init; }
@@ -2464,7 +2547,7 @@ Equals(object obj) → bool
 GetHashCode() → int
 ToString() → string
 
-### class FocusManager
+### class FocusManager (in Microsoft.UI.Reactor.Hooks)
 new()
 IReadOnlyList<string> Fields { get; }
 Clear() → void
@@ -2477,6 +2560,10 @@ IsLastField(string fieldName) → bool
 Register(string fieldName) → void
 SetControl(string fieldName, Control control) → void
 SetSubmitHandler(Action handler) → void
+
+### static class FocusManager (in Microsoft.UI.Reactor.Input)
+Focus(ElementRef target, FocusState state = FocusState.Programmatic) → bool
+FocusAsync(ElementRef target, FocusState state = FocusState.Programmatic) → Task<bool>
 
 ### class FocusRevalidationService
 new(QueryCache cache)
@@ -2514,6 +2601,10 @@ Equals(object obj) → bool
 GetHashCode() → int
 ToString() → string
 
+### static class FormFieldDsl
+FormField(Element content, string label = null, bool required = false, string description = null, string fieldName = null, ShowWhen showWhen = ShowWhen.WhenTouched) → FormFieldElement
+FormField(FieldDescriptor field, object value, Action<object> onChange, TypeRegistry registry = null) → FormFieldElement
+
 ### record FormFieldElement
 new(Element Content, string Label = null, bool Required = false, string Description = null)
 Element Content { get; init; }
@@ -2528,6 +2619,13 @@ Equals(FormFieldElement other) → bool
 Equals(object obj) → bool
 GetHashCode() → int
 ToString() → string
+
+### static class FormFieldHelpers
+DetectFieldName(Element content) → string
+GetAutomationName(string label) → string
+GetDescriptionOrError(ValidationContext ctx, string fieldName, string description, ShowWhen showWhen, bool submitAttempted = false) → ValueTuple<string, bool>
+GetDisplayLabel(string label, bool required) → string
+ResolveFieldName(string explicitFieldName, Element content) → string
 
 ### struct FormatResult
 new(string Output, int CursorPos)
@@ -3014,6 +3112,13 @@ DefaultPath() → string
 TryRead(string id, ref Byte[] data) → bool
 Write(string id, Byte[] data) → void
 
+### static class JumpList
+bool ShowFrequent { get; set; }
+bool ShowRecent { get; set; }
+string AppUserModelId { get; set; }
+ClearAsync() → Task
+UpdateAsync(IEnumerable<JumpListItem> items) → Task
+
 ### record JumpListItem
 new(string Title, string Arguments, JumpListItemKind Kind = JumpListItemKind.Task, string Description = null, WindowIcon Icon = null, string GroupCategory = null)
 JumpListItemKind Kind { get; init; }
@@ -3381,6 +3486,9 @@ IsLiteral(int position) → bool
 NextInputPosition(int position) → int
 PreviousInputPosition(int position) → int
 
+### static class MaskedTextBoxDsl
+MaskedTextBox(string value, Action<string> onChanged = null, string mask = null, string header = null, Char placeholder = _) → MaskedTextBoxElement
+
 ### record MaskedTextBoxElement
 new(string Value, Action<string> OnChanged = null, string Mask = null, string Header = null, Char Placeholder = _)
 Action<string> OnChanged { get; init; }
@@ -3618,6 +3726,17 @@ object From { get; }
 object To { get; }
 string Reason { get; init; }
 
+### static class NavigationDiagnostics
+event EventHandler<CacheDiagnosticEvent> CacheEviction
+event EventHandler<CacheDiagnosticEvent> CacheHit
+event EventHandler<CacheDiagnosticEvent> CacheMiss
+event EventHandler<DeepLinkDiagnosticEvent> DeepLinkResolved
+event EventHandler<NavigationDiagnosticEvent> NavigationCancelled
+event EventHandler<NavigationDiagnosticEvent> NavigationCompleted
+event EventHandler<NavigationDiagnosticEvent> NavigationRequested
+event EventHandler<TransitionDiagnosticEvent> TransitionCompleted
+event EventHandler<TransitionDiagnosticEvent> TransitionStarted
+
 ### record NavigationEventArgs<TRoute>
 new(TRoute Route, TRoute PreviousRoute, NavigationMode Mode, NavigateOptions Options = null)
 NavigateOptions Options { get; init; }
@@ -3827,6 +3946,11 @@ Equals(object obj) → bool
 GetHashCode() → int
 ToString() → string
 
+### static class PageHelper
+Mount<TComponent, TProps>(Page page, NavigationEventArgs e) → ReactorHostControl
+Mount<TComponent>(Page page, NavigationEventArgs e) → ReactorHostControl
+Unmount(ref ReactorHostControl host) → void
+
 ### struct PanGesture
 new(Point Translation, Point Delta, Point Velocity, Point Position, Point StartPosition, GesturePhase Phase, bool IsInertial)
 GesturePhase Phase { get; init; }
@@ -3901,6 +4025,9 @@ Equals(object obj) → bool
 GetHashCode() → int
 ToString() → string
 
+### static class PathDataParser
+Parse(string pathData) → Geometry
+
 ### record PathElement
 new()
 Brush Fill { get; init; }
@@ -3936,6 +4063,9 @@ ToString() → string
 ### class PendingComponent
 new()
 Render() → Element
+
+### static class PendingFactory
+Pending(Element fallback, Element child) → Element
 
 ### record PendingProps
 new(Element Fallback, Element Child)
@@ -4122,6 +4252,12 @@ Type EditorType { get; }
 new()
 Render() → Element
 
+### static class PropertyGridDefaults
+ArrayItemTemplate(int index, string summary, bool isExpanded, Action<bool> onExpandedChanged, Action onMoveUp, Action onMoveDown, Action onRemove) → Element
+ArrayToolbarTemplate(string propertyName, int count, Func<Task> onAdd) → Element
+PropertyLabelTemplate(FieldDescriptor descriptor, int indentLevel) → Element
+PropertyRowTemplate(FieldDescriptor descriptor, Element label, Element editor, int indentLevel) → Element
+
 ### record PropertyGridElement
 Action<object> OnRootChanged { get; init; }
 ArrayItemTemplate ArrayItemTemplate { get; init; }
@@ -4148,6 +4284,10 @@ int Order { get; }
 
 ### class PropertyReadOnlyAttribute
 new()
+
+### static class PseudoLocalizer
+MissingKeyMarker(MessageKey key) → string
+Transform(string input) → string
 
 ### class QueryCache
 new()
@@ -4223,6 +4363,33 @@ Equals(object obj) → bool
 GetHashCode() → int
 ToString() → string
 
+### static class ReactorApp
+DispatcherQueue UIDispatcher { get; }
+ILogger AppLogger { get; set; }
+IReadOnlyList<ReactorTrayIcon> TrayIcons { get; }
+IReadOnlyList<ReactorWindow> Windows { get; }
+IWindowPersistenceStore WindowPersistenceStore { get; set; }
+ReactorWindow PrimaryWindow { get; }
+ShutdownPolicy ShutdownPolicy { get; set; }
+bool DevtoolsEnabled { get; }
+Exit(int exitCode = 0) → void
+FindTrayIcon(WindowKey key) → ReactorTrayIcon
+FindWindow(WindowKey key) → ReactorWindow
+OpenTrayIcon(TrayIconSpec spec) → ReactorTrayIcon
+OpenWindow(WindowSpec spec, Func<Component> root, Action<ReactorHost> configure = null) → ReactorWindow
+OpenWindow(WindowSpec spec, Func<RenderContext, Element> render, Action<ReactorHost> configure = null) → ReactorWindow
+RegisterAllBuiltIns() → void
+RegisterControlAssembly(Assembly assembly) → void
+RegisterControlAssembly(IXamlMetadataProvider provider) → void
+Run(Action<ReactorAppContext> startup) → void
+Run(string title, Func<RenderContext, Element> rootRender, double? width = null, double? height = null, bool fullScreen = false, Action<ReactorHost> configure = null) → void
+Run<TRoot>(string title = "Reactor App", double? width = null, double? height = null, bool fullScreen = false, Action<ReactorHost> configure = null) → void
+TryRegisterControlAssembly(Assembly assembly) → bool
+event EventHandler<ReactorTrayIcon> TrayIconClosed
+event EventHandler<ReactorTrayIcon> TrayIconOpened
+event EventHandler<ReactorWindow> WindowClosed
+event EventHandler<ReactorWindow> WindowOpened
+
 ### class ReactorAppContext
 LaunchActivation LaunchActivation { get; }
 
@@ -4235,6 +4402,11 @@ GetXamlType(Type type) → IXamlType
 GetXamlType(string fullName) → IXamlType
 GetXmlnsDefinitions() → XmlnsDefinition[]
 InitializeComponent() → void
+
+### static class ReactorBinding
+ShouldSuppressEcho(UIElement target) → bool
+WriteSuppressed(UIElement target, Action mutate) → void
+WriteSuppressed<T>(T target, Action<T> mutate) → void
 
 ### struct ReactorBinding<TElement>
 FrameworkElement Control { get; }
@@ -4275,6 +4447,19 @@ Equals(object obj) → bool
 GetHashCode() → int
 ToString() → string
 
+### static class ReactorDevtoolsBootstrap
+Register(IReactorDevtoolsHost host) → void
+
+### static class ReactorDiagnostics
+IReadOnlyList<KeyedListDiagnostic> RecentKeyedListWarnings { get; }
+ClearRecentKeyedListWarnings() → void
+
+### static class ReactorDisplay
+DisplayInfo Primary { get; }
+IReadOnlyList<DisplayInfo> Displays { get; }
+NearestTo(double dipX, double dipY) → DisplayInfo
+event EventHandler DisplayLayoutChanged
+
 ### struct ReactorEvent
 new(int EventId, string EventName, EventLevel Level, EventKeywords Keywords, DateTime TimestampUtc, int ThreadId, IReadOnlyList<object> Payload, IReadOnlyList<string> PayloadNames)
 DateTime TimestampUtc { get; init; }
@@ -4290,6 +4475,12 @@ Equals(ReactorEvent other) → bool
 Equals(object obj) → bool
 GetHashCode() → int
 ToString() → string
+
+### static class ReactorFeatureFlags
+bool FocusRevalidation { get; set; }
+bool HighlightReconcileChanges { get; set; }
+bool UseHookBasedPaging { get; set; }
+bool WarnLayoutFootguns { get; set; }
 
 ### class ReactorHost
 new(Window window, ILogger logger = null)
@@ -4315,6 +4506,9 @@ ref RenderStats Stats { get; }
 Dispose() → void
 Mount(Component component) → void
 Mount(Func<RenderContext, Element> renderFunc) → void
+
+### static class ReactorTrace
+Subscribe(Action<ReactorEvent> onEvent, EventLevel level = EventLevel.Verbose, EventKeywords keywords = EventKeywords.All) → IDisposable
 
 ### class ReactorTrayIcon
 TrayIconSpec Spec { get; }
@@ -4425,6 +4619,10 @@ ToString() → string
 ### class Ref<T>
 new(T initial)
 T Current { get; set; }
+
+### static class ReflectionTypeMetadataProvider
+CreateDescriptor(PropertyInfo property, int defaultOrder) → FieldDescriptor
+CreateMetadata(Type type) → TypeMetadata
 
 ### record RefreshContainerElement
 new(Element Content)
@@ -4781,6 +4979,9 @@ Equals(object obj) → bool
 GetHashCode() → int
 ToString() → string
 
+### static class RtlHelper
+IsRtlLocale(string locale) → bool
+
 ### record ScaleTransition
 new(float From)
 float From { get; init; }
@@ -5085,6 +5286,40 @@ Equals(StaggerConfig other) → bool
 Equals(object obj) → bool
 GetHashCode() → int
 ToString() → string
+
+### static class StandardCommand
+Backward(Action execute, bool canExecute = true) → Command
+Backward(Func<Task> executeAsync, bool canExecute = true) → Command
+Close(Action execute, bool canExecute = true) → Command
+Close(Func<Task> executeAsync, bool canExecute = true) → Command
+Copy(Action execute, bool canExecute = true) → Command
+Copy(Func<Task> executeAsync, bool canExecute = true) → Command
+Cut(Action execute, bool canExecute = true) → Command
+Cut(Func<Task> executeAsync, bool canExecute = true) → Command
+Delete(Action execute, bool canExecute = true) → Command
+Delete(Func<Task> executeAsync, bool canExecute = true) → Command
+Forward(Action execute, bool canExecute = true) → Command
+Forward(Func<Task> executeAsync, bool canExecute = true) → Command
+Open(Action execute, bool canExecute = true) → Command
+Open(Func<Task> executeAsync, bool canExecute = true) → Command
+Paste(Action execute, bool canExecute = true) → Command
+Paste(Func<Task> executeAsync, bool canExecute = true) → Command
+Pause(Action execute, bool canExecute = true) → Command
+Pause(Func<Task> executeAsync, bool canExecute = true) → Command
+Play(Action execute, bool canExecute = true) → Command
+Play(Func<Task> executeAsync, bool canExecute = true) → Command
+Redo(Action execute, bool canExecute = true) → Command
+Redo(Func<Task> executeAsync, bool canExecute = true) → Command
+Save(Action execute, bool canExecute = true) → Command
+Save(Func<Task> executeAsync, bool canExecute = true) → Command
+SelectAll(Action execute, bool canExecute = true) → Command
+SelectAll(Func<Task> executeAsync, bool canExecute = true) → Command
+Share(Action execute, bool canExecute = true) → Command
+Share(Func<Task> executeAsync, bool canExecute = true) → Command
+Stop(Action execute, bool canExecute = true) → Command
+Stop(Func<Task> executeAsync, bool canExecute = true) → Command
+Undo(Action execute, bool canExecute = true) → Command
+Undo(Func<Task> executeAsync, bool canExecute = true) → Command
 
 ### record SuppressTransition
 new()
@@ -5464,6 +5699,9 @@ Equals(object obj) → bool
 GetHashCode() → int
 ToString() → string
 
+### static class Theme
+Ref(string resourceKey) → ThemeRef
+
 ### struct ThemeRef
 new(string ResourceKey)
 string ResourceKey { get; init; }
@@ -5473,6 +5711,13 @@ Equals(object obj) → bool
 GetHashCode() → int
 Resolve(string resourceKey, bool isDark) → Brush
 ToString() → string
+
+### static class ThemeResource
+Brush(string key) → Brush
+CornerRadius(string key) → CornerRadius
+Double(string key) → double
+Get<T>(string key, T defaultValue = null) → T
+Thickness(string key) → Thickness
 
 ### record ThemeTransitions
 new()
@@ -5678,8 +5923,24 @@ RegisterFormatter<T>(Func<object, string> formatter) → TypeRegistry
 Resolve(Type type) → TypeMetadata
 ResolveEditor(Type type, EditorTier tier) → Func<object, Action<object>, Element>
 
+### static class TypedElementRef
+Create<T>() → ElementRef<T>
+
 ### class UIThreadOnlyAttribute
 new()
+
+### static class Validate
+Email(string message = null) → IValidator
+EqualTo<T>(T otherValue, string message = null) → IValidator
+Match(string regex, string message = null) → IValidator
+MaxLength(int n, string message = null) → IValidator
+MinLength(int n, string message = null) → IValidator
+Must<T>(Func<T, bool> predicate, string message) → IValidator
+MustAsync<T>(Func<T, Task<bool>> predicate, string message) → IAsyncValidator
+MustBeTrue(string message = null) → IValidator
+Range(double min, double max, string message = null) → IValidator
+Required(string message = null) → IValidator
+Url(string message = null) → IValidator
 
 ### record ValidationAttached
 new(string FieldName, IValidator[] Validators, IAsyncValidator[] AsyncValidators)
@@ -5734,6 +5995,16 @@ Equals(object obj) → bool
 GetHashCode() → int
 ToString() → string
 
+### static class ValidationReconciler
+EvaluateRules(ValidationContext ctx, ValidationRuleElement[] rules) → void
+ValidateAttached(ValidationContext ctx, ValidationAttached attached, object value) → void
+ValidateField(ValidationContext ctx, string fieldName, object value, IValidator[] validators) → void
+ValidateFieldAsync(ValidationContext ctx, string fieldName, object value, IAsyncValidator[] asyncValidators, CancellationToken cancellationToken = null) → Task
+
+### static class ValidationRuleDsl
+ValidationRule(Func<bool> predicate, string message, string field, Severity severity = Severity.Error) → ValidationRuleElement
+ValidationRuleAsync(Func<Task<bool>> asyncPredicate, string message, string field, Severity severity = Severity.Error) → ValidationRuleElement
+
 ### record ValidationRuleElement
 new(string Field, Func<bool> Predicate, string Message, Severity Severity = Severity.Error)
 Func<Task<bool>> AsyncPredicate { get; init; }
@@ -5747,6 +6018,10 @@ Equals(ValidationRuleElement other) → bool
 Equals(object obj) → bool
 GetHashCode() → int
 ToString() → string
+
+### static class ValidationVisualizerDsl
+ValidationVisualizer(Func<IReadOnlyList<ValidationMessage>, Element> render, Element content, Severity? severityFilter = null, ShowWhen showWhen = ShowWhen.Always) → ValidationVisualizerElement
+ValidationVisualizer(VisualizerStyle style, Element content, string title = null, Severity? severityFilter = null, ShowWhen showWhen = ShowWhen.Always) → ValidationVisualizerElement
 
 ### record ValidationVisualizerElement
 new(VisualizerStyle Style, Element Content)
@@ -5957,6 +6232,9 @@ Equals(XamlHostElement other) → bool
 Equals(object obj) → bool
 GetHashCode() → int
 ToString() → string
+
+### static class XamlInterop
+Register(Reconciler reconciler) → void
 
 ### class XamlMetaDataProvider
 new()

--- a/plugins/reactor/skills/reactor-dsl/references/reactor.api.txt
+++ b/plugins/reactor/skills/reactor-dsl/references/reactor.api.txt
@@ -884,7 +884,7 @@ RenderContext.UseDataSource<T>(IDataSource<T> source, DataRequest request, Infin
 RenderContext.UseDataSource<T>(IDataSource<T> source, DataRequest request, QueryCache cache, InfiniteResourceOptions options = null, IHookDispatcher dispatcher = null) → InfiniteResource<T>
 RenderContext.UseDevtools() → bool
 RenderContext.UseDisplays() → IReadOnlyList<DisplayInfo>
-RenderContext.UseDpi() → UInt32
+RenderContext.UseDpi() → uint
 RenderContext.UseEffect(Action effect, object[] dependencies) → void
 RenderContext.UseEffect(Func<Action> effectWithCleanup, object[] dependencies) → void
 RenderContext.UseEffect<T1, T2, T3>(Action effect, T1 d1, T2 d2, T3 d3) → void
@@ -1934,9 +1934,9 @@ ToString() → string
 ### record DisplayInfo
 Rect BoundsDip { get; init; }
 Rect WorkAreaDip { get; init; }
-UInt32 Dpi { get; init; }
 bool IsPrimary { get; init; }
 string Id { get; init; }
+uint Dpi { get; init; }
 Equals(DisplayInfo other) → bool
 Equals(object obj) → bool
 GetHashCode() → int
@@ -2105,7 +2105,7 @@ Combo<TValue>(IReadOnlyList<TValue> choices) → Func<object, Action<object>, El
 Date() → Func<object, Action<object>, Element>
 DateOffset() → Func<object, Action<object>, Element>
 DateOnly() → Func<object, Action<object>, Element>
-Decimal(Decimal? min = null, Decimal? max = null) → Func<object, Action<object>, Element>
+Decimal(decimal? min = null, decimal? max = null) → Func<object, Action<object>, Element>
 Double(double? min = null, double? max = null) → Func<object, Action<object>, Element>
 EnumCombo(Type enumType) → Func<object, Action<object>, Element>
 Float(float? min = null, float? max = null) → Func<object, Action<object>, Element>
@@ -2824,8 +2824,8 @@ GetString(string locale, string ns, string key) → string
 Validate(object value, string field) → ValidationMessage
 
 ### interface IWindowPersistenceStore
-TryRead(string id, ref Byte[] data) → bool
-Write(string id, Byte[] data) → void
+TryRead(string id, ref byte[] data) → bool
+Write(string id, byte[] data) → void
 
 ### record IconData
 Equals(IconData other) → bool
@@ -3109,8 +3109,8 @@ new()
 new(string path)
 string Path { get; }
 DefaultPath() → string
-TryRead(string id, ref Byte[] data) → bool
-Write(string id, Byte[] data) → void
+TryRead(string id, ref byte[] data) → bool
+Write(string id, byte[] data) → void
 
 ### static class JumpList
 bool ShowFrequent { get; set; }
@@ -3479,26 +3479,26 @@ ToString() → string
 new(string mask)
 int Length { get; }
 string Mask { get; }
-Apply(string input, Char placeholder = _) → string
-GetRawValue(string formatted, Char placeholder = _) → string
-IsComplete(string formatted, Char placeholder = _) → bool
+Apply(string input, char placeholder = '_') → string
+GetRawValue(string formatted, char placeholder = '_') → string
+IsComplete(string formatted, char placeholder = '_') → bool
 IsLiteral(int position) → bool
 NextInputPosition(int position) → int
 PreviousInputPosition(int position) → int
 
 ### static class MaskedTextBoxDsl
-MaskedTextBox(string value, Action<string> onChanged = null, string mask = null, string header = null, Char placeholder = _) → MaskedTextBoxElement
+MaskedTextBox(string value, Action<string> onChanged = null, string mask = null, string header = null, char placeholder = '_') → MaskedTextBoxElement
 
 ### record MaskedTextBoxElement
-new(string Value, Action<string> OnChanged = null, string Mask = null, string Header = null, Char Placeholder = _)
+new(string Value, Action<string> OnChanged = null, string Mask = null, string Header = null, char Placeholder = '_')
 Action<string> OnChanged { get; init; }
-Char Placeholder { get; init; }
 bool IsComplete { get; }
+char Placeholder { get; init; }
 string Header { get; init; }
 string Mask { get; init; }
 string RawValue { get; }
 string Value { get; init; }
-Deconstruct(ref string Value, ref Action<string> OnChanged, ref string Mask, ref string Header, ref Char Placeholder) → void
+Deconstruct(ref string Value, ref Action<string> OnChanged, ref string Mask, ref string Header, ref char Placeholder) → void
 Equals(Element other) → bool
 Equals(MaskedTextBoxElement other) → bool
 Equals(object obj) → bool
@@ -3932,8 +3932,8 @@ ToString() → string
 ### class PackagedSettingsStore
 new()
 IsAvailable() → bool
-TryRead(string id, ref Byte[] data) → bool
-Write(string id, Byte[] data) → void
+TryRead(string id, ref byte[] data) → bool
+Write(string id, byte[] data) → void
 
 ### record Page<TItem, TCursor>
 new(IReadOnlyList<TItem> Items, TCursor NextCursor, int? TotalCount = null)
@@ -4532,7 +4532,6 @@ ReactorHost Host { get; }
 TaskbarItem TaskbarItem { get; }
 TaskbarOverlay Overlay { get; }
 TaskbarProgress Progress { get; }
-UInt32 Dpi { get; }
 ValueTuple<double, double> Position { get; }
 Window NativeWindow { get; }
 WindowKey? Key { get; }
@@ -4543,6 +4542,7 @@ bool IsActive { get; }
 bool IsVisible { get; }
 double DipScale { get; }
 string Id { get; }
+uint Dpi { get; }
 Activate() → void
 BeginDragMove() → void
 CenterOnScreen() → void
@@ -4565,12 +4565,12 @@ Update(WindowSpec next) → void
 event EventHandler Activated
 event EventHandler Closed
 event EventHandler Deactivated
-event EventHandler<UInt32> DpiChanged
 event EventHandler<WindowClosingEventArgs> Closing
 event EventHandler<WindowDipPositionChangedEventArgs> PositionChanged
 event EventHandler<WindowDipSizeChangedEventArgs> SizeChanged
 event EventHandler<WindowState> StateChanged
 event EventHandler<WindowZOrderChangedEventArgs> ZOrderChanged
+event EventHandler<uint> DpiChanged
 
 ### class Reconciler
 new(ILogger logger = null)
@@ -4686,7 +4686,7 @@ UseCommand(Command command) → Command
 UseCommand<T>(Command<T> command) → Command<T>
 UseContext<T>(Context<T> context) → T
 UseDisplays() → IReadOnlyList<DisplayInfo>
-UseDpi() → UInt32
+UseDpi() → uint
 UseEffect(Action effect, object[] dependencies) → void
 UseEffect(Func<Action> effectWithCleanup, object[] dependencies) → void
 UseEffect<T1, T2, T3>(Action effect, T1 d1, T2 d2, T3 d3) → void

--- a/skills/reactor.api.txt
+++ b/skills/reactor.api.txt
@@ -8,8 +8,9 @@
 # including public *static* classes — so process-wide entry points such as
 # ControlRegistry.Register and ReactorApp.Run are listed there, alongside
 # instance members like WindowSpec.Opacity and ReactorWindow.SetPosition.
-# Extension methods are listed under Modifiers/Hooks in the fluent form you
-# call them, not again under their declaring static class.
+# Extension methods with an Element receiver are listed under Modifiers, and
+# RenderContext/Component ones under Hooks, in the fluent form you call them;
+# any other extension is listed under its declaring class.
 
 ## Factories
 # All in `Microsoft.UI.Reactor.Factories` — `using static Microsoft.UI.Reactor.Factories;`
@@ -23,7 +24,7 @@ AppBarButton(Command command) → AppBarButtonData
 AppBarButton(string label, Action onClick = null, string icon = null) → AppBarButtonData
 AppBarSeparator() → AppBarSeparatorData
 AppBarToggleButton(string label, bool isChecked = false, Action<bool> onIsCheckedChanged = null, string icon = null) → AppBarToggleButtonData
-AutoSuggestBox(Optional<string> text = null, Action<string> onTextChanged = null, Action<string> onQuerySubmitted = null) → AutoSuggestBoxElement
+AutoSuggestBox(Optional<string> text = default, Action<string> onTextChanged = null, Action<string> onQuerySubmitted = null) → AutoSuggestBoxElement
 BitmapIcon(Uri source, bool showAsMonochrome = true) → BitmapIconData
 Body(string content) → TextBlockElement
 BodyLarge(string content) → TextBlockElement
@@ -34,15 +35,15 @@ BreadcrumbBar(BreadcrumbBarItemData[] items, Action<BreadcrumbBarItemData> onIte
 Button(Command command) → ButtonElement
 Button(Element content, Action onClick = null) → ButtonElement
 Button(string label, Action onClick = null) → ButtonElement
-CalendarDatePicker(Optional<DateTimeOffset?> date = null, Action<DateTimeOffset?> onDateChanged = null) → CalendarDatePickerElement
+CalendarDatePicker(Optional<DateTimeOffset?> date = default, Action<DateTimeOffset?> onDateChanged = null) → CalendarDatePickerElement
 CalendarView() → CalendarViewElement
 Canvas(Element[] children) → CanvasElement
 Caption(string content) → TextBlockElement
 Card(Element child) → BorderElement
-CheckBox(Optional<bool?> isChecked = null, Action<bool> onIsCheckedChanged = null, string label = null) → CheckBoxElement
-ColorPicker(Optional<Color> color = null, Action<Color> onColorChanged = null) → ColorPickerElement
+CheckBox(Optional<bool?> isChecked = default, Action<bool> onIsCheckedChanged = null, string label = null) → CheckBoxElement
+ColorPicker(Optional<Color> color = default, Action<Color> onColorChanged = null) → ColorPickerElement
 ComboBox(Element[] itemElements, Optional<int> selectedIndex, Action<int> onSelectedIndexChanged) → ComboBoxElement
-ComboBox(string[] items, Optional<int> selectedIndex = null, Action<int> onSelectedIndexChanged = null) → ComboBoxElement
+ComboBox(string[] items, Optional<int> selectedIndex = default, Action<int> onSelectedIndexChanged = null) → ComboBoxElement
 CommandBar(AppBarItemBase[] primaryCommands = null, AppBarItemBase[] secondaryCommands = null) → CommandBarElement
 CommandBarFlyout(Element target, AppBarItemBase[] primaryCommands = null, AppBarItemBase[] secondaryCommands = null) → CommandBarFlyoutElement
 CommandHost(Command[] commands, Element child) → CommandHostElement
@@ -50,14 +51,14 @@ Component<T, TProps>(TProps props) → ComponentElement<TProps>
 Component<T>() → ComponentElement
 ContentDialog(string title, Element content, string primaryButtonText = "OK") → ContentDialogElement
 ContentFlyout(Element content, FlyoutPlacementMode placement = FlyoutPlacementMode.Auto) → ContentFlyoutElement
-DatePicker(Optional<DateTimeOffset> date = null, Action<DateTimeOffset> onDateChanged = null) → DatePickerElement
+DatePicker(Optional<DateTimeOffset> date = default, Action<DateTimeOffset> onDateChanged = null) → DatePickerElement
 DevtoolsMenu(Func<IEnumerable<MenuFlyoutItemBase>> items = null, string glyph = "⚡", string toolTip = "Devtools", string automationId = null) → Element
 DropDownButton(string label, Element flyout = null) → DropDownButtonElement
 Ellipse() → EllipseElement
 Empty() → Element
 ErrorBoundary(Element child, Element fallback) → ErrorBoundaryElement
 ErrorBoundary(Element child, Func<Exception, Element> fallback) → ErrorBoundaryElement
-Expander(string header, Element content, Optional<bool> isExpanded = null, Action<bool> onIsExpandedChanged = null) → ExpanderElement
+Expander(string header, Element content, Optional<bool> isExpanded = default, Action<bool> onIsExpandedChanged = null) → ExpanderElement
 Expr(Func<Element> render) → Element
 Flex(Element[] children) → FlexElement
 Flex(FlexDirection direction, Element[] children) → FlexElement
@@ -108,7 +109,7 @@ LazyHStack<T>(IReadOnlyList<T> items, Func<T, string> keySelector, Func<T, int, 
 LazyVStack<T>(IReadOnlyList<T> items, Func<T, int, Element> viewBuilder) → LazyVStackElement<T>
 LazyVStack<T>(IReadOnlyList<T> items, Func<T, string> keySelector, Func<T, int, Element> viewBuilder) → LazyVStackElement<T>
 Line(double x1, double y1, double x2, double y2) → LineElement
-ListBox(string[] items, Optional<int> selectedIndex = null, Action<int> onSelectedIndexChanged = null) → ListBoxElement
+ListBox(string[] items, Optional<int> selectedIndex = default, Action<int> onSelectedIndexChanged = null) → ListBoxElement
 ListView(Element[] items) → ListViewElement
 ListView(Optional<int> selectedIndex, Action<int> onSelectedIndexChanged = null, Element[] items) → ListViewElement
 ListView(int? selectedIndex, Action<int> onSelectedIndexChanged = null, Element[] items) → ListViewElement
@@ -133,14 +134,14 @@ NavItem(string content, string icon = null, string tag = null) → NavigationVie
 NavItemHeader(string content) → NavigationViewItemData
 NavigationHost<TRoute>(NavigationHandle<TRoute> nav, Func<TRoute, Element> routeMap) → NavigationHostElement
 NavigationView(NavigationViewItemData[] menuItems, Element content = null) → NavigationViewElement
-NumberBox(Optional<double> value = null, Action<double> onValueChanged = null, string header = null) → NumberBoxElement
+NumberBox(Optional<double> value = default, Action<double> onValueChanged = null, string header = null) → NumberBoxElement
 Paragraph(RichTextInline[] inlines) → RichTextParagraph
 ParallaxView(Element child, double verticalShift = 0, double horizontalShift = 0) → ParallaxViewElement
-PasswordBox(Optional<string> password = null, Action<string> onPasswordChanged = null, string placeholderText = null) → PasswordBoxElement
+PasswordBox(Optional<string> password = default, Action<string> onPasswordChanged = null, string placeholderText = null) → PasswordBoxElement
 Path2D() → PathElement
 PathIcon(string data) → PathIconData
 PersonPicture() → PersonPictureElement
-PipsPager(int numberOfPages, Optional<int> selectedPageIndex = null, Action<int> onSelectedPageIndexChanged = null) → PipsPagerElement
+PipsPager(int numberOfPages, Optional<int> selectedPageIndex = default, Action<int> onSelectedPageIndexChanged = null) → PipsPagerElement
 Pivot(Optional<int> selectedIndex, Action<int> onSelectedIndexChanged = null, PivotItemData[] items) → PivotElement
 Pivot(PivotItemData[] items) → PivotElement
 Pivot(int? selectedIndex, Action<int> onSelectedIndexChanged = null, PivotItemData[] items) → PivotElement
@@ -151,26 +152,26 @@ ProgressIndeterminate() → ProgressElement
 ProgressRing() → ProgressRingElement
 ProgressRing(double value) → ProgressRingElement
 PropertyGrid(object target, TypeRegistry registry, Action<object> onRootChanged = null) → ComponentElement<PropertyGridElement>
-RadioButton(string label, Optional<bool> isChecked = null, Action<bool> onIsCheckedChanged = null, string groupName = null) → RadioButtonElement
-RadioButtons(string[] items, Optional<int> selectedIndex = null, Action<int> onSelectedIndexChanged = null) → RadioButtonsElement
+RadioButton(string label, Optional<bool> isChecked = default, Action<bool> onIsCheckedChanged = null, string groupName = null) → RadioButtonElement
+RadioButtons(string[] items, Optional<int> selectedIndex = default, Action<int> onSelectedIndexChanged = null) → RadioButtonsElement
 RadioMenuItem(string text, string groupName, bool isChecked = false, Action onClick = null, string icon = null) → RadioMenuFlyoutItemData
-RatingControl(Optional<double> value = null, Action<double> onValueChanged = null) → RatingControlElement
+RatingControl(Optional<double> value = default, Action<double> onValueChanged = null) → RatingControlElement
 Rectangle() → RectangleElement
 RefreshContainer(Element content, Action onRefreshRequested = null) → RefreshContainerElement
 RelativePanel(Element[] children) → RelativePanelElement
 RenderEachTime(Func<RenderContext, Element> render) → FuncElement
 RepeatButton(Command command) → RepeatButtonElement
 RepeatButton(string label, Action onClick = null) → RepeatButtonElement
-RichEditBox(Optional<string> text = null, Action<string> onTextChanged = null) → RichEditBoxElement
+RichEditBox(Optional<string> text = default, Action<string> onTextChanged = null) → RichEditBoxElement
 RichTextBlock(RichTextParagraph[] paragraphs) → RichTextBlockElement
 RichTextBlock(string text) → RichTextBlockElement
 Run(string text) → RichTextRun
 ScrollView(Element child) → ScrollViewElement
 ScrollViewer(Element child) → ScrollViewerElement
-SelectorBar(SelectorBarItemData[] items, Optional<int> selectedIndex = null, Action<int> onSelectedIndexChanged = null) → SelectorBarElement
+SelectorBar(SelectorBarItemData[] items, Optional<int> selectedIndex = default, Action<int> onSelectedIndexChanged = null) → SelectorBarElement
 SelectorBarItem(string text, string icon = null) → SelectorBarItemData
 SemanticZoom(Element zoomedInView, Element zoomedOutView) → SemanticZoomElement
-Slider(Optional<double> value = null, double min = 0, double max = 100, Action<double> onValueChanged = null) → SliderElement
+Slider(Optional<double> value = default, double min = 0, double max = 100, Action<double> onValueChanged = null) → SliderElement
 SplitButton(Command command, Element flyout = null) → SplitButtonElement
 SplitButton(string label, Action onClick = null, Element flyout = null) → SplitButtonElement
 SplitView(Element pane = null, Element content = null) → SplitViewElement
@@ -184,21 +185,21 @@ TabView(TabViewItemData[] tabs) → TabViewElement
 TabView(int? selectedIndex, Action<int> onSelectedIndexChanged = null, TabViewItemData[] tabs) → TabViewElement
 TeachingTip(string title, string subtitle = null, ElementRef target = null) → TeachingTipElement
 TextBlock(string content) → TextBlockElement
-TextBox(Optional<string> value = null, Action<string> onChanged = null, string placeholderText = null, string header = null) → TextBoxElement
+TextBox(Optional<string> value = default, Action<string> onChanged = null, string placeholderText = null, string header = null) → TextBoxElement
 Thick(double horizontal, double vertical) → Thickness
 Thick(double left, double top, double right, double bottom) → Thickness
 Thick(double uniform) → Thickness
-ThreeStateCheckBox(Optional<bool?> checkedState = null, Action<bool?> onCheckedStateChanged = null, string label = null) → CheckBoxElement
+ThreeStateCheckBox(Optional<bool?> checkedState = default, Action<bool?> onCheckedStateChanged = null, string label = null) → CheckBoxElement
 ThreeStateToggleButton(string label, bool? checkedState = null, Action<bool?> onCheckedStateChanged = null) → ToggleButtonElement
-TimePicker(Optional<TimeSpan> time = null, Action<TimeSpan> onTimeChanged = null) → TimePickerElement
+TimePicker(Optional<TimeSpan> time = default, Action<TimeSpan> onTimeChanged = null) → TimePickerElement
 Title(string content) → TextBlockElement
 TitleBar(string title) → TitleBarElement
 ToggleButton(Command command, bool isChecked = false) → ToggleButtonElement
 ToggleButton(string label, bool isChecked = false, Action<bool> onIsCheckedChanged = null) → ToggleButtonElement
 ToggleMenuItem(string text, bool isChecked = false, Action<bool> onIsCheckedChanged = null, string icon = null) → ToggleMenuFlyoutItemData
-ToggleSplitButton(Command command, Optional<bool> isChecked = null, Element flyout = null) → ToggleSplitButtonElement
-ToggleSplitButton(string label, Optional<bool> isChecked = null, Action<bool> onIsCheckedChanged = null, Element flyout = null) → ToggleSplitButtonElement
-ToggleSwitch(Optional<bool> isOn = null, Action<bool> onIsOnChanged = null, string onContent = null, string offContent = null, string header = null) → ToggleSwitchElement
+ToggleSplitButton(Command command, Optional<bool> isChecked = default, Element flyout = null) → ToggleSplitButtonElement
+ToggleSplitButton(string label, Optional<bool> isChecked = default, Action<bool> onIsCheckedChanged = null, Element flyout = null) → ToggleSplitButtonElement
+ToggleSwitch(Optional<bool> isOn = default, Action<bool> onIsOnChanged = null, string onContent = null, string offContent = null, string header = null) → ToggleSwitchElement
 TreeNode(string content, TreeViewNodeData[] children) → TreeViewNodeData
 TreeView(TreeViewNodeData[] nodes) → TreeViewElement
 TreeView<T>(IReadOnlyList<T> items, Func<T, IReadOnlyList<T>> childrenSelector, Func<T, Element> viewBuilder) → TemplatedTreeViewElement<T>
@@ -703,7 +704,7 @@ T.Semantics<T>(string role = null, string value = null, double? rangeMin = null,
 T.ShowErrors<T>(ShowWhen showWhen = ShowWhen.Always) → ValidationVisualizerElement
 T.Size<T>(double width, double height) → T
 T.SoundMode<T>(ElementSoundMode mode) → T
-T.SpringLayoutAnimation<T>(float dampingRatio = 0.6, float period = 0.08) → T
+T.SpringLayoutAnimation<T>(float dampingRatio = 0.6f, float period = 0.08f) → T
 T.Stagger<T>(TimeSpan delay, Curve curve = null) → T
 T.TabIndex<T>(int index) → T
 T.TabNavigation<T>(KeyboardNavigationMode mode) → T
@@ -840,7 +841,7 @@ TreeViewElement.Expanding(Action<TreeViewNodeData> handler) → TreeViewElement
 TreeViewElement.ItemInvoked(Action<TreeViewNodeData> handler) → TreeViewElement
 TreeViewElement.Set(Action<TreeView> configure) → TreeViewElement
 ValidationRuleElement.Evaluate(ValidationContext ctx) → void
-ValidationRuleElement.EvaluateAsync(ValidationContext ctx, CancellationToken cancellationToken = null) → Task
+ValidationRuleElement.EvaluateAsync(ValidationContext ctx, CancellationToken cancellationToken = default) → Task
 ViewboxElement.Set(Action<Viewbox> configure) → ViewboxElement
 ViewboxElement.Stretch(Stretch stretch) → ViewboxElement
 ViewboxElement.StretchDirection(StretchDirection direction) → ViewboxElement
@@ -929,7 +930,7 @@ RenderContext.UsePersisted<T>(string key, T initialValue, PersistedScope scope) 
 RenderContext.UseReducedMotion() → bool
 RenderContext.UseReducer<T>(T initialValue, bool threadSafe = false) → ValueTuple<T, Action<Func<T, T>>>
 RenderContext.UseReducer<TState, TAction>(Func<TState, TAction, TState> reducer, TState initialValue, bool threadSafe = false) → ValueTuple<TState, Action<TAction>>
-RenderContext.UseRef<T>(T initialValue = null) → Ref<T>
+RenderContext.UseRef<T>(T initialValue = default) → Ref<T>
 RenderContext.UseResource<T>(Func<CancellationToken, Task<T>> fetcher, QueryCache cache, object[] deps, ResourceOptions options = null, IHookDispatcher dispatcher = null) → AsyncValue<T>
 RenderContext.UseResource<T>(Func<CancellationToken, Task<T>> fetcher, object[] deps, ResourceOptions options = null, IHookDispatcher dispatcher = null) → AsyncValue<T>
 RenderContext.UseState<T>(T initialValue, bool threadSafe = false) → ValueTuple<T, Action<T>>
@@ -1298,7 +1299,7 @@ GetHashCode() → int
 ToString() → string
 
 ### record AutoSuggestBoxElement
-new(Optional<string> Text = null, Action<string> OnTextChanged = null, Action<string> OnQuerySubmitted = null, Action<string> OnSuggestionChosen = null)
+new(Optional<string> Text = default, Action<string> OnTextChanged = null, Action<string> OnQuerySubmitted = null, Action<string> OnSuggestionChosen = null)
 Action<string> OnQuerySubmitted { get; init; }
 Action<string> OnSuggestionChosen { get; init; }
 Action<string> OnTextChanged { get; init; }
@@ -1440,7 +1441,7 @@ GetHashCode() → int
 ToString() → string
 
 ### record CalendarDatePickerElement
-new(Optional<DateTimeOffset?> Date = null, Action<DateTimeOffset?> OnDateChanged = null)
+new(Optional<DateTimeOffset?> Date = default, Action<DateTimeOffset?> OnDateChanged = null)
 Action<DateTimeOffset?> OnDateChanged { get; init; }
 DateTimeOffset? MaxDate { get; init; }
 DateTimeOffset? MinDate { get; init; }
@@ -1524,7 +1525,7 @@ Time(string format = "t") → Func<object, Element>
 ToggleIndicator() → Func<object, Element>
 
 ### record CheckBoxElement
-new(Optional<bool?> IsChecked = null, Action<bool> OnIsCheckedChanged = null, string Label = null)
+new(Optional<bool?> IsChecked = default, Action<bool> OnIsCheckedChanged = null, string Label = null)
 Action<bool> OnIsCheckedChanged { get; init; }
 Action<bool?> OnCheckedStateChanged { get; init; }
 Optional<bool?> IsChecked { get; init; }
@@ -1545,7 +1546,7 @@ GetHashCode() → int
 ToString() → string
 
 ### record ColorPickerElement
-new(Optional<Color> Color = null, Action<Color> OnColorChanged = null)
+new(Optional<Color> Color = default, Action<Color> OnColorChanged = null)
 Action<Color> OnColorChanged { get; init; }
 ColorSpectrumShape ColorSpectrumShape { get; init; }
 Optional<Color> Color { get; init; }
@@ -1590,7 +1591,7 @@ GetHashCode() → int
 ToString() → string
 
 ### record ComboBoxElement
-new(string[] Items, Optional<int> SelectedIndex = null, Action<int> OnSelectedIndexChanged = null)
+new(string[] Items, Optional<int> SelectedIndex = default, Action<int> OnSelectedIndexChanged = null)
 Action OnDropDownClosed { get; init; }
 Action OnDropDownOpened { get; init; }
 Action<int> OnSelectedIndexChanged { get; init; }
@@ -1713,6 +1714,11 @@ Equals(object obj) → bool
 GetHashCode() → int
 ToString() → string
 
+### static class ComponentUseMemoCellsExtensions
+Component.UseMemoCells<T>(IReadOnlyList<T> items, Func<T, int, Element> builder, object[] dependencies) → Element[]
+Component.UseMemoCellsByIndex<T>(IReadOnlyList<T> items, IReadOnlyList<int> changedIndices, Func<T, int, Element> builder, object[] dependencies) → Element[]
+Component.UseMemoCellsByKey<T, TKey>(IReadOnlyList<T> items, Func<T, TKey> keySelector, Func<T, int, Element> builder, object[] dependencies) → Element[]
+
 ### static class CompositorProvider
 Compositor Current { get; set; }
 EnsureCompositor(UIElement element) → Compositor
@@ -1793,12 +1799,12 @@ RegisterDecoratorForDerivedTypes<TBase>(Func<IDecoratorElementHandler<TBase>> ha
 RegisterForDerivedTypes<TBase, TControl>(Func<IElementHandler<TBase, TControl>> handlerFactory) → void
 
 ### record Curve
-Ease(int durationMs, Easing easing = null) → Curve
+Ease(int durationMs, Easing easing = default) → Curve
 Equals(Curve other) → bool
 Equals(object obj) → bool
 GetHashCode() → int
 Linear(int durationMs) → Curve
-Spring(float dampingRatio = 0.8, float period = 0.05) → Curve
+Spring(float dampingRatio = 0.8f, float period = 0.05f) → Curve
 ToString() → string
 
 ### record DataPage<T>
@@ -1820,7 +1826,7 @@ int CachedBlockCount { get; }
 int MaxBlocks { get; }
 int? TotalCount { get; }
 GetBlock(int blockIndex) → CacheBlock<T>
-GetBlockAsync(int blockIndex, CancellationToken cancellationToken = null) → ValueTask<CacheBlock<T>>
+GetBlockAsync(int blockIndex, CancellationToken cancellationToken = default) → ValueTask<CacheBlock<T>>
 GetBlockStatus(int blockIndex) → BlockStatus
 GetItem(int rowIndex) → T
 Invalidate() → void
@@ -1848,7 +1854,7 @@ new()
 DateStyle Style { get; init; }
 
 ### record DatePickerElement
-new(Optional<DateTimeOffset> Date = null, Action<DateTimeOffset> OnDateChanged = null)
+new(Optional<DateTimeOffset> Date = default, Action<DateTimeOffset> OnDateChanged = null)
 Action<DateTimeOffset> OnDateChanged { get; init; }
 DateTimeOffset? MaxYear { get; init; }
 DateTimeOffset? MinYear { get; init; }
@@ -1955,13 +1961,13 @@ ToString() → string
 new()
 IReadOnlyCollection<string> AvailableFormats { get; }
 int OriginProcessId { get; }
-GetBitmapAsync(CancellationToken cancellationToken = null) → Task<RandomAccessStreamReference>
-GetCustomFormatAsync<T>(string formatId, CancellationToken cancellationToken = null) → Task<T>
-GetFilesAsync(CancellationToken cancellationToken = null) → Task<IReadOnlyList<IStorageItem>>
-GetHtmlAsync(CancellationToken cancellationToken = null) → Task<string>
-GetRtfAsync(CancellationToken cancellationToken = null) → Task<string>
-GetTextAsync(CancellationToken cancellationToken = null) → Task<string>
-GetUriAsync(CancellationToken cancellationToken = null) → Task<Uri>
+GetBitmapAsync(CancellationToken cancellationToken = default) → Task<RandomAccessStreamReference>
+GetCustomFormatAsync<T>(string formatId, CancellationToken cancellationToken = default) → Task<T>
+GetFilesAsync(CancellationToken cancellationToken = default) → Task<IReadOnlyList<IStorageItem>>
+GetHtmlAsync(CancellationToken cancellationToken = default) → Task<string>
+GetRtfAsync(CancellationToken cancellationToken = default) → Task<string>
+GetTextAsync(CancellationToken cancellationToken = default) → Task<string>
+GetUriAsync(CancellationToken cancellationToken = default) → Task<Uri>
 HasFormat(string formatId) → bool
 Text(string text) → DragData
 TryGetBitmap(ref RandomAccessStreamReference value) → bool
@@ -2143,6 +2149,54 @@ Equals(Element other) → bool
 Equals(object obj) → bool
 GetHashCode() → int
 ToString() → string
+
+### static class ElementExtensions
+AppBarButtonData.Command(Command command) → AppBarButtonData
+RichTextHyperlink.CharacterSpacing(int spacing) → RichTextHyperlink
+RichTextHyperlink.FontFamily(string family) → RichTextHyperlink
+RichTextHyperlink.FontSize(double size) → RichTextHyperlink
+RichTextHyperlink.FontStretch(FontStretch stretch) → RichTextHyperlink
+RichTextHyperlink.FontStyle(FontStyle style) → RichTextHyperlink
+RichTextHyperlink.FontWeight(FontWeight weight) → RichTextHyperlink
+RichTextHyperlink.Foreground(Brush brush) → RichTextHyperlink
+RichTextHyperlink.Foreground(string color) → RichTextHyperlink
+RichTextHyperlink.IsTabStop(bool isTabStop = true) → RichTextHyperlink
+RichTextHyperlink.IsTextScaleFactorEnabled(bool enabled = true) → RichTextHyperlink
+RichTextHyperlink.Language(string language) → RichTextHyperlink
+RichTextHyperlink.TabIndex(int tabIndex) → RichTextHyperlink
+RichTextHyperlink.TextDecorations(TextDecorations decorations) → RichTextHyperlink
+RichTextHyperlink.UnderlineStyle(UnderlineStyle style) → RichTextHyperlink
+RichTextParagraph.CharacterSpacing(int spacing) → RichTextParagraph
+RichTextParagraph.FontFamily(string family) → RichTextParagraph
+RichTextParagraph.FontSize(double size) → RichTextParagraph
+RichTextParagraph.FontStretch(FontStretch stretch) → RichTextParagraph
+RichTextParagraph.FontStyle(FontStyle style) → RichTextParagraph
+RichTextParagraph.FontWeight(FontWeight weight) → RichTextParagraph
+RichTextParagraph.Foreground(Brush brush) → RichTextParagraph
+RichTextParagraph.Foreground(string color) → RichTextParagraph
+RichTextParagraph.HorizontalTextAlignment(TextAlignment alignment) → RichTextParagraph
+RichTextParagraph.IsTextScaleFactorEnabled(bool enabled = true) → RichTextParagraph
+RichTextParagraph.Language(string language) → RichTextParagraph
+RichTextParagraph.LineHeight(double height) → RichTextParagraph
+RichTextParagraph.LineStackingStrategy(LineStackingStrategy strategy) → RichTextParagraph
+RichTextParagraph.Margin(double horizontal, double vertical) → RichTextParagraph
+RichTextParagraph.Margin(double left = 0, double top = 0, double right = 0, double bottom = 0) → RichTextParagraph
+RichTextParagraph.Margin(double uniform) → RichTextParagraph
+RichTextParagraph.TextAlignment(TextAlignment alignment) → RichTextParagraph
+RichTextParagraph.TextDecorations(TextDecorations decorations) → RichTextParagraph
+RichTextParagraph.TextIndent(double indent) → RichTextParagraph
+RichTextRun.CharacterSpacing(int spacing) → RichTextRun
+RichTextRun.FlowDirection(FlowDirection direction) → RichTextRun
+RichTextRun.FontFamily(string family) → RichTextRun
+RichTextRun.FontSize(double size) → RichTextRun
+RichTextRun.FontStretch(FontStretch stretch) → RichTextRun
+RichTextRun.FontStyle(FontStyle style) → RichTextRun
+RichTextRun.FontWeight(FontWeight weight) → RichTextRun
+RichTextRun.Foreground(Brush brush) → RichTextRun
+RichTextRun.Foreground(string color) → RichTextRun
+RichTextRun.IsTextScaleFactorEnabled(bool enabled = true) → RichTextRun
+RichTextRun.Language(string language) → RichTextRun
+RichTextRun.TextDecorations(TextDecorations decorations) → RichTextRun
 
 ### record ElementExtras
 new()
@@ -2353,7 +2407,7 @@ GetHashCode() → int
 ToString() → string
 
 ### record ExpanderElement
-new(string Header, Element Content, Optional<bool> IsExpanded = null, Action<bool> OnIsExpandedChanged = null)
+new(string Header, Element Content, Optional<bool> IsExpanded = default, Action<bool> OnIsExpandedChanged = null)
 Action<bool> OnIsExpandedChanged { get; init; }
 Element Content { get; init; }
 Element HeaderTemplate { get; init; }
@@ -2760,11 +2814,11 @@ GetHashCode() → int
 ToString() → string
 
 ### interface IAsyncValidator
-ValidateAsync(object value, string field, CancellationToken cancellationToken = null) → Task<ValidationMessage>
+ValidateAsync(object value, string field, CancellationToken cancellationToken = default) → Task<ValidationMessage>
 
 ### interface IDataSource<T>
 DataSourceCapabilities Capabilities { get; }
-GetPageAsync(DataRequest request, CancellationToken cancellationToken = null) → Task<DataPage<T>>
+GetPageAsync(DataRequest request, CancellationToken cancellationToken = default) → Task<DataPage<T>>
 GetRowKey(T item) → RowKey
 
 ### interface IDecoratorElementHandler<TElement>
@@ -2789,16 +2843,16 @@ int ItemCount { get; }
 BuildItemView(int index) → Element
 
 ### interface IKeyedDataSource<T>
-GetByKeyAsync(RowKey key, CancellationToken cancellationToken = null) → Task<T>
-GetByKeysAsync(IEnumerable<RowKey> keys, CancellationToken cancellationToken = null) → Task<IReadOnlyList<T>>
+GetByKeyAsync(RowKey key, CancellationToken cancellationToken = default) → Task<T>
+GetByKeysAsync(IEnumerable<RowKey> keys, CancellationToken cancellationToken = default) → Task<IReadOnlyList<T>>
 
 ### interface IKeyedItemSource
 GetKeyAt(int index) → string
 
 ### interface IMutableDataSource<T>
-CreateAsync(T item, CancellationToken cancellationToken = null) → Task<T>
-DeleteAsync(RowKey key, CancellationToken cancellationToken = null) → Task
-UpdateAsync(RowKey key, T item, CancellationToken cancellationToken = null) → Task<T>
+CreateAsync(T item, CancellationToken cancellationToken = default) → Task<T>
+DeleteAsync(RowKey key, CancellationToken cancellationToken = default) → Task
+UpdateAsync(RowKey key, T item, CancellationToken cancellationToken = default) → Task<T>
 
 ### interface IObservableDataSource<T>
 event EventHandler DataChanged
@@ -3364,11 +3418,11 @@ ToString() → string
 ### class ListDataSource<T>
 new(IEnumerable<T> items, Func<T, RowKey> getRowKey)
 DataSourceCapabilities Capabilities { get; }
-CreateAsync(T item, CancellationToken cancellationToken = null) → Task<T>
-DeleteAsync(RowKey key, CancellationToken cancellationToken = null) → Task
-GetPageAsync(DataRequest request, CancellationToken cancellationToken = null) → Task<DataPage<T>>
+CreateAsync(T item, CancellationToken cancellationToken = default) → Task<T>
+DeleteAsync(RowKey key, CancellationToken cancellationToken = default) → Task
+GetPageAsync(DataRequest request, CancellationToken cancellationToken = default) → Task<DataPage<T>>
 GetRowKey(T item) → RowKey
-UpdateAsync(RowKey key, T item, CancellationToken cancellationToken = null) → Task<T>
+UpdateAsync(RowKey key, T item, CancellationToken cancellationToken = default) → Task<T>
 
 ### record ListViewElement
 new(Element[] Items)
@@ -3799,7 +3853,7 @@ Equals(object obj) → bool
 Fade(TimeSpan? duration = null) → NavigationTransition
 GetHashCode() → int
 Slide(SlideDirection direction = SlideDirection.FromRight, TimeSpan? duration = null, CompositionEasingFunction easing = null, float? distance = null) → NavigationTransition
-Spring(float dampingRatio = 0.6, float period = 0.08, SlideDirection direction = SlideDirection.FromRight) → NavigationTransition
+Spring(float dampingRatio = 0.6f, float period = 0.08f, SlideDirection direction = SlideDirection.FromRight) → NavigationTransition
 ToString() → string
 
 ### record NavigationViewElement
@@ -3878,7 +3932,7 @@ new()
 new()
 
 ### record NumberBoxElement
-new(Optional<double> Value = null, Action<double> OnValueChanged = null, string Header = null)
+new(Optional<double> Value = default, Action<double> OnValueChanged = null, string Header = null)
 Action<double> OnValueChanged { get; init; }
 INumberFormatter2 NumberFormatter { get; init; }
 NumberBoxSpinButtonPlacementMode SpinButtonPlacement { get; init; }
@@ -4010,7 +4064,7 @@ GetHashCode() → int
 ToString() → string
 
 ### record PasswordBoxElement
-new(Optional<string> Password = null, Action<string> OnPasswordChanged = null, string PlaceholderText = null)
+new(Optional<string> Password = default, Action<string> OnPasswordChanged = null, string PlaceholderText = null)
 Action<string> OnPasswordChanged { get; init; }
 Optional<string> Password { get; init; }
 PasswordRevealMode PasswordRevealMode { get; init; }
@@ -4307,7 +4361,7 @@ Unsubscribe(string key) → int
 event Action<string> EntryChanged
 
 ### record RadioButtonElement
-new(string Label, Optional<bool> IsChecked = null, Action<bool> OnIsCheckedChanged = null, string GroupName = null)
+new(string Label, Optional<bool> IsChecked = default, Action<bool> OnIsCheckedChanged = null, string GroupName = null)
 Action<bool> OnIsCheckedChanged { get; init; }
 Optional<bool> IsChecked { get; init; }
 string GroupName { get; init; }
@@ -4320,7 +4374,7 @@ GetHashCode() → int
 ToString() → string
 
 ### record RadioButtonsElement
-new(string[] Items, Optional<int> SelectedIndex = null, Action<int> OnSelectedIndexChanged = null)
+new(string[] Items, Optional<int> SelectedIndex = default, Action<int> OnSelectedIndexChanged = null)
 Action<int> OnSelectedIndexChanged { get; init; }
 Optional<int> SelectedIndex { get; init; }
 string Header { get; init; }
@@ -4348,7 +4402,7 @@ GetHashCode() → int
 ToString() → string
 
 ### record RatingControlElement
-new(Optional<double> Value = null, Action<double> OnValueChanged = null)
+new(Optional<double> Value = default, Action<double> OnValueChanged = null)
 Action<double> OnValueChanged { get; init; }
 Optional<double> Value { get; init; }
 bool IsReadOnly { get; init; }
@@ -4720,7 +4774,7 @@ UsePersisted<T>(string key, T initialValue, PersistedScope scope) → ValueTuple
 UseReducedMotion() → bool
 UseReducer<T>(T initialValue, bool threadSafe = false) → ValueTuple<T, Action<Func<T, T>>>
 UseReducer<TState, TAction>(Func<TState, TAction, TState> reducer, TState initialValue, bool threadSafe = false) → ValueTuple<TState, Action<TAction>>
-UseRef<T>(T initialValue = null) → Ref<T>
+UseRef<T>(T initialValue = default) → Ref<T>
 UseState<T>(T initialValue, bool threadSafe = false) → ValueTuple<T, Action<T>>
 UseSystemBackButton<TRoute>(NavigationHandle<TRoute> nav, Window window) → void
 UseTrayIcon(TrayIconSpec spec) → ReactorTrayIcon
@@ -4796,7 +4850,7 @@ new(string defaultLocale = "en-US", string stringsBasePath = null)
 GetString(string locale, string ns, string key) → string
 
 ### record RichEditBoxElement
-new(Optional<string> Text = null)
+new(Optional<string> Text = default)
 Action<string> OnTextChanged { get; init; }
 Optional<string> Text { get; init; }
 SolidColorBrush SelectionHighlightColor { get; init; }
@@ -4964,10 +5018,10 @@ ToString() → string
 
 ### class RouteArgs
 Get<T>(string name) → T
-GetOrDefault<T>(string name, T defaultValue = null) → T
+GetOrDefault<T>(string name, T defaultValue = default) → T
 GetString(string name) → string
 GetWildcard() → string
-Query<T>(string name, T defaultValue = null) → T
+Query<T>(string name, T defaultValue = default) → T
 QueryString(string name) → string
 
 ### struct RowKey
@@ -5181,7 +5235,7 @@ GetHashCode() → int
 ToString() → string
 
 ### record SliderElement
-new(Optional<double> Value = null, double Min = 0, double Max = 100, Action<double> OnValueChanged = null)
+new(Optional<double> Value = default, double Min = 0, double Max = 100, Action<double> OnValueChanged = null)
 Action<double> OnValueChanged { get; init; }
 Optional<double> Value { get; init; }
 Orientation Orientation { get; init; }
@@ -5676,7 +5730,7 @@ GetHashCode() → int
 ToString() → string
 
 ### record TextBoxElement
-new(Optional<string> Value = null, Action<string> OnChanged = null, string PlaceholderText = null)
+new(Optional<string> Value = default, Action<string> OnChanged = null, string PlaceholderText = null)
 Action<string, int, int> OnSelectionChanged { get; init; }
 Action<string> OnChanged { get; init; }
 CharacterCasing CharacterCasing { get; init; }
@@ -5716,7 +5770,7 @@ ToString() → string
 Brush(string key) → Brush
 CornerRadius(string key) → CornerRadius
 Double(string key) → double
-Get<T>(string key, T defaultValue = null) → T
+Get<T>(string key, T defaultValue = default) → T
 Thickness(string key) → Thickness
 
 ### record ThemeTransitions
@@ -5744,7 +5798,7 @@ GetHashCode() → int
 ToString() → string
 
 ### record TimePickerElement
-new(Optional<TimeSpan> Time = null, Action<TimeSpan> OnTimeChanged = null)
+new(Optional<TimeSpan> Time = default, Action<TimeSpan> OnTimeChanged = null)
 Action<TimeSpan> OnTimeChanged { get; init; }
 Optional<TimeSpan> Time { get; init; }
 int ClockIdentifier { get; init; }
@@ -5809,7 +5863,7 @@ GetHashCode() → int
 ToString() → string
 
 ### record ToggleSplitButtonElement
-new(string Label, Optional<bool> IsChecked = null, Action<bool> OnIsCheckedChanged = null, Element Flyout = null)
+new(string Label, Optional<bool> IsChecked = default, Action<bool> OnIsCheckedChanged = null, Element Flyout = null)
 Action<bool> OnIsCheckedChanged { get; init; }
 Command Command { get; init; }
 Element Flyout { get; init; }
@@ -5823,7 +5877,7 @@ GetHashCode() → int
 ToString() → string
 
 ### record ToggleSwitchElement
-new(Optional<bool> IsOn = null, Action<bool> OnIsOnChanged = null, string OnContent = null, string OffContent = null)
+new(Optional<bool> IsOn = default, Action<bool> OnIsOnChanged = null, string OnContent = null, string OffContent = null)
 Action<bool> OnIsOnChanged { get; init; }
 Optional<bool> IsOn { get; init; }
 string Header { get; init; }
@@ -5842,7 +5896,7 @@ Equals(Transition other) → bool
 Equals(object obj) → bool
 Exit(Transition exit) → Transition
 GetHashCode() → int
-Scale(float from = 0.85) → Transition
+Scale(float from = 0.85f) → Transition
 Slide(Edge edge = Edge.Bottom) → Transition
 ToString() → string
 
@@ -5929,6 +5983,21 @@ Create<T>() → ElementRef<T>
 ### class UIThreadOnlyAttribute
 new()
 
+### static class UseAnnounceExtensions
+Component.UseAnnounce() → AnnounceHandle
+
+### static class UseElementFocusExtensions
+Component.UseElementFocus(FocusState state = FocusState.Programmatic) → ValueTuple<ElementRef, Action>
+
+### static class UseElementRefExtensions
+Component.UseElementRef<T>() → ElementRef<T>
+
+### static class UseFocusExtensions
+Component.UseFocus() → FocusManager
+
+### static class UseFocusTrapExtensions
+Component.UseFocusTrap(bool isActive) → FocusTrapHandle
+
 ### static class Validate
 Email(string message = null) → IValidator
 EqualTo<T>(T otherValue, string message = null) → IValidator
@@ -5941,6 +6010,10 @@ MustBeTrue(string message = null) → IValidator
 Range(double min, double max, string message = null) → IValidator
 Required(string message = null) → IValidator
 Url(string message = null) → IValidator
+
+### static class ValidateExtensions
+ValidationAttached.RunAsyncValidators(object value, CancellationToken cancellationToken = default) → Task<IReadOnlyList<ValidationMessage>>
+ValidationAttached.RunValidators(object value) → IReadOnlyList<ValidationMessage>
 
 ### record ValidationAttached
 new(string FieldName, IValidator[] Validators, IAsyncValidator[] AsyncValidators)
@@ -5983,6 +6056,10 @@ Reset(string field) → object
 ResetAll() → IReadOnlyDictionary<string, object>
 SetInitialValue(string field, object value) → void
 
+### static class ValidationContextComponentExtensions
+Component.UseChildValidationContext() → ValueTuple<ValidationContext, ValidationContext>
+Component.UseValidationContext() → ValidationContext
+
 ### record ValidationMessage
 new(string Field, string Text, Severity Severity = Severity.Error, string Code = null)
 Severity Severity { get; init; }
@@ -5999,7 +6076,7 @@ ToString() → string
 EvaluateRules(ValidationContext ctx, ValidationRuleElement[] rules) → void
 ValidateAttached(ValidationContext ctx, ValidationAttached attached, object value) → void
 ValidateField(ValidationContext ctx, string fieldName, object value, IValidator[] validators) → void
-ValidateFieldAsync(ValidationContext ctx, string fieldName, object value, IAsyncValidator[] asyncValidators, CancellationToken cancellationToken = null) → Task
+ValidateFieldAsync(ValidationContext ctx, string fieldName, object value, IAsyncValidator[] asyncValidators, CancellationToken cancellationToken = default) → Task
 
 ### static class ValidationRuleDsl
 ValidationRule(Func<bool> predicate, string message, string field, Severity severity = Severity.Error) → ValidationRuleElement

--- a/skills/reactor.api.txt
+++ b/skills/reactor.api.txt
@@ -4,8 +4,12 @@
 #             AfterBuild target rewrites this file).
 # Format: one symbol per line. No prose. Alphabetized within each section.
 # Sections: Factories, Modifiers, Reference builders, Hooks, Theme, Enums, Public types.
-# Public types now ARE covered — ctors/properties/methods/events on every
-# public type (e.g. WindowSpec.Opacity, ReactorWindow.SetPosition).
+# Public types covers ctors/properties/methods/events on every public type,
+# including public *static* classes — so process-wide entry points such as
+# ControlRegistry.Register and ReactorApp.Run are listed there, alongside
+# instance members like WindowSpec.Opacity and ReactorWindow.SetPosition.
+# Extension methods are listed under Modifiers/Hooks in the fluent form you
+# call them, not again under their declaring static class.
 
 ## Factories
 # All in `Microsoft.UI.Reactor.Factories` — `using static Microsoft.UI.Reactor.Factories;`
@@ -1105,6 +1109,10 @@ GetHashCode() → int
 Merge(AccessibilityModifiers other) → AccessibilityModifiers
 ToString() → string
 
+### static class AccessibilityScanner
+ExportJson(List<A11yDiagnostic> diagnostics, string filePath) → void
+Scan(Element root) → List<A11yDiagnostic>
+
 ### record AnimatedIconElement
 new()
 IconSource FallbackIconSource { get; init; }
@@ -1133,6 +1141,16 @@ Equals(AnimationConfig other) → bool
 Equals(object obj) → bool
 GetHashCode() → int
 ToString() → string
+
+### static class AnimationScope
+Curve Current { get; }
+bool HasScope { get; }
+WithAnimation(Curve curve, Action action) → void
+WithAnimationAsync(Curve curve, Action action) → Task
+
+### static class Animations
+Animate(AnimationKind kind, Action action) → void
+Animate<T>(AnimationKind kind, Func<T> func) → T
 
 ### record AnnotatedScrollBarElement
 new()
@@ -1297,6 +1315,9 @@ Equals(object obj) → bool
 GetHashCode() → int
 ToString() → string
 
+### static class AutoSuggestDsl
+AutoSuggest<T>(T selected, Action<T> onSelected = null, Func<string, CancellationToken, Task<IReadOnlyList<T>>> search = null, Func<T, string> displayText = null, string placeholderText = null, int debounceMs = 300, Func<T, Element> template = null) → AutoSuggestElement<T>
+
 ### record AutoSuggestElement<T>
 new(T Selected, Action<T> OnSelected = null, Func<string, CancellationToken, Task<IReadOnlyList<T>>> Search = null, Func<T, string> DisplayText = null, string PlaceholderText = null)
 Action<T> OnSelected { get; init; }
@@ -1370,6 +1391,9 @@ Equals(BreadcrumbBarItemData other) → bool
 Equals(object obj) → bool
 GetHashCode() → int
 ToString() → string
+
+### static class BrushHelper
+Parse(string color) → SolidColorBrush
 
 ### record ButtonElement
 new(string Label, Action OnClick = null)
@@ -1487,6 +1511,17 @@ Equals(Element other) → bool
 Equals(object obj) → bool
 GetHashCode() → int
 ToString() → string
+
+### static class CellRenderers
+CheckMark() → Func<object, Element>
+ColorSwatch() → Func<object, Element>
+Date(string format = "d") → Func<object, Element>
+Enum() → Func<object, Element>
+Hyperlink(string displayTextFormat = null) → Func<object, Element>
+Number(string format = null) → Func<object, Element>
+Text(string format = null) → Func<object, Element>
+Time(string format = "t") → Func<object, Element>
+ToggleIndicator() → Func<object, Element>
 
 ### record CheckBoxElement
 new(Optional<bool?> IsChecked = null, Action<bool> OnIsCheckedChanged = null, string Label = null)
@@ -1648,6 +1683,10 @@ Equals(object obj) → bool
 GetHashCode() → int
 ToString() → string
 
+### static class CommandInterop
+FromCommand(ICommand command, string label, IconData icon = null, string description = null, KeyboardAcceleratorData accelerator = null, object parameter = null) → Command
+FromCommand<T>(ICommand command, string label, IconData icon = null, string description = null, KeyboardAcceleratorData accelerator = null) → Command<T>
+
 ### class Component
 Render() → Element
 
@@ -1673,6 +1712,10 @@ Equals(ComponentElement<TProps> other) → bool
 Equals(object obj) → bool
 GetHashCode() → int
 ToString() → string
+
+### static class CompositorProvider
+Compositor Current { get; set; }
+EnsureCompositor(UIElement element) → Compositor
 
 ### record ConnectedTransition
 string AnimationKey { get; init; }
@@ -1742,6 +1785,12 @@ OneWayConditional<TValue>(Func<TElement, TValue> get, Action<TControl, TValue> s
 Reference(Func<TElement, ElementRef> get, Action<TControl, FrameworkElement> set) → ControlDescriptor<TElement, TControl>
 Reference<TTarget>(Func<TElement, ElementRef<TTarget>> get, Action<TControl, TTarget> set) → ControlDescriptor<TElement, TControl>
 ReferenceList<TTarget>(Func<TElement, IReadOnlyList<ElementRef<TTarget>>> get, Action<TControl, IReadOnlyList<TTarget>> apply) → ControlDescriptor<TElement, TControl>
+
+### static class ControlRegistry
+Register<TElement, TControl>(Func<IElementHandler<TElement, TControl>> handlerFactory) → void
+RegisterDecorator<TElement>(Func<IDecoratorElementHandler<TElement>> handlerFactory) → void
+RegisterDecoratorForDerivedTypes<TBase>(Func<IDecoratorElementHandler<TBase>> handlerFactory) → void
+RegisterForDerivedTypes<TBase, TControl>(Func<IElementHandler<TBase, TControl>> handlerFactory) → void
 
 ### record Curve
 Ease(int durationMs, Easing easing = null) → Curve
@@ -1959,6 +2008,9 @@ Equals(object obj) → bool
 GetHashCode() → int
 ToString() → string
 
+### static class DragOperationNegotiation
+Negotiate(DragOperations source, DragOperations target) → DragOperations
+
 ### record DragSourceConfig
 new(Func<DragData> GetData)
 Action<DragEndContext> OnEnd { get; init; }
@@ -2044,6 +2096,28 @@ Equals(Easing other) → bool
 Equals(object obj) → bool
 GetHashCode() → int
 ToString() → string
+
+### static class Editors
+CheckBox() → Func<object, Action<object>, Element>
+Color() → Func<object, Action<object>, Element>
+ColorCompact() → Func<object, Action<object>, Element>
+Combo<TValue>(IReadOnlyList<TValue> choices) → Func<object, Action<object>, Element>
+Date() → Func<object, Action<object>, Element>
+DateOffset() → Func<object, Action<object>, Element>
+DateOnly() → Func<object, Action<object>, Element>
+Decimal(Decimal? min = null, Decimal? max = null) → Func<object, Action<object>, Element>
+Double(double? min = null, double? max = null) → Func<object, Action<object>, Element>
+EnumCombo(Type enumType) → Func<object, Action<object>, Element>
+Float(float? min = null, float? max = null) → Func<object, Action<object>, Element>
+Int(int? min = null, int? max = null) → Func<object, Action<object>, Element>
+Long(long? min = null, long? max = null) → Func<object, Action<object>, Element>
+Number(Type numberType, double? min = null, double? max = null, double smallChange = 1) → Func<object, Action<object>, Element>
+Text(string placeholderText = null, int? maxLength = null) → Func<object, Action<object>, Element>
+TimeOfDay() → Func<object, Action<object>, Element>
+TimeOnlyEditor() → Func<object, Action<object>, Element>
+TimeSpanEditor() → Func<object, Action<object>, Element>
+Toggle(string onContent = null, string offContent = null) → Func<object, Action<object>, Element>
+Uri() → Func<object, Action<object>, Element>
 
 ### record Element
 AnimationConfig AnimationConfig { get; init; }
@@ -2259,6 +2333,15 @@ Equals(object obj) → bool
 GetHashCode() → int
 ToString() → string
 
+### static class ErrorBubbling
+FilterMessages(IReadOnlyList<ValidationMessage> messages, Severity? severityFilter) → ValueTuple<IReadOnlyList<ValidationMessage>, IReadOnlyList<ValidationMessage>>
+HighestSeverity(IReadOnlyList<ValidationMessage> messages) → Severity?
+ShouldDisplay(IReadOnlyList<ValidationMessage> messages, ShowWhen showWhen, ValidationContext ctx = null, bool submitAttempted = false) → bool
+
+### static class ErrorStyling
+GetBrushKey(Severity severity) → string
+ShouldShowErrors(ValidationContext ctx, string fieldName, ShowWhen showWhen, bool submitAttempted = false) → bool
+
 ### record ErrorStylingAttached
 new(Func<Element, Element> OnErrorTransform = null, Func<Element, Element> OnWarningTransform = null)
 Func<Element, Element> OnErrorTransform { get; init; }
@@ -2464,7 +2547,7 @@ Equals(object obj) → bool
 GetHashCode() → int
 ToString() → string
 
-### class FocusManager
+### class FocusManager (in Microsoft.UI.Reactor.Hooks)
 new()
 IReadOnlyList<string> Fields { get; }
 Clear() → void
@@ -2477,6 +2560,10 @@ IsLastField(string fieldName) → bool
 Register(string fieldName) → void
 SetControl(string fieldName, Control control) → void
 SetSubmitHandler(Action handler) → void
+
+### static class FocusManager (in Microsoft.UI.Reactor.Input)
+Focus(ElementRef target, FocusState state = FocusState.Programmatic) → bool
+FocusAsync(ElementRef target, FocusState state = FocusState.Programmatic) → Task<bool>
 
 ### class FocusRevalidationService
 new(QueryCache cache)
@@ -2514,6 +2601,10 @@ Equals(object obj) → bool
 GetHashCode() → int
 ToString() → string
 
+### static class FormFieldDsl
+FormField(Element content, string label = null, bool required = false, string description = null, string fieldName = null, ShowWhen showWhen = ShowWhen.WhenTouched) → FormFieldElement
+FormField(FieldDescriptor field, object value, Action<object> onChange, TypeRegistry registry = null) → FormFieldElement
+
 ### record FormFieldElement
 new(Element Content, string Label = null, bool Required = false, string Description = null)
 Element Content { get; init; }
@@ -2528,6 +2619,13 @@ Equals(FormFieldElement other) → bool
 Equals(object obj) → bool
 GetHashCode() → int
 ToString() → string
+
+### static class FormFieldHelpers
+DetectFieldName(Element content) → string
+GetAutomationName(string label) → string
+GetDescriptionOrError(ValidationContext ctx, string fieldName, string description, ShowWhen showWhen, bool submitAttempted = false) → ValueTuple<string, bool>
+GetDisplayLabel(string label, bool required) → string
+ResolveFieldName(string explicitFieldName, Element content) → string
 
 ### struct FormatResult
 new(string Output, int CursorPos)
@@ -3014,6 +3112,13 @@ DefaultPath() → string
 TryRead(string id, ref Byte[] data) → bool
 Write(string id, Byte[] data) → void
 
+### static class JumpList
+bool ShowFrequent { get; set; }
+bool ShowRecent { get; set; }
+string AppUserModelId { get; set; }
+ClearAsync() → Task
+UpdateAsync(IEnumerable<JumpListItem> items) → Task
+
 ### record JumpListItem
 new(string Title, string Arguments, JumpListItemKind Kind = JumpListItemKind.Task, string Description = null, WindowIcon Icon = null, string GroupCategory = null)
 JumpListItemKind Kind { get; init; }
@@ -3381,6 +3486,9 @@ IsLiteral(int position) → bool
 NextInputPosition(int position) → int
 PreviousInputPosition(int position) → int
 
+### static class MaskedTextBoxDsl
+MaskedTextBox(string value, Action<string> onChanged = null, string mask = null, string header = null, Char placeholder = _) → MaskedTextBoxElement
+
 ### record MaskedTextBoxElement
 new(string Value, Action<string> OnChanged = null, string Mask = null, string Header = null, Char Placeholder = _)
 Action<string> OnChanged { get; init; }
@@ -3618,6 +3726,17 @@ object From { get; }
 object To { get; }
 string Reason { get; init; }
 
+### static class NavigationDiagnostics
+event EventHandler<CacheDiagnosticEvent> CacheEviction
+event EventHandler<CacheDiagnosticEvent> CacheHit
+event EventHandler<CacheDiagnosticEvent> CacheMiss
+event EventHandler<DeepLinkDiagnosticEvent> DeepLinkResolved
+event EventHandler<NavigationDiagnosticEvent> NavigationCancelled
+event EventHandler<NavigationDiagnosticEvent> NavigationCompleted
+event EventHandler<NavigationDiagnosticEvent> NavigationRequested
+event EventHandler<TransitionDiagnosticEvent> TransitionCompleted
+event EventHandler<TransitionDiagnosticEvent> TransitionStarted
+
 ### record NavigationEventArgs<TRoute>
 new(TRoute Route, TRoute PreviousRoute, NavigationMode Mode, NavigateOptions Options = null)
 NavigateOptions Options { get; init; }
@@ -3827,6 +3946,11 @@ Equals(object obj) → bool
 GetHashCode() → int
 ToString() → string
 
+### static class PageHelper
+Mount<TComponent, TProps>(Page page, NavigationEventArgs e) → ReactorHostControl
+Mount<TComponent>(Page page, NavigationEventArgs e) → ReactorHostControl
+Unmount(ref ReactorHostControl host) → void
+
 ### struct PanGesture
 new(Point Translation, Point Delta, Point Velocity, Point Position, Point StartPosition, GesturePhase Phase, bool IsInertial)
 GesturePhase Phase { get; init; }
@@ -3901,6 +4025,9 @@ Equals(object obj) → bool
 GetHashCode() → int
 ToString() → string
 
+### static class PathDataParser
+Parse(string pathData) → Geometry
+
 ### record PathElement
 new()
 Brush Fill { get; init; }
@@ -3936,6 +4063,9 @@ ToString() → string
 ### class PendingComponent
 new()
 Render() → Element
+
+### static class PendingFactory
+Pending(Element fallback, Element child) → Element
 
 ### record PendingProps
 new(Element Fallback, Element Child)
@@ -4122,6 +4252,12 @@ Type EditorType { get; }
 new()
 Render() → Element
 
+### static class PropertyGridDefaults
+ArrayItemTemplate(int index, string summary, bool isExpanded, Action<bool> onExpandedChanged, Action onMoveUp, Action onMoveDown, Action onRemove) → Element
+ArrayToolbarTemplate(string propertyName, int count, Func<Task> onAdd) → Element
+PropertyLabelTemplate(FieldDescriptor descriptor, int indentLevel) → Element
+PropertyRowTemplate(FieldDescriptor descriptor, Element label, Element editor, int indentLevel) → Element
+
 ### record PropertyGridElement
 Action<object> OnRootChanged { get; init; }
 ArrayItemTemplate ArrayItemTemplate { get; init; }
@@ -4148,6 +4284,10 @@ int Order { get; }
 
 ### class PropertyReadOnlyAttribute
 new()
+
+### static class PseudoLocalizer
+MissingKeyMarker(MessageKey key) → string
+Transform(string input) → string
 
 ### class QueryCache
 new()
@@ -4223,6 +4363,33 @@ Equals(object obj) → bool
 GetHashCode() → int
 ToString() → string
 
+### static class ReactorApp
+DispatcherQueue UIDispatcher { get; }
+ILogger AppLogger { get; set; }
+IReadOnlyList<ReactorTrayIcon> TrayIcons { get; }
+IReadOnlyList<ReactorWindow> Windows { get; }
+IWindowPersistenceStore WindowPersistenceStore { get; set; }
+ReactorWindow PrimaryWindow { get; }
+ShutdownPolicy ShutdownPolicy { get; set; }
+bool DevtoolsEnabled { get; }
+Exit(int exitCode = 0) → void
+FindTrayIcon(WindowKey key) → ReactorTrayIcon
+FindWindow(WindowKey key) → ReactorWindow
+OpenTrayIcon(TrayIconSpec spec) → ReactorTrayIcon
+OpenWindow(WindowSpec spec, Func<Component> root, Action<ReactorHost> configure = null) → ReactorWindow
+OpenWindow(WindowSpec spec, Func<RenderContext, Element> render, Action<ReactorHost> configure = null) → ReactorWindow
+RegisterAllBuiltIns() → void
+RegisterControlAssembly(Assembly assembly) → void
+RegisterControlAssembly(IXamlMetadataProvider provider) → void
+Run(Action<ReactorAppContext> startup) → void
+Run(string title, Func<RenderContext, Element> rootRender, double? width = null, double? height = null, bool fullScreen = false, Action<ReactorHost> configure = null) → void
+Run<TRoot>(string title = "Reactor App", double? width = null, double? height = null, bool fullScreen = false, Action<ReactorHost> configure = null) → void
+TryRegisterControlAssembly(Assembly assembly) → bool
+event EventHandler<ReactorTrayIcon> TrayIconClosed
+event EventHandler<ReactorTrayIcon> TrayIconOpened
+event EventHandler<ReactorWindow> WindowClosed
+event EventHandler<ReactorWindow> WindowOpened
+
 ### class ReactorAppContext
 LaunchActivation LaunchActivation { get; }
 
@@ -4235,6 +4402,11 @@ GetXamlType(Type type) → IXamlType
 GetXamlType(string fullName) → IXamlType
 GetXmlnsDefinitions() → XmlnsDefinition[]
 InitializeComponent() → void
+
+### static class ReactorBinding
+ShouldSuppressEcho(UIElement target) → bool
+WriteSuppressed(UIElement target, Action mutate) → void
+WriteSuppressed<T>(T target, Action<T> mutate) → void
 
 ### struct ReactorBinding<TElement>
 FrameworkElement Control { get; }
@@ -4275,6 +4447,19 @@ Equals(object obj) → bool
 GetHashCode() → int
 ToString() → string
 
+### static class ReactorDevtoolsBootstrap
+Register(IReactorDevtoolsHost host) → void
+
+### static class ReactorDiagnostics
+IReadOnlyList<KeyedListDiagnostic> RecentKeyedListWarnings { get; }
+ClearRecentKeyedListWarnings() → void
+
+### static class ReactorDisplay
+DisplayInfo Primary { get; }
+IReadOnlyList<DisplayInfo> Displays { get; }
+NearestTo(double dipX, double dipY) → DisplayInfo
+event EventHandler DisplayLayoutChanged
+
 ### struct ReactorEvent
 new(int EventId, string EventName, EventLevel Level, EventKeywords Keywords, DateTime TimestampUtc, int ThreadId, IReadOnlyList<object> Payload, IReadOnlyList<string> PayloadNames)
 DateTime TimestampUtc { get; init; }
@@ -4290,6 +4475,12 @@ Equals(ReactorEvent other) → bool
 Equals(object obj) → bool
 GetHashCode() → int
 ToString() → string
+
+### static class ReactorFeatureFlags
+bool FocusRevalidation { get; set; }
+bool HighlightReconcileChanges { get; set; }
+bool UseHookBasedPaging { get; set; }
+bool WarnLayoutFootguns { get; set; }
 
 ### class ReactorHost
 new(Window window, ILogger logger = null)
@@ -4315,6 +4506,9 @@ ref RenderStats Stats { get; }
 Dispose() → void
 Mount(Component component) → void
 Mount(Func<RenderContext, Element> renderFunc) → void
+
+### static class ReactorTrace
+Subscribe(Action<ReactorEvent> onEvent, EventLevel level = EventLevel.Verbose, EventKeywords keywords = EventKeywords.All) → IDisposable
 
 ### class ReactorTrayIcon
 TrayIconSpec Spec { get; }
@@ -4425,6 +4619,10 @@ ToString() → string
 ### class Ref<T>
 new(T initial)
 T Current { get; set; }
+
+### static class ReflectionTypeMetadataProvider
+CreateDescriptor(PropertyInfo property, int defaultOrder) → FieldDescriptor
+CreateMetadata(Type type) → TypeMetadata
 
 ### record RefreshContainerElement
 new(Element Content)
@@ -4781,6 +4979,9 @@ Equals(object obj) → bool
 GetHashCode() → int
 ToString() → string
 
+### static class RtlHelper
+IsRtlLocale(string locale) → bool
+
 ### record ScaleTransition
 new(float From)
 float From { get; init; }
@@ -5085,6 +5286,40 @@ Equals(StaggerConfig other) → bool
 Equals(object obj) → bool
 GetHashCode() → int
 ToString() → string
+
+### static class StandardCommand
+Backward(Action execute, bool canExecute = true) → Command
+Backward(Func<Task> executeAsync, bool canExecute = true) → Command
+Close(Action execute, bool canExecute = true) → Command
+Close(Func<Task> executeAsync, bool canExecute = true) → Command
+Copy(Action execute, bool canExecute = true) → Command
+Copy(Func<Task> executeAsync, bool canExecute = true) → Command
+Cut(Action execute, bool canExecute = true) → Command
+Cut(Func<Task> executeAsync, bool canExecute = true) → Command
+Delete(Action execute, bool canExecute = true) → Command
+Delete(Func<Task> executeAsync, bool canExecute = true) → Command
+Forward(Action execute, bool canExecute = true) → Command
+Forward(Func<Task> executeAsync, bool canExecute = true) → Command
+Open(Action execute, bool canExecute = true) → Command
+Open(Func<Task> executeAsync, bool canExecute = true) → Command
+Paste(Action execute, bool canExecute = true) → Command
+Paste(Func<Task> executeAsync, bool canExecute = true) → Command
+Pause(Action execute, bool canExecute = true) → Command
+Pause(Func<Task> executeAsync, bool canExecute = true) → Command
+Play(Action execute, bool canExecute = true) → Command
+Play(Func<Task> executeAsync, bool canExecute = true) → Command
+Redo(Action execute, bool canExecute = true) → Command
+Redo(Func<Task> executeAsync, bool canExecute = true) → Command
+Save(Action execute, bool canExecute = true) → Command
+Save(Func<Task> executeAsync, bool canExecute = true) → Command
+SelectAll(Action execute, bool canExecute = true) → Command
+SelectAll(Func<Task> executeAsync, bool canExecute = true) → Command
+Share(Action execute, bool canExecute = true) → Command
+Share(Func<Task> executeAsync, bool canExecute = true) → Command
+Stop(Action execute, bool canExecute = true) → Command
+Stop(Func<Task> executeAsync, bool canExecute = true) → Command
+Undo(Action execute, bool canExecute = true) → Command
+Undo(Func<Task> executeAsync, bool canExecute = true) → Command
 
 ### record SuppressTransition
 new()
@@ -5464,6 +5699,9 @@ Equals(object obj) → bool
 GetHashCode() → int
 ToString() → string
 
+### static class Theme
+Ref(string resourceKey) → ThemeRef
+
 ### struct ThemeRef
 new(string ResourceKey)
 string ResourceKey { get; init; }
@@ -5473,6 +5711,13 @@ Equals(object obj) → bool
 GetHashCode() → int
 Resolve(string resourceKey, bool isDark) → Brush
 ToString() → string
+
+### static class ThemeResource
+Brush(string key) → Brush
+CornerRadius(string key) → CornerRadius
+Double(string key) → double
+Get<T>(string key, T defaultValue = null) → T
+Thickness(string key) → Thickness
 
 ### record ThemeTransitions
 new()
@@ -5678,8 +5923,24 @@ RegisterFormatter<T>(Func<object, string> formatter) → TypeRegistry
 Resolve(Type type) → TypeMetadata
 ResolveEditor(Type type, EditorTier tier) → Func<object, Action<object>, Element>
 
+### static class TypedElementRef
+Create<T>() → ElementRef<T>
+
 ### class UIThreadOnlyAttribute
 new()
+
+### static class Validate
+Email(string message = null) → IValidator
+EqualTo<T>(T otherValue, string message = null) → IValidator
+Match(string regex, string message = null) → IValidator
+MaxLength(int n, string message = null) → IValidator
+MinLength(int n, string message = null) → IValidator
+Must<T>(Func<T, bool> predicate, string message) → IValidator
+MustAsync<T>(Func<T, Task<bool>> predicate, string message) → IAsyncValidator
+MustBeTrue(string message = null) → IValidator
+Range(double min, double max, string message = null) → IValidator
+Required(string message = null) → IValidator
+Url(string message = null) → IValidator
 
 ### record ValidationAttached
 new(string FieldName, IValidator[] Validators, IAsyncValidator[] AsyncValidators)
@@ -5734,6 +5995,16 @@ Equals(object obj) → bool
 GetHashCode() → int
 ToString() → string
 
+### static class ValidationReconciler
+EvaluateRules(ValidationContext ctx, ValidationRuleElement[] rules) → void
+ValidateAttached(ValidationContext ctx, ValidationAttached attached, object value) → void
+ValidateField(ValidationContext ctx, string fieldName, object value, IValidator[] validators) → void
+ValidateFieldAsync(ValidationContext ctx, string fieldName, object value, IAsyncValidator[] asyncValidators, CancellationToken cancellationToken = null) → Task
+
+### static class ValidationRuleDsl
+ValidationRule(Func<bool> predicate, string message, string field, Severity severity = Severity.Error) → ValidationRuleElement
+ValidationRuleAsync(Func<Task<bool>> asyncPredicate, string message, string field, Severity severity = Severity.Error) → ValidationRuleElement
+
 ### record ValidationRuleElement
 new(string Field, Func<bool> Predicate, string Message, Severity Severity = Severity.Error)
 Func<Task<bool>> AsyncPredicate { get; init; }
@@ -5747,6 +6018,10 @@ Equals(ValidationRuleElement other) → bool
 Equals(object obj) → bool
 GetHashCode() → int
 ToString() → string
+
+### static class ValidationVisualizerDsl
+ValidationVisualizer(Func<IReadOnlyList<ValidationMessage>, Element> render, Element content, Severity? severityFilter = null, ShowWhen showWhen = ShowWhen.Always) → ValidationVisualizerElement
+ValidationVisualizer(VisualizerStyle style, Element content, string title = null, Severity? severityFilter = null, ShowWhen showWhen = ShowWhen.Always) → ValidationVisualizerElement
 
 ### record ValidationVisualizerElement
 new(VisualizerStyle Style, Element Content)
@@ -5957,6 +6232,9 @@ Equals(XamlHostElement other) → bool
 Equals(object obj) → bool
 GetHashCode() → int
 ToString() → string
+
+### static class XamlInterop
+Register(Reconciler reconciler) → void
 
 ### class XamlMetaDataProvider
 new()

--- a/skills/reactor.api.txt
+++ b/skills/reactor.api.txt
@@ -884,7 +884,7 @@ RenderContext.UseDataSource<T>(IDataSource<T> source, DataRequest request, Infin
 RenderContext.UseDataSource<T>(IDataSource<T> source, DataRequest request, QueryCache cache, InfiniteResourceOptions options = null, IHookDispatcher dispatcher = null) → InfiniteResource<T>
 RenderContext.UseDevtools() → bool
 RenderContext.UseDisplays() → IReadOnlyList<DisplayInfo>
-RenderContext.UseDpi() → UInt32
+RenderContext.UseDpi() → uint
 RenderContext.UseEffect(Action effect, object[] dependencies) → void
 RenderContext.UseEffect(Func<Action> effectWithCleanup, object[] dependencies) → void
 RenderContext.UseEffect<T1, T2, T3>(Action effect, T1 d1, T2 d2, T3 d3) → void
@@ -1934,9 +1934,9 @@ ToString() → string
 ### record DisplayInfo
 Rect BoundsDip { get; init; }
 Rect WorkAreaDip { get; init; }
-UInt32 Dpi { get; init; }
 bool IsPrimary { get; init; }
 string Id { get; init; }
+uint Dpi { get; init; }
 Equals(DisplayInfo other) → bool
 Equals(object obj) → bool
 GetHashCode() → int
@@ -2105,7 +2105,7 @@ Combo<TValue>(IReadOnlyList<TValue> choices) → Func<object, Action<object>, El
 Date() → Func<object, Action<object>, Element>
 DateOffset() → Func<object, Action<object>, Element>
 DateOnly() → Func<object, Action<object>, Element>
-Decimal(Decimal? min = null, Decimal? max = null) → Func<object, Action<object>, Element>
+Decimal(decimal? min = null, decimal? max = null) → Func<object, Action<object>, Element>
 Double(double? min = null, double? max = null) → Func<object, Action<object>, Element>
 EnumCombo(Type enumType) → Func<object, Action<object>, Element>
 Float(float? min = null, float? max = null) → Func<object, Action<object>, Element>
@@ -2824,8 +2824,8 @@ GetString(string locale, string ns, string key) → string
 Validate(object value, string field) → ValidationMessage
 
 ### interface IWindowPersistenceStore
-TryRead(string id, ref Byte[] data) → bool
-Write(string id, Byte[] data) → void
+TryRead(string id, ref byte[] data) → bool
+Write(string id, byte[] data) → void
 
 ### record IconData
 Equals(IconData other) → bool
@@ -3109,8 +3109,8 @@ new()
 new(string path)
 string Path { get; }
 DefaultPath() → string
-TryRead(string id, ref Byte[] data) → bool
-Write(string id, Byte[] data) → void
+TryRead(string id, ref byte[] data) → bool
+Write(string id, byte[] data) → void
 
 ### static class JumpList
 bool ShowFrequent { get; set; }
@@ -3479,26 +3479,26 @@ ToString() → string
 new(string mask)
 int Length { get; }
 string Mask { get; }
-Apply(string input, Char placeholder = _) → string
-GetRawValue(string formatted, Char placeholder = _) → string
-IsComplete(string formatted, Char placeholder = _) → bool
+Apply(string input, char placeholder = '_') → string
+GetRawValue(string formatted, char placeholder = '_') → string
+IsComplete(string formatted, char placeholder = '_') → bool
 IsLiteral(int position) → bool
 NextInputPosition(int position) → int
 PreviousInputPosition(int position) → int
 
 ### static class MaskedTextBoxDsl
-MaskedTextBox(string value, Action<string> onChanged = null, string mask = null, string header = null, Char placeholder = _) → MaskedTextBoxElement
+MaskedTextBox(string value, Action<string> onChanged = null, string mask = null, string header = null, char placeholder = '_') → MaskedTextBoxElement
 
 ### record MaskedTextBoxElement
-new(string Value, Action<string> OnChanged = null, string Mask = null, string Header = null, Char Placeholder = _)
+new(string Value, Action<string> OnChanged = null, string Mask = null, string Header = null, char Placeholder = '_')
 Action<string> OnChanged { get; init; }
-Char Placeholder { get; init; }
 bool IsComplete { get; }
+char Placeholder { get; init; }
 string Header { get; init; }
 string Mask { get; init; }
 string RawValue { get; }
 string Value { get; init; }
-Deconstruct(ref string Value, ref Action<string> OnChanged, ref string Mask, ref string Header, ref Char Placeholder) → void
+Deconstruct(ref string Value, ref Action<string> OnChanged, ref string Mask, ref string Header, ref char Placeholder) → void
 Equals(Element other) → bool
 Equals(MaskedTextBoxElement other) → bool
 Equals(object obj) → bool
@@ -3932,8 +3932,8 @@ ToString() → string
 ### class PackagedSettingsStore
 new()
 IsAvailable() → bool
-TryRead(string id, ref Byte[] data) → bool
-Write(string id, Byte[] data) → void
+TryRead(string id, ref byte[] data) → bool
+Write(string id, byte[] data) → void
 
 ### record Page<TItem, TCursor>
 new(IReadOnlyList<TItem> Items, TCursor NextCursor, int? TotalCount = null)
@@ -4532,7 +4532,6 @@ ReactorHost Host { get; }
 TaskbarItem TaskbarItem { get; }
 TaskbarOverlay Overlay { get; }
 TaskbarProgress Progress { get; }
-UInt32 Dpi { get; }
 ValueTuple<double, double> Position { get; }
 Window NativeWindow { get; }
 WindowKey? Key { get; }
@@ -4543,6 +4542,7 @@ bool IsActive { get; }
 bool IsVisible { get; }
 double DipScale { get; }
 string Id { get; }
+uint Dpi { get; }
 Activate() → void
 BeginDragMove() → void
 CenterOnScreen() → void
@@ -4565,12 +4565,12 @@ Update(WindowSpec next) → void
 event EventHandler Activated
 event EventHandler Closed
 event EventHandler Deactivated
-event EventHandler<UInt32> DpiChanged
 event EventHandler<WindowClosingEventArgs> Closing
 event EventHandler<WindowDipPositionChangedEventArgs> PositionChanged
 event EventHandler<WindowDipSizeChangedEventArgs> SizeChanged
 event EventHandler<WindowState> StateChanged
 event EventHandler<WindowZOrderChangedEventArgs> ZOrderChanged
+event EventHandler<uint> DpiChanged
 
 ### class Reconciler
 new(ILogger logger = null)
@@ -4686,7 +4686,7 @@ UseCommand(Command command) → Command
 UseCommand<T>(Command<T> command) → Command<T>
 UseContext<T>(Context<T> context) → T
 UseDisplays() → IReadOnlyList<DisplayInfo>
-UseDpi() → UInt32
+UseDpi() → uint
 UseEffect(Action effect, object[] dependencies) → void
 UseEffect(Func<Action> effectWithCleanup, object[] dependencies) → void
 UseEffect<T1, T2, T3>(Action effect, T1 d1, T2 d2, T3 d3) → void

--- a/tests/Reactor.Tests/Tooling/ApiIndexGeneratorTests.cs
+++ b/tests/Reactor.Tests/Tooling/ApiIndexGeneratorTests.cs
@@ -95,6 +95,72 @@ public sealed class ApiIndexGeneratorTests
     }
 
     [Fact]
+    public void PublicTypes_Surfaces_ControlRegistry_Registration_Entry_Points()
+    {
+        // ControlRegistry is a public *static* class, and static classes used to be
+        // excluded from the index wholesale — so the frozen registration seam (and the
+        // API the unregistered-mount throw tells you to call) returned zero hits.
+        var block = TypeBlock(Generate(), "ControlRegistry");
+
+        Assert.Contains("Register<TElement, TControl>(", block);
+        Assert.Contains("RegisterDecorator<TElement>(", block);
+        Assert.Contains("RegisterForDerivedTypes<TBase, TControl>(", block);
+        Assert.Contains("RegisterDecoratorForDerivedTypes<TBase>(", block);
+    }
+
+    [Fact]
+    public void PublicTypes_Surfaces_ReactorApp_Entry_Points()
+    {
+        var block = TypeBlock(Generate(), "ReactorApp");
+
+        Assert.Contains("RegisterAllBuiltIns() → void", block);
+        Assert.Contains("Run(Action<ReactorAppContext> startup) → void", block);
+    }
+
+    [Fact]
+    public void PublicTypes_Does_Not_Duplicate_Theme_Tokens()
+    {
+        // Theme is a static class, so it now reaches Public types — but its ThemeRef
+        // tokens have their own dedicated section that also resolves each resource key.
+        // Emitting them twice would add ~36 strictly-less-informative lines.
+        var output = Generate();
+        var split = output.IndexOf("## Public types", StringComparison.Ordinal);
+        Assert.True(split > 0, "## Public types not found");
+
+        var beforePublicTypes = output[..split];
+        var publicTypes = output[split..];
+
+        Assert.Contains("Theme.SolidBackground", beforePublicTypes);
+        Assert.DoesNotContain("SolidBackground", publicTypes);
+
+        // The non-token member of Theme is still surfaced, so the type isn't just skipped.
+        Assert.Contains("Ref(string resourceKey) → ThemeRef", TypeBlock(output, "Theme"));
+    }
+
+    [Fact]
+    public void PublicTypes_Does_Not_Duplicate_Element_Modifier_Extensions()
+    {
+        // Extension methods can only live on a static class. Now that static classes are
+        // indexed, an unfiltered pass would emit every modifier a second time — byte
+        // identical, since both paths run through FormatMethod.
+        var output = Generate();
+        const string modifier = "T.Margin<T>(double horizontal, double vertical) → T";
+
+        Assert.Equal(1, CountOccurrences(output, modifier));
+    }
+
+    static int CountOccurrences(string haystack, string needle)
+    {
+        var n = 0;
+        for (var i = haystack.IndexOf(needle, StringComparison.Ordinal); i >= 0;
+             i = haystack.IndexOf(needle, i + needle.Length, StringComparison.Ordinal))
+        {
+            n++;
+        }
+        return n;
+    }
+
+    [Fact]
     public void Index_IsUpToDate()
     {
         var generated = Generate();

--- a/tests/Reactor.Tests/Tooling/ApiIndexGeneratorTests.cs
+++ b/tests/Reactor.Tests/Tooling/ApiIndexGeneratorTests.cs
@@ -161,6 +161,18 @@ public sealed class ApiIndexGeneratorTests
     }
 
     [Fact]
+    public void Signatures_Render_Char_Defaults_As_Pasteable_CSharp()
+    {
+        // The index exists to be copy-pasted, so a char parameter has to render as the
+        // C# keyword with a quoted default — `char placeholder = '_'`, never the raw
+        // metadata form `Char placeholder = _`, which does not compile.
+        var output = Generate();
+
+        Assert.Contains("char placeholder = '_'", output);
+        Assert.DoesNotContain("Char placeholder = _", output);
+    }
+
+    [Fact]
     public void Index_IsUpToDate()
     {
         var generated = Generate();

--- a/tests/Reactor.Tests/Tooling/ApiIndexGeneratorTests.cs
+++ b/tests/Reactor.Tests/Tooling/ApiIndexGeneratorTests.cs
@@ -130,14 +130,19 @@ public sealed class ApiIndexGeneratorTests
         var split = output.IndexOf("## Public types", StringComparison.Ordinal);
         Assert.True(split > 0, "## Public types not found");
 
-        var beforePublicTypes = output[..split];
-        var publicTypes = output[split..];
+        // The tokens must still be in their own section.
+        Assert.Contains("Theme.SolidBackground", output[..split]);
 
-        Assert.Contains("Theme.SolidBackground", beforePublicTypes);
-        Assert.DoesNotContain("SolidBackground", publicTypes);
+        // Scoped to the Theme block rather than all of ## Public types: a bare
+        // DoesNotContain("SolidBackground") over the whole section would break the day
+        // any unrelated public member happens to contain that substring.
+        var themeBlock = TypeBlock(output, "Theme");
+        Assert.DoesNotMatch(
+            new global::System.Text.RegularExpressions.Regex(@"ThemeRef \w+ \{ get;"),
+            themeBlock);
 
         // The non-token member of Theme is still surfaced, so the type isn't just skipped.
-        Assert.Contains("Ref(string resourceKey) → ThemeRef", TypeBlock(output, "Theme"));
+        Assert.Contains("Ref(string resourceKey) → ThemeRef", themeBlock);
     }
 
     [Fact]

--- a/tests/Reactor.Tests/Tooling/ApiIndexGeneratorTests.cs
+++ b/tests/Reactor.Tests/Tooling/ApiIndexGeneratorTests.cs
@@ -1,4 +1,7 @@
+using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using System.Text;
 using Microsoft.UI.Reactor.ApiIndex;
@@ -142,22 +145,68 @@ public sealed class ApiIndexGeneratorTests
     {
         // Extension methods can only live on a static class. Now that static classes are
         // indexed, an unfiltered pass would emit every modifier a second time — byte
-        // identical, since both paths run through FormatMethod.
+        // identical, since both paths run through FormatMethod. Structural oracle: no
+        // line emitted by ## Modifiers or ## Hooks may reappear under ## Public types.
         var output = Generate();
-        const string modifier = "T.Margin<T>(double horizontal, double vertical) → T";
 
-        Assert.Equal(1, CountOccurrences(output, modifier));
+        var modifierAndHookLines = SectionLines(output, "## Modifiers", "## Reference builders")
+            .Concat(SectionLines(output, "## Hooks", "## Theme tokens"))
+            .Where(l => l.Length > 0 && !l.StartsWith("#", StringComparison.Ordinal))
+            .ToHashSet(StringComparer.Ordinal);
+
+        Assert.NotEmpty(modifierAndHookLines);
+
+        var publicTypeLines = SectionLines(output, "## Public types", null)
+            .Where(l => l.Length > 0 && !l.StartsWith("#", StringComparison.Ordinal))
+            .ToList();
+
+        var duplicated = publicTypeLines.Where(modifierAndHookLines.Contains).Distinct(StringComparer.Ordinal).ToList();
+        Assert.True(
+            duplicated.Count == 0,
+            "Lines emitted by ## Modifiers / ## Hooks reappear under ## Public types:\n  " +
+            string.Join("\n  ", duplicated.Take(10)));
     }
 
-    static int CountOccurrences(string haystack, string needle)
+    [Fact]
+    public void PublicTypes_Surfaces_Extensions_No_Other_Section_Owns()
     {
-        var n = 0;
-        for (var i = haystack.IndexOf(needle, StringComparison.Ordinal); i >= 0;
-             i = haystack.IndexOf(needle, i + needle.Length, StringComparison.Ordinal))
-        {
-            n++;
-        }
-        return n;
+        // ## Modifiers only claims Element receivers and ## Hooks only RenderContext /
+        // Component ones. An extension whose receiver is neither — e.g. the RichText
+        // builders — is owned by nobody, so ## Public types has to carry it or it is
+        // absent from the index entirely.
+        //
+        // The assertions must be RECEIVER-QUALIFIED: a bare "TextIndent(" also matches
+        // RichTextBlockElement.TextIndent, which ## Modifiers emits either way, so it
+        // would pass even with these extensions filtered out.
+        var output = Generate();
+
+        Assert.Contains("RichTextParagraph.TextIndent(double indent) → RichTextParagraph", output);
+        Assert.Contains("RichTextParagraph.Margin(double uniform) → RichTextParagraph", output);
+        Assert.Contains("RichTextRun.", output);
+        Assert.Contains("RichTextHyperlink.", output);
+
+        // Cross-check against the declaring source so a rename fails loudly here rather
+        // than silently weakening the assertions above.
+        Assert.Contains("Margin(this RichTextParagraph", SourceOfRichTextExtensions());
+        Assert.Contains("TextIndent(this RichTextParagraph", SourceOfRichTextExtensions());
+    }
+
+    // Reads the declaring source so the test fails loudly if these extensions are ever
+    // renamed or moved, rather than silently passing against a stale expectation.
+    static string SourceOfRichTextExtensions() =>
+        File.ReadAllText(Path.Combine(RepoRoot(), "src", "Reactor", "Elements", "ElementExtensions.cs"));
+
+    // Lines strictly between `start` and the next `## ` heading (or `end` when given).
+    static IEnumerable<string> SectionLines(string output, string start, string? end)
+    {
+        var from = output.IndexOf(start, StringComparison.Ordinal);
+        Assert.True(from >= 0, start + " not found");
+        from += start.Length;
+
+        var to = end is null ? -1 : output.IndexOf(end, from, StringComparison.Ordinal);
+        if (to < 0) to = output.Length;
+
+        return output[from..to].Split('\n').Select(l => l.TrimEnd('\r'));
     }
 
     [Fact]
@@ -170,6 +219,57 @@ public sealed class ApiIndexGeneratorTests
 
         Assert.Contains("char placeholder = '_'", output);
         Assert.DoesNotContain("Char placeholder = _", output);
+    }
+
+    [Fact]
+    public void Signatures_Render_Value_Type_And_Generic_Defaults_As_Default_Not_Null()
+    {
+        // Reflection reports `= default` on a struct or generic parameter as a null
+        // constant. Emitting `null` there does not compile: CancellationToken is a
+        // struct, and `T x = null` is invalid for an unconstrained T.
+        var output = Generate();
+
+        Assert.DoesNotContain("CancellationToken cancellationToken = null", output);
+        Assert.Contains("CancellationToken cancellationToken = default", output);
+        Assert.Contains("T defaultValue = default", output);
+
+        // Reference-type defaults must still read `null`.
+        Assert.Contains("= null) →", output);
+    }
+
+    [Fact]
+    public void Numeric_Defaults_Are_Invariant_And_Carry_Their_Literal_Suffix()
+    {
+        // The index is committed twice and byte-compared by CI, so a culture-sensitive
+        // ToString would corrupt it on a comma-decimal machine. And `float x = 0.6` is
+        // not valid C# without the `f`.
+        var output = Generate();
+
+        Assert.Contains("float dampingRatio = 0.6f", output);
+        Assert.DoesNotContain("float dampingRatio = 0.6,", output);
+        Assert.DoesNotMatch(new global::System.Text.RegularExpressions.Regex(@"= \d+,\d+[,)]"), output);
+    }
+
+    [Fact]
+    public void Generator_Output_Is_Culture_Invariant()
+    {
+        // Directly pins the determinism property rather than inferring it from the text:
+        // regenerating under a comma-decimal culture must produce identical bytes.
+        var original = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("de-DE");
+            var underGerman = Generate();
+
+            CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
+            var underInvariant = Generate();
+
+            Assert.Equal(underInvariant, underGerman);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = original;
+        }
     }
 
     [Fact]
@@ -194,6 +294,27 @@ public sealed class ApiIndexGeneratorTests
                 "skills/reactor.api.txt is stale. Regenerate by running:\n" +
                 "  $env:UPDATE_API_INDEX=1; dotnet test tests/Reactor.Tests --filter \"FullyQualifiedName~Tooling.ApiIndexGeneratorTests.Index_IsUpToDate\" -p:SkipSignaturesGen=true -p:SkipReactorApiGen=true -r win-arm64\n" +
                 "First diff: " + FirstDiffPreview(committed, generated));
+        }
+    }
+
+    [Fact]
+    public void Every_Committed_Copy_Matches_The_Generator()
+    {
+        // The index is committed TWICE — `skills/` for `mur --api` / the agentkit NuGet
+        // layout, and `plugins/.../references/` for the reactor-dsl skill. Both are packed
+        // independently, and Index_IsUpToDate only ever compared the first, so the mirror
+        // could drift silently and still ship.
+        var generated = Generate();
+
+        foreach (var path in OutputPaths())
+        {
+            Assert.True(File.Exists(path), $"Committed API index copy is missing: {path}");
+            if (File.ReadAllText(path) != generated)
+            {
+                throw new Xunit.Sdk.XunitException(
+                    $"{path} is stale. Regenerate with the UPDATE_API_INDEX=1 command in Index_IsUpToDate.\n" +
+                    "First diff: " + FirstDiffPreview(File.ReadAllText(path), generated));
+            }
         }
     }
 

--- a/tests/Reactor.Tests/Tooling/ApiIndexGeneratorTests.cs
+++ b/tests/Reactor.Tests/Tooling/ApiIndexGeneratorTests.cs
@@ -193,8 +193,11 @@ public sealed class ApiIndexGeneratorTests
 
     // Reads the declaring source so the test fails loudly if these extensions are ever
     // renamed or moved, rather than silently passing against a stale expectation.
+    // Path.Join rather than Path.Combine: Combine discards everything before a segment
+    // that looks rooted, which is a silent-wrong-path hazard even when the segments are
+    // constants (CodeQL flags it).
     static string SourceOfRichTextExtensions() =>
-        File.ReadAllText(Path.Combine(RepoRoot(), "src", "Reactor", "Elements", "ElementExtensions.cs"));
+        File.ReadAllText(Path.Join(RepoRoot(), "src", "Reactor", "Elements", "ElementExtensions.cs"));
 
     // Lines strictly between `start` and the next `## ` heading (or `end` when given).
     static IEnumerable<string> SectionLines(string output, string start, string? end)

--- a/tools/Reactor.ApiIndex/ApiIndexGenerator.cs
+++ b/tools/Reactor.ApiIndex/ApiIndexGenerator.cs
@@ -51,8 +51,12 @@ public static class ApiIndexGenerator
         sb.AppendLine("#             AfterBuild target rewrites this file).");
         sb.AppendLine("# Format: one symbol per line. No prose. Alphabetized within each section.");
         sb.AppendLine("# Sections: Factories, Modifiers, Reference builders, Hooks, Theme, Enums, Public types.");
-        sb.AppendLine("# Public types now ARE covered — ctors/properties/methods/events on every");
-        sb.AppendLine("# public type (e.g. WindowSpec.Opacity, ReactorWindow.SetPosition).");
+        sb.AppendLine("# Public types covers ctors/properties/methods/events on every public type,");
+        sb.AppendLine("# including public *static* classes — so process-wide entry points such as");
+        sb.AppendLine("# ControlRegistry.Register and ReactorApp.Run are listed there, alongside");
+        sb.AppendLine("# instance members like WindowSpec.Opacity and ReactorWindow.SetPosition.");
+        sb.AppendLine("# Extension methods are listed under Modifiers/Hooks in the fluent form you");
+        sb.AppendLine("# call them, not again under their declaring static class.");
         sb.AppendLine();
 
         EmitFactories(asm, sb);
@@ -312,6 +316,7 @@ public static class ApiIndexGenerator
             // Properties (instance + static), excluding indexers.
             var props = t.GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly)
                 .Where(p => p.GetIndexParameters().Length == 0)
+                .Where(p => !IsThemeToken(t, p))
                 .Where(p => !IsObsolete(p))
                 .Select(FormatProperty)
                 .Where(s => s is not null)
@@ -320,8 +325,12 @@ public static class ApiIndexGenerator
 
             // Public DeclaredOnly methods — instance AND static (symmetric with the
             // property query). `IsSpecialName` filters operator overloads / accessors.
+            // Extension methods are skipped: they can only live on a static class, and
+            // the `## Modifiers` / `## Hooks` sections already emit them in the form an
+            // author actually calls (`.Margin(...)` rather than `Margin(Element, ...)`).
             var methods = t.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly)
                 .Where(m => !m.IsSpecialName)
+                .Where(m => !IsExtensionMethod(m))
                 .Where(m => !m.Name.Contains('<') && !m.Name.Contains('>'))
                 .Where(m => !IsObsolete(m))
                 .Select(FormatMethod);
@@ -341,12 +350,20 @@ public static class ApiIndexGenerator
     {
         if (t.FullName == "Microsoft.UI.Reactor.Factories") return false;
         if (t.IsEnum) return false;
-        if (t.IsClass && t.IsAbstract && t.IsSealed) return false;     // static class
         if (typeof(Delegate).IsAssignableFrom(t)) return false;
         if (t.Name.Contains('<') || t.Name.Contains('>')) return false; // compiler-generated
         if (IsObsolete(t)) return false;
         return true;
     }
+
+    // The `## Theme tokens` section already lists every ThemeRef on Theme, with its
+    // resolved resource key. Re-emitting them as ordinary static properties here would
+    // duplicate that whole block with strictly less information.
+    static bool IsThemeToken(Type t, PropertyInfo p) =>
+        t.FullName == "Microsoft.UI.Reactor.Core.Theme" && p.PropertyType.Name == "ThemeRef";
+
+    static bool IsExtensionMethod(MethodInfo m) =>
+        m.IsDefined(typeof(global::System.Runtime.CompilerServices.ExtensionAttribute), false);
 
     [RequiresUnreferencedCode(ReflectionJustification)]
     static string KindOf(Type t)
@@ -356,6 +373,7 @@ public static class ApiIndexGenerator
         if (t.GetMethod("<Clone>$", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance) is not null)
             return "record";
         if (t.IsValueType) return "struct";
+        if (t.IsClass && t.IsAbstract && t.IsSealed) return "static class";
         return "class";
     }
 

--- a/tools/Reactor.ApiIndex/ApiIndexGenerator.cs
+++ b/tools/Reactor.ApiIndex/ApiIndexGenerator.cs
@@ -16,6 +16,7 @@
 // (which treats trimming/AOT warnings as errors).
 
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Reflection;
 using System.Text;
 
@@ -55,8 +56,9 @@ public static class ApiIndexGenerator
         sb.AppendLine("# including public *static* classes — so process-wide entry points such as");
         sb.AppendLine("# ControlRegistry.Register and ReactorApp.Run are listed there, alongside");
         sb.AppendLine("# instance members like WindowSpec.Opacity and ReactorWindow.SetPosition.");
-        sb.AppendLine("# Extension methods are listed under Modifiers/Hooks in the fluent form you");
-        sb.AppendLine("# call them, not again under their declaring static class.");
+        sb.AppendLine("# Extension methods with an Element receiver are listed under Modifiers, and");
+        sb.AppendLine("# RenderContext/Component ones under Hooks, in the fluent form you call them;");
+        sb.AppendLine("# any other extension is listed under its declaring class.");
         sb.AppendLine();
 
         EmitFactories(asm, sb);
@@ -190,12 +192,12 @@ public static class ApiIndexGenerator
         sb.AppendLine("# Each token resolves to the WinUI resource key shown in the comment.");
         sb.AppendLine();
 
-        var theme = asm.GetType("Microsoft.UI.Reactor.Core.Theme");
+        var theme = asm.GetType(ThemeTypeFullName);
         if (theme is null) { sb.AppendLine(); return; }
 
         var properties = theme
             .GetProperties(BindingFlags.Public | BindingFlags.Static)
-            .Where(p => p.PropertyType.Name == "ThemeRef")
+            .Where(IsThemeRefProperty)
             .Where(p => !IsObsolete(p))
             .OrderBy(p => p.Name, StringComparer.Ordinal);
 
@@ -325,12 +327,15 @@ public static class ApiIndexGenerator
 
             // Public DeclaredOnly methods — instance AND static (symmetric with the
             // property query). `IsSpecialName` filters operator overloads / accessors.
-            // Extension methods are skipped: they can only live on a static class, and
-            // the `## Modifiers` / `## Hooks` sections already emit them in the form an
-            // author actually calls (`.Margin(...)` rather than `Margin(Element, ...)`).
+            // Extension methods are skipped ONLY when an earlier section already owns
+            // them: `## Modifiers` emits the Element-receiver ones and `## Hooks` the
+            // RenderContext/Component ones, both in the fluent form an author actually
+            // calls. An extension owned by neither (e.g. the RichTextParagraph /
+            // RichTextRun / RichTextHyperlink builders, whose receiver is not an Element)
+            // must still be listed here, or it appears nowhere in the index at all.
             var methods = t.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly)
                 .Where(m => !m.IsSpecialName)
-                .Where(m => !IsExtensionMethod(m))
+                .Where(m => !IsOwnedByEarlierSection(m))
                 .Where(m => !m.Name.Contains('<') && !m.Name.Contains('>'))
                 .Where(m => !IsObsolete(m))
                 .Select(FormatMethod);
@@ -360,10 +365,24 @@ public static class ApiIndexGenerator
     // resolved resource key. Re-emitting them as ordinary static properties here would
     // duplicate that whole block with strictly less information.
     static bool IsThemeToken(Type t, PropertyInfo p) =>
-        t.FullName == "Microsoft.UI.Reactor.Core.Theme" && p.PropertyType.Name == "ThemeRef";
+        IsThemeType(t) && IsThemeRefProperty(p);
+
+    // Shared by EmitTheme and the Public-types skip above so the two cannot disagree
+    // about what a theme token is.
+    const string ThemeTypeFullName = "Microsoft.UI.Reactor.Core.Theme";
+
+    static bool IsThemeType(Type t) => t.FullName == ThemeTypeFullName;
+
+    static bool IsThemeRefProperty(PropertyInfo p) => p.PropertyType.Name == "ThemeRef";
 
     static bool IsExtensionMethod(MethodInfo m) =>
         m.IsDefined(typeof(global::System.Runtime.CompilerServices.ExtensionAttribute), false);
+
+    // True only for extension methods a specialized section already emits: `## Modifiers`
+    // (Element receivers) and `## Hooks` (RenderContext / Component receivers). Any other
+    // extension is owned by nobody, so `## Public types` must keep it.
+    static bool IsOwnedByEarlierSection(MethodInfo m) =>
+        IsExtensionMethod(m) && (IsElementExtension(m) || IsHookExtension(m));
 
     [RequiresUnreferencedCode(ReflectionJustification)]
     static string KindOf(Type t)
@@ -490,24 +509,56 @@ public static class ApiIndexGenerator
 
     static string FormatDefault(object? v, Type t)
     {
-        if (v is null) return "null";
+        // Reflection reports `= default` on a non-nullable value type or a generic
+        // parameter as a *null* constant. Emitting `null` there is not merely imprecise,
+        // it does not compile — `CancellationToken ct = null` is a type error.
+        if (v is null)
+        {
+            return t.IsGenericParameter || (t.IsValueType && Nullable.GetUnderlyingType(t) is null)
+                ? "default"
+                : "null";
+        }
+
         if (v is bool b) return b ? "true" : "false";
         if (v is string s) return "\"" + s + "\"";
         // A char default has to carry its quotes and escapes, or the signature is not
         // pasteable C# (`placeholder = _` instead of `placeholder = '_'`).
         if (v is char c) return "'" + EscapeChar(c) + "'";
         if (t.IsEnum) return t.Name + "." + v;
-        return v.ToString() ?? "?";
+        return FormatNumeric(v);
     }
+
+    // Numeric literals must be culture-invariant and carry the suffix their type needs.
+    // Without the invariant culture a comma-decimal machine regenerates `0.6` as `0,6`,
+    // which silently corrupts a file that is committed twice and byte-compared by CI;
+    // without the suffix `float x = 0.6` is not valid C#.
+    static string FormatNumeric(object v) => v switch
+    {
+        float f => f.ToString("R", CultureInfo.InvariantCulture) + "f",
+        double d => d.ToString("R", CultureInfo.InvariantCulture),
+        decimal m => m.ToString(CultureInfo.InvariantCulture) + "m",
+        uint u => u.ToString(CultureInfo.InvariantCulture) + "u",
+        long l => l.ToString(CultureInfo.InvariantCulture) + "L",
+        ulong ul => ul.ToString(CultureInfo.InvariantCulture) + "UL",
+        IFormattable formattable => formattable.ToString(null, CultureInfo.InvariantCulture),
+        _ => v.ToString() ?? "?",
+    };
 
     static string EscapeChar(char c) => c switch
     {
         '\'' => "\\'",
         '\\' => "\\\\",
         '\0' => "\\0",
+        '\a' => "\\a",
+        '\b' => "\\b",
+        '\f' => "\\f",
         '\n' => "\\n",
         '\r' => "\\r",
         '\t' => "\\t",
+        '\v' => "\\v",
+        // Anything else non-printable (control chars, lone surrogates) has no literal
+        // spelling, so escape it numerically rather than emitting a raw byte.
+        _ when char.IsControl(c) || char.IsSurrogate(c) => "\\u" + ((int)c).ToString("x4", CultureInfo.InvariantCulture),
         _ => c.ToString(),
     };
 

--- a/tools/Reactor.ApiIndex/ApiIndexGenerator.cs
+++ b/tools/Reactor.ApiIndex/ApiIndexGenerator.cs
@@ -493,9 +493,23 @@ public static class ApiIndexGenerator
         if (v is null) return "null";
         if (v is bool b) return b ? "true" : "false";
         if (v is string s) return "\"" + s + "\"";
+        // A char default has to carry its quotes and escapes, or the signature is not
+        // pasteable C# (`placeholder = _` instead of `placeholder = '_'`).
+        if (v is char c) return "'" + EscapeChar(c) + "'";
         if (t.IsEnum) return t.Name + "." + v;
         return v.ToString() ?? "?";
     }
+
+    static string EscapeChar(char c) => c switch
+    {
+        '\'' => "\\'",
+        '\\' => "\\\\",
+        '\0' => "\\0",
+        '\n' => "\\n",
+        '\r' => "\\r",
+        '\t' => "\\t",
+        _ => c.ToString(),
+    };
 
     // Compact type display: drop System.* / WinUI namespaces, keep generics.
     static string Short(Type t)
@@ -520,10 +534,18 @@ public static class ApiIndexGenerator
             "Void" => "void",
             "Boolean" => "bool",
             "String" => "string",
+            "Char" => "char",
+            "Byte" => "byte",
+            "SByte" => "sbyte",
+            "Int16" => "short",
+            "UInt16" => "ushort",
             "Int32" => "int",
+            "UInt32" => "uint",
             "Int64" => "long",
+            "UInt64" => "ulong",
             "Double" => "double",
             "Single" => "float",
+            "Decimal" => "decimal",
             "Object" => "object",
             _ => t.Name,
         };


### PR DESCRIPTION
## Summary

`skills/reactor.api.txt` — the API index shipped in the agent kit — claims to cover "every public type", but silently excluded **every public static class**. That hid `ControlRegistry` and `ReactorApp` entirely. Both are named in the unregistered-mount throw reworded in #933, so an agent following that message's advice could not find either signature in the index.

## Linked issue / spec

- Found while doing #163 / spec-062 E2 (#934), which documents `ControlRegistry.Register*` as the §8 escape hatch

## Root cause

`ApiIndexGenerator.IsIndexablePublicType` had a blanket exclusion:

```csharp
if (t.IsClass && t.IsAbstract && t.IsSealed) return false;     // static class
```

The exclusion isn't unreasonable on its face — most static classes in this assembly are extension-method holders, and those *are* covered, by `## Modifiers` and `## Hooks`. `Factories` and `Theme` have dedicated sections too. But a static class holding **ordinary static members** was covered nowhere, and nothing flagged it because the exclusion is type-level.

`EmitPublicTypes` already queried `BindingFlags.Static` for properties, methods and events — so the members were always reachable. Only the type filter stood in the way.

## Fix

Drop the type-level exclusion; instead skip the *members* that other sections own:

- **Extension methods** — they can only live on a static class, and `## Modifiers` / `## Hooks` already emit them in the fluent form you actually call (`T.Margin<T>(…) → T`, not `Margin(Element, …)`). Without this filter every modifier would appear twice, byte-identical, since both paths run through `FormatMethod`.
- **`Theme`'s `ThemeRef` tokens** — `## Theme tokens` already lists all 36 *and* resolves each resource key, so re-emitting them here would add strictly-less-informative duplicates. `Theme` still surfaces its one non-token member, `Ref(string resourceKey) → ThemeRef`, which was previously invisible.

Pure-extension holders now emit nothing at all — the existing header-on-first-line logic suppresses empty blocks, so `ElementExtensions` and friends produce no header.

Static classes are labelled `### static class X` so the kind is obvious.

## Result

+281 lines (~4.6%), covering **43** previously-invisible public static classes:

```
### static class ControlRegistry
   Register<TElement, TControl>(Func<IElementHandler<TElement, TControl>> handlerFactory) → void
   RegisterDecorator<TElement>(Func<IDecoratorElementHandler<TElement>> handlerFactory) → void
   RegisterDecoratorForDerivedTypes<TBase>(Func<IDecoratorElementHandler<TBase>> handlerFactory) → void
   RegisterForDerivedTypes<TBase, TControl>(Func<IElementHandler<TBase, TControl>> handlerFactory) → void
```

`ReactorApp` gains `RegisterAllBuiltIns()`, all three `Run` overloads, `OpenWindow`, the window/tray events and its static properties. Also newly visible: `XamlInterop`, `StandardCommand`, `Validate`, `ThemeResource`, `Animations`, `AnimationScope`, `ReactorDiagnostics`, `PathDataParser`, and others.

**Exactly one existing line changed**, and it's an improvement: `### class FocusManager` became `### class FocusManager (in Microsoft.UI.Reactor.Hooks)`, because the static `Microsoft.UI.Reactor.Input.FocusManager` now also appears and trips the generator's existing namespace-disambiguation for colliding simple names.

The header now states the rule, since that's the first thing an agent reads.

## Test plan

- [x] **4 new regression tests**, each **mutation-checked** — restoring the static-class exclusion fails the `ControlRegistry` and `ReactorApp` tests; dropping the extension filter fails the modifier-duplication test; dropping the Theme filter fails the token-duplication test. All four verified to fail, then the source verified restored.
- [x] `dotnet test tests/Reactor.Tests` → **12,528 passed, 0 failed** (12,524 baseline + 4 new), clean rebuild
- [x] `ExistingSections_Unchanged` and `Index_IsUpToDate` both green — the five pre-existing sections are byte-identical
- [x] Both committed copies regenerated via the documented `UPDATE_API_INDEX=1` path and verified **byte-identical to each other** by hash
- [x] `tools/Reactor.ApiIndex` and `tools/Reactor.SignaturesGen` build **0 warnings / 0 errors** — no new IL2026/IL3050

## Risk / breaking changes

**None to product code** — this is a build-time index generator plus its generated output. No runtime API changes. The index only grows; nothing that was findable before became unfindable.

Fixes: #163