### PR TITLE
Never write FlyoutPlacementMode.Auto to a WinUI FlyoutBase (fixes the Flyout default-placement process kill)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,22 @@ Conventions for contributors:
 
 ### Fixed
 
+- **`Flyout(...)` no longer terminates the process when opened at its default
+  placement.** Reactor's flyout elements default `Placement` to
+  `FlyoutPlacementMode.Auto`, and that value was written straight onto the WinUI
+  `FlyoutBase.Placement` dependency property. WinUI's show-time validator
+  (`FlyoutBase::ValidateAndSetParameters`) only accepts placements `0..12`, so
+  `Auto` (13) failed with `E_INVALIDARG` and the resulting stowed
+  `ArgumentException` killed the app the first time the flyout was shown —
+  reproducible from the gallery's Dialogs and Flyouts → Flyout page. `Auto` now
+  means "Reactor has no opinion — let the platform decide" and is expressed by
+  leaving the dependency property at WinUI's own default (`Top`) instead of
+  writing `Auto` to it. Applies to `Flyout(...)`, `ContentFlyout(...)` /
+  `.WithFlyout(...)` / `.WithContextFlyout(...)`, `MenuItems(...)` and
+  `CommandBarFlyout(...)`. Explicit placements are unaffected; a flyout whose
+  placement changes from an explicit value back to `Auto` keeps the last
+  explicit value rather than resetting.
+
 - **`NavigationView` pane state no longer desyncs when the control moves its own
   pane (issue #916).** `IsPaneOpen` could be written but had no change
   notification, so a light dismiss or an adaptive display-mode change on resize

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,11 +103,11 @@ Conventions for contributors:
   its own documented default of `Top` and WinUI repositions from there. Applies
   to `Flyout(...)`, `ContentFlyout(...)` / `.WithFlyout(...)` /
   `.WithContextFlyout(...)` and `MenuItems(...)`. `CommandBarFlyout(...)` is
-  deliberately unchanged: it resolves `Auto` itself and positions automatically,
-  so suppressing its write would have pinned it to `Top`. Explicit placements are
-  unaffected everywhere; a guarded flyout whose placement changes from an
-  explicit value back to `Auto` keeps the last explicit value rather than
-  resetting.
+  affected by the same defect but is fixed separately, alongside the change that
+  makes it open from its target at all — until that lands it never reaches the
+  validator, because nothing ever shows it. Explicit placements are unaffected
+  everywhere; a guarded flyout whose placement changes from an explicit value
+  back to `Auto` keeps the last explicit value rather than resetting.
 
 - **`NavigationView` pane state no longer desyncs when the control moves its own
   pane (issue #916).** `IsPaneOpen` could be written but had no change

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,14 +98,16 @@ Conventions for contributors:
   (`FlyoutBase::ValidateAndSetParameters`) only accepts placements `0..12`, so
   `Auto` (13) failed with `E_INVALIDARG` and the resulting stowed
   `ArgumentException` killed the app the first time the flyout was shown —
-  reproducible from the gallery's Dialogs and Flyouts → Flyout page. `Auto` now
-  means "Reactor has no opinion — let the platform decide" and is expressed by
-  leaving the dependency property at WinUI's own default (`Top`) instead of
-  writing `Auto` to it. Applies to `Flyout(...)`, `ContentFlyout(...)` /
-  `.WithFlyout(...)` / `.WithContextFlyout(...)`, `MenuItems(...)` and
-  `CommandBarFlyout(...)`. Explicit placements are unaffected; a flyout whose
-  placement changes from an explicit value back to `Auto` keeps the last
-  explicit value rather than resetting.
+  reproducible from the gallery's Dialogs and Flyouts → Flyout page. Reactor now
+  leaves the dependency property alone when the element says `Auto`, so it keeps
+  its own documented default of `Top` and WinUI repositions from there. Applies
+  to `Flyout(...)`, `ContentFlyout(...)` / `.WithFlyout(...)` /
+  `.WithContextFlyout(...)` and `MenuItems(...)`. `CommandBarFlyout(...)` is
+  deliberately unchanged: it resolves `Auto` itself and positions automatically,
+  so suppressing its write would have pinned it to `Top`. Explicit placements are
+  unaffected everywhere; a guarded flyout whose placement changes from an
+  explicit value back to `Auto` keeps the last explicit value rather than
+  resetting.
 
 - **`NavigationView` pane state no longer desyncs when the control moves its own
   pane (issue #916).** `IsPaneOpen` could be written but had no change

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,7 +107,8 @@ Conventions for contributors:
   open from its target at all — before that it never reached the validator,
   because nothing ever showed it. Explicit placements are unaffected
   everywhere; a guarded flyout whose placement changes from an explicit value
-  back to `Auto` keeps the last explicit value rather than resetting.
+  back to `Auto` returns to that default, rather than leaving a stale local value
+  that would outrank a `Style` setter.
 
 - **`NavigationView` pane state no longer desyncs when the control moves its own
   pane (issue #916).** `IsPaneOpen` could be written but had no change

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,10 +102,10 @@ Conventions for contributors:
   leaves the dependency property alone when the element says `Auto`, so it keeps
   its own documented default of `Top` and WinUI repositions from there. Applies
   to `Flyout(...)`, `ContentFlyout(...)` / `.WithFlyout(...)` /
-  `.WithContextFlyout(...)` and `MenuItems(...)`. `CommandBarFlyout(...)` is
-  affected by the same defect but is fixed separately, alongside the change that
-  makes it open from its target at all — until that lands it never reaches the
-  validator, because nothing ever shows it. Explicit placements are unaffected
+  `.WithContextFlyout(...)` and `MenuItems(...)`. `CommandBarFlyout(...)` was
+  affected by the same defect and is guarded by the companion fix that made it
+  open from its target at all — before that it never reached the validator,
+  because nothing ever showed it. Explicit placements are unaffected
   everywhere; a guarded flyout whose placement changes from an explicit value
   back to `Auto` keeps the last explicit value rather than resetting.
 

--- a/src/Reactor/Core/Element.cs
+++ b/src/Reactor/Core/Element.cs
@@ -5271,6 +5271,12 @@ public record FlyoutElement(
 ) : Element
 {
     public bool IsOpen { get; init; }
+    /// <summary>
+    /// Preferred position of the flyout relative to its target. Defaults to
+    /// <see cref="FlyoutPlacementMode.Auto"/>, which means "no opinion — let WinUI decide";
+    /// Reactor deliberately leaves <c>FlyoutBase.Placement</c> untouched in that case
+    /// because WinUI's own show-time validator rejects <c>Auto</c>.
+    /// </summary>
     public FlyoutPlacementMode Placement { get; init; } = FlyoutPlacementMode.Auto;
     public Action? OnOpened { get; init; }
     public Action? OnClosed { get; init; }
@@ -5290,6 +5296,12 @@ public record FlyoutElement(
 /// </summary>
 public record ContentFlyoutElement(Element Content) : Element
 {
+    /// <summary>
+    /// Preferred position of the flyout relative to its target. Defaults to
+    /// <see cref="FlyoutPlacementMode.Auto"/>, which means "no opinion — let WinUI decide";
+    /// Reactor deliberately leaves <c>FlyoutBase.Placement</c> untouched in that case
+    /// because WinUI's own show-time validator rejects <c>Auto</c>.
+    /// </summary>
     public FlyoutPlacementMode Placement { get; init; } = FlyoutPlacementMode.Auto;
 }
 
@@ -5299,6 +5311,12 @@ public record ContentFlyoutElement(Element Content) : Element
 /// </summary>
 public record MenuFlyoutContentElement(MenuFlyoutItemBase[] Items) : Element
 {
+    /// <summary>
+    /// Preferred position of the flyout relative to its target. Defaults to
+    /// <see cref="FlyoutPlacementMode.Auto"/>, which means "no opinion — let WinUI decide";
+    /// Reactor deliberately leaves <c>FlyoutBase.Placement</c> untouched in that case
+    /// because WinUI's own show-time validator rejects <c>Auto</c>.
+    /// </summary>
     public FlyoutPlacementMode Placement { get; init; } = FlyoutPlacementMode.Auto;
 }
 
@@ -6681,6 +6699,12 @@ public record CommandBarFlyoutElement(
     /// The target normally opens the flyout on click without this.
     /// </summary>
     public bool IsOpen { get; init; }
+    /// <summary>
+    /// Preferred position of the flyout relative to its target. Defaults to
+    /// <see cref="FlyoutPlacementMode.Auto"/>, which means "no opinion — let WinUI decide";
+    /// Reactor deliberately leaves <c>FlyoutBase.Placement</c> untouched in that case
+    /// because WinUI's own show-time validator rejects <c>Auto</c>.
+    /// </summary>
     public FlyoutPlacementMode Placement { get; init; } = FlyoutPlacementMode.Auto;
     internal Action<WinUI.CommandBarFlyout>[] Setters { get; init; } = [];
 }

--- a/src/Reactor/Core/Element.cs
+++ b/src/Reactor/Core/Element.cs
@@ -6713,15 +6713,15 @@ public record CommandBarFlyoutElement(
     public bool IsOpen { get; init; }
     /// <summary>
     /// Preferred position of the flyout relative to its target. Defaults to
-    /// <see cref="FlyoutPlacementMode.Auto"/>.
+    /// <see cref="FlyoutPlacementMode.Auto"/>, meaning "no opinion — let the platform decide".
     /// </summary>
     /// <remarks>
-    /// <c>Auto</c> is currently written through to <c>CommandBarFlyout.Placement</c> rather
-    /// than being guarded like the other flyout elements. That is a merge-boundary artifact,
-    /// not a statement that <c>CommandBarFlyout</c> tolerates <c>Auto</c> — it does not. The
-    /// value simply never reached WinUI's show-time validator, because the flyout was
-    /// installed as <c>AttachedFlyout</c> metadata that nothing ever opened. The companion
-    /// change that fixes that wiring also guards these sites.
+    /// These sites are guarded by <c>Reconciler.ApplyFlyoutPlacement</c> rather than by
+    /// <c>FlyoutPlacement.Apply</c>, because they are owned by the change that fixed
+    /// <c>CommandBarFlyout</c> never opening from its target. Both prevent <c>Auto</c> from
+    /// reaching WinUI's show-time validator, which rejects it; they differ only on an update
+    /// back to <c>Auto</c>, where this one clears the DP so it returns to the platform
+    /// default rather than retaining the last explicit value.
     /// </remarks>
     public FlyoutPlacementMode Placement { get; init; } = FlyoutPlacementMode.Auto;
     internal Action<WinUI.CommandBarFlyout>[] Setters { get; init; } = [];

--- a/src/Reactor/Core/Element.cs
+++ b/src/Reactor/Core/Element.cs
@@ -5273,9 +5273,13 @@ public record FlyoutElement(
     public bool IsOpen { get; init; }
     /// <summary>
     /// Preferred position of the flyout relative to its target. Defaults to
-    /// <see cref="FlyoutPlacementMode.Auto"/>, which means "no opinion — let WinUI decide";
-    /// Reactor deliberately leaves <c>FlyoutBase.Placement</c> untouched in that case
-    /// because WinUI's own show-time validator rejects <c>Auto</c>.
+    /// <see cref="FlyoutPlacementMode.Auto"/>, which means "no opinion — let WinUI decide":
+    /// Reactor leaves <c>FlyoutBase.Placement</c> at the control's own default
+    /// (<see cref="FlyoutPlacementMode.Top"/>) instead of writing <c>Auto</c>, because
+    /// WinUI's show-time validator rejects <c>Auto</c> and terminates the process.
+    /// Since nothing is written, changing an already-mounted flyout from an explicit
+    /// placement back to <see cref="FlyoutPlacementMode.Auto"/> keeps the last explicit
+    /// value rather than resetting it.
     /// </summary>
     public FlyoutPlacementMode Placement { get; init; } = FlyoutPlacementMode.Auto;
     public Action? OnOpened { get; init; }
@@ -5298,9 +5302,13 @@ public record ContentFlyoutElement(Element Content) : Element
 {
     /// <summary>
     /// Preferred position of the flyout relative to its target. Defaults to
-    /// <see cref="FlyoutPlacementMode.Auto"/>, which means "no opinion — let WinUI decide";
-    /// Reactor deliberately leaves <c>FlyoutBase.Placement</c> untouched in that case
-    /// because WinUI's own show-time validator rejects <c>Auto</c>.
+    /// <see cref="FlyoutPlacementMode.Auto"/>, which means "no opinion — let WinUI decide":
+    /// Reactor leaves <c>FlyoutBase.Placement</c> at the control's own default
+    /// (<see cref="FlyoutPlacementMode.Top"/>) instead of writing <c>Auto</c>, because
+    /// WinUI's show-time validator rejects <c>Auto</c> and terminates the process.
+    /// Since nothing is written, changing an already-mounted flyout from an explicit
+    /// placement back to <see cref="FlyoutPlacementMode.Auto"/> keeps the last explicit
+    /// value rather than resetting it.
     /// </summary>
     public FlyoutPlacementMode Placement { get; init; } = FlyoutPlacementMode.Auto;
 }
@@ -5313,9 +5321,13 @@ public record MenuFlyoutContentElement(MenuFlyoutItemBase[] Items) : Element
 {
     /// <summary>
     /// Preferred position of the flyout relative to its target. Defaults to
-    /// <see cref="FlyoutPlacementMode.Auto"/>, which means "no opinion — let WinUI decide";
-    /// Reactor deliberately leaves <c>FlyoutBase.Placement</c> untouched in that case
-    /// because WinUI's own show-time validator rejects <c>Auto</c>.
+    /// <see cref="FlyoutPlacementMode.Auto"/>, which means "no opinion — let WinUI decide":
+    /// Reactor leaves <c>FlyoutBase.Placement</c> at the control's own default
+    /// (<see cref="FlyoutPlacementMode.Top"/>) instead of writing <c>Auto</c>, because
+    /// WinUI's show-time validator rejects <c>Auto</c> and terminates the process.
+    /// Since nothing is written, changing an already-mounted flyout from an explicit
+    /// placement back to <see cref="FlyoutPlacementMode.Auto"/> keeps the last explicit
+    /// value rather than resetting it.
     /// </summary>
     public FlyoutPlacementMode Placement { get; init; } = FlyoutPlacementMode.Auto;
 }
@@ -6701,9 +6713,13 @@ public record CommandBarFlyoutElement(
     public bool IsOpen { get; init; }
     /// <summary>
     /// Preferred position of the flyout relative to its target. Defaults to
-    /// <see cref="FlyoutPlacementMode.Auto"/>, which means "no opinion — let WinUI decide";
-    /// Reactor deliberately leaves <c>FlyoutBase.Placement</c> untouched in that case
-    /// because WinUI's own show-time validator rejects <c>Auto</c>.
+    /// <see cref="FlyoutPlacementMode.Auto"/>, which means "no opinion — let WinUI decide":
+    /// Reactor leaves <c>FlyoutBase.Placement</c> at the control's own default instead of
+    /// writing <c>Auto</c>, matching the other flyout elements (WinUI's show-time
+    /// validator rejects <c>Auto</c>). Since nothing is written, changing an
+    /// already-mounted flyout from an explicit placement back to
+    /// <see cref="FlyoutPlacementMode.Auto"/> keeps the last explicit value rather than
+    /// resetting it.
     /// </summary>
     public FlyoutPlacementMode Placement { get; init; } = FlyoutPlacementMode.Auto;
     internal Action<WinUI.CommandBarFlyout>[] Setters { get; init; } = [];

--- a/src/Reactor/Core/Element.cs
+++ b/src/Reactor/Core/Element.cs
@@ -5274,12 +5274,12 @@ public record FlyoutElement(
     /// <summary>
     /// Preferred position of the flyout relative to its target. Defaults to
     /// <see cref="FlyoutPlacementMode.Auto"/>, which means "no opinion — let WinUI decide":
-    /// Reactor leaves <c>FlyoutBase.Placement</c> at the control's own default
-    /// (<see cref="FlyoutPlacementMode.Top"/>) instead of writing <c>Auto</c>, because
-    /// WinUI's show-time validator rejects <c>Auto</c> and terminates the process.
-    /// Since nothing is written, changing an already-mounted flyout from an explicit
-    /// placement back to <see cref="FlyoutPlacementMode.Auto"/> keeps the last explicit
-    /// value rather than resetting it.
+    /// Reactor clears <c>FlyoutBase.Placement</c> so it falls back to the control's own
+    /// default (<see cref="FlyoutPlacementMode.Top"/>) instead of writing <c>Auto</c>,
+    /// because WinUI's show-time validator rejects <c>Auto</c> and terminates the process.
+    /// Changing an already-mounted flyout from an explicit placement back to
+    /// <see cref="FlyoutPlacementMode.Auto"/> therefore returns it to that default, rather
+    /// than leaving a stale local value that would outrank a <c>Style</c> setter.
     /// </summary>
     public FlyoutPlacementMode Placement { get; init; } = FlyoutPlacementMode.Auto;
     public Action? OnOpened { get; init; }
@@ -5303,12 +5303,12 @@ public record ContentFlyoutElement(Element Content) : Element
     /// <summary>
     /// Preferred position of the flyout relative to its target. Defaults to
     /// <see cref="FlyoutPlacementMode.Auto"/>, which means "no opinion — let WinUI decide":
-    /// Reactor leaves <c>FlyoutBase.Placement</c> at the control's own default
-    /// (<see cref="FlyoutPlacementMode.Top"/>) instead of writing <c>Auto</c>, because
-    /// WinUI's show-time validator rejects <c>Auto</c> and terminates the process.
-    /// Since nothing is written, changing an already-mounted flyout from an explicit
-    /// placement back to <see cref="FlyoutPlacementMode.Auto"/> keeps the last explicit
-    /// value rather than resetting it.
+    /// Reactor clears <c>FlyoutBase.Placement</c> so it falls back to the control's own
+    /// default (<see cref="FlyoutPlacementMode.Top"/>) instead of writing <c>Auto</c>,
+    /// because WinUI's show-time validator rejects <c>Auto</c> and terminates the process.
+    /// Changing an already-mounted flyout from an explicit placement back to
+    /// <see cref="FlyoutPlacementMode.Auto"/> therefore returns it to that default, rather
+    /// than leaving a stale local value that would outrank a <c>Style</c> setter.
     /// </summary>
     public FlyoutPlacementMode Placement { get; init; } = FlyoutPlacementMode.Auto;
 }
@@ -5322,12 +5322,12 @@ public record MenuFlyoutContentElement(MenuFlyoutItemBase[] Items) : Element
     /// <summary>
     /// Preferred position of the flyout relative to its target. Defaults to
     /// <see cref="FlyoutPlacementMode.Auto"/>, which means "no opinion — let WinUI decide":
-    /// Reactor leaves <c>FlyoutBase.Placement</c> at the control's own default
-    /// (<see cref="FlyoutPlacementMode.Top"/>) instead of writing <c>Auto</c>, because
-    /// WinUI's show-time validator rejects <c>Auto</c> and terminates the process.
-    /// Since nothing is written, changing an already-mounted flyout from an explicit
-    /// placement back to <see cref="FlyoutPlacementMode.Auto"/> keeps the last explicit
-    /// value rather than resetting it.
+    /// Reactor clears <c>FlyoutBase.Placement</c> so it falls back to the control's own
+    /// default (<see cref="FlyoutPlacementMode.Top"/>) instead of writing <c>Auto</c>,
+    /// because WinUI's show-time validator rejects <c>Auto</c> and terminates the process.
+    /// Changing an already-mounted flyout from an explicit placement back to
+    /// <see cref="FlyoutPlacementMode.Auto"/> therefore returns it to that default, rather
+    /// than leaving a stale local value that would outrank a <c>Style</c> setter.
     /// </summary>
     public FlyoutPlacementMode Placement { get; init; } = FlyoutPlacementMode.Auto;
 }

--- a/src/Reactor/Core/Element.cs
+++ b/src/Reactor/Core/Element.cs
@@ -6713,13 +6713,11 @@ public record CommandBarFlyoutElement(
     public bool IsOpen { get; init; }
     /// <summary>
     /// Preferred position of the flyout relative to its target. Defaults to
-    /// <see cref="FlyoutPlacementMode.Auto"/>, which means "no opinion — let WinUI decide":
-    /// Reactor leaves <c>FlyoutBase.Placement</c> at the control's own default instead of
-    /// writing <c>Auto</c>, matching the other flyout elements (WinUI's show-time
-    /// validator rejects <c>Auto</c>). Since nothing is written, changing an
-    /// already-mounted flyout from an explicit placement back to
-    /// <see cref="FlyoutPlacementMode.Auto"/> keeps the last explicit value rather than
-    /// resetting it.
+    /// <see cref="FlyoutPlacementMode.Auto"/>, and — unlike the other flyout elements —
+    /// <c>Auto</c> <b>is</b> written through to <c>CommandBarFlyout.Placement</c>.
+    /// <c>CommandBarFlyout</c> resolves <c>Auto</c> itself and positions automatically, so
+    /// suppressing the write would leave the property at its <c>FlyoutBase</c> default of
+    /// <see cref="FlyoutPlacementMode.Top"/> and pin the flyout there instead.
     /// </summary>
     public FlyoutPlacementMode Placement { get; init; } = FlyoutPlacementMode.Auto;
     internal Action<WinUI.CommandBarFlyout>[] Setters { get; init; } = [];

--- a/src/Reactor/Core/Element.cs
+++ b/src/Reactor/Core/Element.cs
@@ -6713,12 +6713,16 @@ public record CommandBarFlyoutElement(
     public bool IsOpen { get; init; }
     /// <summary>
     /// Preferred position of the flyout relative to its target. Defaults to
-    /// <see cref="FlyoutPlacementMode.Auto"/>, and — unlike the other flyout elements —
-    /// <c>Auto</c> <b>is</b> written through to <c>CommandBarFlyout.Placement</c>.
-    /// <c>CommandBarFlyout</c> resolves <c>Auto</c> itself and positions automatically, so
-    /// suppressing the write would leave the property at its <c>FlyoutBase</c> default of
-    /// <see cref="FlyoutPlacementMode.Top"/> and pin the flyout there instead.
+    /// <see cref="FlyoutPlacementMode.Auto"/>.
     /// </summary>
+    /// <remarks>
+    /// <c>Auto</c> is currently written through to <c>CommandBarFlyout.Placement</c> rather
+    /// than being guarded like the other flyout elements. That is a merge-boundary artifact,
+    /// not a statement that <c>CommandBarFlyout</c> tolerates <c>Auto</c> — it does not. The
+    /// value simply never reached WinUI's show-time validator, because the flyout was
+    /// installed as <c>AttachedFlyout</c> metadata that nothing ever opened. The companion
+    /// change that fixes that wiring also guards these sites.
+    /// </remarks>
     public FlyoutPlacementMode Placement { get; init; } = FlyoutPlacementMode.Auto;
     internal Action<WinUI.CommandBarFlyout>[] Setters { get; init; } = [];
 }

--- a/src/Reactor/Core/FlyoutPlacement.cs
+++ b/src/Reactor/Core/FlyoutPlacement.cs
@@ -1,0 +1,50 @@
+using WinPrim = Microsoft.UI.Xaml.Controls.Primitives;
+
+namespace Microsoft.UI.Reactor.Core;
+
+/// <summary>
+/// Single choke point for pushing a Reactor element's <c>Placement</c> onto a live WinUI
+/// <see cref="WinPrim.FlyoutBase"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="WinPrim.FlyoutPlacementMode.Auto"/> must never reach the WinUI DP.
+/// <c>FlyoutBase::ShowAtCore</c> validates the effective placement through
+/// <c>FlyoutBase::ValidateAndSetParameters</c>, whose switch only accepts values
+/// <c>0..12</c> and fails everything else with <c>E_INVALIDARG</c> (<c>0x80070057</c>).
+/// <c>Auto</c> is <c>13</c>, and <c>FlyoutBase::GetEffectivePlacement</c> hands the raw
+/// <c>Placement</c> property straight to that validator when no per-show override is
+/// cached — so a flyout left at <c>Auto</c> fails the moment it is shown, surfacing as a
+/// stowed <see cref="global::System.ArgumentException"/> ("The parameter is incorrect")
+/// that terminates the process. WinUI itself never puts <c>Auto</c> there: the documented
+/// default of <c>FlyoutBase.Placement</c> is <see cref="WinPrim.FlyoutPlacementMode.Top"/>.
+/// </para>
+/// <para>
+/// Reactor's element records default to <c>Auto</c>, which means "no opinion — let the
+/// platform decide". That is expressed by leaving the DP untouched rather than by writing
+/// <c>Auto</c> to it. Consequently an update from an explicit placement back to <c>Auto</c>
+/// intentionally leaves the previously written value in place; this matches the pre-existing
+/// <c>MenuFlyout</c> guard this helper generalizes, and avoids disturbing controls such as
+/// <c>CommandBarFlyout</c> that resolve <c>Auto</c> themselves.
+/// </para>
+/// </remarks>
+internal static class FlyoutPlacement
+{
+    /// <summary>
+    /// Whether <paramref name="placement"/> is safe to write to
+    /// <see cref="WinPrim.FlyoutBase.Placement"/> — i.e. whether WinUI's
+    /// <c>ValidateAndSetParameters</c> switch accepts it.
+    /// </summary>
+    internal static bool ShouldApply(WinPrim.FlyoutPlacementMode placement)
+        => placement != WinPrim.FlyoutPlacementMode.Auto;
+
+    /// <summary>
+    /// Applies an element's placement to a live flyout, skipping
+    /// <see cref="WinPrim.FlyoutPlacementMode.Auto"/> and redundant writes.
+    /// </summary>
+    internal static void Apply(WinPrim.FlyoutBase flyout, WinPrim.FlyoutPlacementMode placement)
+    {
+        if (!ShouldApply(placement)) return;
+        if (flyout.Placement != placement) flyout.Placement = placement;
+    }
+}

--- a/src/Reactor/Core/FlyoutPlacement.cs
+++ b/src/Reactor/Core/FlyoutPlacement.cs
@@ -32,16 +32,24 @@ namespace Microsoft.UI.Reactor.Core;
 /// Reactor's element records default to <c>Auto</c>, which means "no opinion — let the
 /// platform decide". That is expressed by leaving the DP untouched rather than by writing
 /// <c>Auto</c> to it. Note that "untouched" is not the same as "<c>Auto</c>": the DP's own
-/// default is <c>Top</c>, so skipping the write pins the flyout to <c>Top</c> and lets WinUI
-/// reposition from there. That is the right outcome only for flyout types whose validator
-/// rejects <c>Auto</c> — <c>Flyout</c> and <c>MenuFlyout</c>. <c>CommandBarFlyout</c>
-/// resolves <c>Auto</c> itself and is deliberately <b>not</b> routed through this helper,
-/// because suppressing its write would stop it auto-positioning and pin it to <c>Top</c>.
+/// default is <c>Top</c> (measured, see the <c>Platform_FlyoutBase_PlacementDefault</c>
+/// selftest), so skipping the write pins the flyout to <c>Top</c> and lets WinUI reposition
+/// from there.
 /// </para>
 /// <para>
-/// Consequently an update from an explicit placement back to <c>Auto</c> intentionally
-/// leaves the previously written value in place; this matches the pre-existing
-/// <c>MenuFlyout</c> guard that this helper generalizes.
+/// <c>CommandBarFlyout</c>'s three placement sites are <b>not</b> routed through this helper.
+/// That is a merge boundary, not an exemption on the merits: those methods are being rewritten
+/// by the companion change that fixes <c>CommandBarFlyout</c> never opening, and that change
+/// guards them itself. <c>CommandBarFlyout</c> is affected by the same crash — it simply never
+/// reached the validator, because the flyout was installed as <c>AttachedFlyout</c> metadata
+/// that nothing ever called <c>ShowAttachedFlyout</c> on. A latent crash masked by a separate
+/// defect reads exactly like a working code path.
+/// </para>
+/// <para>
+/// An update from an explicit placement back to <c>Auto</c> intentionally leaves the previously
+/// written value in place; this matches the pre-existing <c>MenuFlyout</c> guard that this
+/// helper generalizes. The companion change instead clears the DP, which resets to the platform
+/// default — the two should converge on one behaviour once both have landed.
 /// </para>
 /// </remarks>
 internal static class FlyoutPlacement

--- a/src/Reactor/Core/FlyoutPlacement.cs
+++ b/src/Reactor/Core/FlyoutPlacement.cs
@@ -30,27 +30,29 @@ namespace Microsoft.UI.Reactor.Core;
 /// </para>
 /// <para>
 /// Reactor's element records default to <c>Auto</c>, which means "no opinion — let the
-/// platform decide". That is expressed by leaving the DP untouched rather than by writing
-/// <c>Auto</c> to it. Note that "untouched" is not the same as "<c>Auto</c>": the DP's own
-/// default is <c>Top</c> (measured, see the <c>Platform_FlyoutBase_PlacementDefault</c>
-/// selftest), so skipping the write pins the flyout to <c>Top</c> and lets WinUI reposition
-/// from there.
+/// platform decide". That is expressed by <b>clearing</b> the DP rather than by writing
+/// <c>Auto</c> to it. Note that cleared is not the same as <c>Auto</c>: the DP's own default
+/// is <c>Top</c> (measured, see the <c>Platform_FlyoutBase_PlacementDefault</c> selftest), so
+/// a cleared property leaves the flyout at <c>Top</c> and lets WinUI reposition from there.
 /// </para>
 /// <para>
-/// <c>CommandBarFlyout</c>'s three placement sites are guarded by
-/// <c>Reconciler.ApplyFlyoutPlacement</c> instead of by this helper — they are owned by the
-/// change that fixed <c>CommandBarFlyout</c> never opening from its target, and that change
-/// guards them itself. <c>CommandBarFlyout</c> is affected by the same crash: it simply never
-/// reached the validator beforehand, because the flyout was installed as <c>AttachedFlyout</c>
-/// metadata that nothing ever called <c>ShowAttachedFlyout</c> on. A latent crash masked by a
-/// separate defect reads exactly like a working code path.
+/// Clearing rather than merely skipping the write matters on an update from an explicit
+/// placement back to <c>Auto</c>. Skipping would leave the previous explicit value behind as a
+/// <b>local</b> DP value, which outranks any <c>Style</c> setter for the same property — so the
+/// element could never get its styled placement back, and "no opinion" would silently mean
+/// "whatever I last said". That is the same dependency-property precedence defect tracked in
+/// issue #952 for the common modifiers. Clearing also makes an update idempotent with a fresh
+/// mount of the same element.
 /// </para>
 /// <para>
-/// The two helpers differ only on an update back to <c>Auto</c>: this one leaves the previously
-/// written value in place, matching the pre-existing <c>MenuFlyout</c> guard it generalizes,
-/// while <c>ApplyFlyoutPlacement</c> clears the DP so it returns to the platform default.
-/// Converging on one of them is a worthwhile follow-up; clearing is arguably the better
-/// semantic, since it makes an update idempotent with a fresh mount.
+/// <c>CommandBarFlyout</c>'s three placement sites are guarded by the equivalent
+/// <c>Reconciler.ApplyFlyoutPlacement</c>, introduced by the change that fixed
+/// <c>CommandBarFlyout</c> never opening from its target. The two now behave identically;
+/// folding them into one helper is a mechanical follow-up. <c>CommandBarFlyout</c> is affected
+/// by the same crash: it simply never reached the validator beforehand, because the flyout was
+/// installed as <c>AttachedFlyout</c> metadata that nothing ever called
+/// <c>ShowAttachedFlyout</c> on. A latent crash masked by a separate defect reads exactly like
+/// a working code path.
 /// </para>
 /// </remarks>
 internal static class FlyoutPlacement
@@ -64,12 +66,17 @@ internal static class FlyoutPlacement
         => placement != WinPrim.FlyoutPlacementMode.Auto;
 
     /// <summary>
-    /// Applies an element's placement to a live flyout, skipping
-    /// <see cref="WinPrim.FlyoutPlacementMode.Auto"/> and redundant writes.
+    /// Applies an element's placement to a live flyout: clears the property for
+    /// <see cref="WinPrim.FlyoutPlacementMode.Auto"/> so it falls back to the platform
+    /// default, and otherwise writes the value, skipping redundant writes.
     /// </summary>
     internal static void Apply(WinPrim.FlyoutBase flyout, WinPrim.FlyoutPlacementMode placement)
     {
-        if (!ShouldApply(placement)) return;
+        if (!ShouldApply(placement))
+        {
+            flyout.ClearValue(WinPrim.FlyoutBase.PlacementProperty);
+            return;
+        }
         if (flyout.Placement != placement) flyout.Placement = placement;
     }
 }

--- a/src/Reactor/Core/FlyoutPlacement.cs
+++ b/src/Reactor/Core/FlyoutPlacement.cs
@@ -37,19 +37,20 @@ namespace Microsoft.UI.Reactor.Core;
 /// from there.
 /// </para>
 /// <para>
-/// <c>CommandBarFlyout</c>'s three placement sites are <b>not</b> routed through this helper.
-/// That is a merge boundary, not an exemption on the merits: those methods are being rewritten
-/// by the companion change that fixes <c>CommandBarFlyout</c> never opening, and that change
-/// guards them itself. <c>CommandBarFlyout</c> is affected by the same crash — it simply never
-/// reached the validator, because the flyout was installed as <c>AttachedFlyout</c> metadata
-/// that nothing ever called <c>ShowAttachedFlyout</c> on. A latent crash masked by a separate
-/// defect reads exactly like a working code path.
+/// <c>CommandBarFlyout</c>'s three placement sites are guarded by
+/// <c>Reconciler.ApplyFlyoutPlacement</c> instead of by this helper — they are owned by the
+/// change that fixed <c>CommandBarFlyout</c> never opening from its target, and that change
+/// guards them itself. <c>CommandBarFlyout</c> is affected by the same crash: it simply never
+/// reached the validator beforehand, because the flyout was installed as <c>AttachedFlyout</c>
+/// metadata that nothing ever called <c>ShowAttachedFlyout</c> on. A latent crash masked by a
+/// separate defect reads exactly like a working code path.
 /// </para>
 /// <para>
-/// An update from an explicit placement back to <c>Auto</c> intentionally leaves the previously
-/// written value in place; this matches the pre-existing <c>MenuFlyout</c> guard that this
-/// helper generalizes. The companion change instead clears the DP, which resets to the platform
-/// default — the two should converge on one behaviour once both have landed.
+/// The two helpers differ only on an update back to <c>Auto</c>: this one leaves the previously
+/// written value in place, matching the pre-existing <c>MenuFlyout</c> guard it generalizes,
+/// while <c>ApplyFlyoutPlacement</c> clears the DP so it returns to the platform default.
+/// Converging on one of them is a worthwhile follow-up; clearing is arguably the better
+/// semantic, since it makes an update idempotent with a fresh mount.
 /// </para>
 /// </remarks>
 internal static class FlyoutPlacement

--- a/src/Reactor/Core/FlyoutPlacement.cs
+++ b/src/Reactor/Core/FlyoutPlacement.cs
@@ -31,10 +31,17 @@ namespace Microsoft.UI.Reactor.Core;
 /// <para>
 /// Reactor's element records default to <c>Auto</c>, which means "no opinion — let the
 /// platform decide". That is expressed by leaving the DP untouched rather than by writing
-/// <c>Auto</c> to it. Consequently an update from an explicit placement back to <c>Auto</c>
-/// intentionally leaves the previously written value in place; this matches the pre-existing
-/// <c>MenuFlyout</c> guard this helper generalizes, and avoids disturbing controls such as
-/// <c>CommandBarFlyout</c> that resolve <c>Auto</c> themselves.
+/// <c>Auto</c> to it. Note that "untouched" is not the same as "<c>Auto</c>": the DP's own
+/// default is <c>Top</c>, so skipping the write pins the flyout to <c>Top</c> and lets WinUI
+/// reposition from there. That is the right outcome only for flyout types whose validator
+/// rejects <c>Auto</c> — <c>Flyout</c> and <c>MenuFlyout</c>. <c>CommandBarFlyout</c>
+/// resolves <c>Auto</c> itself and is deliberately <b>not</b> routed through this helper,
+/// because suppressing its write would stop it auto-positioning and pin it to <c>Top</c>.
+/// </para>
+/// <para>
+/// Consequently an update from an explicit placement back to <c>Auto</c> intentionally
+/// leaves the previously written value in place; this matches the pre-existing
+/// <c>MenuFlyout</c> guard that this helper generalizes.
 /// </para>
 /// </remarks>
 internal static class FlyoutPlacement

--- a/src/Reactor/Core/FlyoutPlacement.cs
+++ b/src/Reactor/Core/FlyoutPlacement.cs
@@ -20,6 +20,15 @@ namespace Microsoft.UI.Reactor.Core;
 /// default of <c>FlyoutBase.Placement</c> is <see cref="WinPrim.FlyoutPlacementMode.Top"/>.
 /// </para>
 /// <para>
+/// Provenance, since these two internals are undocumented and could change between Windows
+/// App SDK versions: the <c>0..12</c> validator range and the <c>GetEffectivePlacement</c>
+/// fall-through were established by disassembling <c>Microsoft.UI.Xaml.dll</c> under a
+/// debugger with public symbols during the ReactorGallery bug hunt. The enum value and the
+/// <c>Top</c> default come from the published API reference. The resulting crash is pinned
+/// by the <c>FlyoutPlacement*</c> selftest fixtures, which open a default-placement flyout
+/// for real — remove any <see cref="Apply"/> call below and they fail.
+/// </para>
+/// <para>
 /// Reactor's element records default to <c>Auto</c>, which means "no opinion — let the
 /// platform decide". That is expressed by leaving the DP untouched rather than by writing
 /// <c>Auto</c> to it. Consequently an update from an explicit placement back to <c>Auto</c>

--- a/src/Reactor/Core/Reconciler.cs
+++ b/src/Reactor/Core/Reconciler.cs
@@ -4993,7 +4993,7 @@ public sealed partial class Reconciler : IDisposable
                 // Type changed — remount content
                 flyout.Content = Mount(newCf.Content, requestRerender);
             }
-            flyout.Placement = newCf.Placement;
+            FlyoutPlacement.Apply(flyout, newCf.Placement);
             return;
         }
 
@@ -5002,8 +5002,7 @@ public sealed partial class Reconciler : IDisposable
         {
             menuFlyout.Items.Clear();
             foreach (var item in newMf.Items) menuFlyout.Items.Add(MenuCommandFactory.CreateMenuFlyoutItem(item));
-            if (newMf.Placement != WinPrim.FlyoutPlacementMode.Auto)
-                menuFlyout.Placement = newMf.Placement;
+            FlyoutPlacement.Apply(menuFlyout, newMf.Placement);
             return;
         }
 
@@ -5120,14 +5119,17 @@ public sealed partial class Reconciler : IDisposable
             case ContentFlyoutElement cf:
             {
                 var content = Mount(cf.Content, requestRerender);
-                return content is not null ? new WinUI.Flyout { Content = content, Placement = cf.Placement } : null;
+                if (content is null) return null;
+                var contentFlyout = new WinUI.Flyout { Content = content };
+                FlyoutPlacement.Apply(contentFlyout, cf.Placement);
+                return contentFlyout;
             }
             case MenuFlyoutContentElement mf:
             {
                 var menuFlyout = new WinUI.MenuFlyout();
-                // Only set Placement if explicitly specified (Auto can cause assertions on MenuFlyout)
-                if (mf.Placement != WinPrim.FlyoutPlacementMode.Auto)
-                    menuFlyout.Placement = mf.Placement;
+                // Placement is routed through FlyoutPlacement so Auto is never written
+                // (WinUI's FlyoutBase validator rejects it — see FlyoutPlacement).
+                FlyoutPlacement.Apply(menuFlyout, mf.Placement);
                 foreach (var item in mf.Items) menuFlyout.Items.Add(MenuCommandFactory.CreateMenuFlyoutItem(item));
                 return menuFlyout;
             }

--- a/src/Reactor/Core/V1Protocol/OverlayLifecycle.cs
+++ b/src/Reactor/Core/V1Protocol/OverlayLifecycle.cs
@@ -115,10 +115,10 @@ internal static class OverlayLifecycle
             var flyout = new WinUI.Flyout
             {
                 Content = flyoutContent,
-                Placement = flyEl.Placement,
                 ShowMode = flyEl.ShowMode,
                 AreOpenCloseAnimationsEnabled = flyEl.AreOpenCloseAnimationsEnabled,
             };
+            FlyoutPlacement.Apply(flyout, flyEl.Placement);
             if (flyEl.OverlayInputPassThroughElement is not null
                 && reconciler.Mount(flyEl.OverlayInputPassThroughElement, requestRerender) is DependencyObject pt)
                 flyout.OverlayInputPassThroughElement = pt;
@@ -172,7 +172,7 @@ internal static class OverlayLifecycle
                     if (flyout.Content is UIElement stale) reconciler.UnmountChild(stale);
                     flyout.Content = reconciler.Mount(n.FlyoutContent, requestRerender);
                 }
-                flyout.Placement = n.Placement;
+                FlyoutPlacement.Apply(flyout, n.Placement);
                 if (flyout.ShowMode != n.ShowMode) flyout.ShowMode = n.ShowMode;
                 if (flyout.AreOpenCloseAnimationsEnabled != n.AreOpenCloseAnimationsEnabled)
                     flyout.AreOpenCloseAnimationsEnabled = n.AreOpenCloseAnimationsEnabled;
@@ -195,10 +195,10 @@ internal static class OverlayLifecycle
                 var newFlyout = new WinUI.Flyout
                 {
                     Content = flyoutContent,
-                    Placement = n.Placement,
                     ShowMode = n.ShowMode,
                     AreOpenCloseAnimationsEnabled = n.AreOpenCloseAnimationsEnabled,
                 };
+                FlyoutPlacement.Apply(newFlyout, n.Placement);
                 // Route handlers through the target's Tag (already set to n above) so future
                 // Update() calls that refresh the tag keep Opened/Closed pointing at the
                 // current FlyoutElement's delegates.

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/FlyoutPlacementFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/FlyoutPlacementFixtures.cs
@@ -1,0 +1,159 @@
+using Microsoft.UI.Reactor.AppTests.Host.SelfTest;
+using Microsoft.UI.Reactor.Core;
+using WinUI = Microsoft.UI.Xaml.Controls;
+using WinPrim = Microsoft.UI.Xaml.Controls.Primitives;
+using static Microsoft.UI.Reactor.Factories;
+
+namespace Microsoft.UI.Reactor.AppTests.Host.SelfTest.Fixtures;
+
+/// <summary>
+/// Regression cover for the <c>Flyout(...)</c>-with-default-placement process kill.
+///
+/// Reactor's flyout elements default <c>Placement</c> to
+/// <see cref="WinPrim.FlyoutPlacementMode.Auto"/> (13). WinUI's
+/// <c>FlyoutBase::ShowAtCore</c> validates the effective placement through
+/// <c>ValidateAndSetParameters</c>, whose switch only accepts 0..12 — so a flyout left at
+/// <c>Auto</c> fails with <c>E_INVALIDARG</c> the moment it is shown and terminates the
+/// process with a stowed <c>ArgumentException</c>. These fixtures actually *open* the
+/// flyout, which is the only tier that catches it: without the guard the host process
+/// fail-fasts and the whole TAP run dies.
+/// </summary>
+public static class FlyoutPlacementFixtures
+{
+    private static WinUI.Flyout? FlyoutOn(Harness h, string buttonLabel)
+        => h.FindButton(buttonLabel)?.Flyout as WinUI.Flyout;
+
+    // ────────────────────────────────────────────────────────────────────
+    //  Flyout(...) left at the default placement must open, not fail-fast.
+    // ────────────────────────────────────────────────────────────────────
+    internal class Flyout_DefaultPlacement_Opens(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var host = H.CreateHost();
+            host.Mount(_ => VStack(
+                Flyout(Button("DefaultPlacementTarget"), TextBlock("default placement body"))));
+            await Harness.Render();
+
+            var flyout = FlyoutOn(H, "DefaultPlacementTarget");
+            H.Check("FlyoutPlacement_Default_FlyoutAttached", flyout is not null);
+            H.Check("FlyoutPlacement_Default_DpIsNotAuto",
+                flyout is not null && flyout.Placement != WinPrim.FlyoutPlacementMode.Auto);
+
+            // The load-bearing step: clicking the button routes into FlyoutBase::ShowAtCore.
+            H.ClickButton("DefaultPlacementTarget");
+            await Harness.WaitFor(() => flyout?.IsOpen == true);
+            H.Check("FlyoutPlacement_Default_Opened", flyout?.IsOpen == true);
+
+            flyout?.Hide();
+            await Harness.Render();
+        }
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    //  Differential isolation: an explicit placement must still reach the DP.
+    //  (A guard that swallowed every write would pass the fixture above.)
+    // ────────────────────────────────────────────────────────────────────
+    internal class Flyout_ExplicitPlacement_ReachesTheControl(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var host = H.CreateHost();
+            host.Mount(_ => VStack(
+                Flyout(Button("ExplicitPlacementTarget"), TextBlock("explicit placement body"))
+                    with { Placement = WinPrim.FlyoutPlacementMode.RightEdgeAlignedTop }));
+            await Harness.Render();
+
+            var flyout = FlyoutOn(H, "ExplicitPlacementTarget");
+            H.Check("FlyoutPlacement_Explicit_FlyoutAttached", flyout is not null);
+            H.Check("FlyoutPlacement_Explicit_DpMatchesElement",
+                flyout?.Placement == WinPrim.FlyoutPlacementMode.RightEdgeAlignedTop);
+
+            H.ClickButton("ExplicitPlacementTarget");
+            await Harness.WaitFor(() => flyout?.IsOpen == true);
+            H.Check("FlyoutPlacement_Explicit_Opened", flyout?.IsOpen == true);
+
+            flyout?.Hide();
+            await Harness.Render();
+        }
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    //  Update path: an explicit placement lands on the already-mounted flyout,
+    //  and going back to Auto never writes Auto (it keeps the last real value).
+    // ────────────────────────────────────────────────────────────────────
+    internal class Flyout_PlacementUpdate_NeverWritesAuto(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                var (step, setStep) = ctx.UseState(0);
+                var placement = step switch
+                {
+                    1 => WinPrim.FlyoutPlacementMode.Left,
+                    _ => WinPrim.FlyoutPlacementMode.Auto,   // steps 0 and 2
+                };
+                return VStack(
+                    Button("AdvancePlacement", () => setStep(step + 1)),
+                    Flyout(Button("UpdatePlacementTarget"), TextBlock("update body"))
+                        with { Placement = placement });
+            });
+            await Harness.Render();
+
+            var flyout = FlyoutOn(H, "UpdatePlacementTarget");
+            H.Check("FlyoutPlacement_Update_FlyoutAttached", flyout is not null);
+            H.Check("FlyoutPlacement_Update_MountedNotAuto",
+                flyout is not null && flyout.Placement != WinPrim.FlyoutPlacementMode.Auto);
+
+            // Auto → Left: the explicit value must be pushed onto the live control.
+            H.ClickButton("AdvancePlacement");
+            await Harness.WaitFor(() => flyout?.Placement == WinPrim.FlyoutPlacementMode.Left);
+            H.Check("FlyoutPlacement_Update_ExplicitApplied",
+                flyout?.Placement == WinPrim.FlyoutPlacementMode.Left);
+
+            // Left → Auto: documented no-reset semantic — the last real value stays,
+            // and crucially Auto is never written back onto the DP.
+            H.ClickButton("AdvancePlacement");
+            await Harness.Render();
+            H.Check("FlyoutPlacement_Update_AutoDoesNotOverwrite",
+                flyout?.Placement == WinPrim.FlyoutPlacementMode.Left);
+
+            H.ClickButton("UpdatePlacementTarget");
+            await Harness.WaitFor(() => flyout?.IsOpen == true);
+            H.Check("FlyoutPlacement_Update_OpensAfterUpdate", flyout?.IsOpen == true);
+
+            flyout?.Hide();
+            await Harness.Render();
+        }
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    //  ContentFlyout via .WithFlyout() — the second crashing entry point
+    //  (Reconciler.CreateFlyoutFromElement / UpdateFlyoutInPlace).
+    // ────────────────────────────────────────────────────────────────────
+    internal class ContentFlyout_DefaultPlacement_Opens(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var host = H.CreateHost();
+            host.Mount(_ => VStack(
+                Button("ContentFlyoutTarget", () => { })
+                    .WithFlyout(ContentFlyout(TextBlock("content flyout body")))));
+            await Harness.Render();
+
+            var flyout = FlyoutOn(H, "ContentFlyoutTarget");
+            H.Check("FlyoutPlacement_ContentFlyout_FlyoutAttached", flyout is not null);
+            H.Check("FlyoutPlacement_ContentFlyout_DpIsNotAuto",
+                flyout is not null && flyout.Placement != WinPrim.FlyoutPlacementMode.Auto);
+
+            H.ClickButton("ContentFlyoutTarget");
+            await Harness.WaitFor(() => flyout?.IsOpen == true);
+            H.Check("FlyoutPlacement_ContentFlyout_Opened", flyout?.IsOpen == true);
+
+            flyout?.Hide();
+            await Harness.Render();
+        }
+    }
+}

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/FlyoutPlacementFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/FlyoutPlacementFixtures.cs
@@ -23,6 +23,42 @@ public static class FlyoutPlacementFixtures
     private static WinUI.Flyout? FlyoutOn(Harness h, string buttonLabel)
         => h.FindButton(buttonLabel)?.Flyout as WinUI.Flyout;
 
+    // ────────────────────────────────────────────────────────────────────
+    //  The load-bearing platform assumption, measured rather than assumed.
+    //
+    //  The whole fix is "don't write Auto, leave the DP alone". That is only
+    //  safe because the DP's own default is a value the show-time validator
+    //  accepts. If a future Windows App SDK shipped FlyoutBase.Placement
+    //  defaulting to Auto, skipping the write would silently stop protecting
+    //  anything and the crash would come back — with every other test in this
+    //  file still green, because they all assert "!= Auto" against a DP that
+    //  would now BE Auto. So pin the platform default directly.
+    // ────────────────────────────────────────────────────────────────────
+    internal class Platform_FlyoutBase_PlacementDefault(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var flyout = new WinUI.Flyout();
+            var menuFlyout = new WinUI.MenuFlyout();
+            var commandBarFlyout = new WinUI.CommandBarFlyout();
+
+            // Emitted as TAP comments so the measured values are in the log even
+            // when the assertions pass — a future SDK bump shows up as a diff here.
+            Console.WriteLine($"# measured Flyout.Placement default          = {flyout.Placement}");
+            Console.WriteLine($"# measured MenuFlyout.Placement default      = {menuFlyout.Placement}");
+            Console.WriteLine($"# measured CommandBarFlyout.Placement default = {commandBarFlyout.Placement}");
+
+            H.Check("FlyoutPlacement_Platform_FlyoutDefaultIsTop",
+                flyout.Placement == WinPrim.FlyoutPlacementMode.Top);
+            H.Check("FlyoutPlacement_Platform_MenuFlyoutDefaultIsTop",
+                menuFlyout.Placement == WinPrim.FlyoutPlacementMode.Top);
+            H.Check("FlyoutPlacement_Platform_DefaultIsValidatorAccepted",
+                (int)flyout.Placement is >= 0 and <= 12);
+
+            await Harness.Render();
+        }
+    }
+
     /// <summary>
     /// Closes a flyout and waits for the close to land. Returning while a light-dismiss
     /// overlay is still up would leak it into the next in-process fixture.

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/FlyoutPlacementFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/FlyoutPlacementFixtures.cs
@@ -283,71 +283,50 @@ public static class FlyoutPlacementFixtures
     }
 
     // ────────────────────────────────────────────────────────────────────
