### PR TITLE
Detect package identity without throwing

### DIFF
--- a/docs/specs/035-demo-script-tool-design.md
+++ b/docs/specs/035-demo-script-tool-design.md
@@ -785,9 +785,12 @@ shareable installer.
 
 Both modes share the same `App` assembly and component code — only the
 `.csproj` head changes. There must be no `#if PACKAGED` divergence in
-component code; runtime mode is detected at startup if needed via
-`Windows.ApplicationModel.Package.Current` (wrapped in a try/catch since
-unpackaged throws).
+component code; runtime mode is detected at startup if needed via the
+non-throwing Win32 `GetCurrentPackageFullName` probe
+(`APPMODEL_ERROR_NO_PACKAGE` ⇒ unpackaged), the same mechanism
+`Microsoft.UI.Reactor`'s own `PackageRuntime` uses. Do not probe
+`Windows.ApplicationModel.Package.Current`: it reports "unpackaged" by
+throwing, so it raises a first-chance exception on every unpackaged launch.
 
 ### Project layout addition
 

--- a/docs/specs/tasks/035-demo-script-tool-implementation.md
+++ b/docs/specs/tasks/035-demo-script-tool-implementation.md
@@ -15,7 +15,11 @@ Conventions:
 - The unpackaged head (`App/DemoScriptTool.csproj`) is the F5 default; the
   packaged head (`Package/DemoScriptTool.Package.wapproj`) builds the MSIX.
 - Component code must not branch on packaged vs. unpackaged via `#if`; runtime
-  detection through `Windows.ApplicationModel.Package.Current` only.
+  detection through the non-throwing Win32 `GetCurrentPackageFullName` probe
+  (`APPMODEL_ERROR_NO_PACKAGE` ⇒ unpackaged), mirroring Reactor's own
+  `Hosting.Shell.PackageRuntime`. Never probe
+  `Windows.ApplicationModel.Package.Current`: it reports "unpackaged" by
+  throwing, so it raises a first-chance exception on every unpackaged launch.
 - Selftest fixtures live under `tests/Reactor.AppTests.Host/SelfTest/Fixtures/`
   matching existing samples; UI-driver tests under `tests/Reactor.AppTests/`.
 - Public services expose `IDisposable` / cancellation tokens — every long-lived
@@ -375,7 +379,7 @@ A task is "done" only when:
 
 - [ ] `F5` against `Package/DemoScriptTool.Package.wapproj` launches the packaged app under MSIX deployment.
 - [ ] Verify Mica still renders in the packaged head (Mica-on-MSIX is a known-working but worth-confirming combo).
-- [ ] Verify `Windows.ApplicationModel.Package.Current` works in packaged mode and throws/returns null in unpackaged mode (try/catch as spec §Run modes prescribes — record the exact behavior in a comment).
+- [ ] Verify the `GetCurrentPackageFullName` probe reports package identity in packaged mode and `APPMODEL_ERROR_NO_PACKAGE` in unpackaged mode, and that neither raises a first-chance exception.
 - [ ] Smoke test: install via `build/install.ps1` on a clean Windows 11 VM and confirm "Demo Script Tool" appears in Start, launches, opens a folder, and runs a step.
 
 ---

--- a/docs/specs/tasks/036-window-design-implementation.md
+++ b/docs/specs/tasks/036-window-design-implementation.md
@@ -24,7 +24,10 @@ Conventions:
   036 § number, and a `PublicAPI.Unshipped.txt` entry if the project uses
   the public-API analyzer (verify per project — see Phase 0).
 - Component code must not branch on packaged vs. unpackaged via `#if`;
-  runtime detection through `Windows.ApplicationModel.Package.Current` only.
+  runtime detection through `Hosting.Shell.PackageRuntime.IsPackaged` only.
+  That helper wraps the non-throwing Win32 `GetCurrentPackageFullName` probe —
+  never `Windows.ApplicationModel.Package.Current`, which reports "unpackaged"
+  by throwing and so raises a first-chance exception on every unpackaged launch.
 - "Production-quality fundamentals" applied per phase: input validation,
   threading (UI vs. arbitrary), disposal, logging, localization,
   accessibility, exception safety, trim/AOT-safety. Tasks call these out

--- a/src/Reactor/Hosting/Persistence/PackagedSettingsStore.cs
+++ b/src/Reactor/Hosting/Persistence/PackagedSettingsStore.cs
@@ -13,8 +13,8 @@ namespace Microsoft.UI.Reactor.Hosting.Persistence;
 /// <remarks>
 /// <para>Constructing this store from an unpackaged process throws on first
 /// access (the WinRT API requires package identity). Callers must check