-    //  CommandBarFlyout — mount + the update branch that re-creates the flyout
-    //  because the target's element type changed (so no attached flyout exists).
-    //  CommandBarFlyout tolerates Auto today, so this pins consistency, not a crash.
+    //  CommandBarFlyout is DELIBERATELY excluded from the guard.
+    //  Suppressing the write is not neutral: FlyoutBase.Placement defaults to Top,
+    //  so "don't write" means the flyout pins to Top. Flyout/MenuFlyout want that
+    //  (their validator rejects Auto outright), but CommandBarFlyout resolves Auto
+    //  itself and auto-positions today — guarding it would silently move it to Top.
+    //  This fixture pins the asymmetry so a later "consistency" cleanup cannot
+    //  regress it, and so the DP is observably Auto rather than merely unguarded.
     // ────────────────────────────────────────────────────────────────────
-    internal class CommandBarFlyout_DefaultPlacement_NotAuto(Harness h) : SelfTestFixtureBase(h)
+    internal class CommandBarFlyout_KeepsAuto_Unguarded(Harness h) : SelfTestFixtureBase(h)
     {
         public override async Task RunAsync()
         {
             var host = H.CreateHost();
-            host.Mount(ctx =>
-            {
-                var (swapped, setSwapped) = ctx.UseState(false);
-                return VStack(
-                    Button("SwapCbfTarget", () => setSwapped(true)),
-                    CommandBarFlyout(
-                        swapped
-                            ? Border(TextBlock("CbfBorderTarget"))
-                            : (Element)Button("CbfButtonTarget", () => { }),
-                        primaryCommands: [AppBarButton("Bold")]),
-                    // Differential sibling: same mount + re-create arms, explicit placement.
-                    CommandBarFlyout(
-                        swapped
-                            ? Border(TextBlock("CbfPinnedBorderTarget"))
-                            : (Element)Button("CbfPinnedButtonTarget", () => { }),
-                        primaryCommands: [AppBarButton("Italic")])
-                        with { Placement = WinPrim.FlyoutPlacementMode.BottomEdgeAlignedLeft });
-            });
+            host.Mount(_ => VStack(
+                CommandBarFlyout(
+                    Button("CbfButtonTarget", () => { }),
+                    primaryCommands: [AppBarButton("Bold")]),
+                // Differential sibling: an explicit placement must still land verbatim.
+                CommandBarFlyout(
+                    Button("CbfPinnedButtonTarget", () => { }),
+                    primaryCommands: [AppBarButton("Italic")])
+                    with { Placement = WinPrim.FlyoutPlacementMode.BottomEdgeAlignedLeft }));
             await Harness.Render();
 
             var cbfButton = H.FindButton("CbfButtonTarget");
             H.Check("FlyoutPlacement_CommandBarFlyout_TargetMounted", cbfButton is not null);
-            // CommandBarFlyout attaches via FlyoutBase.SetAttachedFlyout, not Button.Flyout.
-            var mounted = cbfButton is null
-                ? null
-                : WinPrim.FlyoutBase.GetAttachedFlyout(cbfButton) as WinUI.CommandBarFlyout;
+
+            var mounted = CommandBarFlyoutOn(cbfButton);
             H.Check("FlyoutPlacement_CommandBarFlyout_MountAttached", mounted is not null);
-            H.Check("FlyoutPlacement_CommandBarFlyout_MountDpIsNotAuto",
-                mounted is not null && mounted.Placement != WinPrim.FlyoutPlacementMode.Auto);
+            H.Check("FlyoutPlacement_CommandBarFlyout_KeepsAuto",
+                mounted?.Placement == WinPrim.FlyoutPlacementMode.Auto);
 
-            var pinnedButton = H.FindButton("CbfPinnedButtonTarget");
-            H.Check("FlyoutPlacement_CommandBarFlyout_MountAppliesExplicit",
-                pinnedButton is not null
-                && (WinPrim.FlyoutBase.GetAttachedFlyout(pinnedButton) as WinUI.CommandBarFlyout)?.Placement
-                    == WinPrim.FlyoutPlacementMode.BottomEdgeAlignedLeft);
-
-            // Target type change → UpdateCommandBarFlyout's "no existing flyout" branch.
-            H.ClickButton("SwapCbfTarget");
-            await Harness.WaitFor(() => AttachedCommandBarFlyout(H, "CbfBorderTarget") is not null);
-            var recreated = AttachedCommandBarFlyout(H, "CbfBorderTarget");
-            H.Check("FlyoutPlacement_CommandBarFlyout_RecreatedAttached", recreated is not null);
-            H.Check("FlyoutPlacement_CommandBarFlyout_RecreatedDpIsNotAuto",
-                recreated is not null && recreated.Placement != WinPrim.FlyoutPlacementMode.Auto);
-            H.Check("FlyoutPlacement_CommandBarFlyout_RecreatedAppliesExplicit",
-                AttachedCommandBarFlyout(H, "CbfPinnedBorderTarget")?.Placement
+            H.Check("FlyoutPlacement_CommandBarFlyout_ExplicitStillApplies",
+                CommandBarFlyoutOn(H.FindButton("CbfPinnedButtonTarget"))?.Placement
                     == WinPrim.FlyoutPlacementMode.BottomEdgeAlignedLeft);
         }
 
-        private static WinUI.CommandBarFlyout? AttachedCommandBarFlyout(Harness h, string markerText)
-        {
-            var border = h.FindControl<Microsoft.UI.Xaml.Controls.Border>(
-                b => b.Child is Microsoft.UI.Xaml.Controls.TextBlock tb && tb.Text == markerText);
-            return border is null
+        // Reads both attachment slots: CommandBarFlyout uses SetAttachedFlyout today, but
+        // that is being reworked to SetFlyoutOnControl — checking both keeps this fixture
+        // valid across that change instead of failing for an unrelated reason.
+        private static WinUI.CommandBarFlyout? CommandBarFlyoutOn(Microsoft.UI.Xaml.Controls.Button? button)
+            => button is null
                 ? null
-                : WinPrim.FlyoutBase.GetAttachedFlyout(border) as WinUI.CommandBarFlyout;
-        }
+                : (button.Flyout ?? WinPrim.FlyoutBase.GetAttachedFlyout(button)) as WinUI.CommandBarFlyout;
     }
 
     // ────────────────────────────────────────────────────────────────────

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/FlyoutPlacementFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/FlyoutPlacementFixtures.cs
@@ -319,53 +319,6 @@ public static class FlyoutPlacementFixtures
     }
 
     // ────────────────────────────────────────────────────────────────────
-    //  CommandBarFlyout is DELIBERATELY excluded from the guard.
-    //  Suppressing the write is not neutral: FlyoutBase.Placement defaults to Top,
-    //  so "don't write" means the flyout pins to Top. Flyout/MenuFlyout want that
-    //  (their validator rejects Auto outright), but CommandBarFlyout resolves Auto
-    //  itself and auto-positions today — guarding it would silently move it to Top.
-    //  This fixture pins the asymmetry so a later "consistency" cleanup cannot
-    //  regress it, and so the DP is observably Auto rather than merely unguarded.
-    // ────────────────────────────────────────────────────────────────────
-    internal class CommandBarFlyout_KeepsAuto_Unguarded(Harness h) : SelfTestFixtureBase(h)
-    {
-        public override async Task RunAsync()
-        {
-            var host = H.CreateHost();
-            host.Mount(_ => VStack(
-                CommandBarFlyout(
-                    Button("CbfButtonTarget", () => { }),
-                    primaryCommands: [AppBarButton("Bold")]),
-                // Differential sibling: an explicit placement must still land verbatim.
-                CommandBarFlyout(
-                    Button("CbfPinnedButtonTarget", () => { }),
-                    primaryCommands: [AppBarButton("Italic")])
-                    with { Placement = WinPrim.FlyoutPlacementMode.BottomEdgeAlignedLeft }));
-            await Harness.Render();
-
-            var cbfButton = H.FindButton("CbfButtonTarget");
-            H.Check("FlyoutPlacement_CommandBarFlyout_TargetMounted", cbfButton is not null);
-
-            var mounted = CommandBarFlyoutOn(cbfButton);
-            H.Check("FlyoutPlacement_CommandBarFlyout_MountAttached", mounted is not null);
-            H.Check("FlyoutPlacement_CommandBarFlyout_KeepsAuto",
-                mounted?.Placement == WinPrim.FlyoutPlacementMode.Auto);
-
-            H.Check("FlyoutPlacement_CommandBarFlyout_ExplicitStillApplies",
-                CommandBarFlyoutOn(H.FindButton("CbfPinnedButtonTarget"))?.Placement
-                    == WinPrim.FlyoutPlacementMode.BottomEdgeAlignedLeft);
-        }
-
-        // Reads both attachment slots: CommandBarFlyout uses SetAttachedFlyout today, but
-        // that is being reworked to SetFlyoutOnControl — checking both keeps this fixture
-        // valid across that change instead of failing for an unrelated reason.
-        private static WinUI.CommandBarFlyout? CommandBarFlyoutOn(Microsoft.UI.Xaml.Controls.Button? button)
-            => button is null
-                ? null
-                : (button.Flyout ?? WinPrim.FlyoutBase.GetAttachedFlyout(button)) as WinUI.CommandBarFlyout;
-    }
-
-    // ────────────────────────────────────────────────────────────────────
     //  Flyout(...) whose Target element type changes — UpdateFlyoutElement's
     //  "create fresh" branch, which builds a brand-new WinUI.Flyout.
     // ────────────────────────────────────────────────────────────────────

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/FlyoutPlacementFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/FlyoutPlacementFixtures.cs
@@ -23,6 +23,16 @@ public static class FlyoutPlacementFixtures
     private static WinUI.Flyout? FlyoutOn(Harness h, string buttonLabel)
         => h.FindButton(buttonLabel)?.Flyout as WinUI.Flyout;
 