-/// <c>Windows.ApplicationModel.Package.Current</c> before instantiating, or
-/// fall back to <see cref="JsonFileStore"/>.</para>
+/// <see cref="IsAvailable"/> before instantiating, or fall back to
+/// <see cref="JsonFileStore"/>.</para>
 /// <para>All read failures (missing key, type mismatch) return <c>false</c>;
 /// write failures are swallowed with a stderr diagnostic.</para>
 /// </remarks>
@@ -112,18 +112,5 @@ public sealed class PackagedSettingsStore : IWindowPersistenceStore
     /// context still works at construction time; this static check lets
     /// auto-detection logic pick the right default.
     /// </summary>
-    public static bool IsAvailable()
-    {
-        try
-        {
-            // Touching Package.Current throws InvalidOperationException
-            // (HRESULT 0x80073D54) under unpackaged contexts.
-            _ = global::Windows.ApplicationModel.Package.Current;
-            return true;
-        }
-        catch
-        {
-            return false;
-        }
-    }
+    public static bool IsAvailable() => Shell.PackageRuntime.IsPackaged;
 }

--- a/src/Reactor/Hosting/Shell/PackageRuntime.cs
+++ b/src/Reactor/Hosting/Shell/PackageRuntime.cs
@@ -1,3 +1,5 @@
+using System.Runtime.InteropServices;
+
 namespace Microsoft.UI.Reactor.Hosting.Shell;
 
 /// <summary>
@@ -7,8 +9,22 @@ namespace Microsoft.UI.Reactor.Hosting.Shell;
 /// fallback path before the WinRT call. (spec 036 §11.3, §0.5 — no
 /// <c>#if PACKAGED</c> branching anywhere.)
 /// </summary>
-internal static class PackageRuntime
+/// <remarks>
+/// Detection goes through the Win32 <c>GetCurrentPackageFullName</c> probe rather
+/// than <c>Windows.ApplicationModel.Package.Current</c>: the WinRT property answers
+/// "unpackaged" by <em>throwing</em> <see cref="InvalidOperationException"/>
+/// (HRESULT 0x80073D54, "the process has no package identity"), so every unpackaged
+/// launch used to raise a first-chance exception that polluted the debugger, the
+/// exception log, and any crash telemetry the host wires up — masking the real
+/// first-chance exceptions those tools exist to surface.
+/// </remarks>
+internal static partial class PackageRuntime
 {
+    // winerror.h / appmodel.h return codes for the identity probe below.
+    private const int ErrorSuccess = 0;
+    private const int ErrorInsufficientBuffer = 122;
+    private const int AppmodelErrorNoPackage = 15700;
+
     private static int _isPackagedComputed;
     private static int _isPackaged;
 
@@ -20,22 +36,48 @@ internal static class PackageRuntime
             if (Volatile.Read(ref _isPackagedComputed) != 0)
                 return Volatile.Read(ref _isPackaged) != 0;
 
-            bool packaged;
-            try
-            {
-                // Package.Current throws InvalidOperationException on unpackaged.
-                _ = global::Windows.ApplicationModel.Package.Current;
-                packaged = true;
-            }
-            catch
-            {
-                packaged = false;
-            }
+            bool packaged = IsPackagedIdentityCode(QueryPackageIdentityCode());
             Volatile.Write(ref _isPackaged, packaged ? 1 : 0);
             Volatile.Write(ref _isPackagedComputed, 1);
             return packaged;
         }
     }
+
+    /// <summary>
+    /// Non-throwing package-identity probe. Passing a null buffer with a zero
+    /// length asks only the identity question — the name itself is never needed.
+    /// </summary>
+    /// <returns>
+    /// The raw <c>GetCurrentPackageFullName</c> status code; feed it to
+    /// <see cref="IsPackagedIdentityCode"/> to get the verdict.
+    /// </returns>
+    internal static int QueryPackageIdentityCode()
+    {
+        uint length = 0;
+        // No try/catch: GetCurrentPackageFullName has been exported from
+        // kernel32 since Windows 8 and this assembly's TargetPlatformMinVersion
+        // is 10.0.17763.0, so the entry point always resolves.
+        return GetCurrentPackageFullName(ref length, nint.Zero);
+    }
+
+    /// <summary>
+    /// Maps a <see cref="QueryPackageIdentityCode"/> status onto the packaged
+    /// verdict. A process with identity reports <c>ERROR_INSUFFICIENT_BUFFER</c>
+    /// (the full name doesn't fit in zero characters); one without reports
+    /// <c>APPMODEL_ERROR_NO_PACKAGE</c>. Any other code is unexpected and reads as
+    /// unpackaged, matching the conservative fallback the previous try/catch gave.
+    /// </summary>
+    internal static bool IsPackagedIdentityCode(int code) => code switch
+    {
+        ErrorSuccess or ErrorInsufficientBuffer => true,
+        AppmodelErrorNoPackage => false,
+        _ => false,
+    };
+
+    // Blittable signature only (uint by-ref + native int), so the source-generated
+    // marshalling stub stays trim/AOT-clean.
+    [LibraryImport("kernel32.dll")]
+    private static partial int GetCurrentPackageFullName(ref uint packageFullNameLength, nint packageFullName);
 
     internal static void ResetForTests()
     {

--- a/src/Reactor/Hosting/Shell/PackageRuntime.cs
+++ b/src/Reactor/Hosting/Shell/PackageRuntime.cs
@@ -44,8 +44,14 @@ internal static partial class PackageRuntime
     }
 
     /// <summary>
-    /// Non-throwing package-identity probe. Passing a null buffer with a zero
-    /// length asks only the identity question — the name itself is never needed.
+    /// Non-throwing package-identity probe. <c>packageFullName</c> is documented
+    /// <c>[out, optional]</c>, so passing <c>NULL</c> with a zero length asks only the
+    /// identity question — the name itself is never needed here. The documented status
+    /// codes are <c>ERROR_SUCCESS</c>, <c>APPMODEL_ERROR_NO_PACKAGE</c> ("the process has
+    /// no package identity") and <c>ERROR_INSUFFICIENT_BUFFER</c> ("the buffer is not
+    /// large enough to hold the data"), the last being what a process that *does* have
+    /// identity reports for a zero-length buffer. <c>ERROR_INVALID_PARAMETER</c> is not a
+    /// documented outcome for this call shape.
     /// </summary>
     /// <returns>
     /// The raw <c>GetCurrentPackageFullName</c> status code; feed it to
@@ -75,7 +81,8 @@ internal static partial class PackageRuntime
     };
 
     // Blittable signature only (uint by-ref + native int), so the source-generated
-    // marshalling stub stays trim/AOT-clean.
+    // marshalling stub stays trim/AOT-clean. The return is `int` because the documented
+    // Win32 signature returns LONG (signed 32-bit), not DWORD.
     [LibraryImport("kernel32.dll")]
     private static partial int GetCurrentPackageFullName(ref uint packageFullNameLength, nint packageFullName);
 