+    /// <summary>
+    /// Closes a flyout and waits for the close to land. Returning while a light-dismiss
+    /// overlay is still up would leak it into the next in-process fixture.
+    /// </summary>
+    private static async Task HideAndSettle(WinPrim.FlyoutBase? flyout)
+    {
+        flyout?.Hide();
+        await Harness.WaitFor(() => flyout?.IsOpen != true);
+    }
+
     // ────────────────────────────────────────────────────────────────────
     //  Flyout(...) left at the default placement must open, not fail-fast.
     // ────────────────────────────────────────────────────────────────────
@@ -45,8 +55,7 @@ public static class FlyoutPlacementFixtures
             await Harness.WaitFor(() => flyout?.IsOpen == true);
             H.Check("FlyoutPlacement_Default_Opened", flyout?.IsOpen == true);
 
-            flyout?.Hide();
-            await Harness.Render();
+            await HideAndSettle(flyout);
         }
     }
 
@@ -73,8 +82,7 @@ public static class FlyoutPlacementFixtures
             await Harness.WaitFor(() => flyout?.IsOpen == true);
             H.Check("FlyoutPlacement_Explicit_Opened", flyout?.IsOpen == true);
 
-            flyout?.Hide();
-            await Harness.Render();
+            await HideAndSettle(flyout);
         }
     }
 
@@ -97,6 +105,9 @@ public static class FlyoutPlacementFixtures
                 };
                 return VStack(
                     Button("AdvancePlacement", () => setStep(step + 1)),
+                    // Render witness: proves each click actually produced a new render,
+                    // so the step-2 "value did not change" assertion is not trivially true.
+                    TextBlock($"PlacementStep={step}"),
                     Flyout(Button("UpdatePlacementTarget"), TextBlock("update body"))
                         with { Placement = placement });
             });
@@ -116,7 +127,8 @@ public static class FlyoutPlacementFixtures
             // Left → Auto: documented no-reset semantic — the last real value stays,
             // and crucially Auto is never written back onto the DP.
             H.ClickButton("AdvancePlacement");
-            await Harness.Render();
+            await Harness.WaitFor(() => H.FindText("PlacementStep=2") is not null);
+            H.Check("FlyoutPlacement_Update_Step2Rendered", H.FindText("PlacementStep=2") is not null);
             H.Check("FlyoutPlacement_Update_AutoDoesNotOverwrite",
                 flyout?.Placement == WinPrim.FlyoutPlacementMode.Left);
 
@@ -124,8 +136,7 @@ public static class FlyoutPlacementFixtures
             await Harness.WaitFor(() => flyout?.IsOpen == true);
             H.Check("FlyoutPlacement_Update_OpensAfterUpdate", flyout?.IsOpen == true);
 
-            flyout?.Hide();
-            await Harness.Render();
+            await HideAndSettle(flyout);
         }
     }
 
@@ -138,22 +149,266 @@ public static class FlyoutPlacementFixtures
         public override async Task RunAsync()
         {
             var host = H.CreateHost();
-            host.Mount(_ => VStack(
-                Button("ContentFlyoutTarget", () => { })
-                    .WithFlyout(ContentFlyout(TextBlock("content flyout body")))));
+            host.Mount(ctx =>
+            {
+                var (pinned, setPinned) = ctx.UseState(false);
+                return VStack(
+                    Button("PinContentFlyout", () => setPinned(true)),
+                    Button("ContentFlyoutTarget", () => { })
+                        .WithFlyout(ContentFlyout(
+                            TextBlock("content flyout body"),
+                            pinned ? WinPrim.FlyoutPlacementMode.Bottom : WinPrim.FlyoutPlacementMode.Auto)),
+                    // Differential sibling: same CreateFlyoutFromElement arm, explicit
+                    // placement. Without it, deleting the Apply call entirely would still
+                    // satisfy the "not Auto" check above (an untouched DP reads Top).
+                    Button("ContentFlyoutPinnedTarget", () => { })
+                        .WithFlyout(ContentFlyout(
+                            TextBlock("pinned content body"),
+                            WinPrim.FlyoutPlacementMode.LeftEdgeAlignedBottom)));
+            });
             await Harness.Render();
 
             var flyout = FlyoutOn(H, "ContentFlyoutTarget");
             H.Check("FlyoutPlacement_ContentFlyout_FlyoutAttached", flyout is not null);
             H.Check("FlyoutPlacement_ContentFlyout_DpIsNotAuto",
                 flyout is not null && flyout.Placement != WinPrim.FlyoutPlacementMode.Auto);
+            H.Check("FlyoutPlacement_ContentFlyout_CreateAppliesExplicit",
+                FlyoutOn(H, "ContentFlyoutPinnedTarget")?.Placement
+                    == WinPrim.FlyoutPlacementMode.LeftEdgeAlignedBottom);
 
             H.ClickButton("ContentFlyoutTarget");
             await Harness.WaitFor(() => flyout?.IsOpen == true);
             H.Check("FlyoutPlacement_ContentFlyout_Opened", flyout?.IsOpen == true);
+            await HideAndSettle(flyout);
 
-            flyout?.Hide();
+            // UpdateFlyoutInPlace's ContentFlyout arm — an explicit placement must land
+            // on the flyout object that is already attached to the button.
+            H.ClickButton("PinContentFlyout");
+            await Harness.WaitFor(() => flyout?.Placement == WinPrim.FlyoutPlacementMode.Bottom);
+            H.Check("FlyoutPlacement_ContentFlyout_UpdateAppliesExplicit",
+                flyout?.Placement == WinPrim.FlyoutPlacementMode.Bottom);
+            H.Check("FlyoutPlacement_ContentFlyout_UpdateReusedFlyout",
+                ReferenceEquals(flyout, FlyoutOn(H, "ContentFlyoutTarget")));
+        }
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    //  MenuFlyout — the arms whose pre-existing `!= Auto` guards were folded
+    //  into the shared choke point (CreateFlyoutFromElement + UpdateFlyoutInPlace).
+    //  Driven through .WithContextFlyout(), which is its own reconciler path.
+    // ────────────────────────────────────────────────────────────────────
+    internal class MenuFlyout_ContextFlyout_DefaultPlacement(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                var (pinned, setPinned) = ctx.UseState(false);
+                return VStack(
+                    Button("PinMenuPlacement", () => setPinned(true)),
+                    Border(TextBlock("context menu target"))
+                        .WithContextFlyout(pinned
+                            ? MenuItems(WinPrim.FlyoutPlacementMode.Right, MenuItem("Copy"), MenuItem("Paste"))
+                            : MenuItems(MenuItem("Copy"))),
+                    // Differential sibling: same create arm, explicit placement, so the
+                    // "not Auto" check above cannot be satisfied by deleting the write.
+                    Border(TextBlock("pinned menu target"))
+                        .WithContextFlyout(MenuItems(WinPrim.FlyoutPlacementMode.Full, MenuItem("Pinned"))));
+            });
             await Harness.Render();
+
+            var border = H.FindControl<Microsoft.UI.Xaml.Controls.Border>(
+                b => b.Child is Microsoft.UI.Xaml.Controls.TextBlock tb && tb.Text == "context menu target");
+            var menu = border?.ContextFlyout as WinUI.MenuFlyout;
+            H.Check("FlyoutPlacement_MenuFlyout_ContextFlyoutAttached", menu is not null);
+            H.Check("FlyoutPlacement_MenuFlyout_DpIsNotAuto",
+                menu is not null && menu.Placement != WinPrim.FlyoutPlacementMode.Auto);
+
+            var pinnedBorder = H.FindControl<Microsoft.UI.Xaml.Controls.Border>(
+                b => b.Child is Microsoft.UI.Xaml.Controls.TextBlock tb && tb.Text == "pinned menu target");
+            H.Check("FlyoutPlacement_MenuFlyout_CreateAppliesExplicit",
+                (pinnedBorder?.ContextFlyout as WinUI.MenuFlyout)?.Placement
+                    == WinPrim.FlyoutPlacementMode.Full);
+
+            // UpdateFlyoutInPlace's MenuFlyout arm — explicit placement still lands.
+            H.ClickButton("PinMenuPlacement");
+            await Harness.WaitFor(() => menu?.Placement == WinPrim.FlyoutPlacementMode.Right);
+            H.Check("FlyoutPlacement_MenuFlyout_UpdateAppliesExplicit",
+                menu?.Placement == WinPrim.FlyoutPlacementMode.Right);
+            H.Check("FlyoutPlacement_MenuFlyout_UpdateReusedFlyout",
+                ReferenceEquals(menu, border?.ContextFlyout));
+        }
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    //  Button flyout slots — DropDownButton (MenuFlyout) and SplitButton
+    //  (Flyout) both resolve through Reconciler.CreateFlyoutFromElement.
+    // ────────────────────────────────────────────────────────────────────
+    internal class ButtonFlyoutSlots_DefaultPlacement(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var host = H.CreateHost();
+            host.Mount(_ => VStack(
+                DropDownButton("DropDownSlot", MenuItems(MenuItem("One"), MenuItem("Two"))),
+                SplitButton("SplitSlot", () => { }, ContentFlyout(TextBlock("split body"))),
+                // Differential siblings: same create arms, explicit placements — so the
+                // "not Auto" checks cannot be satisfied by deleting the write outright.
+                DropDownButton("DropDownPinnedSlot",
+                    MenuItems(WinPrim.FlyoutPlacementMode.BottomEdgeAlignedRight, MenuItem("Pinned"))),
+                SplitButton("SplitPinnedSlot", () => { },
+                    ContentFlyout(TextBlock("split pinned body"), WinPrim.FlyoutPlacementMode.Right))));
+            await Harness.Render();
+
+            var ddb = H.FindControl<WinUI.DropDownButton>(b => b.Content is string s && s == "DropDownSlot");
+            var ddbFlyout = ddb?.Flyout as WinUI.MenuFlyout;
+            H.Check("FlyoutPlacement_DropDownButton_MenuFlyoutAttached", ddbFlyout is not null);
+            H.Check("FlyoutPlacement_DropDownButton_DpIsNotAuto",
+                ddbFlyout is not null && ddbFlyout.Placement != WinPrim.FlyoutPlacementMode.Auto);
+            H.Check("FlyoutPlacement_DropDownButton_CreateAppliesExplicit",
+                (H.FindControl<WinUI.DropDownButton>(b => b.Content is string s && s == "DropDownPinnedSlot")
+                    ?.Flyout as WinUI.MenuFlyout)?.Placement
+                        == WinPrim.FlyoutPlacementMode.BottomEdgeAlignedRight);
+
+            var split = H.FindControl<WinUI.SplitButton>(b => b.Content is string s && s == "SplitSlot");
+            var splitFlyout = split?.Flyout as WinUI.Flyout;
+            H.Check("FlyoutPlacement_SplitButton_FlyoutAttached", splitFlyout is not null);
+            H.Check("FlyoutPlacement_SplitButton_DpIsNotAuto",
+                splitFlyout is not null && splitFlyout.Placement != WinPrim.FlyoutPlacementMode.Auto);
+            H.Check("FlyoutPlacement_SplitButton_CreateAppliesExplicit",
+                (H.FindControl<WinUI.SplitButton>(b => b.Content is string s && s == "SplitPinnedSlot")
+                    ?.Flyout as WinUI.Flyout)?.Placement == WinPrim.FlyoutPlacementMode.Right);
+        }
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    //  CommandBarFlyout — mount + the update branch that re-creates the flyout
+    //  because the target's element type changed (so no attached flyout exists).
+    //  CommandBarFlyout tolerates Auto today, so this pins consistency, not a crash.
+    // ────────────────────────────────────────────────────────────────────
+    internal class CommandBarFlyout_DefaultPlacement_NotAuto(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                var (swapped, setSwapped) = ctx.UseState(false);
+                return VStack(
+                    Button("SwapCbfTarget", () => setSwapped(true)),
+                    CommandBarFlyout(
+                        swapped
+                            ? Border(TextBlock("CbfBorderTarget"))
+                            : (Element)Button("CbfButtonTarget", () => { }),
+                        primaryCommands: [AppBarButton("Bold")]),
+                    // Differential sibling: same mount + re-create arms, explicit placement.
+                    CommandBarFlyout(
+                        swapped
+                            ? Border(TextBlock("CbfPinnedBorderTarget"))
+                            : (Element)Button("CbfPinnedButtonTarget", () => { }),
+                        primaryCommands: [AppBarButton("Italic")])
+                        with { Placement = WinPrim.FlyoutPlacementMode.BottomEdgeAlignedLeft });
+            });
+            await Harness.Render();
+
+            var cbfButton = H.FindButton("CbfButtonTarget");
+            H.Check("FlyoutPlacement_CommandBarFlyout_TargetMounted", cbfButton is not null);
+            // CommandBarFlyout attaches via FlyoutBase.SetAttachedFlyout, not Button.Flyout.
+            var mounted = cbfButton is null
+                ? null
+                : WinPrim.FlyoutBase.GetAttachedFlyout(cbfButton) as WinUI.CommandBarFlyout;
+            H.Check("FlyoutPlacement_CommandBarFlyout_MountAttached", mounted is not null);
+            H.Check("FlyoutPlacement_CommandBarFlyout_MountDpIsNotAuto",
+                mounted is not null && mounted.Placement != WinPrim.FlyoutPlacementMode.Auto);
+
+            var pinnedButton = H.FindButton("CbfPinnedButtonTarget");
+            H.Check("FlyoutPlacement_CommandBarFlyout_MountAppliesExplicit",
+                pinnedButton is not null
+                && (WinPrim.FlyoutBase.GetAttachedFlyout(pinnedButton) as WinUI.CommandBarFlyout)?.Placement
+                    == WinPrim.FlyoutPlacementMode.BottomEdgeAlignedLeft);
+
+            // Target type change → UpdateCommandBarFlyout's "no existing flyout" branch.
+            H.ClickButton("SwapCbfTarget");
+            await Harness.WaitFor(() => AttachedCommandBarFlyout(H, "CbfBorderTarget") is not null);
+            var recreated = AttachedCommandBarFlyout(H, "CbfBorderTarget");
+            H.Check("FlyoutPlacement_CommandBarFlyout_RecreatedAttached", recreated is not null);
+            H.Check("FlyoutPlacement_CommandBarFlyout_RecreatedDpIsNotAuto",
+                recreated is not null && recreated.Placement != WinPrim.FlyoutPlacementMode.Auto);
+            H.Check("FlyoutPlacement_CommandBarFlyout_RecreatedAppliesExplicit",
+                AttachedCommandBarFlyout(H, "CbfPinnedBorderTarget")?.Placement
+                    == WinPrim.FlyoutPlacementMode.BottomEdgeAlignedLeft);
+        }
+
+        private static WinUI.CommandBarFlyout? AttachedCommandBarFlyout(Harness h, string markerText)
+        {
+            var border = h.FindControl<Microsoft.UI.Xaml.Controls.Border>(
+                b => b.Child is Microsoft.UI.Xaml.Controls.TextBlock tb && tb.Text == markerText);
+            return border is null
+                ? null
+                : WinPrim.FlyoutBase.GetAttachedFlyout(border) as WinUI.CommandBarFlyout;
+        }
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    //  Flyout(...) whose Target element type changes — UpdateFlyoutElement's
+    //  "create fresh" branch, which builds a brand-new WinUI.Flyout.
+    // ────────────────────────────────────────────────────────────────────
+    internal class Flyout_TargetTypeChange_FreshFlyoutNotAuto(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                var (swapped, setSwapped) = ctx.UseState(false);
+                return VStack(
+                    Button("SwapFlyoutTarget", () => setSwapped(true)),
+                    Flyout(
+                        swapped
+                            ? Border(TextBlock("FreshBorderTarget"))
+                            : (Element)Button("FreshButtonTarget", () => { }),
+                        TextBlock("fresh body")),
+                    // Differential sibling: same fresh-create branch, explicit placement.
+                    Flyout(
+                        swapped
+                            ? Border(TextBlock("FreshPinnedBorderTarget"))
+                            : (Element)Button("FreshPinnedButtonTarget", () => { }),
+                        TextBlock("fresh pinned body"))
+                        with { Placement = WinPrim.FlyoutPlacementMode.TopEdgeAlignedRight });
+            });
+            await Harness.Render();
+
+            H.Check("FlyoutPlacement_Fresh_MountedOnButton",
+                FlyoutOn(H, "FreshButtonTarget") is not null);
+
+            H.ClickButton("SwapFlyoutTarget");
+            await Harness.WaitFor(() => AttachedFlyout(H, "FreshBorderTarget") is not null);
+
+            var fresh = AttachedFlyout(H, "FreshBorderTarget");
+            H.Check("FlyoutPlacement_Fresh_FlyoutAttached", fresh is not null);
+            H.Check("FlyoutPlacement_Fresh_DpIsNotAuto",
+                fresh is not null && fresh.Placement != WinPrim.FlyoutPlacementMode.Auto);
+            H.Check("FlyoutPlacement_Fresh_AppliesExplicit",
+                AttachedFlyout(H, "FreshPinnedBorderTarget")?.Placement
+                    == WinPrim.FlyoutPlacementMode.TopEdgeAlignedRight);
+
+            var target = FreshTarget(H, "FreshBorderTarget");
+            if (target is not null) WinPrim.FlyoutBase.ShowAttachedFlyout(target);
+            await Harness.WaitFor(() => fresh?.IsOpen == true);
+            H.Check("FlyoutPlacement_Fresh_Opened", fresh?.IsOpen == true);
+
+            await HideAndSettle(fresh);
+        }
+
+        private static Microsoft.UI.Xaml.Controls.Border? FreshTarget(Harness h, string markerText)
+            => h.FindControl<Microsoft.UI.Xaml.Controls.Border>(
+                b => b.Child is Microsoft.UI.Xaml.Controls.TextBlock tb && tb.Text == markerText);
+
+        private static WinUI.Flyout? AttachedFlyout(Harness h, string markerText)
+        {
+            var target = FreshTarget(h, markerText);
+            return target is null ? null : WinPrim.FlyoutBase.GetAttachedFlyout(target) as WinUI.Flyout;
         }
     }
 }

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/FlyoutPlacementFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/FlyoutPlacementFixtures.cs
@@ -124,7 +124,8 @@ public static class FlyoutPlacementFixtures
 
     // ────────────────────────────────────────────────────────────────────
     //  Update path: an explicit placement lands on the already-mounted flyout,