--- a/tests/Reactor.Tests/PackageRuntimeTests.cs
+++ b/tests/Reactor.Tests/PackageRuntimeTests.cs
@@ -1,0 +1,188 @@
+using System.Reflection;
+using System.Runtime.ExceptionServices;
+using System.Runtime.InteropServices;
+using Microsoft.UI.Reactor.Hosting.Shell;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests;
+
+/// <summary>
+/// Captures the first-chance exceptions a delegate raises on the calling thread.
+/// <see cref="AppDomain.FirstChanceException"/> fires for every exception the CLR
+/// dispatches, whether or not it is caught — which is exactly what a debugger, an
+/// exception log, or crash telemetry sees. Observations are filtered to the calling
+/// thread so unrelated work elsewhere in the process can never be miscounted.
+/// </summary>
+internal static class FirstChanceExceptionProbe
+{
+    public static IReadOnlyList<Exception> Capture(Action action)
+    {
+        int probeThreadId = Environment.CurrentManagedThreadId;
+        var observed = new List<Exception>();
+
+        void OnFirstChance(object? sender, FirstChanceExceptionEventArgs e)
+        {
+            if (Environment.CurrentManagedThreadId == probeThreadId)
+                observed.Add(e.Exception);
+        }
+
+        AppDomain.CurrentDomain.FirstChanceException += OnFirstChance;
+        try
+        {
+            action();
+        }
+        finally
+        {
+            AppDomain.CurrentDomain.FirstChanceException -= OnFirstChance;
+        }
+
+        return observed;
+    }
+
+    /// <summary>Renders captured exceptions for an assertion failure message.</summary>
+    public static string Describe(IReadOnlyList<Exception> observed)
+        => string.Join("; ", observed.Select(e => $"{e.GetType().FullName}: {e.Message}"));
+}
+
+/// <summary>
+/// Overwrites <see cref="PackageRuntime"/>'s cached identity verdict so tests can exercise
+/// the packaged arm from an unpackaged host, where the live probe can only ever say
+/// "unpackaged". Disposing restores the normal (recompute-on-next-read) state.
+/// </summary>
+internal static class PackageIdentityCache
+{
+    public static IDisposable Force(bool packaged)
+    {
+        var valueField = typeof(PackageRuntime).GetField(
+            "_isPackaged", BindingFlags.NonPublic | BindingFlags.Static);
+        var computedField = typeof(PackageRuntime).GetField(
+            "_isPackagedComputed", BindingFlags.NonPublic | BindingFlags.Static);
+        // Fail loudly if the cache fields are renamed rather than silently passing.
+        Assert.NotNull(valueField);
+        Assert.NotNull(computedField);
+
+        valueField!.SetValue(null, packaged ? 1 : 0);
+        computedField!.SetValue(null, 1);
+        return new Restore();
+    }
+
+    private sealed class Restore : IDisposable
+    {
+        public void Dispose() => PackageRuntime.ResetForTests();
+    }
+}
+
+/// <summary>
+/// Spec 036 §11.3 — <see cref="PackageRuntime"/> answers "is this process running
+/// under an MSIX package identity?".
+/// </summary>
+/// <remarks>
+/// The detection used to probe <c>Windows.ApplicationModel.Package.Current</c> inside a
+/// try/catch. That property signals "unpackaged" by <em>throwing</em>
+/// <c>InvalidOperationException</c> (HRESULT 0x80073D54, "the process has no package
+/// identity"), so every unpackaged launch raised a first-chance exception into the
+/// debugger, the exception log, and any crash telemetry the host wires up — drowning the
+/// real first-chance exceptions those tools exist to surface. Detection now goes through
+/// the non-throwing Win32 <c>GetCurrentPackageFullName</c> status code instead.
+/// </remarks>
+[Collection("PackageIdentityProbe")]
+public class PackageRuntimeTests
+{
+    // Declared independently of the product constants on purpose: a test that reused
+    // PackageRuntime's own values could not catch a wrong constant.
+    // winerror.h / appmodel.h.
+    private const int ErrorSuccess = 0;
+    private const int ErrorInsufficientBuffer = 122;
+    private const int AppmodelErrorNoPackage = 15700;
+
+    // Deliberately a plain DllImport rather than the product's source-generated
+    // [LibraryImport]: an independent binding to the same export (and this project
+    // does not enable unsafe blocks, which the generated stub requires).
+    [DllImport("kernel32.dll")]
+    private static extern int GetCurrentPackageFullName(ref uint packageFullNameLength, nint packageFullName);
+
+    // ══════════════════════════════════════════════════════════════
+    //  The regression pin: detection must not throw.
+    // ══════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void IsPackaged_ComputesWithoutRaisingAFirstChanceException()
+    {
+        PackageRuntime.ResetForTests();
+
+        bool packaged = false;
+        var observed = FirstChanceExceptionProbe.Capture(() => packaged = PackageRuntime.IsPackaged);
+
+        // The xUnit host is unpackaged, so this is the arm that used to throw. Assert
+        // the verdict too, so the "no exception" claim is about a probe that actually ran.
+        Assert.False(packaged);
+        Assert.True(
+            observed.Count == 0,
+            "PackageRuntime.IsPackaged must determine package identity without throwing. Observed: "
+                + FirstChanceExceptionProbe.Describe(observed));
+    }
+
+    // ══════════════════════════════════════════════════════════════
+    //  The status-code mapping.
+    // ══════════════════════════════════════════════════════════════
+
+    [Theory]
+    // Identity exists and the full name was written / would not fit in a zero-length buffer.
+    [InlineData(ErrorSuccess, true)]
+    [InlineData(ErrorInsufficientBuffer, true)]
+    // The documented "this process has no package identity" status.
+    [InlineData(AppmodelErrorNoPackage, false)]
+    // Anything undocumented must stay on the conservative unpackaged path, matching the
+    // fallback the old catch-all produced — reporting "packaged" would send callers down
+    // WinRT paths (JumpList, SecondaryTile, ApplicationData) that then throw for real.
+    [InlineData(unchecked((int)0x80070005), false)]
+    [InlineData(int.MaxValue, false)]
+    public void IsPackagedIdentityCode_MapsTheDocumentedStatusCodes(int code, bool expected)
+        => Assert.Equal(expected, PackageRuntime.IsPackagedIdentityCode(code));
+
+    [Fact]
+    public void QueryPackageIdentityCode_ReturnsTheSameStatusAsKernel32()
+    {
+        // Independent call to the same Win32 API. Pins that the probe really asks the OS
+        // (rather than hard-coding an answer) and that it passes the zero-length/NULL
+        // buffer that makes the call a pure identity question.
+        uint length = 0;
+        int expected = GetCurrentPackageFullName(ref length, nint.Zero);
+
+        Assert.Equal(expected, PackageRuntime.QueryPackageIdentityCode());
+        Assert.True(
+            expected is ErrorSuccess or ErrorInsufficientBuffer or AppmodelErrorNoPackage,
+            $"Unexpected GetCurrentPackageFullName status {expected}.");
+    }
+
+    [Fact]
+    public void IsPackaged_AgreesWithTheLiveProbe()
+    {
+        PackageRuntime.ResetForTests();
+
+        // Ties the public verdict to OS truth end to end: a probe that stopped calling
+        // kernel32, or a mapping that inverted a status, breaks this on some host.
+        bool expected = PackageRuntime.IsPackagedIdentityCode(PackageRuntime.QueryPackageIdentityCode());
+        Assert.Equal(expected, PackageRuntime.IsPackaged);
+    }
+
+    // ══════════════════════════════════════════════════════════════
+    //  Caching + ResetForTests.
+    // ══════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void IsPackaged_CachesTheVerdict_AndResetForTestsRecomputesIt()
+    {
+        // Poison the cache with the verdict the live probe never gives on this
+        // (unpackaged) host. Reading `true` back proves the getter served the cached
+        // value instead of re-probing.
+        using (PackageIdentityCache.Force(packaged: true))
+        {
+            Assert.True(PackageRuntime.IsPackaged);
+
+            // ...and ResetForTests must drop it so the next read probes again.
+            PackageRuntime.ResetForTests();
+            Assert.False(PackageRuntime.IsPackaged);
+        }
+    }
+}

--- a/tests/Reactor.Tests/PackagedSettingsStoreTests.cs
+++ b/tests/Reactor.Tests/PackagedSettingsStoreTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.UI.Reactor.Hosting.Persistence;
+using Microsoft.UI.Reactor.Hosting.Shell;
 using Xunit;
 
 namespace Microsoft.UI.Reactor.Tests;
@@ -13,6 +14,7 @@ namespace Microsoft.UI.Reactor.Tests;
 /// tests pin that the catch-all paths return false / swallow without
 /// bubbling exceptions to the caller.
 /// </summary>
+[Collection("PackageIdentityProbe")]
 public class PackagedSettingsStoreTests
 {
     // ══════════════════════════════════════════════════════════════
@@ -92,5 +94,44 @@ public class PackagedSettingsStoreTests
         // over PackagedSettingsStore at app bring-up; a regression that
         // throw'd here would crash the bring-up before the store choice.
         Assert.False(PackagedSettingsStore.IsAvailable());
+    }
+
+    [Fact]
+    public void IsAvailable_DetectsIdentity_WithoutRaisingAFirstChanceException()
+    {
+        // IsAvailable() used to answer the identity question by touching
+        // Windows.ApplicationModel.Package.Current inside a try/catch, so every
+        // unpackaged bring-up (ReactorApp picks the store through this call) raised a
+        // first-chance InvalidOperationException 0x80073D54 into the debugger and into
+        // any crash telemetry the host wires up. It now shares PackageRuntime's
+        // non-throwing Win32 probe. Reset the shared cache first so the probe genuinely
+        // runs inside the capture window.
+        PackageRuntime.ResetForTests();
+
+        bool available = true;
+        var observed = FirstChanceExceptionProbe.Capture(
+            () => available = PackagedSettingsStore.IsAvailable());
+
+        Assert.False(available);
+        Assert.True(
+            observed.Count == 0,
+            "PackagedSettingsStore.IsAvailable() must detect package identity without throwing. Observed: "
+                + FirstChanceExceptionProbe.Describe(observed));
+    }
+
+    [Fact]
+    public void IsAvailable_TracksPackageRuntime_InBothDirections()
+    {
+        // Pins the delegation itself. The unpackaged test host can only ever produce
+        // `false` from a live probe, so force the packaged verdict: an IsAvailable() that
+        // hard-coded a result, or that went back to probing WinRT on its own, would not
+        // follow PackageRuntime here.
+        using (PackageIdentityCache.Force(packaged: true))
+        {
+            Assert.True(PackagedSettingsStore.IsAvailable());
+
+            PackageRuntime.ResetForTests();
+            Assert.False(PackagedSettingsStore.IsAvailable());
+        }
     }
 }