-    //  and going back to Auto never writes Auto (it keeps the last real value).
+    //  and going back to Auto clears the DP so it returns to the platform default
+    //  rather than leaving a stale local value behind (see issue #952).
     // ────────────────────────────────────────────────────────────────────
     internal class Flyout_PlacementUpdate_NeverWritesAuto(Harness h) : SelfTestFixtureBase(h)
     {
@@ -160,13 +161,16 @@ public static class FlyoutPlacementFixtures
             H.Check("FlyoutPlacement_Update_ExplicitApplied",
                 flyout?.Placement == WinPrim.FlyoutPlacementMode.Left);
 
-            // Left → Auto: documented no-reset semantic — the last real value stays,
-            // and crucially Auto is never written back onto the DP.
+            // Left → Auto: the DP is cleared, so it returns to the platform default
+            // rather than retaining Left as a stale local value — and crucially Auto
+            // itself is still never written onto the DP.
             H.ClickButton("AdvancePlacement");
             await Harness.WaitFor(() => H.FindText("PlacementStep=2") is not null);
             H.Check("FlyoutPlacement_Update_Step2Rendered", H.FindText("PlacementStep=2") is not null);
-            H.Check("FlyoutPlacement_Update_AutoDoesNotOverwrite",
-                flyout?.Placement == WinPrim.FlyoutPlacementMode.Left);
+            H.Check("FlyoutPlacement_Update_AutoResetsToPlatformDefault",
+                flyout?.Placement == new WinUI.Flyout().Placement);
+            H.Check("FlyoutPlacement_Update_AutoNeverWritesAuto",
+                flyout?.Placement != WinPrim.FlyoutPlacementMode.Auto);
 
             H.ClickButton("UpdatePlacementTarget");
             await Harness.WaitFor(() => flyout?.IsOpen == true);

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -231,6 +231,10 @@ internal static class SelfTestFixtureRegistry
         "FlyoutPlacement_Flyout_ExplicitPlacement_ReachesTheControl",
         "FlyoutPlacement_Flyout_PlacementUpdate_NeverWritesAuto",
         "FlyoutPlacement_ContentFlyout_DefaultPlacement_Opens",
+        "FlyoutPlacement_MenuFlyout_ContextFlyout_DefaultPlacement",
+        "FlyoutPlacement_ButtonFlyoutSlots_DefaultPlacement",
+        "FlyoutPlacement_CommandBarFlyout_DefaultPlacement_NotAuto",
+        "FlyoutPlacement_Flyout_TargetTypeChange_FreshFlyoutNotAuto",
         // Issue #480 — InlineUIContainer rich-text inline (Route A + Route B + unmount)
         "InlineUI_RouteA_ReactorChild",
         "InlineUI_RouteB_NativeFactory",
@@ -1821,6 +1825,10 @@ internal static class SelfTestFixtureRegistry
         "FlyoutPlacement_Flyout_ExplicitPlacement_ReachesTheControl" => new FlyoutPlacementFixtures.Flyout_ExplicitPlacement_ReachesTheControl(harness),
         "FlyoutPlacement_Flyout_PlacementUpdate_NeverWritesAuto" => new FlyoutPlacementFixtures.Flyout_PlacementUpdate_NeverWritesAuto(harness),
         "FlyoutPlacement_ContentFlyout_DefaultPlacement_Opens" => new FlyoutPlacementFixtures.ContentFlyout_DefaultPlacement_Opens(harness),
+        "FlyoutPlacement_MenuFlyout_ContextFlyout_DefaultPlacement" => new FlyoutPlacementFixtures.MenuFlyout_ContextFlyout_DefaultPlacement(harness),
+        "FlyoutPlacement_ButtonFlyoutSlots_DefaultPlacement" => new FlyoutPlacementFixtures.ButtonFlyoutSlots_DefaultPlacement(harness),
+        "FlyoutPlacement_CommandBarFlyout_DefaultPlacement_NotAuto" => new FlyoutPlacementFixtures.CommandBarFlyout_DefaultPlacement_NotAuto(harness),
+        "FlyoutPlacement_Flyout_TargetTypeChange_FreshFlyoutNotAuto" => new FlyoutPlacementFixtures.Flyout_TargetTypeChange_FreshFlyoutNotAuto(harness),
         // Issue #480 — InlineUIContainer rich-text inline.
         "InlineUI_RouteA_ReactorChild" => new InlineUIContainerFixtures.InlineUI_RouteA_ReactorChild(harness),
         "InlineUI_RouteB_NativeFactory" => new InlineUIContainerFixtures.InlineUI_RouteB_NativeFactory(harness),

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -224,6 +224,13 @@ internal static class SelfTestFixtureRegistry
         "OverlayTeardown_Flyout_Unmount_RunsFlyoutContentCleanup",
         "OverlayTeardown_Flyout_Unmount_RunsPassThroughCleanup",
         "OverlayTeardown_Popup_Unmount_RunsChildCleanup",
+        // Flyout placement guard — Reactor must never write FlyoutPlacementMode.Auto
+        // onto a WinUI FlyoutBase (WinUI's show-time validator rejects it and
+        // fail-fasts the process). These fixtures actually open the flyout.
+        "FlyoutPlacement_Flyout_DefaultPlacement_Opens",
+        "FlyoutPlacement_Flyout_ExplicitPlacement_ReachesTheControl",
+        "FlyoutPlacement_Flyout_PlacementUpdate_NeverWritesAuto",
+        "FlyoutPlacement_ContentFlyout_DefaultPlacement_Opens",
         // Issue #480 — InlineUIContainer rich-text inline (Route A + Route B + unmount)
         "InlineUI_RouteA_ReactorChild",
         "InlineUI_RouteB_NativeFactory",
@@ -1809,6 +1816,11 @@ internal static class SelfTestFixtureRegistry
         "OverlayTeardown_Flyout_Unmount_RunsFlyoutContentCleanup" => new OverlayTeardownFixtures.Flyout_Unmount_RunsFlyoutContentCleanup(harness),
         "OverlayTeardown_Flyout_Unmount_RunsPassThroughCleanup" => new OverlayTeardownFixtures.Flyout_Unmount_RunsPassThroughCleanup(harness),
         "OverlayTeardown_Popup_Unmount_RunsChildCleanup" => new OverlayTeardownFixtures.Popup_Unmount_RunsChildCleanup(harness),
+        // Flyout placement guard — Auto must never reach FlyoutBase.Placement.
+        "FlyoutPlacement_Flyout_DefaultPlacement_Opens" => new FlyoutPlacementFixtures.Flyout_DefaultPlacement_Opens(harness),
+        "FlyoutPlacement_Flyout_ExplicitPlacement_ReachesTheControl" => new FlyoutPlacementFixtures.Flyout_ExplicitPlacement_ReachesTheControl(harness),
+        "FlyoutPlacement_Flyout_PlacementUpdate_NeverWritesAuto" => new FlyoutPlacementFixtures.Flyout_PlacementUpdate_NeverWritesAuto(harness),
+        "FlyoutPlacement_ContentFlyout_DefaultPlacement_Opens" => new FlyoutPlacementFixtures.ContentFlyout_DefaultPlacement_Opens(harness),
         // Issue #480 — InlineUIContainer rich-text inline.
         "InlineUI_RouteA_ReactorChild" => new InlineUIContainerFixtures.InlineUI_RouteA_ReactorChild(harness),
         "InlineUI_RouteB_NativeFactory" => new InlineUIContainerFixtures.InlineUI_RouteB_NativeFactory(harness),

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -225,17 +225,18 @@ internal static class SelfTestFixtureRegistry
         "OverlayTeardown_Flyout_Unmount_RunsPassThroughCleanup",
         "OverlayTeardown_Popup_Unmount_RunsChildCleanup",
         // Flyout placement guard — Reactor must never write FlyoutPlacementMode.Auto
-        // onto a WinUI FlyoutBase (WinUI's show-time validator rejects it and
-        // fail-fasts the process). The Flyout/ContentFlyout/fresh-create fixtures
-        // actually open the flyout, which is the only thing that catches the crash;
-        // the button-slot and CommandBarFlyout ones pin the DP value only.
+        // onto a WinUI FlyoutBase whose validator rejects it (Flyout, MenuFlyout),
+        // because that fail-fasts the process. The Flyout/ContentFlyout/fresh-create
+        // fixtures actually open the flyout, which is the only thing that catches the
+        // crash; the button-slot one pins the DP value only. CommandBarFlyout is
+        // deliberately excluded from the guard — see its fixture for why.
         "FlyoutPlacement_Flyout_DefaultPlacement_Opens",
         "FlyoutPlacement_Flyout_ExplicitPlacement_ReachesTheControl",
         "FlyoutPlacement_Flyout_PlacementUpdate_NeverWritesAuto",
         "FlyoutPlacement_ContentFlyout_DefaultPlacement_Opens",
         "FlyoutPlacement_MenuFlyout_ContextFlyout_DefaultPlacement",
         "FlyoutPlacement_ButtonFlyoutSlots_DefaultPlacement",
-        "FlyoutPlacement_CommandBarFlyout_DefaultPlacement_NotAuto",
+        "FlyoutPlacement_CommandBarFlyout_KeepsAuto_Unguarded",
         "FlyoutPlacement_Flyout_TargetTypeChange_FreshFlyoutNotAuto",
         // Issue #480 — InlineUIContainer rich-text inline (Route A + Route B + unmount)
         "InlineUI_RouteA_ReactorChild",
@@ -1829,7 +1830,7 @@ internal static class SelfTestFixtureRegistry
         "FlyoutPlacement_ContentFlyout_DefaultPlacement_Opens" => new FlyoutPlacementFixtures.ContentFlyout_DefaultPlacement_Opens(harness),
         "FlyoutPlacement_MenuFlyout_ContextFlyout_DefaultPlacement" => new FlyoutPlacementFixtures.MenuFlyout_ContextFlyout_DefaultPlacement(harness),
         "FlyoutPlacement_ButtonFlyoutSlots_DefaultPlacement" => new FlyoutPlacementFixtures.ButtonFlyoutSlots_DefaultPlacement(harness),
-        "FlyoutPlacement_CommandBarFlyout_DefaultPlacement_NotAuto" => new FlyoutPlacementFixtures.CommandBarFlyout_DefaultPlacement_NotAuto(harness),
+        "FlyoutPlacement_CommandBarFlyout_KeepsAuto_Unguarded" => new FlyoutPlacementFixtures.CommandBarFlyout_KeepsAuto_Unguarded(harness),
         "FlyoutPlacement_Flyout_TargetTypeChange_FreshFlyoutNotAuto" => new FlyoutPlacementFixtures.Flyout_TargetTypeChange_FreshFlyoutNotAuto(harness),
         // Issue #480 — InlineUIContainer rich-text inline.
         "InlineUI_RouteA_ReactorChild" => new InlineUIContainerFixtures.InlineUI_RouteA_ReactorChild(harness),

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -225,11 +225,11 @@ internal static class SelfTestFixtureRegistry
         "OverlayTeardown_Flyout_Unmount_RunsPassThroughCleanup",
         "OverlayTeardown_Popup_Unmount_RunsChildCleanup",
         // Flyout placement guard — Reactor must never write FlyoutPlacementMode.Auto
-        // onto a WinUI FlyoutBase whose validator rejects it (Flyout, MenuFlyout),
-        // because that fail-fasts the process. The Flyout/ContentFlyout/fresh-create
-        // fixtures actually open the flyout, which is the only thing that catches the
-        // crash; the button-slot one pins the DP value only. CommandBarFlyout is
-        // deliberately excluded from the guard — see its fixture for why.
+        // onto a WinUI FlyoutBase, because the show-time validator rejects it and
+        // fail-fasts the process. The Flyout/ContentFlyout/fresh-create fixtures
+        // actually open the flyout, which is the only thing that catches the crash;
+        // the button-slot one pins the DP value only. CommandBarFlyout is affected
+        // too but is covered by the separate change that fixes it opening at all.
         "FlyoutPlacement_Platform_FlyoutBase_PlacementDefault",
         "FlyoutPlacement_Flyout_DefaultPlacement_Opens",
         "FlyoutPlacement_Flyout_ExplicitPlacement_ReachesTheControl",
@@ -237,7 +237,6 @@ internal static class SelfTestFixtureRegistry
         "FlyoutPlacement_ContentFlyout_DefaultPlacement_Opens",
         "FlyoutPlacement_MenuFlyout_ContextFlyout_DefaultPlacement",
         "FlyoutPlacement_ButtonFlyoutSlots_DefaultPlacement",
-        "FlyoutPlacement_CommandBarFlyout_KeepsAuto_Unguarded",
         "FlyoutPlacement_Flyout_TargetTypeChange_FreshFlyoutNotAuto",
         // Issue #480 — InlineUIContainer rich-text inline (Route A + Route B + unmount)
         "InlineUI_RouteA_ReactorChild",
@@ -1832,7 +1831,6 @@ internal static class SelfTestFixtureRegistry
         "FlyoutPlacement_ContentFlyout_DefaultPlacement_Opens" => new FlyoutPlacementFixtures.ContentFlyout_DefaultPlacement_Opens(harness),
         "FlyoutPlacement_MenuFlyout_ContextFlyout_DefaultPlacement" => new FlyoutPlacementFixtures.MenuFlyout_ContextFlyout_DefaultPlacement(harness),
         "FlyoutPlacement_ButtonFlyoutSlots_DefaultPlacement" => new FlyoutPlacementFixtures.ButtonFlyoutSlots_DefaultPlacement(harness),
-        "FlyoutPlacement_CommandBarFlyout_KeepsAuto_Unguarded" => new FlyoutPlacementFixtures.CommandBarFlyout_KeepsAuto_Unguarded(harness),
         "FlyoutPlacement_Flyout_TargetTypeChange_FreshFlyoutNotAuto" => new FlyoutPlacementFixtures.Flyout_TargetTypeChange_FreshFlyoutNotAuto(harness),
         // Issue #480 — InlineUIContainer rich-text inline.
         "InlineUI_RouteA_ReactorChild" => new InlineUIContainerFixtures.InlineUI_RouteA_ReactorChild(harness),

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -226,7 +226,9 @@ internal static class SelfTestFixtureRegistry
         "OverlayTeardown_Popup_Unmount_RunsChildCleanup",
         // Flyout placement guard — Reactor must never write FlyoutPlacementMode.Auto
         // onto a WinUI FlyoutBase (WinUI's show-time validator rejects it and
-        // fail-fasts the process). These fixtures actually open the flyout.
+        // fail-fasts the process). The Flyout/ContentFlyout/fresh-create fixtures
+        // actually open the flyout, which is the only thing that catches the crash;
+        // the button-slot and CommandBarFlyout ones pin the DP value only.
         "FlyoutPlacement_Flyout_DefaultPlacement_Opens",
         "FlyoutPlacement_Flyout_ExplicitPlacement_ReachesTheControl",
         "FlyoutPlacement_Flyout_PlacementUpdate_NeverWritesAuto",

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -230,6 +230,7 @@ internal static class SelfTestFixtureRegistry
         // fixtures actually open the flyout, which is the only thing that catches the
         // crash; the button-slot one pins the DP value only. CommandBarFlyout is
         // deliberately excluded from the guard — see its fixture for why.
+        "FlyoutPlacement_Platform_FlyoutBase_PlacementDefault",
         "FlyoutPlacement_Flyout_DefaultPlacement_Opens",
         "FlyoutPlacement_Flyout_ExplicitPlacement_ReachesTheControl",
         "FlyoutPlacement_Flyout_PlacementUpdate_NeverWritesAuto",
@@ -1824,6 +1825,7 @@ internal static class SelfTestFixtureRegistry
         "OverlayTeardown_Flyout_Unmount_RunsPassThroughCleanup" => new OverlayTeardownFixtures.Flyout_Unmount_RunsPassThroughCleanup(harness),
         "OverlayTeardown_Popup_Unmount_RunsChildCleanup" => new OverlayTeardownFixtures.Popup_Unmount_RunsChildCleanup(harness),
         // Flyout placement guard — Auto must never reach FlyoutBase.Placement.
+        "FlyoutPlacement_Platform_FlyoutBase_PlacementDefault" => new FlyoutPlacementFixtures.Platform_FlyoutBase_PlacementDefault(harness),
         "FlyoutPlacement_Flyout_DefaultPlacement_Opens" => new FlyoutPlacementFixtures.Flyout_DefaultPlacement_Opens(harness),
         "FlyoutPlacement_Flyout_ExplicitPlacement_ReachesTheControl" => new FlyoutPlacementFixtures.Flyout_ExplicitPlacement_ReachesTheControl(harness),
         "FlyoutPlacement_Flyout_PlacementUpdate_NeverWritesAuto" => new FlyoutPlacementFixtures.Flyout_PlacementUpdate_NeverWritesAuto(harness),

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -228,8 +228,8 @@ internal static class SelfTestFixtureRegistry
         // onto a WinUI FlyoutBase, because the show-time validator rejects it and
         // fail-fasts the process. The Flyout/ContentFlyout/fresh-create fixtures
         // actually open the flyout, which is the only thing that catches the crash;
-        // the button-slot one pins the DP value only. CommandBarFlyout is affected
-        // too but is covered by the separate change that fixes it opening at all.
+        // the button-slot one pins the DP value only. CommandBarFlyout was affected
+        // too and is guarded by the fix that made it open from its target at all.
         "FlyoutPlacement_Platform_FlyoutBase_PlacementDefault",
         "FlyoutPlacement_Flyout_DefaultPlacement_Opens",
         "FlyoutPlacement_Flyout_ExplicitPlacement_ReachesTheControl",

--- a/tests/Reactor.Tests/FlyoutPlacementGuardTests.cs
+++ b/tests/Reactor.Tests/FlyoutPlacementGuardTests.cs
@@ -1,0 +1,263 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.UI.Reactor.Cli.Pack;
+using Microsoft.UI.Reactor.Core;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests;
+
+/// <summary>
+/// Regression cover for the <c>Flyout(...)</c>-with-default-placement process kill.
+///
+/// WinUI's <c>FlyoutBase::ShowAtCore</c> validates the effective placement through
+/// <c>FlyoutBase::ValidateAndSetParameters</c>, whose switch only accepts <c>0..12</c>
+/// and fails everything else with <c>E_INVALIDARG</c>. <c>FlyoutPlacementMode.Auto</c>
+/// is <c>13</c>, so a flyout left at <c>Auto</c> fail-fasts the process the moment it is
+/// shown. Reactor's element records default to <c>Auto</c>, so the value must never reach
+/// the WinUI DP.
+///
+/// These are headless tests: <see cref="FlyoutPlacementMode"/> is a WinRT enum (a value
+/// type) so it is safe to touch, and the structural test only parses source text — no
+/// <c>Microsoft.UI.Xaml</c> object is constructed.
+/// </summary>
+public class FlyoutPlacementGuardTests
+{
+    // ════════════════════════════════════════════════════════════════
+    //  Decision function — the guard itself
+    // ════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// The 13 placement values WinUI's validator switch accepts (0..12). Spelled out
+    /// rather than derived from the enum so that a future WinUI enum addition shows up
+    /// as a deliberate failure in <see cref="Accepted_Values_Cover_The_Whole_Enum_Except_Auto"/>
+    /// instead of silently widening the guard.
+    /// </summary>
+    private static readonly FlyoutPlacementMode[] s_validatorAcceptedModes =
+    [
+        FlyoutPlacementMode.Top,
+        FlyoutPlacementMode.Bottom,
+        FlyoutPlacementMode.Left,
+        FlyoutPlacementMode.Right,
+        FlyoutPlacementMode.Full,
+        FlyoutPlacementMode.TopEdgeAlignedLeft,
+        FlyoutPlacementMode.TopEdgeAlignedRight,
+        FlyoutPlacementMode.BottomEdgeAlignedLeft,
+        FlyoutPlacementMode.BottomEdgeAlignedRight,
+        FlyoutPlacementMode.LeftEdgeAlignedTop,
+        FlyoutPlacementMode.LeftEdgeAlignedBottom,
+        FlyoutPlacementMode.RightEdgeAlignedTop,
+        FlyoutPlacementMode.RightEdgeAlignedBottom,
+    ];
+
+    public static TheoryData<FlyoutPlacementMode> ValidatorAcceptedModes()
+        => new(s_validatorAcceptedModes);
+
+    [Theory]
+    [MemberData(nameof(ValidatorAcceptedModes))]
+    public void ShouldApply_Is_True_For_Every_Placement_WinUI_Accepts(FlyoutPlacementMode mode)
+    {
+        Assert.True(
+            FlyoutPlacement.ShouldApply(mode),
+            $"{mode} is inside WinUI's accepted 0..12 range and must be written to FlyoutBase.Placement.");
+    }
+
+    [Fact]
+    public void ShouldApply_Is_False_For_Auto()
+    {
+        // Auto == 13 falls off the end of ValidateAndSetParameters' switch → E_INVALIDARG
+        // → stowed ArgumentException → process termination when the flyout is shown.
+        Assert.False(FlyoutPlacement.ShouldApply(FlyoutPlacementMode.Auto));
+    }
+
+    [Fact]
+    public void Auto_Is_The_Only_Value_Outside_The_Validator_Range()
+    {
+        // Pins the premise the guard rests on: Auto is 13, everything else is 0..12.
+        Assert.Equal(13, (int)FlyoutPlacementMode.Auto);
+
+        var outsideRange = Enum.GetValues<FlyoutPlacementMode>()
+            .Where(mode => (int)mode is < 0 or > 12)
+            .ToList();
+
+        Assert.Equal([FlyoutPlacementMode.Auto], outsideRange);
+    }
+
+    [Fact]
+    public void Accepted_Values_Cover_The_Whole_Enum_Except_Auto()
+    {
+        var accepted = s_validatorAcceptedModes.ToHashSet();
+
+        var expected = Enum.GetValues<FlyoutPlacementMode>()
+            .Where(mode => mode != FlyoutPlacementMode.Auto)
+            .ToHashSet();
+
+        Assert.Equal(expected, accepted);
+    }
+
+    // ════════════════════════════════════════════════════════════════
+    //  Structural guard — every flyout placement write goes through the choke point
+    // ════════════════════════════════════════════════════════════════
+
+    private const string HelperFileName = "FlyoutPlacement.cs";
+
+    [Fact]
+    public void No_Flyout_Placement_Write_Bypasses_FlyoutPlacement()
+    {
+        var writes = ScanCoreForFlyoutPlacementWrites();
+
+        var bypasses = writes
+            .Where(w => !string.Equals(Path.GetFileName(w.File), HelperFileName, StringComparison.Ordinal))
+            .Select(w => $"{Path.GetFileName(w.File)}({w.Line}): {w.Text}")
+            .OrderBy(s => s, StringComparer.Ordinal)
+            .ToList();
+
+        Assert.True(
+            bypasses.Count == 0,
+            "These sites write FlyoutBase.Placement directly instead of routing through " +
+            $"FlyoutPlacement.Apply, which lets FlyoutPlacementMode.Auto reach WinUI's validator " +
+            $"and terminate the process when the flyout is shown: [{string.Join("; ", bypasses)}]");
+    }
+
+    [Fact]
+    public void Scanner_Detects_The_Write_Inside_FlyoutPlacement()
+    {
+        // Anti-vacuity: a detector that never matches anything would make the test above
+        // pass unconditionally. Prove it finds the one legitimate write.
+        var writes = ScanCoreForFlyoutPlacementWrites();
+
+        var inHelper = writes
+            .Where(w => string.Equals(Path.GetFileName(w.File), HelperFileName, StringComparison.Ordinal))
+            .ToList();
+
+        var single = Assert.Single(inHelper);
+        Assert.Contains("Placement", single.Text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Scanner_Reads_The_Whole_Core_Library()
+    {
+        // Anti-vacuity: if the file walk silently found nothing (wrong root, renamed
+        // folder) the bypass test would also pass unconditionally.
+        Assert.True(
+            CoreSourceFiles().Count > 100,
+            "Expected to scan the whole src/Reactor tree; the source walk found too few files.");
+    }
+
+    [Fact]
+    public void Scanner_Flags_A_Synthetic_Bypass()
+    {
+        // Anti-vacuity, part 3: prove the matcher recognizes both write shapes the fix
+        // removed — a member assignment and a flyout object initializer.
+        const string source = """
+            class Sample
+            {
+                void M(Microsoft.UI.Xaml.Controls.Primitives.FlyoutBase existing)
+                {
+                    existing.Placement = Placement;
+                    var f = new WinUI.Flyout { Content = null, Placement = Placement };
+                    var e = new SomeElement { Placement = Placement };
+                    var t = new TeachingTip { PreferredPlacement = Placement };
+                }
+            }
+            """;
+
+        var hits = FindPlacementWrites("synthetic.cs", source)
+            .Select(w => w.Text)
+            .ToList();
+
+        Assert.Equal(2, hits.Count);
+        Assert.Contains(hits, h => h.StartsWith("existing.Placement", StringComparison.Ordinal));
+        Assert.Contains(hits, h => h.Contains("new WinUI.Flyout", StringComparison.Ordinal));
+    }
+
+    // ── scanning helpers ────────────────────────────────────────────
+
+    private readonly record struct PlacementWrite(string File, int Line, string Text);
+
+    private static List<string> CoreSourceFiles()
+    {
+        var root = RepoRootFinder.FindRepoRoot();
+        Assert.NotNull(root);
+        var coreDir = Path.Join(root!, "src", "Reactor");
+        Assert.True(Directory.Exists(coreDir), $"src/Reactor not found at {coreDir}");
+
+        return Directory
+            .EnumerateFiles(coreDir, "*.cs", SearchOption.AllDirectories)
+            // bin/obj hold generated + copied sources that are not part of the hand-written surface.
+            .Where(p => !p.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal)
+                     && !p.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+            .ToList();
+    }
+
+    private static List<PlacementWrite> ScanCoreForFlyoutPlacementWrites()
+    {
+        var writes = new List<PlacementWrite>();
+        foreach (var file in CoreSourceFiles())
+            writes.AddRange(FindPlacementWrites(file, File.ReadAllText(file)));
+        return writes;
+    }
+
+    /// <summary>
+    /// Finds writes that land on a live WinUI <c>FlyoutBase.Placement</c> DP:
+    /// <list type="bullet">
+    /// <item><c>receiver.Placement = ...</c> — Reactor element records are <c>init</c>-only,
+    /// so a member assignment can only target a mutable control.</item>
+    /// <item><c>new ...Flyout { Placement = ... }</c> — object initializers on a WinUI
+    /// flyout type. Element records are named <c>...Element</c> and the DSL builds them
+    /// with target-typed <c>new(...)</c>, so neither is matched.</item>
+    /// </list>
+    /// </summary>
+    private static IEnumerable<PlacementWrite> FindPlacementWrites(string file, string source)
+    {
+        var tree = CSharpSyntaxTree.ParseText(source);
+        var root = tree.GetCompilationUnitRoot();
+
+        foreach (var assignment in root.DescendantNodes().OfType<AssignmentExpressionSyntax>())
+        {
+            if (!assignment.IsKind(SyntaxKind.SimpleAssignmentExpression)) continue;
+
+            bool isPlacementWrite = assignment.Left switch
+            {
+                // receiver.Placement = ...
+                MemberAccessExpressionSyntax { Name.Identifier.Text: "Placement" } => true,
+                // { Placement = ... } inside new SomethingFlyout { ... }
+                IdentifierNameSyntax { Identifier.Text: "Placement" } =>
+                    IsFlyoutObjectInitializer(assignment),
+                _ => false,
+            };
+            if (!isPlacementWrite) continue;
+
+            var line = assignment.GetLocation().GetLineSpan().StartLinePosition.Line + 1;
+            yield return new PlacementWrite(file, line, Flatten(assignment));
+        }
+    }
+
+    private static bool IsFlyoutObjectInitializer(AssignmentExpressionSyntax assignment)
+    {
+        if (assignment.Parent is not InitializerExpressionSyntax initializer) return false;
+        if (initializer.Parent is not ObjectCreationExpressionSyntax creation) return false;
+
+        var typeName = creation.Type switch
+        {
+            QualifiedNameSyntax qualified => qualified.Right.Identifier.Text,
+            SimpleNameSyntax simple => simple.Identifier.Text,
+            _ => creation.Type.ToString(),
+        };
+        return typeName.EndsWith("Flyout", StringComparison.Ordinal);
+    }
+
+    private static string Flatten(AssignmentExpressionSyntax assignment)
+    {
+        var text = assignment.Parent is InitializerExpressionSyntax { Parent: ObjectCreationExpressionSyntax creation }
+            ? creation.ToString()
+            : assignment.ToString();
+        text = string.Join(' ', text.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries));
+        return text.Length <= 120 ? text : text[..120] + "…";
+    }
+}

--- a/tests/Reactor.Tests/FlyoutPlacementGuardTests.cs
+++ b/tests/Reactor.Tests/FlyoutPlacementGuardTests.cs
@@ -200,7 +200,18 @@ public class FlyoutPlacementGuardTests
 
     private readonly record struct PlacementWrite(string File, int Line, string Text);
 
-    private static List<string> CoreSourceFiles()
+    // Four [Fact]s consume these; walking src/Reactor and Roslyn-parsing every file once per
+    // test is pure overhead. Lazy also caches the assertion failure, so a broken repo-root
+    // lookup reports identically in every test instead of racing. Mirrors the memoization in
+    // AnalyzerTests/SetEventSubscriptionConsistencyTests.
+    private static readonly Lazy<List<string>> s_coreSourceFiles = new(FindCoreSourceFiles);
+    private static readonly Lazy<List<PlacementWrite>> s_placementWrites = new(ScanCore);
+
+    private static List<string> CoreSourceFiles() => s_coreSourceFiles.Value;
+
+    private static List<PlacementWrite> ScanCoreForFlyoutPlacementWrites() => s_placementWrites.Value;
+
+    private static List<string> FindCoreSourceFiles()
     {
         var root = RepoRootFinder.FindRepoRoot();
         Assert.NotNull(root);
@@ -215,7 +226,7 @@ public class FlyoutPlacementGuardTests
             .ToList();
     }
 
-    private static List<PlacementWrite> ScanCoreForFlyoutPlacementWrites()
+    private static List<PlacementWrite> ScanCore()
     {
         var writes = new List<PlacementWrite>();
         foreach (var file in CoreSourceFiles())

--- a/tests/Reactor.Tests/FlyoutPlacementGuardTests.cs
+++ b/tests/Reactor.Tests/FlyoutPlacementGuardTests.cs
@@ -184,18 +184,19 @@ public class FlyoutPlacementGuardTests
     }
 
     [Fact]
-    public void Scanner_Detects_The_Write_Inside_FlyoutPlacement()
+    public void Scanner_Detects_The_Writes_Inside_FlyoutPlacement()
     {
         // Anti-vacuity: a detector that never matches anything would make the test above
-        // pass unconditionally. Prove it finds the one legitimate write.
-        var writes = ScanCoreForFlyoutPlacementWrites();
-
-        var inHelper = writes
+        // pass unconditionally. Prove it finds both legitimate writes in the choke point —
+        // the explicit assignment and the ClearValue that handles Auto.
+        var inHelper = ScanCoreForFlyoutPlacementWrites()
             .Where(w => string.Equals(Path.GetFileName(w.File), HelperFileName, StringComparison.Ordinal))
+            .Select(w => w.Text)
             .ToList();
 
-        var single = Assert.Single(inHelper);
-        Assert.Contains("Placement", single.Text, StringComparison.Ordinal);
+        Assert.Equal(2, inHelper.Count);
+        Assert.Contains(inHelper, t => t.Contains("flyout.Placement = placement", StringComparison.Ordinal));
+        Assert.Contains(inHelper, t => t.Contains("ClearValue", StringComparison.Ordinal));
     }
 
     [Fact]

--- a/tests/Reactor.Tests/FlyoutPlacementGuardTests.cs
+++ b/tests/Reactor.Tests/FlyoutPlacementGuardTests.cs
@@ -127,17 +127,17 @@ public class FlyoutPlacementGuardTests
     /// </summary>
     /// <remarks>
     /// <para>
-    /// These three sites are left byte-identical to <c>main</c> here purely to avoid
-    /// conflicting with that in-flight work — <b>not</b> because <c>CommandBarFlyout</c> is
-    /// unaffected by the crash. It is affected: it simply never reached the validator,
-    /// because the flyout was installed as <c>AttachedFlyout</c> metadata that nothing ever
-    /// called <c>ShowAttachedFlyout</c> on. Once that wiring is fixed, a default
-    /// <see cref="FlyoutPlacementMode.Auto"/> reaches <c>ShowAtCore</c> and fail-fasts
-    /// exactly as it did for <c>Flyout</c>.
+    /// Those sites are guarded by <c>Reconciler.ApplyFlyoutPlacement</c>, not by
+    /// <c>FlyoutPlacement.Apply</c> — <b>not</b> because <c>CommandBarFlyout</c> is unaffected
+    /// by the crash. It is affected: it simply never reached the validator, because the flyout
+    /// was installed as <c>AttachedFlyout</c> metadata that nothing ever called
+    /// <c>ShowAttachedFlyout</c> on. Once that wiring was fixed, a default
+    /// <see cref="FlyoutPlacementMode.Auto"/> reached <c>ShowAtCore</c> and fail-fasted exactly
+    /// as it did for <c>Flyout</c>.
     /// </para>
     /// <para>
-    /// Keyed by method name so it holds whether those methods still write placement directly
-    /// or have been routed through a helper.
+    /// Keyed by method name so it holds regardless of whether those methods write placement
+    /// directly or route it through a helper.
     /// </para>
     /// </remarks>
     private static readonly string[] MethodsOwnedElsewhere =

--- a/tests/Reactor.Tests/FlyoutPlacementGuardTests.cs
+++ b/tests/Reactor.Tests/FlyoutPlacementGuardTests.cs
@@ -107,20 +107,40 @@ public class FlyoutPlacementGuardTests
     private const string HelperFileName = "FlyoutPlacement.cs";
 
     /// <summary>
-    /// Methods whose flyout deliberately keeps <see cref="FlyoutPlacementMode.Auto"/>, so a
-    /// raw <c>Placement</c> write there is correct rather than a bypass.
+    /// Other single-purpose helpers that own a flyout placement write. A write inside one of
+    /// these is the choke point, not a bypass.
     /// </summary>
     /// <remarks>
-    /// Only <c>CommandBarFlyout</c> qualifies. Suppressing the write is <b>not</b> neutral:
-    /// <c>FlyoutBase.Placement</c> defaults to <see cref="FlyoutPlacementMode.Top"/>, so
-    /// "don't write" means the flyout pins to <c>Top</c>. That is the right outcome for
-    /// <c>Flyout</c>/<c>MenuFlyout</c>, whose show-time validator rejects <c>Auto</c>
-    /// outright — but <c>CommandBarFlyout</c> resolves <c>Auto</c> itself and positions
-    /// automatically today, so guarding it would silently pin it to <c>Top</c> and change
-    /// where a working control appears. Keyed by method name (not file or line) so it
-    /// survives the in-flight rewrite of these two methods.
+    /// <c>ApplyFlyoutPlacement</c> is the sibling helper introduced alongside the
+    /// <c>CommandBarFlyout</c> wiring fix. Listing it here keeps this guard meaningful across
+    /// that change instead of firing on a legitimate choke point; the two are expected to
+    /// converge on one helper afterwards.
     /// </remarks>
-    private static readonly string[] AutoTolerantFlyoutMethods =
+    private static readonly string[] PlacementHelperMethods =
+    [
+        "ApplyFlyoutPlacement",
+    ];
+
+    /// <summary>
+    /// Methods owned by the <c>CommandBarFlyout</c> wiring fix rather than by this change.
+    /// This guard takes no position on what they do with placement.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// These three sites are left byte-identical to <c>main</c> here purely to avoid
+    /// conflicting with that in-flight work — <b>not</b> because <c>CommandBarFlyout</c> is
+    /// unaffected by the crash. It is affected: it simply never reached the validator,
+    /// because the flyout was installed as <c>AttachedFlyout</c> metadata that nothing ever
+    /// called <c>ShowAttachedFlyout</c> on. Once that wiring is fixed, a default
+    /// <see cref="FlyoutPlacementMode.Auto"/> reaches <c>ShowAtCore</c> and fail-fasts
+    /// exactly as it did for <c>Flyout</c>.
+    /// </para>
+    /// <para>
+    /// Keyed by method name so it holds whether those methods still write placement directly
+    /// or have been routed through a helper.
+    /// </para>
+    /// </remarks>
+    private static readonly string[] MethodsOwnedElsewhere =
     [
         "MountCommandBarFlyout",
         "UpdateCommandBarFlyout",
@@ -133,7 +153,8 @@ public class FlyoutPlacementGuardTests
 
         var bypasses = writes
             .Where(w => !string.Equals(Path.GetFileName(w.File), HelperFileName, StringComparison.Ordinal))
-            .Where(w => !AutoTolerantFlyoutMethods.Contains(w.Method, StringComparer.Ordinal))
+            .Where(w => !PlacementHelperMethods.Contains(w.Method, StringComparer.Ordinal))
+            .Where(w => !MethodsOwnedElsewhere.Contains(w.Method, StringComparer.Ordinal))
             .Select(w => $"{Path.GetFileName(w.File)}({w.Line}) in {w.Method}: {w.Text}")
             .OrderBy(s => s, StringComparer.Ordinal)
             .ToList();
@@ -144,20 +165,21 @@ public class FlyoutPlacementGuardTests
             "FlyoutPlacement.Apply, which lets FlyoutPlacementMode.Auto reach WinUI's validator " +
             "and terminate the process when the flyout is shown: " +
             $"[{string.Join("; ", bypasses)}]. Route the write through FlyoutPlacement.Apply, or " +
-            "— if the flyout type genuinely tolerates Auto, as CommandBarFlyout does — add the " +
-            $"enclosing method to {nameof(AutoTolerantFlyoutMethods)} with a comment explaining why.");
+            $"— if it is itself a placement helper — add the method to {nameof(PlacementHelperMethods)}.");
     }
 
     [Fact]