--- a/tests/Reactor.Tests/TestIsolationCollections.cs
+++ b/tests/Reactor.Tests/TestIsolationCollections.cs
@@ -60,3 +60,14 @@ public sealed class HotReloadCollection { }
 /// </summary>
 [CollectionDefinition("LayoutFootgunDetector", DisableParallelization = true)]
 public sealed class LayoutFootgunDetectorCollection { }
+
+/// <summary>
+/// xUnit collection marker for tests that probe MSIX package identity — they call
+/// <c>PackageRuntime.ResetForTests()</c> / poke its cached flag and install a
+/// process-wide <see cref="AppDomain.FirstChanceException"/> handler. Both are global
+/// to the test process: a concurrent reset from another class would make the caching
+/// assertions flaky, and a first-chance handler would otherwise observe exceptions
+/// thrown by unrelated tests running in parallel.
+/// </summary>
+[CollectionDefinition("PackageIdentityProbe", DisableParallelization = true)]
+public sealed class PackageIdentityProbeCollection { }


### PR DESCRIPTION
## Symptom  Every unpackaged launch of a Reactor app raises a first-chance WinRT exception before anything useful happens:  ``` System.InvalidOperationException: Operation is not valid due to the current state of the object.    (HRESULT 0x80073D54 — The process has no package identity) ```  From the ReactorGallery bug-hunt report (finding **R5**):  > `src/Reactor/Hosting/Shell/PackageRuntime.cs:24-33` probes > `Windows.ApplicationModel.Package.Current` inside a `try/catch`. On every unpackaged launch this > throws and catches an `InvalidOperationException`. **All 8 agents independently reported it as the > first entry in their crash log**, and it shows up in every debugger session and any first-chance > telemetry.  The verdict is cached after the first read, so this is a diagnostics/correctness-of-approach problem rather than a hot path — but it pollutes the exact tooling (debugger, first-chance logs, crash telemetry) that exists to surface *real* exceptions.  ## Root cause  `Package.Current` reports "unpackaged" by **throwing**. Using it as a probe means the normal, expected, non-error case is implemented as an exception. There is a documented non-throwing Win32 API for exactly this question.  **The same pattern existed a second time**, and this PR fixes it too: `PackagedSettingsStore.IsAvailable()` (`src/Reactor/Hosting/Persistence/PackagedSettingsStore.cs`) had a verbatim copy of the probe, is called on the unpackaged startup path from `ReactorApp.cs:156` to choose the persistence store, and — unlike `PackageRuntime` — was **not cached**, so it threw on *every* call. Fixing only `PackageRuntime` would have left the reported symptom fully intact and made this PR's central claim false, so I brought it into scope. A repo-wide grep for `Package.Current` confirms these were the only two sites.  ## What changed  **`src/Reactor/Hosting/Shell/PackageRuntime.cs`** — detection now goes through `GetCurrentPackageFullName` (kernel32) with a zero-length / `NULL` buffer, which asks only the identity question:  | Status | Meaning | Verdict | |---|---|---| | `APPMODEL_ERROR_NO_PACKAGE` (15700) | no package identity | unpackaged | | `ERROR_INSUFFICIENT_BUFFER` (122) | identity exists, name doesn't fit in 0 chars | packaged | | `ERROR_SUCCESS` (0) | identity exists | packaged | | anything else | unexpected | unpackaged — conservative, matches the old catch-all |  - Declared as a `[LibraryImport]` with a fully blittable signature (`ref uint`, `nint`, `int`   return) so the source-generated stub stays trim/AOT-clean — `src/Reactor` promotes IL2\*/IL3\*   to errors (`Directory.Build.targets:36-37`). `TaskbarComInterop.cs:155` is the existing   `[LibraryImport]` precedent in this folder. - No `try/catch` around the P/Invoke: the export has shipped in kernel32 since Windows 8 and this   assembly's `TargetPlatformMinVersion` is `10.0.17763.0`. Wrapping it would reintroduce   exception-driven control flow and untestable dead code. Documented in a comment. - Caching (`Volatile` double-check), the benign double-probe race, `ResetForTests()`, and the   observable contract of `IsPackaged` are unchanged. The status→verdict decision is a pure internal   function, `IsPackagedIdentityCode(int)`, so it can be table-tested independently of the host's own   packaging state (see Tests).  ### The call shape, against the documented contract  Because the packaged arm can't be exercised on an unpackaged CI runner, the docs are the evidence. Per [`GetCurrentPackageFullName`](https://learn.microsoft.com/en-us/windows/win32/api/appmodel/nf-appmodel-getcurrentpackagefullname):  ```cpp LONG GetCurrentPackageFullName(   [in, out]       UINT32 *packageFullNameLength,   [out, optional] PWSTR  packageFullName ); ```  - `packageFullName` is **`[out, optional]`** — passing `NULL` is the documented identity-only form,   not an abuse of the API. - The documented failure codes are exactly `APPMODEL_ERROR_NO_PACKAGE` ("the process has no package   identity") and `ERROR_INSUFFICIENT_BUFFER` ("the buffer is not large enough to hold the data. The   required size is specified by `packageFullNameLength`") — which is what a process that *does* have   identity returns for a zero-length buffer. `ERROR_INVALID_PARAMETER` is **not** a documented   outcome for this shape. - The return type is `LONG` (signed 32-bit), hence `int` rather than `uint` on the managed side. - `Requirements` lists **Windows 8 / Windows Server 2012**, `Kernel32.dll` — supporting the   no-`try`/`catch` decision above.  This is now cited in a comment at the call site.  **`src/Reactor/Hosting/Persistence/PackagedSettingsStore.cs`** — `IsAvailable()` now delegates to `PackageRuntime.IsPackaged`.  I checked the pre-change method against `origin/main` to be sure the delegation is behaviour- preserving, because a cached identity bool would silently change behaviour if the method had folded in some other failure mode. It had not — the entire body was the identity check:  ```csharp try  { _ = global::Windows.ApplicationModel.Package.Current; return true; } catch { return false; } ```  Nothing else was probed and nothing else was swallowed. Its bare `catch` meant "any failure ⇒ `false`", which the new `_ => false` default arm preserves exactly. The public signature is untouched; the only observable difference is that the answer is now computed once instead of per-call, which is safe because package identity is fixed for a process lifetime. Its stale XML doc remark ("Callers must check `Windows.ApplicationModel.Package.Current`") now points at `IsAvailable` itself.  **Docs** — four spec sites still instructed implementers to do runtime packaged-detection via `Package.Current` in a `try/catch`; they now prescribe the non-throwing probe (`docs/specs/035-demo-script-tool-design.md`, `docs/specs/tasks/035-demo-script-tool-implementation.md`, `docs/specs/tasks/036-window-design-implementation.md`).  No public API change, so no `mur --regen-api` / `reactor.api.txt` churn. `PackageRuntime` is `internal`.  ## Tests  New `tests/Reactor.Tests/PackageRuntimeTests.cs` plus a `[CollectionDefinition("PackageIdentityProbe", DisableParallelization = true)]` marker in `TestIsolationCollections.cs` — these tests mutate the process-global cached flag and install a process-global first-chance hook, so they need the same exclusivity as the existing `ConsoleTests` / `JumpListGlobals` markers. Handler observations are additionally filtered to the test's own managed thread.  | Test | What it pins | |---|---| | `IsPackaged_ComputesWithoutRaisingAFirstChanceException` | Subscribes to `AppDomain.CurrentDomain.FirstChanceException`, reads `IsPackaged`, asserts **zero** exceptions observed and `IsPackaged == false`. **This is the regression pin.** | | `PackagedSettingsStoreTests.IsAvailable_DetectsIdentity_WithoutRaisingAFirstChanceException` | Same oracle for the second site. | | `IsPackagedIdentityCode_MapsTheDocumentedStatusCodes` | **The mapping table.** `[Theory]` over `0` ⇒ packaged, `122` ⇒ packaged, `15700` ⇒ unpackaged, `0x80070005` ⇒ unpackaged, `int.MaxValue` ⇒ unpackaged. This is what actually pins the logic: every machine this suite runs on is unpackaged, so an end-to-end test alone would only ever see `APPMODEL_ERROR_NO_PACKAGE` and an inverted mapping (e.g. treating `ERROR_INSUFFICIENT_BUFFER` as unpackaged) would sail straight through. | | `QueryPackageIdentityCode_ReturnsTheSameStatusAsKernel32` | The test declares its **own** `[DllImport]` of the same export and compares — pins that the probe really asks the OS and passes the zero-length/NULL buffer. | | `IsPackaged_AgreesWithTheLiveProbe` | End-to-end oracle tying the public verdict to OS truth. | | `IsPackaged_CachesTheVerdict_AndResetForTestsRecomputesIt` | Reflection-poisons the private cache to `true` (a verdict the live probe can never give on an unpackaged host) — reading `true` back proves the cache is served, not re-probed; then `ResetForTests()` must return it to `false`. `Assert.NotNull` on the `FieldInfo`s so a field rename fails loudly instead of silently passing. | | `PackagedSettingsStoreTests.IsAvailable_TracksPackageRuntime_InBothDirections` | Pins the delegation itself in both directions. | | `PackagedSettingsStoreTests.IsAvailable_In_Unpackaged_Test_Context_Returns_False` | Kept unchanged as the pre-existing regression pin for the delegation. |  The status constants are declared independently in the test rather than reused from the product, so a wrong constant in `PackageRuntime` would be caught.  ### Proof the tests fail without the fix  I temporarily restored the old mechanism behind the same seam (`try { _ = Package.Current; return ErrorSuccess; } catch { return AppmodelErrorNoPackage; }`) and re-ran:  ``` Microsoft.UI.Reactor.Tests.PackagedSettingsStoreTests.IsAvailable_DetectsIdentity_WithoutRaisingAFirstChanceException [FAIL]    PackagedSettingsStore.IsAvailable() must detect package identity without throwing. Observed:    System.InvalidOperationException: Operation is not valid due to the current state of the object.  Microsoft.UI.Reactor.Tests.PackageRuntimeTests.IsPackaged_ComputesWithoutRaisingAFirstChanceException [FAIL]    PackageRuntime.IsPackaged must determine package identity without throwing. Observed:    System.InvalidOperationException: Operation is not valid due to the current state of the object.  Failed!  - Failed: 2, Passed: 14, Skipped: 0, Total: 16 ```  — i.e. exactly the exception the report describes, and only the two first-chance tests fail. Restored the fix → all pass. Separately, stubbing `IsAvailable()` to `return false` makes exactly `IsAvailable_TracksPackageRuntime_InBothDirections` fail, confirming that oracle isn't vacuous.  ## Validation  - `dotnet test tests/Reactor.Tests` → **12535 passed, 0 failed**, 64 skipped. - `dotnet build src/Reactor/Reactor.csproj -c Release` → 0 warnings, 0 errors (Release promotes all   warnings to errors; the trim/AOT codes are errors in every configuration). - **All 20 CI checks green** on the first commit — including Build solution, Unit Tests, Selftests,   E2E, AOT Selftests, AOT Trim Proof, Pack, Docs build and Merged coverage. - `dotnet test tests/Reactor.SelfTests` locally → 2 failures, **pre-existing**: verified identical on   a clean stash of this branch. The selftest host times out (300 s) on a `NativeDocking*` drag   fixture, which needs an interactive desktop for input injection; the whole `NativeDockingMatrix`   group passes in isolation, and Selftests pass in CI. - Ran the repo's `.github/skills/pr-review` skill across all 8 dimensions. Zero critical, zero high.   Two mediums (a coverage gap on the `IsAvailable()` delegation, and the stale spec docs) were   raised and are fixed here; the multi-model cross-check (GPT-family, different family from the   orchestrator) confirmed both as resolved with no additional findings. 

---

## Rebase and open questions for the reviewer

Rebased onto `main` at `3bd7dfaa` (PR #930). No conflicts — #930 touched `ElementExtensions.cs`, `Reconciler.Mount.cs`, `Element.Icon.cs`, `V1Protocol/IconResolver.cs` and the gallery; this PR touches `Hosting/Shell/PackageRuntime.cs`, `Hosting/Persistence/PackagedSettingsStore.cs`, three test files and three spec docs. Full unit suite re-run on the new base: **12535 passed, 0 failed**.

This PR introduces no analyzer rule, so it carries **no merge-ordering dependency** on PR #932 or the Release `TreatWarningsAsErrors` gate.

**Both code-quality review threads are answered and resolved.**

- [`PackageRuntimeTests.cs:150`](https://github.com/microsoft/microsoft-ui-reactor/pull/937#discussion_r3678733645) — there is no non-throwing managed API for package identity; that is the defect this PR removes.
- [`PackageRuntimeTests.cs:102`](https://github.com/microsoft/microsoft-ui-reactor/pull/937#discussion_r3678732379) — the suggested `[LibraryImport]` rewrite states it needs no other change, but it also requires a project-level `AllowUnsafeBlocks` or `Reactor.Tests` does not build (`SYSLIB1062` / `CS0227`). The proposal as made is not viable; the separate question of whether that project should enable unsafe blocks was not raised by the thread, and my reasoning on it is recorded there.

Both declines rest on facts rather than preferences, so neither leaves anything for a reviewer to adjudicate.