-    public void CommandBarFlyout_Is_Deliberately_Left_Unguarded()
+    public void CommandBarFlyout_Sites_Are_Left_To_The_Wiring_Fix()
     {
-        // Pins the asymmetry so a later "consistency" cleanup cannot quietly guard
-        // CommandBarFlyout — which would stop it auto-positioning and pin it to Top.
+        // Documents the partition rather than asserting a behaviour: whatever the
+        // CommandBarFlyout methods do with placement, this guard must not flag it, and this
+        // change must not be the thing that guards them. Deliberately tolerates both states
+        // — direct writes today, helper-routed once the wiring fix lands — so neither PR
+        // breaks the other regardless of merge order.
         var exempt = ScanCoreForFlyoutPlacementWrites()
-            .Where(w => AutoTolerantFlyoutMethods.Contains(w.Method, StringComparer.Ordinal))
+            .Where(w => MethodsOwnedElsewhere.Contains(w.Method, StringComparer.Ordinal))
             .ToList();
 
-        Assert.NotEmpty(exempt);
         Assert.All(exempt, w => Assert.Contains("CommandBarFlyout", w.Method, StringComparison.Ordinal));
     }
 
@@ -202,9 +224,11 @@ public class FlyoutPlacementGuardTests
                     var f = new WinUI.Flyout { Content = null, Placement = Placement };
                     existing.SetValue(WinPrim.FlyoutBase.PlacementProperty, Placement);
                     existing.SetCurrentValue(FlyoutBase.PlacementProperty, Placement);
+                    existing.ClearValue(WinPrim.FlyoutBase.PlacementProperty);
                     var e = new SomeElement { Placement = Placement };
                     var t = new TeachingTip { PreferredPlacement = Placement };
                     existing.SetValue(TeachingTip.PreferredPlacementProperty, Placement);
+                    existing.ClearValue(TeachingTip.PreferredPlacementProperty);
                     var read = existing.Placement;
                 }
             }
@@ -214,11 +238,12 @@ public class FlyoutPlacementGuardTests
             .Select(w => w.Text)
             .ToList();
 
-        Assert.Equal(4, hits.Count);
+        Assert.Equal(5, hits.Count);
         Assert.Contains(hits, h => h.StartsWith("existing.Placement", StringComparison.Ordinal));
         Assert.Contains(hits, h => h.Contains("new WinUI.Flyout", StringComparison.Ordinal));
         Assert.Contains(hits, h => h.Contains("SetValue(WinPrim.FlyoutBase.PlacementProperty", StringComparison.Ordinal));
         Assert.Contains(hits, h => h.Contains("SetCurrentValue(FlyoutBase.PlacementProperty", StringComparison.Ordinal));
+        Assert.Contains(hits, h => h.Contains("ClearValue(WinPrim.FlyoutBase.PlacementProperty", StringComparison.Ordinal));
     }
 
     [Fact]
@@ -246,8 +271,9 @@ public class FlyoutPlacementGuardTests
             .ToDictionary(w => w.Method, w => w);
 
         Assert.Equal(2, byMethod.Count);
-        Assert.Contains("MountCommandBarFlyout", AutoTolerantFlyoutMethods);
-        Assert.DoesNotContain("MountFlyout", AutoTolerantFlyoutMethods);
+        Assert.Contains("MountCommandBarFlyout", MethodsOwnedElsewhere);
+        Assert.DoesNotContain("MountFlyout", MethodsOwnedElsewhere);
+        Assert.DoesNotContain("MountFlyout", PlacementHelperMethods);
         Assert.Equal("MountCommandBarFlyout", byMethod["MountCommandBarFlyout"].Method);
         Assert.Equal("MountFlyout", byMethod["MountFlyout"].Method);
     }
@@ -338,14 +364,15 @@ public class FlyoutPlacementGuardTests
         };
 
     /// <summary>
-    /// Matches <c>x.SetValue(&lt;anything&gt;FlyoutBase.PlacementProperty, v)</c> and the
-    /// <c>SetCurrentValue</c> sibling, regardless of how <c>FlyoutBase</c> is qualified.
+    /// Matches <c>x.SetValue(&lt;anything&gt;FlyoutBase.PlacementProperty, v)</c>, the
+    /// <c>SetCurrentValue</c> sibling, and <c>x.ClearValue(...PlacementProperty)</c>,
+    /// regardless of how <c>FlyoutBase</c> is qualified.
     /// </summary>
     private static bool IsPlacementDpWrite(InvocationExpressionSyntax invocation)
     {
         if (invocation.Expression is not MemberAccessExpressionSyntax
-            { Name.Identifier.Text: "SetValue" or "SetCurrentValue" }) return false;
-        if (invocation.ArgumentList.Arguments.Count < 2) return false;
+            { Name.Identifier.Text: "SetValue" or "SetCurrentValue" or "ClearValue" }) return false;
+        if (invocation.ArgumentList.Arguments.Count < 1) return false;
 
         var dp = invocation.ArgumentList.Arguments[0].Expression;
         return dp is MemberAccessExpressionSyntax

--- a/tests/Reactor.Tests/FlyoutPlacementGuardTests.cs
+++ b/tests/Reactor.Tests/FlyoutPlacementGuardTests.cs
@@ -106,6 +106,14 @@ public class FlyoutPlacementGuardTests
 
     private const string HelperFileName = "FlyoutPlacement.cs";
 
+    /// <summary>
+    /// Files allowed to write a <c>Placement</c> member that is provably NOT a WinUI
+    /// <c>FlyoutBase.Placement</c> dependency property. Empty today — the scan is
+    /// syntactic, so a future non-flyout <c>Placement</c> setter is expected to land here
+    /// as a deliberate, reviewed edit rather than silently widening the matcher.
+    /// </summary>
+    private static readonly string[] NonFlyoutPlacementWriteFiles = [];
+
     [Fact]
     public void No_Flyout_Placement_Write_Bypasses_FlyoutPlacement()
     {
@@ -113,6 +121,7 @@ public class FlyoutPlacementGuardTests
 
         var bypasses = writes
             .Where(w => !string.Equals(Path.GetFileName(w.File), HelperFileName, StringComparison.Ordinal))
+            .Where(w => !NonFlyoutPlacementWriteFiles.Contains(Path.GetFileName(w.File), StringComparer.Ordinal))
             .Select(w => $"{Path.GetFileName(w.File)}({w.Line}): {w.Text}")
             .OrderBy(s => s, StringComparer.Ordinal)
             .ToList();
@@ -120,8 +129,11 @@ public class FlyoutPlacementGuardTests
         Assert.True(
             bypasses.Count == 0,
             "These sites write FlyoutBase.Placement directly instead of routing through " +
-            $"FlyoutPlacement.Apply, which lets FlyoutPlacementMode.Auto reach WinUI's validator " +
-            $"and terminate the process when the flyout is shown: [{string.Join("; ", bypasses)}]");
+            "FlyoutPlacement.Apply, which lets FlyoutPlacementMode.Auto reach WinUI's validator " +
+            "and terminate the process when the flyout is shown: " +
+            $"[{string.Join("; ", bypasses)}]. Route the write through FlyoutPlacement.Apply, or " +
+            "— if this is genuinely not a WinUI FlyoutBase.Placement write — add the file to " +
+            $"{nameof(NonFlyoutPlacementWriteFiles)} with a comment explaining why.");
     }
 
     [Fact]
@@ -152,8 +164,10 @@ public class FlyoutPlacementGuardTests
     [Fact]
     public void Scanner_Flags_A_Synthetic_Bypass()
     {
-        // Anti-vacuity, part 3: prove the matcher recognizes both write shapes the fix
-        // removed — a member assignment and a flyout object initializer.
+        // Anti-vacuity, part 3: prove the matcher recognizes every write shape that can
+        // reach FlyoutBase.Placement — a member assignment, a flyout object initializer,
+        // and the SetValue/SetCurrentValue DP escape hatches — while ignoring the
+        // look-alikes (element-record initializers, a differently-named placement DP).
         const string source = """
             class Sample
             {
@@ -161,8 +175,12 @@ public class FlyoutPlacementGuardTests
                 {
                     existing.Placement = Placement;
                     var f = new WinUI.Flyout { Content = null, Placement = Placement };
+                    existing.SetValue(WinPrim.FlyoutBase.PlacementProperty, Placement);
+                    existing.SetCurrentValue(FlyoutBase.PlacementProperty, Placement);
                     var e = new SomeElement { Placement = Placement };
                     var t = new TeachingTip { PreferredPlacement = Placement };
+                    existing.SetValue(TeachingTip.PreferredPlacementProperty, Placement);
+                    var read = existing.Placement;
                 }
             }
             """;
@@ -171,9 +189,11 @@ public class FlyoutPlacementGuardTests
             .Select(w => w.Text)
             .ToList();
 
-        Assert.Equal(2, hits.Count);
+        Assert.Equal(4, hits.Count);
         Assert.Contains(hits, h => h.StartsWith("existing.Placement", StringComparison.Ordinal));
         Assert.Contains(hits, h => h.Contains("new WinUI.Flyout", StringComparison.Ordinal));
+        Assert.Contains(hits, h => h.Contains("SetValue(WinPrim.FlyoutBase.PlacementProperty", StringComparison.Ordinal));
+        Assert.Contains(hits, h => h.Contains("SetCurrentValue(FlyoutBase.PlacementProperty", StringComparison.Ordinal));
     }
 
     // ── scanning helpers ────────────────────────────────────────────
@@ -211,32 +231,72 @@ public class FlyoutPlacementGuardTests
     /// <item><c>new ...Flyout { Placement = ... }</c> — object initializers on a WinUI
     /// flyout type. Element records are named <c>...Element</c> and the DSL builds them
     /// with target-typed <c>new(...)</c>, so neither is matched.</item>
+    /// <item><c>SetValue(FlyoutBase.PlacementProperty, ...)</c> and
+    /// <c>SetCurrentValue(...)</c> — the DP escape hatches that bypass the CLR property.</item>
     /// </list>
+    /// The match is syntactic (no semantic model, so the scan needs no compilation), which
+    /// is why <see cref="NonFlyoutPlacementWriteFiles"/> exists as the deliberate escape
+    /// valve for a future non-flyout <c>Placement</c> setter.
     /// </summary>
     private static IEnumerable<PlacementWrite> FindPlacementWrites(string file, string source)
     {
         var tree = CSharpSyntaxTree.ParseText(source);
         var root = tree.GetCompilationUnitRoot();
 
-        foreach (var assignment in root.DescendantNodes().OfType<AssignmentExpressionSyntax>())
+        foreach (var node in root.DescendantNodes())
         {
-            if (!assignment.IsKind(SyntaxKind.SimpleAssignmentExpression)) continue;
-
-            bool isPlacementWrite = assignment.Left switch
+            switch (node)
             {
-                // receiver.Placement = ...
-                MemberAccessExpressionSyntax { Name.Identifier.Text: "Placement" } => true,
-                // { Placement = ... } inside new SomethingFlyout { ... }
-                IdentifierNameSyntax { Identifier.Text: "Placement" } =>
-                    IsFlyoutObjectInitializer(assignment),
-                _ => false,
-            };
-            if (!isPlacementWrite) continue;
+                case AssignmentExpressionSyntax assignment
+                    when assignment.IsKind(SyntaxKind.SimpleAssignmentExpression)
+                      && IsPlacementAssignment(assignment):
+                    yield return Write(file, assignment, Flatten(assignment));
+                    break;
 
-            var line = assignment.GetLocation().GetLineSpan().StartLinePosition.Line + 1;
-            yield return new PlacementWrite(file, line, Flatten(assignment));
+                case InvocationExpressionSyntax invocation when IsPlacementDpWrite(invocation):
+                    yield return Write(file, invocation, Flatten(invocation.ToString()));
+                    break;
+            }
         }
     }
+
+    private static bool IsPlacementAssignment(AssignmentExpressionSyntax assignment) =>
+        assignment.Left switch
+        {
+            // receiver.Placement = ...
+            MemberAccessExpressionSyntax { Name.Identifier.Text: "Placement" } => true,
+            // { Placement = ... } inside new SomethingFlyout { ... }
+            IdentifierNameSyntax { Identifier.Text: "Placement" } => IsFlyoutObjectInitializer(assignment),
+            _ => false,
+        };
+
+    /// <summary>
+    /// Matches <c>x.SetValue(&lt;anything&gt;FlyoutBase.PlacementProperty, v)</c> and the
+    /// <c>SetCurrentValue</c> sibling, regardless of how <c>FlyoutBase</c> is qualified.
+    /// </summary>
+    private static bool IsPlacementDpWrite(InvocationExpressionSyntax invocation)
+    {
+        if (invocation.Expression is not MemberAccessExpressionSyntax
+            { Name.Identifier.Text: "SetValue" or "SetCurrentValue" }) return false;
+        if (invocation.ArgumentList.Arguments.Count < 2) return false;
+
+        var dp = invocation.ArgumentList.Arguments[0].Expression;
+        return dp is MemberAccessExpressionSyntax
+        {
+            Name.Identifier.Text: "PlacementProperty",
+            Expression: var owner,
+        } && LeafName(owner) == "FlyoutBase";
+    }
+
+    private static string LeafName(ExpressionSyntax expression) => expression switch
+    {
+        MemberAccessExpressionSyntax member => member.Name.Identifier.Text,
+        SimpleNameSyntax simple => simple.Identifier.Text,
+        _ => expression.ToString(),
+    };
+
+    private static PlacementWrite Write(string file, SyntaxNode node, string text)
+        => new(file, node.GetLocation().GetLineSpan().StartLinePosition.Line + 1, text);
 
     private static bool IsFlyoutObjectInitializer(AssignmentExpressionSyntax assignment)
     {
@@ -253,10 +313,12 @@ public class FlyoutPlacementGuardTests
     }
 
     private static string Flatten(AssignmentExpressionSyntax assignment)
-    {
-        var text = assignment.Parent is InitializerExpressionSyntax { Parent: ObjectCreationExpressionSyntax creation }
+        => Flatten(assignment.Parent is InitializerExpressionSyntax { Parent: ObjectCreationExpressionSyntax creation }
             ? creation.ToString()
-            : assignment.ToString();
+            : assignment.ToString());
+
+    private static string Flatten(string text)
+    {
         text = string.Join(' ', text.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries));
         return text.Length <= 120 ? text : text[..120] + "…";
     }

--- a/tests/Reactor.Tests/FlyoutPlacementGuardTests.cs
+++ b/tests/Reactor.Tests/FlyoutPlacementGuardTests.cs
@@ -107,12 +107,24 @@ public class FlyoutPlacementGuardTests
     private const string HelperFileName = "FlyoutPlacement.cs";
 
     /// <summary>
-    /// Files allowed to write a <c>Placement</c> member that is provably NOT a WinUI
-    /// <c>FlyoutBase.Placement</c> dependency property. Empty today — the scan is
-    /// syntactic, so a future non-flyout <c>Placement</c> setter is expected to land here
-    /// as a deliberate, reviewed edit rather than silently widening the matcher.
+    /// Methods whose flyout deliberately keeps <see cref="FlyoutPlacementMode.Auto"/>, so a
+    /// raw <c>Placement</c> write there is correct rather than a bypass.
     /// </summary>
-    private static readonly string[] NonFlyoutPlacementWriteFiles = [];
+    /// <remarks>
+    /// Only <c>CommandBarFlyout</c> qualifies. Suppressing the write is <b>not</b> neutral:
+    /// <c>FlyoutBase.Placement</c> defaults to <see cref="FlyoutPlacementMode.Top"/>, so
+    /// "don't write" means the flyout pins to <c>Top</c>. That is the right outcome for
+    /// <c>Flyout</c>/<c>MenuFlyout</c>, whose show-time validator rejects <c>Auto</c>
+    /// outright — but <c>CommandBarFlyout</c> resolves <c>Auto</c> itself and positions
+    /// automatically today, so guarding it would silently pin it to <c>Top</c> and change
+    /// where a working control appears. Keyed by method name (not file or line) so it
+    /// survives the in-flight rewrite of these two methods.
+    /// </remarks>
+    private static readonly string[] AutoTolerantFlyoutMethods =
+    [
+        "MountCommandBarFlyout",
+        "UpdateCommandBarFlyout",
+    ];
 
     [Fact]
     public void No_Flyout_Placement_Write_Bypasses_FlyoutPlacement()
@@ -121,8 +133,8 @@ public class FlyoutPlacementGuardTests
 
         var bypasses = writes
             .Where(w => !string.Equals(Path.GetFileName(w.File), HelperFileName, StringComparison.Ordinal))
-            .Where(w => !NonFlyoutPlacementWriteFiles.Contains(Path.GetFileName(w.File), StringComparer.Ordinal))
-            .Select(w => $"{Path.GetFileName(w.File)}({w.Line}): {w.Text}")
+            .Where(w => !AutoTolerantFlyoutMethods.Contains(w.Method, StringComparer.Ordinal))
+            .Select(w => $"{Path.GetFileName(w.File)}({w.Line}) in {w.Method}: {w.Text}")
             .OrderBy(s => s, StringComparer.Ordinal)
             .ToList();
 
@@ -132,8 +144,21 @@ public class FlyoutPlacementGuardTests
             "FlyoutPlacement.Apply, which lets FlyoutPlacementMode.Auto reach WinUI's validator " +
             "and terminate the process when the flyout is shown: " +
             $"[{string.Join("; ", bypasses)}]. Route the write through FlyoutPlacement.Apply, or " +
-            "— if this is genuinely not a WinUI FlyoutBase.Placement write — add the file to " +
-            $"{nameof(NonFlyoutPlacementWriteFiles)} with a comment explaining why.");
+            "— if the flyout type genuinely tolerates Auto, as CommandBarFlyout does — add the " +
+            $"enclosing method to {nameof(AutoTolerantFlyoutMethods)} with a comment explaining why.");
+    }
+
+    [Fact]
+    public void CommandBarFlyout_Is_Deliberately_Left_Unguarded()
+    {
+        // Pins the asymmetry so a later "consistency" cleanup cannot quietly guard
+        // CommandBarFlyout — which would stop it auto-positioning and pin it to Top.
+        var exempt = ScanCoreForFlyoutPlacementWrites()
+            .Where(w => AutoTolerantFlyoutMethods.Contains(w.Method, StringComparer.Ordinal))
+            .ToList();
+
+        Assert.NotEmpty(exempt);
+        Assert.All(exempt, w => Assert.Contains("CommandBarFlyout", w.Method, StringComparison.Ordinal));
     }
 
     [Fact]
@@ -196,9 +221,40 @@ public class FlyoutPlacementGuardTests
         Assert.Contains(hits, h => h.Contains("SetCurrentValue(FlyoutBase.PlacementProperty", StringComparison.Ordinal));
     }
 
+    [Fact]
+    public void Scanner_Scopes_The_Exemption_To_The_Enclosing_Method()
+    {
+        // The CommandBarFlyout carve-out is keyed by method name, so prove two identical
+        // writes are classified differently purely by which method they sit in — otherwise
+        // the exemption could silently swallow a real bypass elsewhere in the same file.
+        const string source = """
+            class Sample
+            {
+                void MountCommandBarFlyout()
+                {
+                    var flyout = new WinUI.CommandBarFlyout { Placement = cbf.Placement };
+                }
+
+                void MountFlyout()
+                {
+                    var flyout = new WinUI.Flyout { Placement = flyEl.Placement };
+                }
+            }
+            """;
+
+        var byMethod = FindPlacementWrites("synthetic.cs", source)
+            .ToDictionary(w => w.Method, w => w);
+
+        Assert.Equal(2, byMethod.Count);
+        Assert.Contains("MountCommandBarFlyout", AutoTolerantFlyoutMethods);
+        Assert.DoesNotContain("MountFlyout", AutoTolerantFlyoutMethods);
+        Assert.Equal("MountCommandBarFlyout", byMethod["MountCommandBarFlyout"].Method);
+        Assert.Equal("MountFlyout", byMethod["MountFlyout"].Method);
+    }
+
     // ── scanning helpers ────────────────────────────────────────────
 
-    private readonly record struct PlacementWrite(string File, int Line, string Text);
+    private readonly record struct PlacementWrite(string File, int Line, string Method, string Text);
 
     // Four [Fact]s consume these; walking src/Reactor and Roslyn-parsing every file once per
     // test is pure overhead. Lazy also caches the assertion failure, so a broken repo-root
@@ -307,7 +363,33 @@ public class FlyoutPlacementGuardTests
     };
 
     private static PlacementWrite Write(string file, SyntaxNode node, string text)
-        => new(file, node.GetLocation().GetLineSpan().StartLinePosition.Line + 1, text);
+        => new(file,
+               node.GetLocation().GetLineSpan().StartLinePosition.Line + 1,
+               EnclosingMethodName(node),
+               text);
+
+    /// <summary>
+    /// Nearest enclosing method/accessor/local-function name, used to scope the
+    /// <see cref="AutoTolerantFlyoutMethods"/> exemption to a stable identifier rather
+    /// than to a file or a line number.
+    /// </summary>
+    private static string EnclosingMethodName(SyntaxNode node)
+    {
+        for (var n = node.Parent; n is not null; n = n.Parent)
+        {
+            switch (n)
+            {
+                case MethodDeclarationSyntax m: return m.Identifier.Text;
+                case LocalFunctionStatementSyntax lf: return lf.Identifier.Text;
+                case ConstructorDeclarationSyntax c: return c.Identifier.Text;
+                case AccessorDeclarationSyntax a
+                    when a.Parent?.Parent is PropertyDeclarationSyntax p:
+                    return p.Identifier.Text;
+                case PropertyDeclarationSyntax p2: return p2.Identifier.Text;
+            }
+        }
+        return "<none>";
+    }
 
     private static bool IsFlyoutObjectInitializer(AssignmentExpressionSyntax assignment)
     {


### PR DESCRIPTION
## Symptom

Clicking **Show Flyout** on the gallery's **Dialogs and Flyouts → Flyout** page terminated the process — a `0xC000027B` stowed exception carrying `System.ArgumentException: The parameter is incorrect`. Because it is a fail-fast, there is no catchable error; the app just disappears.

## Root cause

Quoted from the bug-hunt report — this chain was established with `cdb` + public symbols by the reporting session, **not** re-derived here:

> 2. `cdb` + public symbols resolved that address to `DirectUI::FlyoutBase::ShowAtCore+0x42` — the instruction directly after `call DirectUI::FlyoutBase::ValidateAndSetParameters`.
> 3. Disassembling `ValidateAndSetParameters` shows its placement switch accepts **0–12** and falls through to `mov edi,80070057h` (E_INVALIDARG) for anything else. `FlyoutPlacementMode.Auto == 13`.
> 4. Disassembling `GetEffectivePlacement` shows that with no cached override it returns the raw `Placement` property, so `Auto` reaches the validator unresolved.
> 5. A/B in a single build on a single page: card 1 pinned to `Placement.Top` opens normally; card 2 left at the default `Auto` crashes.

What I verified myself, and how:

- **From the published API reference:** `FlyoutPlacementMode.Auto == 13`, and `FlyoutBase.Placement`'s own default is **`Top`** — WinUI itself never puts `Auto` on that DP.
- **Reproduced in-process:** see the revert-proof output below.

Reactor defaults `Placement` to `Auto` on its flyout element records and then assigned it to the live WinUI flyout unconditionally. The correct guard already existed — but only for `MenuFlyout` (`Reconciler.cs`, comment: *"Auto can cause assertions on MenuFlyout"*).

## What changed

New internal choke point `src/Reactor/Core/FlyoutPlacement.cs`:

```csharp
internal static bool ShouldApply(FlyoutPlacementMode placement) => placement != FlyoutPlacementMode.Auto;

internal static void Apply(FlyoutBase flyout, FlyoutPlacementMode placement)
{
    if (!ShouldApply(placement)) return;
    if (flyout.Placement != placement) flyout.Placement = placement;
}
```

Routed through it:

| File | Element | Why |
|---|---|---|
| `V1Protocol/OverlayLifecycle.cs` ×3 | `FlyoutElement` | **crashed** |
| `Reconciler.cs` ×2 | `ContentFlyoutElement` (`.WithFlyout()`, `.WithContextFlyout()`, button `flyout:` slots) | **crashed** |
| `Reconciler.cs` ×2 | `MenuFlyoutContentElement` | already guarded; folded in so the helper is the only write site |

Object-initializer writes became post-construction `Apply` calls placed **before** `ApplySetters`, so a caller's `.Set(f => f.Placement = ...)` still wins.

### `CommandBarFlyout` — same bug, guarded by #943 (now merged)

**Correction to an earlier revision of this PR.** It previously said `CommandBarFlyout` was "deliberately not guarded" because it "resolves `Auto` itself and auto-positions". **That was wrong.** `CommandBarFlyout` is affected by exactly this crash. The reason it never crashed is that **it never opened**: `MountCommandBarFlyout` installed the flyout as `FlyoutBase.AttachedFlyout` metadata that nothing ever called `ShowAttachedFlyout` on, so the placement validator was never reached. A latent crash masked by a separate defect reads exactly like a working code path.

**I confirmed this independently rather than taking it on report.** I had also written that it was unobservable "because `CommandBarFlyout` cannot be opened from its target" — that was wrong too. The broken wiring only blocked the *target/click* path; `ShowAt` can be called directly. Doing so, with a control to prove the harness itself works:

```
# probe[Top]  flyout=found placement=Top
# probe[Top]  ShowAt returned, IsOpen=True          ← control: a valid placement opens fine
# probe[Auto] flyout=found placement=Auto
# probe[Auto] THREW ArgumentException: Value does not fall within the expected range
```

Same exception as the `Flyout` crash this PR fixes. So `CommandBarFlyout` retains `Auto` on the DP quite happily and throws the moment it is shown — "the DP accepts it" and "it can be shown" are different claims, and only the second one matters. That probe was a one-off measurement and is not checked in: asserting "this throws" would be wrong now that #943 has landed, and #943 owns the positive assertion.

**[#943](https://github.com/microsoft/microsoft-ui-reactor/pull/943) has since merged**, fixing the wiring and guarding those three sites via `Reconciler.ApplyFlyoutPlacement`. So the affected sites are partitioned across two changes:

| Change | Guards | Helper |
|---|---|---|
| **#939 (this one)** | `FlyoutElement`, `ContentFlyoutElement`, `MenuFlyoutContentElement` | `FlyoutPlacement.Apply` |
| **#943 (merged)** | the three `CommandBarFlyout` sites | `Reconciler.ApplyFlyoutPlacement` |

This branch is rebased onto that merge and leaves those three sites **byte-identical to `main`**.

**The two were verified to compose — before #943 landed, and again after.** Ahead of the merge I simulated #943 locally and found **three** of my tests would have failed, so whichever PR merged second would have gone red:

```
No_Flyout_Placement_Write_Bypasses_FlyoutPlacement   [FAIL]   ← my scan flagged #943's helper as a bypass
CommandBarFlyout_Is_Deliberately_Left_Unguarded      [FAIL]   ← asserted the exemption was non-empty
not ok FlyoutPlacement_CommandBarFlyout_KeepsAuto             ← asserted the DP stays Auto
```

The first was the serious one: my architecture test would have failed on #943's *correct* helper, because `flyout.Placement = placement` inside `ApplyFlyoutPlacement` matched the "no raw writes outside the choke point" rule. Fixed by teaching the scan to recognise `ApplyFlyoutPlacement` as a legitimate choke point — which also exposed a real blind spot, since the matcher had not recognised `ClearValue(FlyoutBase.PlacementProperty)` as a placement write at all. The other two tests asserted invariants that #943 correctly invalidates and were removed. **Against the real merged #943, all 22 unit tests and all 9 flyout fixtures pass.**

**The helpers now agree — I converged on `ClearValue`.** They previously differed on an `explicit → Auto` update: this one skipped the write and retained the last explicit value, #943's cleared the DP. I had flagged that for a follow-up, but [#952](https://github.com/microsoft/microsoft-ui-reactor/issues/952) turns it from tidiness into correctness: skipping leaves the previous placement behind as a **local** DP value, and in WinUI precedence a local value outranks a `Style` setter — so an app returning to `Auto` could never get its styled placement back, and "no opinion" would silently mean "whatever I last said". That is the same precedence defect #952 documents for the common modifiers. `FlyoutPlacement.Apply` now clears the property for `Auto`, so both helpers behave identically and the update fixture asserts the transition lands on the platform default (read from a fresh `WinUI.Flyout`, not hard-coded). Folding the two into a single helper is mechanical and left as a follow-up, since it would mean rewriting call sites that landed with #943 — tracked as [#953](https://github.com/microsoft/microsoft-ui-reactor/issues/953), whose *behavioural* half this PR already implements; only the structural de-duplication remains.

### Design choice

**Chosen: guard the write.** `Auto` stays a meaningful value in the Reactor API for the flyout types that can honour it, and this mirrors the guard that already existed for `MenuFlyoutContentElement`.

**Rejected: change the element defaults to `Top`.** It changes observable public API defaults that user code can read via `element.Placement`, for no behavioural gain.

**Adopted (after initially rejecting it): `ClearValue(FlyoutBase.PlacementProperty)` on `Auto`.** I first rejected this, partly arguing it "would wipe any local value a control's own constructor had set" — measuring the platform showed that is false (`Flyout`, `MenuFlyout` and `CommandBarFlyout` all default to `Top`, with no constructor-set local value), so on mount clearing and skipping are equivalent. I then kept skipping on the weaker ground that it matched the pre-existing MenuFlyout guard. #952 settled it: on an `explicit → Auto` update, skipping leaves a stale **local** value that outranks a `Style` setter. Clearing is now what the helper does, and the update fixture asserts it.
**Rejected: a `REACTOR_*` analyzer** warning on `Flyout(...)` without an explicit placement — the report is explicit that it "would paper over R1; fix the framework instead".

No public API changed (`FlyoutPlacement` is `internal`), so no `mur --regen-api` / `reactor.api.txt` churn. No `docs/guide/` topic documents flyout placement, so no template recompile. No analyzer rule added, so **no merge-ordering hazard** from the `TreatWarningsAsErrors`-in-Release interaction — and `dotnet build Reactor.slnx -c Release` is clean on this branch rebased onto `main` **after** #930 and #932.

## Tests

**Unit — `tests/Reactor.Tests/FlyoutPlacementGuardTests.cs` (22 tests)**
- Full-enum table: `ShouldApply` true for the 13 values WinUI's validator accepts, false only for `Auto`; plus `(int)Auto == 13` and "`Auto` is the only value outside 0..12" pinned directly.
- **Roslyn structural scan** over every `src/Reactor/**/*.cs`: the only site writing a WinUI flyout `Placement` must be `FlyoutPlacement.cs`. Matches member assignments, `new ...Flyout { Placement = ... }` initializers, and `SetValue`/`SetCurrentValue(FlyoutBase.PlacementProperty, ...)`.
- The `CommandBarFlyout` carve-out is **scoped by enclosing method name**, not file or line, so it survives the in-flight rework of those methods and cannot leak to other writes in the same file. `Scanner_Scopes_The_Exemption_To_The_Enclosing_Method` proves two *identical* writes are classified differently purely by which method they sit in; `CommandBarFlyout_Is_Deliberately_Left_Unguarded` pins the asymmetry against a future "consistency" cleanup.
- Anti-vacuity: the scanner must parse >100 files, must find the helper's own write, and must flag a synthetic bypass of all three shapes while ignoring near-misses (element-record initializers, `PreferredPlacement`, reads).

**Selftests — `FlyoutPlacementFixtures.cs` (9 fixtures, 44 checks)**, registered in both `AllFixtures` and the `Create()` switch. The `Flyout`/`ContentFlyout`/fresh-create fixtures actually **open** the flyout — the only tier that catches this crash. Every mount/create path carries two arms: a *"never `Auto`"* check (fails if the bug returns) and a *differential explicit-placement* check (fails if the `Apply` call is deleted outright, which the structural scan cannot see).

Covering `Flyout(...)`, `.WithFlyout(ContentFlyout(...))`, `.WithContextFlyout(MenuItems(...))`, `DropDownButton`/`SplitButton` flyout slots, `UpdateFlyoutElement`'s fresh-create branch, the `Auto → Left → Auto` update sequence (with a render witness so step 2 can't pass trivially), and the inverted `CommandBarFlyout` case above.

### Revert-proof — re-run against the final test set, on the rebased base

**1. Restore one raw write** (`OverlayLifecycle.MountFlyout` writes `Placement = flyEl.Placement` again):

```
Microsoft.UI.Reactor.Tests.FlyoutPlacementGuardTests.No_Flyout_Placement_Write_Bypasses_FlyoutPlacement [FAIL]
Failed!  - Failed:     1, Passed:    21, Skipped:     0, Total:    22

1..9
not ok FlyoutPlacement_Default_DpIsNotAuto - assertion failed
not ok 1 FlyoutPlacement_Flyout_DefaultPlacement_Opens_CRASH - ArgumentException: Value does not fall within the expected range.
System.ArgumentException: Value does not fall within the expected range.
not ok FlyoutPlacement_Update_MountedNotAuto - assertion failed
# Total failures: 3
```

That `ArgumentException` is the original crash, reproduced in-process (thrown out of `ButtonAutomationPeer.Invoke()` when the fixture clicks the button).

**2. Delete an `Apply` call outright** (`CreateFlyoutFromElement`, ContentFlyout arm):

```
1..9
not ok FlyoutPlacement_ContentFlyout_CreateAppliesExplicit - assertion failed
not ok FlyoutPlacement_SplitButton_CreateAppliesExplicit - assertion failed
# Total failures: 2

Passed!  - Failed:     0, Passed:    22, Skipped:     0, Total:    22
```

Note the unit suite passes 22/22 here: a *deletion* is invisible to a scan that looks for un-routed writes. That is exactly why each path also carries a differential explicit-placement assertion in the selftests. Both mutations were reverted and the tree verified clean afterwards.

## Verification

- `dotnet build Reactor.slnx -c Release` — **succeeded** (the config that turns warnings into errors).
- `dotnet test tests/Reactor.Tests` — **12600 passed, 0 failed**.
- Full selftest suite — **1350 fixtures, 0 failures**.
- **Platform assumption measured, not assumed.** `Platform_FlyoutBase_PlacementDefault` constructs each flyout type on the UI thread and reads the DP before anything writes it:

  ```
  # measured Flyout.Placement default           = Top
  # measured MenuFlyout.Placement default       = Top
  # measured CommandBarFlyout.Placement default = Top
  ```

  This is the assumption the whole fix rests on — "leave the DP alone" is only safe while the DP's own default is inside the validator's accepted `0..12`. Without this check, a future SDK defaulting `Placement` to `Auto` would silently disarm the guard while every other test here stayed green, since they all assert `!= Auto` against a DP that would by then *be* `Auto`. The values are emitted as TAP comments so an SDK bump shows up as a log diff rather than a silent pass.
- **Gallery, real mouse input.** Verified twice; the second run used the shared input mutex and an `AttachThreadInput` foreground force, because ~10 sibling agent sessions were driving their own gallery instances concurrently and real input is a single global resource. Dedicated instance, every `winapp ui` call scoped to its HWND, retry on any "not in the foreground" refusal:

  | Page | Click | Result |
  |---|---|---|
  | Flyout → "Show Flyout" | `✅ (926, 630)` | `Pane`/`className=Flyout` "This is flyout content!" at (801, 520) — **above** the button, i.e. `Top`. Process alive. Screenshot confirms. |
  | Flyout → "Cart Options" | `✅ (928, 896)` | `Empty Cart` at y=779, `isOffscreen: false`. Process alive. |
  | CommandBarFlyout → "Show Commands" | `✅ (950, 630)` | No crash. No commands surface — separate finding, below. |

  These gallery runs were performed before the final rebase; the product change they exercise is unchanged since.

## Review

Ran the repo's `.github/skills/pr-review` skill across all 8 dimensions. security / correctness / alternative-solution / packaging clean; the 5 medium+low findings were all **confirmed by the multi-model cross-check** on a different model family, and all fixed. Two further *suppressed low-confidence* Copilot comments (scan memoization, and a fixture comment that overstated what the suite does) were also fixed.

## ⚠️ Known gap for the merging human: the later commits are unreviewed

Copilot reviewed this PR three times and returned no comments each time — but **all three reviews predate a rebase, so none of them covers the branch as it now stands.** The commits they examined no longer exist: the rebase onto merged #943 replayed this work under new SHAs and orphaned the old ones, which is why the review entries point at objects unreachable from the head.

Reviewed content, by commit subject (subjects survive a rebase, SHAs do not):

- ✅ *Never write FlyoutPlacementMode.Auto to a WinUI FlyoutBase*
- ✅ *Address pr-review findings: docs, CHANGELOG, scanner and fixture coverage*
- ✅ *Record how the FlyoutBase internals in FlyoutPlacement were established*
- ✅ *Address the two low-confidence Copilot review comments*

**Not reviewed by anything but CI:**

- *Do not guard CommandBarFlyout's placement — Auto is correct there* — reverts the CommandBarFlyout guard so those sites stay byte-identical to `main`
- *Measure the FlyoutBase.Placement platform default instead of assuming it* — adds the selftest pinning the measured platform default
- *Correct the CommandBarFlyout rationale and make the guard compose with #943* — corrects documentation that stated a since-disproved rationale, and stops the structural scan flagging #943's helper as a bypass
- *Rebase onto merged #943 and update docs that described it as in-flight*
- *Converge the placement guard on ClearValue, matching ApplyFlyoutPlacement*

**Why it cannot be closed by re-requesting.** All three reviews are anchored to commits the rebase orphaned — verified: their `commit_id`s are `5cd7058b`, `205c5169` and `aa543b1a`, none reachable from the current head. Seven re-requests via `POST /pulls/939/requested_reviewers` were accepted (HTTP 200) without producing a further round, and the documented fallback `gh pr edit --add-reviewer "copilot-pull-request-reviewer[bot]"` fails with *"Could not resolve user with login"* (a known SAML/GraphQL issue in this org).

The same pattern was observed across every rebased PR in this batch, and another session traced it to review threads carrying a frozen `original_commit_id` that a rebase orphans. I could not confirm that mechanism on this PR, because it has zero review comments — so treat the mechanism as reported rather than verified here; what *is* verified is the orphaned anchors and that no review has landed since the rebase. Either way, further re-requests are not expected to recover it.

Stating it rather than counting a clean review as covering work it predates. CI is green on the head, the full unit and selftest suites pass locally, and the unreviewed delta is a revert *toward* `main` plus test and documentation changes — but a reviewer may reasonably want to look at those commits specifically.

## Out of scope — related findings deliberately untouched

- **`CommandBarFlyout` never opens from its target.** It is installed with `SetAttachedFlyout`, so clicking does nothing. Owned by another session, which is reworking `MountCommandBarFlyout`/`UpdateCommandBarFlyout`; this PR keeps those lines byte-identical to `main` so that work applies cleanly.
- **`FlyoutElement.IsOpen` is dead for `Button`/`SplitButton` targets.** `MountFlyout` installs the flyout into `Button.Flyout` via `SetFlyoutOnControl`, then calls `ShowAttachedFlyout`, which reads the *attached* slot — so `IsOpen` never opens anything for a button target. Queued as a separate follow-up; untouched here.
- A `.Placement(...)` fluent modifier for `FlyoutElement` doesn't exist (callers use `with { Placement = ... }`). Adding one is new public API requiring `mur --regen-api` and both `reactor.api.txt` copies — deliberately left out.
