### PR TITLE
Fix CommandBarFlyout never opening from its target

### DIFF
--- a/docs/_pipeline/templates/dialogs-and-flyouts.md.dt
+++ b/docs/_pipeline/templates/dialogs-and-flyouts.md.dt
@@ -174,6 +174,18 @@ inline as icon buttons; secondary commands collapse into the overflow
 menu. The same `AppBarItemBase` records that fill a `CommandBar` fill
 this surface — the entire item array is interchangeable.
 
+A `Button` or `SplitButton` target opens the flyout on click with no
+extra wiring. To open it from your own state instead — say, when a
+selection appears — set `IsOpen`:
+
+```csharp
+CommandBarFlyout(Border(selection), primaryCommands: commands)
+    with { IsOpen = hasSelection }
+```
+
+`IsOpen` is a one-shot trigger, like `FlyoutElement.IsOpen`: it opens the
+flyout on the `false` → `true` edge and the user dismisses it from there.
+
 | Item factory | Shape |
 |---|---|
 | `AppBarButton(label, onClick, icon?)` | Standard tool-strip button. |
@@ -317,7 +329,7 @@ user took, but accept that `None` is the user's right.
 |---|---|---|---|
 | `ContentDialogElement` | `ContentDialog(title, content, primaryButtonText)` | `IsOpen` (init), `OnClosed(result)` | `OnOpened`, `OnClosed` |
 | `MenuFlyoutElement` | `MenuFlyout(target, items...)` | Auto on target click | n/a |
-| `CommandBarFlyoutElement` | `CommandBarFlyout(target, primary?, secondary?)` | Auto on target click | n/a |
+| `CommandBarFlyoutElement` | `CommandBarFlyout(target, primary?, secondary?)` | Auto on target click, or `IsOpen` (init) | n/a |
 | `PopupElement` | `Popup(child, isOpen?, onClosed?)` | `isOpen` arg or `.IsOpen` init | `.Opened`, `.Closed` |
 
 ## Patterns

--- a/docs/guide/dialogs-and-flyouts.md
+++ b/docs/guide/dialogs-and-flyouts.md
@@ -286,6 +286,18 @@ inline as icon buttons; secondary commands collapse into the overflow
 menu. The same `AppBarItemBase` records that fill a `CommandBar` fill
 this surface — the entire item array is interchangeable.
 
+A `Button` or `SplitButton` target opens the flyout on click with no
+extra wiring. To open it from your own state instead — say, when a
+selection appears — set `IsOpen`:
+
+```csharp
+CommandBarFlyout(Border(selection), primaryCommands: commands)
+    with { IsOpen = hasSelection }
+```
+
+`IsOpen` is a one-shot trigger, like `FlyoutElement.IsOpen`: it opens the
+flyout on the `false` → `true` edge and the user dismisses it from there.
+
 | Item factory | Shape |
 |---|---|
 | `AppBarButton(label, onClick, icon?)` | Standard tool-strip button. |
@@ -487,7 +499,7 @@ user took, but accept that `None` is the user's right.
 |---|---|---|---|
 | `ContentDialogElement` | `ContentDialog(title, content, primaryButtonText)` | `IsOpen` (init), `OnClosed(result)` | `OnOpened`, `OnClosed` |
 | `MenuFlyoutElement` | `MenuFlyout(target, items...)` | Auto on target click | n/a |
-| `CommandBarFlyoutElement` | `CommandBarFlyout(target, primary?, secondary?)` | Auto on target click | n/a |
+| `CommandBarFlyoutElement` | `CommandBarFlyout(target, primary?, secondary?)` | Auto on target click, or `IsOpen` (init) | n/a |
 | `PopupElement` | `Popup(child, isOpen?, onClosed?)` | `isOpen` arg or `.IsOpen` init | `.Opened`, `.Closed` |
 
 ## Patterns

--- a/plugins/reactor/skills/reactor-dsl/references/reactor.api.txt
+++ b/plugins/reactor/skills/reactor-dsl/references/reactor.api.txt
@@ -1631,6 +1631,7 @@ AppBarItemBase[] PrimaryCommands { get; init; }
 AppBarItemBase[] SecondaryCommands { get; init; }
 Element Target { get; init; }
 FlyoutPlacementMode Placement { get; init; }
+bool IsOpen { get; init; }
 Deconstruct(ref Element Target, ref AppBarItemBase[] PrimaryCommands, ref AppBarItemBase[] SecondaryCommands) → void
 Equals(CommandBarFlyoutElement other) → bool
 Equals(Element other) → bool

--- a/skills/reactor.api.txt
+++ b/skills/reactor.api.txt
@@ -1631,6 +1631,7 @@ AppBarItemBase[] PrimaryCommands { get; init; }
 AppBarItemBase[] SecondaryCommands { get; init; }
 Element Target { get; init; }
 FlyoutPlacementMode Placement { get; init; }
+bool IsOpen { get; init; }
 Deconstruct(ref Element Target, ref AppBarItemBase[] PrimaryCommands, ref AppBarItemBase[] SecondaryCommands) → void
 Equals(CommandBarFlyoutElement other) → bool
 Equals(Element other) → bool

--- a/src/Reactor/Core/Element.cs
+++ b/src/Reactor/Core/Element.cs
@@ -6635,6 +6635,14 @@ public record CommandBarFlyoutElement(
     AppBarItemBase[]? SecondaryCommands = null
 ) : Element
 {
+    /// <summary>
+    /// Opens the flyout declaratively. Like <see cref="FlyoutElement.IsOpen"/> this is a
+    /// one-shot trigger: the flyout is shown on mount when already <c>true</c>, and on the
+    /// <c>false</c> → <c>true</c> edge of an update. Setting it back to <c>false</c> does not
+    /// close the flyout — the user dismisses it (outside click, Esc, or invoking a command).
+    /// The target normally opens the flyout on click without this.
+    /// </summary>
+    public bool IsOpen { get; init; }
     public FlyoutPlacementMode Placement { get; init; } = FlyoutPlacementMode.Auto;
     internal Action<WinUI.CommandBarFlyout>[] Setters { get; init; } = [];
 }

--- a/src/Reactor/Core/Reconciler.cs
+++ b/src/Reactor/Core/Reconciler.cs
@@ -4955,14 +4955,8 @@ public sealed partial class Reconciler : IDisposable
     /// </summary>
     private void ApplyFlyoutAttachment(FrameworkElement fe, Element? oldFlyoutEl, Element newFlyoutEl, Action requestRerender)
     {
-        // Try to get the existing flyout from the control.
-        // SplitButton.Flyout and Button.Flyout are separate properties (different type hierarchies).
-        WinPrim.FlyoutBase? existingFlyout = fe switch
-        {
-            WinUI.SplitButton sb => sb.Flyout,
-            WinUI.Button btn => btn.Flyout,  // AppBarButton inherits from Button
-            _ => WinPrim.FlyoutBase.GetAttachedFlyout(fe),
-        };
+        // Read the existing flyout from whichever slot SetFlyoutOnControl writes to.
+        var existingFlyout = GetFlyoutOnControl(fe);
 
         // If we have an existing flyout and old element, try to update in place
         if (oldFlyoutEl is not null && existingFlyout is not null)
@@ -5079,6 +5073,38 @@ public sealed partial class Reconciler : IDisposable
             FlyoutSlot.Button => ((WinUI.Button)fe).Flyout,
             _ => WinPrim.FlyoutBase.GetAttachedFlyout(fe),
         };
+
+    /// <summary>
+    /// Detaches whatever <see cref="SetFlyoutOnControl"/> installed, so a pooled/reused target
+    /// retains no stale flyout. Clears the same slot the writer and reader agree on.
+    /// </summary>
+    internal static void ClearFlyoutOnControl(FrameworkElement fe)
+    {
+        switch (ResolveFlyoutSlot(fe.GetType()))
+        {
+            case FlyoutSlot.SplitButton: ((WinUI.SplitButton)fe).Flyout = null; break;
+            case FlyoutSlot.Button: ((WinUI.Button)fe).Flyout = null; break;
+            default: WinPrim.FlyoutBase.SetAttachedFlyout(fe, null); break;
+        }
+    }
+
+    /// <summary>
+    /// Assigns a flyout's placement, treating <see cref="WinPrim.FlyoutPlacementMode.Auto"/> as
+    /// "leave it at WinUI's default" rather than writing it through.
+    ///
+    /// <c>Auto</c> (13) is outside the range <c>FlyoutBase::ShowAtCore</c> accepts, and
+    /// <c>GetEffectivePlacement</c> hands the raw value straight to the validator, so an
+    /// <c>Auto</c>-placed flyout fail-fasts the process with <c>E_INVALIDARG</c> the moment it
+    /// opens. Clearing the DP (rather than merely skipping the write) keeps an explicit → Auto
+    /// update consistent with what a fresh mount of the same element would produce.
+    /// </summary>
+    internal static void ApplyFlyoutPlacement(WinPrim.FlyoutBase flyout, WinPrim.FlyoutPlacementMode placement)
+    {
+        if (placement == WinPrim.FlyoutPlacementMode.Auto)
+            flyout.ClearValue(WinPrim.FlyoutBase.PlacementProperty);
+        else if (flyout.Placement != placement)
+            flyout.Placement = placement;
+    }
 
     /// <summary>
     /// Creates a WinUI FlyoutBase from a Reactor element descriptor.

--- a/src/Reactor/Core/Reconciler.cs
+++ b/src/Reactor/Core/Reconciler.cs
@@ -5029,17 +5029,56 @@ public sealed partial class Reconciler : IDisposable
         }
     }
 
-    internal void SetFlyoutOnControl(FrameworkElement fe, WinPrim.FlyoutBase flyout)
+    /// <summary>
+    /// Which slot a flyout occupies on a given target control. Button-family targets
+    /// get the control's own <c>Flyout</c> property, which WinUI opens on click; every
+    /// other target falls back to <c>FlyoutBase.AttachedFlyout</c> metadata, which only
+    /// opens via an explicit <c>ShowAttachedFlyout</c> call.
+    /// </summary>
+    internal enum FlyoutSlot
+    {
+        Attached,
+        Button,
+        SplitButton,
+    }
+
+    /// <summary>
+    /// Single source of truth for the flyout-slot rule shared by
+    /// <see cref="SetFlyoutOnControl"/> and <see cref="GetFlyoutOnControl"/>. Writers and
+    /// readers that disagree on the slot silently lose the flyout, so both go through here.
+    /// </summary>
+    internal static FlyoutSlot ResolveFlyoutSlot(Type targetType)
     {
         // Check SplitButton before Button (SplitButton doesn't inherit from Button,
-        // but DropDownButton does, so Button catch-all handles it).
-        if (fe is WinUI.SplitButton sb)
-            sb.Flyout = flyout;
-        else if (fe is WinUI.Button btn)  // AppBarButton, DropDownButton inherit from Button
-            btn.Flyout = flyout;
-        else
-            WinPrim.FlyoutBase.SetAttachedFlyout(fe, flyout);
+        // but DropDownButton does, so the Button catch-all handles it).
+        if (typeof(WinUI.SplitButton).IsAssignableFrom(targetType)) return FlyoutSlot.SplitButton;
+        if (typeof(WinUI.Button).IsAssignableFrom(targetType)) return FlyoutSlot.Button;  // AppBarButton, DropDownButton inherit from Button
+        return FlyoutSlot.Attached;
     }
+
+    internal void SetFlyoutOnControl(FrameworkElement fe, WinPrim.FlyoutBase flyout)
+    {
+        switch (ResolveFlyoutSlot(fe.GetType()))
+        {
+            case FlyoutSlot.SplitButton: ((WinUI.SplitButton)fe).Flyout = flyout; break;
+            case FlyoutSlot.Button: ((WinUI.Button)fe).Flyout = flyout; break;
+            default: WinPrim.FlyoutBase.SetAttachedFlyout(fe, flyout); break;
+        }
+    }
+
+    /// <summary>
+    /// Reads back the flyout <see cref="SetFlyoutOnControl"/> installed. Update paths must
+    /// use this rather than <c>GetAttachedFlyout</c> — a Button/SplitButton target holds its
+    /// flyout in the control's own slot, so an attached-only lookup returns null and the
+    /// caller creates a duplicate flyout the user can never see.
+    /// </summary>
+    internal static WinPrim.FlyoutBase? GetFlyoutOnControl(FrameworkElement fe) =>
+        ResolveFlyoutSlot(fe.GetType()) switch
+        {
+            FlyoutSlot.SplitButton => ((WinUI.SplitButton)fe).Flyout,
+            FlyoutSlot.Button => ((WinUI.Button)fe).Flyout,
+            _ => WinPrim.FlyoutBase.GetAttachedFlyout(fe),
+        };
 
     /// <summary>
     /// Creates a WinUI FlyoutBase from a Reactor element descriptor.

--- a/src/Reactor/Core/V1Protocol/Handlers/OverlayDecoratorHandlers.cs
+++ b/src/Reactor/Core/V1Protocol/Handlers/OverlayDecoratorHandlers.cs
@@ -74,14 +74,7 @@ internal sealed class FlyoutHandler : IDecoratorElementHandler<FlyoutElement>
         // ContinueDefaultTraversal so the Target subtree still tears down.
         if (control is FrameworkElement targetFe)
         {
-            var attached = targetFe switch
-            {
-                WinUI.SplitButton sb => sb.Flyout,
-                WinUI.Button btn => btn.Flyout,
-                _ => WinPrim.FlyoutBase.GetAttachedFlyout(targetFe),
-            };
-
-            if (attached is WinUI.Flyout flyout)
+            if (Reconciler.GetFlyoutOnControl(targetFe) is WinUI.Flyout flyout)
             {
                 if (flyout.Content is UIElement content)
                     ctx.Reconciler.UnmountChild(content);
@@ -91,12 +84,7 @@ internal sealed class FlyoutHandler : IDecoratorElementHandler<FlyoutElement>
                 flyout.OverlayInputPassThroughElement = null;
             }
 
-            switch (targetFe)
-            {
-                case WinUI.SplitButton sb: sb.Flyout = null; break;
-                case WinUI.Button btn: btn.Flyout = null; break;
-                default: WinPrim.FlyoutBase.SetAttachedFlyout(targetFe, null); break;
-            }
+            Reconciler.ClearFlyoutOnControl(targetFe);
         }
         return V1UnmountDisposition.ContinueDefaultTraversal;
     }
@@ -185,5 +173,15 @@ internal sealed class CommandBarFlyoutHandler : IDecoratorElementHandler<Command
         => OverlayLifecycle.UpdateCommandBarFlyout(ctx.Reconciler, oldEl, newEl, control, ctx.RequestRerender) ?? control;
 
     public V1UnmountDisposition Unmount(UnmountContext ctx, CommandBarFlyoutElement? element, UIElement control)
-        => V1UnmountDisposition.ContinueDefaultTraversal;
+    {
+        // Detach the flyout so a pooled/reused target can't keep showing the previous
+        // component's command bar. ElementPool.CleanElement already nulls Button.Flyout,
+        // but nothing clears the attached-flyout slot a non-button target uses.
+        if (control is FrameworkElement targetFe
+            && Reconciler.GetFlyoutOnControl(targetFe) is WinUI.CommandBarFlyout)
+        {
+            Reconciler.ClearFlyoutOnControl(targetFe);
+        }
+        return V1UnmountDisposition.ContinueDefaultTraversal;
+    }
 }

--- a/src/Reactor/Core/V1Protocol/OverlayLifecycle.cs
+++ b/src/Reactor/Core/V1Protocol/OverlayLifecycle.cs
@@ -157,12 +157,8 @@ internal static class OverlayLifecycle
         if (updated is FrameworkElement targetFe)
         {
             Reconciler.SetElementTag(targetFe, n);
-            WinPrim.FlyoutBase? existingFlyout = targetFe switch
-            {
-                WinUI.SplitButton sb => sb.Flyout,
-                WinUI.Button btn => btn.Flyout,
-                _ => WinPrim.FlyoutBase.GetAttachedFlyout(targetFe),
-            };
+            // Read back from whichever slot SetFlyoutOnControl wrote to.
+            var existingFlyout = Reconciler.GetFlyoutOnControl(targetFe);
 
             if (existingFlyout is WinUI.Flyout flyout)
             {
@@ -339,13 +335,9 @@ internal static class OverlayLifecycle
         if (updated is FrameworkElement targetFe)
         {
             Reconciler.SetElementTag(targetFe, n);
-            // Retrieve the existing MenuFlyout and update items in place.
-            WinPrim.FlyoutBase? existingFlyout = targetFe switch
-            {
-                WinUI.SplitButton sb => sb.Flyout,
-                WinUI.Button btn => btn.Flyout,
-                _ => WinPrim.FlyoutBase.GetAttachedFlyout(targetFe),
-            };
+            // Retrieve the existing MenuFlyout (from whichever slot SetFlyoutOnControl
+            // wrote to) and update items in place.
+            var existingFlyout = Reconciler.GetFlyoutOnControl(targetFe);
             if (existingFlyout is WinUI.MenuFlyout mf)
             {
                 MenuCommandFactory.UpdateMenuFlyoutItems(mf.Items, o.Items, n.Items);
@@ -426,22 +418,29 @@ internal static class OverlayLifecycle
         var target = reconciler.Mount(cbf.Target, requestRerender);
         if (target is FrameworkElement targetFe)
         {
-            var flyout = new WinUI.CommandBarFlyout { Placement = cbf.Placement };
+            var flyout = new WinUI.CommandBarFlyout();
+            ApplyPlacement(flyout, cbf.Placement);
             if (cbf.PrimaryCommands is not null)
                 foreach (var cmd in cbf.PrimaryCommands) flyout.PrimaryCommands.Add(MenuCommandFactory.CreateAppBarItem(cmd));
             if (cbf.SecondaryCommands is not null)
                 foreach (var cmd in cbf.SecondaryCommands) flyout.SecondaryCommands.Add(MenuCommandFactory.CreateAppBarItem(cmd));
             Reconciler.SetElementTag(targetFe, cbf);
-            WinPrim.FlyoutBase.SetAttachedFlyout(targetFe, flyout);
+            // SetFlyoutOnControl (not SetAttachedFlyout) so clicking a Button/SplitButton
+            // target opens the flyout natively, matching Flyout and MenuFlyout. WinUI's
+            // own AttachedFlyout docs say the same: "To attach a flyout to a Button, use
+            // Button.Flyout instead." An attached flyout only ever opens via an explicit
+            // ShowAttachedFlyout call, which nothing here makes.
+            reconciler.SetFlyoutOnControl(targetFe, flyout);
             Reconciler.ApplySetters(cbf.Setters, flyout);
+            if (cbf.IsOpen) ShowFlyoutWhenReady(targetFe, flyout);
         }
         return target;
     }
 
     public static UIElement? UpdateCommandBarFlyout(Reconciler reconciler, CommandBarFlyoutElement o, CommandBarFlyoutElement n, UIElement targetControl, Action requestRerender)
     {
-        // Reconcile the target in place and reuse the attached flyout when
-        // possible — re-attaching a brand-new flyout on every update would
+        // Reconcile the target in place and reuse the installed flyout when
+        // possible — re-installing a brand-new flyout on every update would
         // close an already-open flyout and discard its transient state.
         UIElement? updated = targetControl;
         if (reconciler.CanUpdate(o.Target, n.Target))
@@ -458,24 +457,29 @@ internal static class OverlayLifecycle
         if (updated is FrameworkElement targetFe)
         {
             Reconciler.SetElementTag(targetFe, n);
-            var existing = WinPrim.FlyoutBase.GetAttachedFlyout(targetFe) as WinUI.CommandBarFlyout;
+            // Must read from the same slot mount wrote to — an attached-only lookup
+            // returns null for a Button target and this would create a duplicate
+            // flyout the user can never see while the live one keeps stale commands.
+            var existing = Reconciler.GetFlyoutOnControl(targetFe) as WinUI.CommandBarFlyout;
             var commandsChanged =
                 !ReferenceEquals(o.PrimaryCommands, n.PrimaryCommands) ||
                 !ReferenceEquals(o.SecondaryCommands, n.SecondaryCommands);
 
             if (existing is null)
             {
-                var flyout = new WinUI.CommandBarFlyout { Placement = n.Placement };
+                var flyout = new WinUI.CommandBarFlyout();
+                ApplyPlacement(flyout, n.Placement);
                 if (n.PrimaryCommands is not null)
                     foreach (var cmd in n.PrimaryCommands) flyout.PrimaryCommands.Add(MenuCommandFactory.CreateAppBarItem(cmd));
                 if (n.SecondaryCommands is not null)
                     foreach (var cmd in n.SecondaryCommands) flyout.SecondaryCommands.Add(MenuCommandFactory.CreateAppBarItem(cmd));
-                WinPrim.FlyoutBase.SetAttachedFlyout(targetFe, flyout);
+                reconciler.SetFlyoutOnControl(targetFe, flyout);
                 Reconciler.ApplySetters(n.Setters, flyout);
+                existing = flyout;
             }
             else
             {
-                if (existing.Placement != n.Placement) existing.Placement = n.Placement;
+                ApplyPlacement(existing, n.Placement);
                 if (commandsChanged)
                 {
                     existing.PrimaryCommands.Clear();
@@ -487,7 +491,53 @@ internal static class OverlayLifecycle
                 }
                 Reconciler.ApplySetters(n.Setters, existing);
             }
+            if (n.IsOpen && !o.IsOpen) ShowFlyoutWhenReady(targetFe, existing);
         }
         return updated == targetControl ? null : updated;
+    }
+
+    /// <summary>
+    /// Assigns a flyout's placement, skipping <see cref="WinPrim.FlyoutPlacementMode.Auto"/>.
+    ///
+    /// <c>Auto</c> (13) is outside the range <c>FlyoutBase::ShowAtCore</c> accepts, and
+    /// <c>GetEffectivePlacement</c> hands the raw value straight to the validator, so an
+    /// <c>Auto</c>-placed flyout fail-fasts the process with <c>E_INVALIDARG</c> the moment
+    /// it opens. Skipping the write leaves WinUI's own <c>Placement</c> default (Top) in
+    /// place. Mirrors the guard MenuFlyout already carries in
+    /// <c>Reconciler.CreateFlyoutFromElement</c>.
+    /// </summary>
+    private static void ApplyPlacement(WinPrim.FlyoutBase flyout, WinPrim.FlyoutPlacementMode placement)
+    {
+        if (placement != WinPrim.FlyoutPlacementMode.Auto && flyout.Placement != placement)
+            flyout.Placement = placement;
+    }
+
+    /// <summary>
+    /// Opens <paramref name="flyout"/> against <paramref name="target"/>, deferring to the
+    /// target's first <c>Loaded</c> when it isn't in a live tree yet (at mount time it has no
+    /// XamlRoot and <c>ShowAt</c> would throw).
+    ///
+    /// Deliberately not <c>FlyoutBase.ShowAttachedFlyout</c>: that reads the AttachedFlyout
+    /// property, and a Button/SplitButton target holds its flyout in the control's own
+    /// <c>Flyout</c> slot, so the attached lookup would find nothing and silently no-op.
+    /// </summary>
+    private static void ShowFlyoutWhenReady(FrameworkElement target, WinPrim.FlyoutBase flyout)
+    {
+        if (target.IsLoaded)
+        {
+            flyout.ShowAt(target);
+            return;
+        }
+
+        void OnLoaded(object sender, RoutedEventArgs e)
+        {
+            target.Loaded -= OnLoaded;
+            // The element may have been unmounted (and its flyout replaced) between mount
+            // and Loaded — only show if this flyout is still the one installed on it.
+            if (ReferenceEquals(Reconciler.GetFlyoutOnControl(target), flyout))
+                flyout.ShowAt(target);
+        }
+
+        target.Loaded += OnLoaded;
     }
 }

--- a/src/Reactor/Core/V1Protocol/OverlayLifecycle.cs
+++ b/src/Reactor/Core/V1Protocol/OverlayLifecycle.cs
@@ -419,7 +419,7 @@ internal static class OverlayLifecycle
         if (target is FrameworkElement targetFe)
         {
             var flyout = new WinUI.CommandBarFlyout();
-            ApplyPlacement(flyout, cbf.Placement);
+            Reconciler.ApplyFlyoutPlacement(flyout, cbf.Placement);
             if (cbf.PrimaryCommands is not null)
                 foreach (var cmd in cbf.PrimaryCommands) flyout.PrimaryCommands.Add(MenuCommandFactory.CreateAppBarItem(cmd));
             if (cbf.SecondaryCommands is not null)
@@ -468,7 +468,7 @@ internal static class OverlayLifecycle
             if (existing is null)
             {
                 var flyout = new WinUI.CommandBarFlyout();
-                ApplyPlacement(flyout, n.Placement);
+                Reconciler.ApplyFlyoutPlacement(flyout, n.Placement);
                 if (n.PrimaryCommands is not null)
                     foreach (var cmd in n.PrimaryCommands) flyout.PrimaryCommands.Add(MenuCommandFactory.CreateAppBarItem(cmd));
                 if (n.SecondaryCommands is not null)
@@ -479,7 +479,7 @@ internal static class OverlayLifecycle
             }
             else
             {
-                ApplyPlacement(existing, n.Placement);
+                Reconciler.ApplyFlyoutPlacement(existing, n.Placement);
                 if (commandsChanged)
                 {
                     existing.PrimaryCommands.Clear();
@@ -497,20 +497,12 @@ internal static class OverlayLifecycle
     }
 
     /// <summary>
-    /// Assigns a flyout's placement, skipping <see cref="WinPrim.FlyoutPlacementMode.Auto"/>.
-    ///
-    /// <c>Auto</c> (13) is outside the range <c>FlyoutBase::ShowAtCore</c> accepts, and
-    /// <c>GetEffectivePlacement</c> hands the raw value straight to the validator, so an
-    /// <c>Auto</c>-placed flyout fail-fasts the process with <c>E_INVALIDARG</c> the moment
-    /// it opens. Skipping the write leaves WinUI's own <c>Placement</c> default (Top) in
-    /// place. Mirrors the guard MenuFlyout already carries in
-    /// <c>Reconciler.CreateFlyoutFromElement</c>.
+    /// Whether a target's current element still wants its CommandBarFlyout open. Guards the
+    /// deferred (Loaded) open against the element being re-rendered with <c>IsOpen = false</c>,
+    /// swapped for a different element, or unmounted (the tag is cleared on pool return) in the
+    /// window between mount and the target entering the live tree.
     /// </summary>
-    private static void ApplyPlacement(WinPrim.FlyoutBase flyout, WinPrim.FlyoutPlacementMode placement)
-    {
-        if (placement != WinPrim.FlyoutPlacementMode.Auto && flyout.Placement != placement)
-            flyout.Placement = placement;
-    }
+    internal static bool IsStillRequestingOpen(Element? tag) => tag is CommandBarFlyoutElement { IsOpen: true };
 
     /// <summary>
     /// Opens <paramref name="flyout"/> against <paramref name="target"/>, deferring to the
@@ -532,10 +524,14 @@ internal static class OverlayLifecycle
         void OnLoaded(object sender, RoutedEventArgs e)
         {
             target.Loaded -= OnLoaded;
-            // The element may have been unmounted (and its flyout replaced) between mount
-            // and Loaded — only show if this flyout is still the one installed on it.
-            if (ReferenceEquals(Reconciler.GetFlyoutOnControl(target), flyout))
+            // Only honour a deferred open if this flyout is still the one installed on the
+            // target AND the target's current element still asks to be open — otherwise a
+            // re-render that cleared IsOpen (or a recycled control) would pop a stale flyout.
+            if (ReferenceEquals(Reconciler.GetFlyoutOnControl(target), flyout)
+                && IsStillRequestingOpen(Reconciler.GetElementTag(target)))
+            {
                 flyout.ShowAt(target);
+            }
         }
 
         target.Loaded += OnLoaded;

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/CommandBarFlyoutWiringFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/CommandBarFlyoutWiringFixtures.cs
@@ -1,0 +1,257 @@
+using System.Threading.Tasks;
+using Microsoft.UI.Reactor;
+using Microsoft.UI.Reactor.Core;
+using Microsoft.UI.Xaml.Controls;
+using WinPrim = Microsoft.UI.Xaml.Controls.Primitives;
+using static Microsoft.UI.Reactor.Factories;
+
+namespace Microsoft.UI.Reactor.AppTests.Host.SelfTest.Fixtures;
+
+/// <summary>
+/// Regression coverage for "CommandBarFlyout renders a button that does nothing".
+///
+/// <c>OverlayLifecycle.MountCommandBarFlyout</c> used to install the flyout as
+/// <c>FlyoutBase.AttachedFlyout</c> metadata, which only ever opens via an explicit
+/// <c>ShowAttachedFlyout</c> call that nothing in Reactor makes — so
+/// <c>CommandBarFlyout(Button("Show Commands"), primaryCommands: ...)</c> produced a dead
+/// button. Its two sibling overlays (Flyout, MenuFlyout) both go through
+/// <c>Reconciler.SetFlyoutOnControl</c>, which puts the flyout in <c>Button.Flyout</c> /
+/// <c>SplitButton.Flyout</c> so a click opens it natively. WinUI's own AttachedFlyout docs
+/// say the same: "To attach a flyout to a Button, use Button.Flyout instead."
+///
+/// The update path had the matching half of the bug: it looked the existing flyout up with
+/// <c>GetAttachedFlyout</c> only, so once mount stopped writing there every re-render would
+/// build a *second* flyout and drop it in the slot nobody reads, leaving the live one stale.
+///
+/// Placement is pinned to <c>Top</c> throughout: the default <c>Auto</c> has its own
+/// separate open-time issue and would confound these assertions.
+/// </summary>
+internal static class CommandBarFlyoutWiringFixtures
+{
+    private static bool SameInstance(object? a, object? b) => a is not null && ReferenceEquals(a, b);
+
+    /// <summary>
+    /// Waits (bounded) for a flyout to report open. Opening runs through WinUI's popup
+    /// machinery — deferred to the target's Loaded at mount time, and serialized behind
+    /// any still-closing popup — so a single render pass isn't a reliable barrier. A real
+    /// regression still fails: the flyout never opens within the whole budget.
+    /// </summary>
+    private static async Task<bool> WaitOpen(WinPrim.FlyoutBase? flyout)
+    {
+        for (int i = 0; i < 40 && flyout?.IsOpen != true; i++)
+            await Harness.Render(25);
+        return flyout?.IsOpen == true;
+    }
+
+    /// <summary>Closes a flyout and waits for it to settle so it can't leak into the next fixture.</summary>
+    private static async Task CloseAndSettle(WinPrim.FlyoutBase? flyout)
+    {
+        flyout?.Hide();
+        for (int i = 0; i < 20 && flyout?.IsOpen == true; i++)
+            await Harness.Render(25);
+        await Harness.Render(50);
+    }
+
+    // ════════════════════════════════════════════════════════════════════
+    //  Mount installs into the target's own Flyout slot (the click-to-open
+    //  one), and Update finds it back there instead of duplicating it.
+    // ════════════════════════════════════════════════════════════════════
+    internal class TargetWiring(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                var (phase, set) = ctx.UseState(0);
+                AppBarItemBase[] primary = phase == 0
+                    ? [AppBarButton("cbfw-cut"), AppBarButton("cbfw-copy")]
+                    : [AppBarButton("cbfw-paste")];
+                return VStack(
+                    Button("CbfWireGo", () => set(phase + 1)),
+                    CommandBarFlyout(
+                        Button("cbfw-target", () => { }),
+                        primaryCommands: primary,
+                        secondaryCommands: [AppBarButton("cbfw-more")]) with
+                    {
+                        Placement = WinPrim.FlyoutPlacementMode.Top,
+                    });
+            });
+
+            await Harness.Render();
+            var target0 = H.FindButton("cbfw-target");
+            H.Check("CbfWire_TargetMounted", target0 is not null);
+
+            // THE FIX: the flyout lands in Button.Flyout — the slot WinUI opens on click.
+            var flyout0 = target0?.Flyout as CommandBarFlyout;
+            H.Check("CbfWire_FlyoutInButtonSlot", flyout0 is not null);
+            H.Check("CbfWire_MountPrimary2", flyout0?.PrimaryCommands.Count == 2);
+            H.Check("CbfWire_MountSecondary1", flyout0?.SecondaryCommands.Count == 1);
+            H.Check("CbfWire_MountPrimaryLabels",
+                flyout0?.PrimaryCommands.Count == 2
+                && (flyout0?.PrimaryCommands[0] as AppBarButton)?.Label == "cbfw-cut"
+                && (flyout0?.PrimaryCommands[1] as AppBarButton)?.Label == "cbfw-copy");
+            // ...and NOT also in the attached-flyout slot (would be a second, invisible copy).
+            H.Check("CbfWire_MountNotAttached",
+                target0 is not null && WinPrim.FlyoutBase.GetAttachedFlyout(target0) is null);
+
+            // Update must read the flyout back from the slot mount wrote to. With an
+            // attached-only lookup this branch creates a brand-new flyout, so the
+            // instance changes AND the live Button.Flyout keeps the stale commands.
+            H.ClickButton("CbfWireGo");
+            await Harness.Render();
+            var target1 = H.FindButton("cbfw-target");
+            H.Check("CbfWire_TargetReusedInPlace", SameInstance(target0, target1));
+            var flyout1 = target1?.Flyout as CommandBarFlyout;
+            H.Check("CbfWire_FlyoutReusedInPlace", SameInstance(flyout0, flyout1));
+            H.Check("CbfWire_UpdatePrimaryPatched",
+                flyout1?.PrimaryCommands.Count == 1
+                && (flyout1?.PrimaryCommands[0] as AppBarButton)?.Label == "cbfw-paste");
+            H.Check("CbfWire_UpdateNoAttachedDuplicate",
+                target1 is not null && WinPrim.FlyoutBase.GetAttachedFlyout(target1) is null);
+
+            // The whole point of the Button.Flyout slot: a plain click on the target
+            // opens the flyout, with no ShowAttachedFlyout call anywhere.
+            H.ClickButton("cbfw-target");
+            await Harness.Render();
+            H.Check("CbfWire_TargetClickOpensFlyout", await WaitOpen(flyout1));
+            await CloseAndSettle(flyout1);
+        }
+    }
+
+    // ════════════════════════════════════════════════════════════════════
+    //  A non-button target still uses the attached-flyout fallback — the
+    //  slot rule is per-target-type, not "always Button.Flyout".
+    // ════════════════════════════════════════════════════════════════════
+    internal class NonButtonTargetUsesAttachedSlot(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var host = H.CreateHost();
+            host.Mount(ctx => VStack(
+                CommandBarFlyout(
+                    TextBlock("cbfw-tb-target"),
+                    primaryCommands: [AppBarButton("cbfw-tb-cut")]) with
+                {
+                    Placement = WinPrim.FlyoutPlacementMode.Top,
+                }));
+
+            await Harness.Render();
+            var target = H.FindText("cbfw-tb-target");
+            H.Check("CbfAttached_TargetMounted", target is not null);
+            var flyout = target is null ? null : WinPrim.FlyoutBase.GetAttachedFlyout(target) as CommandBarFlyout;
+            H.Check("CbfAttached_FlyoutInAttachedSlot", flyout is not null);
+            H.Check("CbfAttached_PrimaryCommands1", flyout?.PrimaryCommands.Count == 1);
+        }
+    }
+
+    // ════════════════════════════════════════════════════════════════════
+    //  CommandBarFlyoutElement.IsOpen — declarative open on the false→true
+    //  edge of an update (the target is live, so ShowAt runs immediately).
+    // ════════════════════════════════════════════════════════════════════
+    internal class IsOpenOnUpdate(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                var (open, setOpen) = ctx.UseState(false);
+                return VStack(
+                    Button("CbfOpenGo", () => setOpen(true)),
+                    CommandBarFlyout(
+                        Button("cbfo-target", () => { }),
+                        primaryCommands: [AppBarButton("cbfo-cut")]) with
+                    {
+                        Placement = WinPrim.FlyoutPlacementMode.Top,
+                        IsOpen = open,
+                    });
+            });
+
+            await Harness.Render();
+            var flyout = H.FindButton("cbfo-target")?.Flyout as CommandBarFlyout;
+            H.Check("CbfIsOpen_FlyoutInstalled", flyout is not null);
+            H.Check("CbfIsOpen_ClosedWhenFalse", flyout?.IsOpen == false);
+
+            H.ClickButton("CbfOpenGo");
+            await Harness.Render();
+            H.Check("CbfIsOpen_OpenedOnRisingEdge", await WaitOpen(flyout));
+
+            // Don't leak an open popup into the next fixture.
+            await CloseAndSettle(flyout);
+        }
+    }
+
+    // ════════════════════════════════════════════════════════════════════
+    //  IsOpen already true at mount. The target has no XamlRoot while the
+    //  tree is being built, so the show has to be deferred to its Loaded.
+    // ════════════════════════════════════════════════════════════════════
+    internal class IsOpenOnMount(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var host = H.CreateHost();
+            host.Mount(ctx => VStack(
+                CommandBarFlyout(
+                    Button("cbfm-target", () => { }),
+                    primaryCommands: [AppBarButton("cbfm-cut")]) with
+                {
+                    Placement = WinPrim.FlyoutPlacementMode.Top,
+                    IsOpen = true,
+                }));
+
+            await Harness.Render();
+            var target = H.FindButton("cbfm-target");
+            var flyout = target?.Flyout as CommandBarFlyout;
+            H.Check("CbfIsOpenMount_FlyoutInstalled", flyout is not null);
+
+            // The show is deferred to the target's Loaded, which lands on the dispatcher
+            // after the mount render — poll (bounded) instead of assuming one pass is enough.
+            H.Check("CbfIsOpenMount_OpenedAfterLoaded", await WaitOpen(flyout));
+
+            await CloseAndSettle(flyout);
+        }
+    }
+
+    // ════════════════════════════════════════════════════════════════════
+    //  Default (Auto) placement must survive being opened.
+    //
+    //  FlyoutPlacementMode.Auto (13) is outside the range FlyoutBase::ShowAtCore
+    //  accepts, so writing it through fail-fasts the process with E_INVALIDARG
+    //  the moment the flyout opens — which nothing noticed while CommandBarFlyout
+    //  could never open at all. If this regresses the whole selftest host dies,
+    //  which is exactly the signal we want.
+    // ════════════════════════════════════════════════════════════════════
+    internal class DefaultPlacementOpens(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                var (open, setOpen) = ctx.UseState(false);
+                // No `with { Placement = ... }` — CommandBarFlyoutElement defaults to Auto.
+                return VStack(
+                    Button("CbfAutoGo", () => setOpen(true)),
+                    CommandBarFlyout(
+                        Button("cbfa-target", () => { }),
+                        primaryCommands: [AppBarButton("cbfa-cut")]) with
+                    {
+                        IsOpen = open,
+                    });
+            });
+
+            await Harness.Render();
+            var flyout = H.FindButton("cbfa-target")?.Flyout as CommandBarFlyout;
+            H.Check("CbfAuto_FlyoutInstalled", flyout is not null);
+            // Auto is never written through; WinUI's own default stands.
+            H.Check("CbfAuto_PlacementNotAuto", flyout?.Placement != WinPrim.FlyoutPlacementMode.Auto);
+
+            H.ClickButton("CbfAutoGo");
+            await Harness.Render();
+            H.Check("CbfAuto_OpenedWithoutFailFast", await WaitOpen(flyout));
+
+            await CloseAndSettle(flyout);
+        }
+    }
+}

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/CommandBarFlyoutWiringFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/CommandBarFlyoutWiringFixtures.cs
@@ -244,14 +244,138 @@ internal static class CommandBarFlyoutWiringFixtures
             await Harness.Render();
             var flyout = H.FindButton("cbfa-target")?.Flyout as CommandBarFlyout;
             H.Check("CbfAuto_FlyoutInstalled", flyout is not null);
-            // Auto is never written through; WinUI's own default stands.
-            H.Check("CbfAuto_PlacementNotAuto", flyout?.Placement != WinPrim.FlyoutPlacementMode.Auto);
+            // Auto is never written through; WinUI's own Placement default stands.
+            // (`is CommandBarFlyout` so a null flyout can't pass this by accident.)
+            H.Check("CbfAuto_PlacementNotAuto",
+                flyout is CommandBarFlyout { Placement: not WinPrim.FlyoutPlacementMode.Auto });
 
             H.ClickButton("CbfAutoGo");
             await Harness.Render();
             H.Check("CbfAuto_OpenedWithoutFailFast", await WaitOpen(flyout));
 
             await CloseAndSettle(flyout);
+        }
+    }
+
+    // ════════════════════════════════════════════════════════════════════
+    //  A SplitButton target uses SplitButton.Flyout (its own slot — SplitButton
+    //  does not derive from Button), not the attached-flyout metadata.
+    // ════════════════════════════════════════════════════════════════════
+    internal class SplitButtonTargetWiring(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                var (phase, set) = ctx.UseState(0);
+                AppBarItemBase[] primary = phase == 0
+                    ? [AppBarButton("cbfs-cut")]
+                    : [AppBarButton("cbfs-copy"), AppBarButton("cbfs-paste")];
+                return VStack(
+                    Button("CbfSplitGo", () => set(phase + 1)),
+                    CommandBarFlyout(
+                        SplitButton("cbfs-target", () => { }),
+                        primaryCommands: primary) with
+                    {
+                        Placement = WinPrim.FlyoutPlacementMode.Top,
+                    });
+            });
+
+            await Harness.Render();
+            var target0 = H.FindControl<SplitButton>(sb => sb.Content is string s && s == "cbfs-target");
+            H.Check("CbfSplit_TargetMounted", target0 is not null);
+            var flyout0 = target0?.Flyout as CommandBarFlyout;
+            H.Check("CbfSplit_FlyoutInSplitButtonSlot", flyout0 is not null);
+            H.Check("CbfSplit_MountPrimary1", flyout0?.PrimaryCommands.Count == 1);
+            H.Check("CbfSplit_MountNotAttached",
+                target0 is not null && WinPrim.FlyoutBase.GetAttachedFlyout(target0) is null);
+
+            H.ClickButton("CbfSplitGo");
+            await Harness.Render();
+            var target1 = H.FindControl<SplitButton>(sb => sb.Content is string s && s == "cbfs-target");
+            var flyout1 = target1?.Flyout as CommandBarFlyout;
+            H.Check("CbfSplit_FlyoutReusedInPlace", SameInstance(flyout0, flyout1));
+            H.Check("CbfSplit_UpdatePrimaryPatched",
+                flyout1?.PrimaryCommands.Count == 2
+                && (flyout1?.PrimaryCommands[0] as AppBarButton)?.Label == "cbfs-copy");
+        }
+    }
+
+    // ════════════════════════════════════════════════════════════════════
+    //  Placement explicit → Auto must land back on WinUI's default, matching
+    //  what a fresh mount of the same element would produce. Merely skipping
+    //  the Auto write would strand the previous explicit value.
+    // ════════════════════════════════════════════════════════════════════
+    internal class PlacementExplicitToAutoResets(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                var (phase, set) = ctx.UseState(0);
+                return VStack(
+                    Button("CbfResetGo", () => set(1)),
+                    CommandBarFlyout(
+                        Button("cbfr-target", () => { }),
+                        primaryCommands: [AppBarButton("cbfr-cut")]) with
+                    {
+                        Placement = phase == 0
+                            ? WinPrim.FlyoutPlacementMode.Bottom
+                            : WinPrim.FlyoutPlacementMode.Auto,
+                    });
+            });
+
+            await Harness.Render();
+            var flyout = H.FindButton("cbfr-target")?.Flyout as CommandBarFlyout;
+            H.Check("CbfReset_ExplicitPlacementApplied",
+                flyout?.Placement == WinPrim.FlyoutPlacementMode.Bottom);
+
+            // The default a fresh Auto mount produces — captured from a real fresh flyout so
+            // the assertion doesn't hard-code WinUI's default and silently rot.
+            var freshDefault = new CommandBarFlyout().Placement;
+            H.ClickButton("CbfResetGo");
+            await Harness.Render();
+            H.Check("CbfReset_AutoRestoresDefaultPlacement",
+                flyout is CommandBarFlyout && flyout.Placement == freshDefault);
+            H.Check("CbfReset_DefaultIsNotAuto", freshDefault != WinPrim.FlyoutPlacementMode.Auto);
+        }
+    }
+
+    // ════════════════════════════════════════════════════════════════════
+    //  Unmount detaches the flyout so a recycled target can't keep showing
+    //  the previous component's command bar.
+    // ════════════════════════════════════════════════════════════════════
+    internal class UnmountDetachesFlyout(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                var (shown, set) = ctx.UseState(true);
+                return VStack(
+                    Button("CbfUnmountGo", () => set(false)),
+                    shown
+                        ? CommandBarFlyout(
+                            Button("cbfu-target", () => { }),
+                            primaryCommands: [AppBarButton("cbfu-cut")]) with
+                          {
+                              Placement = WinPrim.FlyoutPlacementMode.Top,
+                          }
+                        : TextBlock("cbfu-gone"));
+            });
+
+            await Harness.Render();
+            // Hold the control across the unmount so the detach is observable.
+            var target = H.FindButton("cbfu-target");
+            H.Check("CbfUnmount_FlyoutInstalled", target?.Flyout is CommandBarFlyout);
+
+            H.ClickButton("CbfUnmountGo");
+            await Harness.Render();
+            H.Check("CbfUnmount_TargetRemoved", H.FindButton("cbfu-target") is null);
+            H.Check("CbfUnmount_FlyoutDetached", target is not null && target.Flyout is null);
         }
     }
 }

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/CommandBarFlyoutWiringFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/CommandBarFlyoutWiringFixtures.cs
@@ -246,7 +246,7 @@ internal static class CommandBarFlyoutWiringFixtures
             H.Check("CbfAuto_FlyoutInstalled", flyout is not null);
             // Auto is never written through; WinUI's own Placement default stands.
             // (`is CommandBarFlyout` so a null flyout can't pass this by accident.)
-            H.Check("CbfAuto_PlacementNotAuto",
+            H.Check($"CbfAuto_PlacementNotAuto[{flyout?.Placement}]",
                 flyout is CommandBarFlyout { Placement: not WinPrim.FlyoutPlacementMode.Auto });
 
             H.ClickButton("CbfAutoGo");
@@ -339,7 +339,11 @@ internal static class CommandBarFlyoutWiringFixtures
             await Harness.Render();
             H.Check("CbfReset_AutoRestoresDefaultPlacement",
                 flyout is CommandBarFlyout && flyout.Placement == freshDefault);
-            H.Check("CbfReset_DefaultIsNotAuto", freshDefault != WinPrim.FlyoutPlacementMode.Auto);
+            // Value embedded in the TAP name (house style) so the resolved default is a
+            // recorded measurement, not an assumption — this is the exact value an unset
+            // CommandBarFlyout placement lands on.
+            H.Check($"CbfReset_DefaultIsNotAuto[{freshDefault}]",
+                freshDefault != WinPrim.FlyoutPlacementMode.Auto);
         }
     }
 

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/CommandBarFlyoutWiringFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/CommandBarFlyoutWiringFixtures.cs
@@ -415,10 +415,11 @@ internal static class CommandBarFlyoutWiringFixtures
                 return VStack([Button("CbfKeyGo", () => set(phase + 1)), .. children]);
             });
 
-            static string? PrimaryLabel(Button? b) =>
-                (b?.Flyout as CommandBarFlyout)?.PrimaryCommands.Count == 1
-                    ? ((b.Flyout as CommandBarFlyout)!.PrimaryCommands[0] as AppBarButton)?.Label
-                    : null;
+            static string? PrimaryLabel(Button? b)
+            {
+                if (b?.Flyout is not CommandBarFlyout f || f.PrimaryCommands.Count != 1) return null;
+                return (f.PrimaryCommands[0] as AppBarButton)?.Label;
+            }
 
             await Harness.Render();
             H.Check("CbfKeyed_MountA", PrimaryLabel(H.FindButton("cbfk-a")) == "cbfk-a-cut");

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/CommandBarFlyoutWiringFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/CommandBarFlyoutWiringFixtures.cs
@@ -378,4 +378,124 @@ internal static class CommandBarFlyoutWiringFixtures
             H.Check("CbfUnmount_FlyoutDetached", target is not null && target.Flyout is null);
         }
     }
+
+    // ════════════════════════════════════════════════════════════════════
+    //  Unmount detach must only reach the decorator's OWN target. Keyed
+    //  reorder + removal is the case where an unmounting decorator could
+    //  plausibly strip a sibling's (or a reused control's) live flyout.
+    // ════════════════════════════════════════════════════════════════════
+    internal class KeyedReorderKeepsSiblingFlyouts(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                var (phase, set) = ctx.UseState(0);
+                Element A = CommandBarFlyout(
+                    Button("cbfk-a", () => { }),
+                    primaryCommands: [AppBarButton("cbfk-a-cut")]) with
+                {
+                    Key = "a",
+                    Placement = WinPrim.FlyoutPlacementMode.Top,
+                };
+                Element B = CommandBarFlyout(
+                    Button("cbfk-b", () => { }),
+                    primaryCommands: [AppBarButton("cbfk-b-cut")]) with
+                {
+                    Key = "b",
+                    Placement = WinPrim.FlyoutPlacementMode.Top,
+                };
+                Element[] children = phase switch
+                {
+                    0 => [A, B],
+                    1 => [B, A],   // reorder
+                    _ => [B],      // drop A entirely
+                };
+                return VStack([Button("CbfKeyGo", () => set(phase + 1)), .. children]);
+            });
+
+            static string? PrimaryLabel(Button? b) =>
+                (b?.Flyout as CommandBarFlyout)?.PrimaryCommands.Count == 1
+                    ? ((b.Flyout as CommandBarFlyout)!.PrimaryCommands[0] as AppBarButton)?.Label
+                    : null;
+
+            await Harness.Render();
+            H.Check("CbfKeyed_MountA", PrimaryLabel(H.FindButton("cbfk-a")) == "cbfk-a-cut");
+            H.Check("CbfKeyed_MountB", PrimaryLabel(H.FindButton("cbfk-b")) == "cbfk-b-cut");
+
+            H.ClickButton("CbfKeyGo");
+            await Harness.Render();
+            H.Check("CbfKeyed_ReorderKeepsA", PrimaryLabel(H.FindButton("cbfk-a")) == "cbfk-a-cut");
+            H.Check("CbfKeyed_ReorderKeepsB", PrimaryLabel(H.FindButton("cbfk-b")) == "cbfk-b-cut");
+
+            H.ClickButton("CbfKeyGo");
+            await Harness.Render();
+            H.Check("CbfKeyed_RemovedAGone", H.FindButton("cbfk-a") is null);
+            // The survivor must keep its own flyout — the removed sibling's unmount
+            // must not detach it.
+            H.Check("CbfKeyed_SurvivorKeepsFlyout", PrimaryLabel(H.FindButton("cbfk-b")) == "cbfk-b-cut");
+        }
+    }
+
+    // ════════════════════════════════════════════════════════════════════
+    //  Wrapping a target in CommandBarFlyout must not cost the target its
+    //  own callbacks.
+    //
+    //  KNOWN GAP (issue #942): all three target-wrapping decorators —
+    //  Flyout, MenuFlyout and CommandBarFlyout — retag the target control
+    //  with the *decorator's* element (SetElementTag), which is the same
+    //  ReactorState slot the target's own event trampolines resolve
+    //  through, so the target's callbacks are dropped. Pre-existing and
+    //  identical on MenuFlyout, so it is not this change's to fix; the two
+    //  assertions below are SKIPped rather than deleted so the gap stays
+    //  visible in the TAP log and flips to a real assertion when #942 lands.
+    // ════════════════════════════════════════════════════════════════════
+    internal class TargetKeepsItsOwnCallbacks(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var host = H.CreateHost();
+            var clicks = 0;
+            var checks = 0;
+            host.Mount(ctx => VStack(
+                CommandBarFlyout(
+                    Button("cbfcb-btn", () => clicks++),
+                    primaryCommands: [AppBarButton("cbfcb-cut")]) with
+                {
+                    Placement = WinPrim.FlyoutPlacementMode.Top,
+                },
+                CommandBarFlyout(
+                    CheckBox(false, _ => checks++, label: "cbfcb-chk"),
+                    primaryCommands: [AppBarButton("cbfcb-copy")]) with
+                {
+                    Placement = WinPrim.FlyoutPlacementMode.Top,
+                }));
+
+            await Harness.Render();
+            H.Check("CbfCallbacks_ButtonMounted", H.FindButton("cbfcb-btn") is not null);
+            H.Check("CbfCallbacks_CheckBoxMounted",
+                H.FindControl<CheckBox>(c => c.Content is string s && s == "cbfcb-chk") is not null);
+
+            // Button target: the flyout opens on click (this change), and the target's own
+            // OnClick should fire on the same click (blocked by #942).
+            H.ClickButton("cbfcb-btn");
+            await Harness.Render();
+            var button = H.FindButton("cbfcb-btn");
+            H.Check("CbfCallbacks_ButtonClickOpensFlyout", await WaitOpen(button?.Flyout));
+            if (clicks == 1)
+                H.Check("CbfCallbacks_ButtonOnClickFired", true);
+            else
+                H.Skip("CbfCallbacks_ButtonOnClickFired", "issue #942 - decorator retags the target");
+            await CloseAndSettle(button?.Flyout);
+
+            // Non-button (attached-slot) target: same gap, no flyout involvement at all.
+            H.ToggleCheckBox("cbfcb-chk");
+            await Harness.Render();
+            if (checks == 1)
+                H.Check("CbfCallbacks_CheckBoxOnChangedFired", true);
+            else
+                H.Skip("CbfCallbacks_CheckBoxOnChangedFired", "issue #942 - decorator retags the target");
+        }
+    }
 }

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/CoreReconcilerRenderCoverageFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/CoreReconcilerRenderCoverageFixtures.cs
@@ -292,19 +292,21 @@ internal static class CoreReconcilerRenderCoverageFixtures
             await Harness.Render();
             var btnTarget0 = H.FindButton("cbf-target");
             H.Check("CmdBarFlyout_ButtonTargetMounted", btnTarget0 is not null);
-            var flyout0 = btnTarget0 is null ? null : WinPrim.FlyoutBase.GetAttachedFlyout(btnTarget0) as CommandBarFlyout;
+            // A Button target holds its flyout in Button.Flyout (the slot WinUI opens on
+            // click), not in the attached-flyout metadata — see SetFlyoutOnControl.
+            var flyout0 = btnTarget0?.Flyout as CommandBarFlyout;
             H.Check("CmdBarFlyout_InitialPrimary1", flyout0?.PrimaryCommands.Count == 1);
             H.Check("CmdBarFlyout_InitialSecondary1", flyout0?.SecondaryCommands.Count == 1);
             H.Check("CmdBarFlyout_InitialPlacementTop", flyout0?.Placement == WinPrim.FlyoutPlacementMode.Top);
 
-            // Phase 0 -> 1: same Button target. The attached CommandBarFlyout is
+            // Phase 0 -> 1: same Button target. The installed CommandBarFlyout is
             // reused; placement is patched and both command collections are
             // cleared and re-populated in place.
             H.ClickButton("CbfGo");
             await Harness.Render();
             var btnTarget1 = H.FindButton("cbf-target");
             H.Check("CmdBarFlyout_TargetReusedInPlace", SameInstance(btnTarget0, btnTarget1));
-            var flyout1 = btnTarget1 is null ? null : WinPrim.FlyoutBase.GetAttachedFlyout(btnTarget1) as CommandBarFlyout;
+            var flyout1 = btnTarget1?.Flyout as CommandBarFlyout;
             H.Check("CmdBarFlyout_FlyoutReusedInPlace", SameInstance(flyout0, flyout1));
             H.Check("CmdBarFlyout_PlacementPatchedBottom", flyout1?.Placement == WinPrim.FlyoutPlacementMode.Bottom);
             H.Check("CmdBarFlyout_PrimaryReAdded2", flyout1?.PrimaryCommands.Count == 2);

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -1576,6 +1576,13 @@ internal static class SelfTestFixtureRegistry
         "CoreRRC_RenderContextThreadSafeState",
         "CoreRRC_RenderContextWindowEnvHooks",
         "CoreRRC_UntypedTreeViewReconcile",
+
+        // CommandBarFlyout target wiring + IsOpen (CommandBarFlyoutWiringFixtures).
+        "CmdBarFlyout_TargetWiring",
+        "CmdBarFlyout_NonButtonTargetUsesAttachedSlot",
+        "CmdBarFlyout_IsOpenOnUpdate",
+        "CmdBarFlyout_IsOpenOnMount",
+        "CmdBarFlyout_DefaultPlacementOpens",
     ];
 
     public static SelfTestFixtureBase? Create(string name, Harness harness) => name switch
@@ -3092,6 +3099,13 @@ internal static class SelfTestFixtureRegistry
         "CoreRRC_RenderContextThreadSafeState" => new CoreReconcilerRenderCoverageFixtures.RenderContextThreadSafeState(harness),
         "CoreRRC_RenderContextWindowEnvHooks" => new CoreReconcilerRenderCoverageFixtures.RenderContextWindowEnvHooks(harness),
         "CoreRRC_UntypedTreeViewReconcile" => new CoreReconcilerRenderCoverageFixtures.UntypedTreeViewReconcile(harness),
+
+        // CommandBarFlyout target wiring + IsOpen.
+        "CmdBarFlyout_TargetWiring" => new CommandBarFlyoutWiringFixtures.TargetWiring(harness),
+        "CmdBarFlyout_NonButtonTargetUsesAttachedSlot" => new CommandBarFlyoutWiringFixtures.NonButtonTargetUsesAttachedSlot(harness),
+        "CmdBarFlyout_IsOpenOnUpdate" => new CommandBarFlyoutWiringFixtures.IsOpenOnUpdate(harness),
+        "CmdBarFlyout_IsOpenOnMount" => new CommandBarFlyoutWiringFixtures.IsOpenOnMount(harness),
+        "CmdBarFlyout_DefaultPlacementOpens" => new CommandBarFlyoutWiringFixtures.DefaultPlacementOpens(harness),
 
         _ => null,
     };

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -1583,6 +1583,9 @@ internal static class SelfTestFixtureRegistry
         "CmdBarFlyout_IsOpenOnUpdate",
         "CmdBarFlyout_IsOpenOnMount",
         "CmdBarFlyout_DefaultPlacementOpens",
+        "CmdBarFlyout_SplitButtonTargetWiring",
+        "CmdBarFlyout_PlacementExplicitToAutoResets",
+        "CmdBarFlyout_UnmountDetachesFlyout",
     ];
 
     public static SelfTestFixtureBase? Create(string name, Harness harness) => name switch
@@ -3106,6 +3109,9 @@ internal static class SelfTestFixtureRegistry
         "CmdBarFlyout_IsOpenOnUpdate" => new CommandBarFlyoutWiringFixtures.IsOpenOnUpdate(harness),
         "CmdBarFlyout_IsOpenOnMount" => new CommandBarFlyoutWiringFixtures.IsOpenOnMount(harness),
         "CmdBarFlyout_DefaultPlacementOpens" => new CommandBarFlyoutWiringFixtures.DefaultPlacementOpens(harness),
+        "CmdBarFlyout_SplitButtonTargetWiring" => new CommandBarFlyoutWiringFixtures.SplitButtonTargetWiring(harness),
+        "CmdBarFlyout_PlacementExplicitToAutoResets" => new CommandBarFlyoutWiringFixtures.PlacementExplicitToAutoResets(harness),
+        "CmdBarFlyout_UnmountDetachesFlyout" => new CommandBarFlyoutWiringFixtures.UnmountDetachesFlyout(harness),
 
         _ => null,
     };

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -1586,6 +1586,8 @@ internal static class SelfTestFixtureRegistry
         "CmdBarFlyout_SplitButtonTargetWiring",
         "CmdBarFlyout_PlacementExplicitToAutoResets",
         "CmdBarFlyout_UnmountDetachesFlyout",
+        "CmdBarFlyout_KeyedReorderKeepsSiblingFlyouts",
+        "CmdBarFlyout_TargetKeepsItsOwnCallbacks",
     ];
 
     public static SelfTestFixtureBase? Create(string name, Harness harness) => name switch
@@ -3112,6 +3114,8 @@ internal static class SelfTestFixtureRegistry
         "CmdBarFlyout_SplitButtonTargetWiring" => new CommandBarFlyoutWiringFixtures.SplitButtonTargetWiring(harness),
         "CmdBarFlyout_PlacementExplicitToAutoResets" => new CommandBarFlyoutWiringFixtures.PlacementExplicitToAutoResets(harness),
         "CmdBarFlyout_UnmountDetachesFlyout" => new CommandBarFlyoutWiringFixtures.UnmountDetachesFlyout(harness),
+        "CmdBarFlyout_KeyedReorderKeepsSiblingFlyouts" => new CommandBarFlyoutWiringFixtures.KeyedReorderKeepsSiblingFlyouts(harness),
+        "CmdBarFlyout_TargetKeepsItsOwnCallbacks" => new CommandBarFlyoutWiringFixtures.TargetKeepsItsOwnCallbacks(harness),
 
         _ => null,
     };

--- a/tests/Reactor.Tests/FlyoutAttachmentTests.cs
+++ b/tests/Reactor.Tests/FlyoutAttachmentTests.cs
@@ -330,4 +330,71 @@ public class FlyoutAttachmentTests
         var el = MenuItems(MenuItem("x"));
         Assert.Equal(FlyoutPlacementMode.Auto, el.Placement);
     }
+
+    // ════════════════════════════════════════════════════════════════
+    //  Flyout slot resolution (Reconciler.ResolveFlyoutSlot)
+    //
+    //  Single source of truth shared by SetFlyoutOnControl (write) and
+    //  GetFlyoutOnControl (read). A writer and a reader that disagree on the
+    //  slot silently lose the flyout — that is exactly how CommandBarFlyout
+    //  ended up installing into AttachedFlyout (which nothing ever opens)
+    //  while Flyout/MenuFlyout used the Button.Flyout slot.
+    //
+    //  Type-only: no WinUI object is constructed, so these stay headless.
+    // ════════════════════════════════════════════════════════════════
+
+    [Theory]
+    // Button family → the control's own Flyout property, which WinUI opens on click.
+    [InlineData(typeof(Button), (int)Reconciler.FlyoutSlot.Button)]
+    [InlineData(typeof(DropDownButton), (int)Reconciler.FlyoutSlot.Button)]
+    [InlineData(typeof(AppBarButton), (int)Reconciler.FlyoutSlot.Button)]
+    // SplitButton does NOT derive from Button and has its own Flyout property.
+    [InlineData(typeof(SplitButton), (int)Reconciler.FlyoutSlot.SplitButton)]
+    [InlineData(typeof(ToggleSplitButton), (int)Reconciler.FlyoutSlot.SplitButton)]
+    // Everything else — including ButtonBase-derived types that have no Flyout
+    // property — falls back to FlyoutBase.AttachedFlyout metadata.
+    [InlineData(typeof(HyperlinkButton), (int)Reconciler.FlyoutSlot.Attached)]
+    [InlineData(typeof(AppBarToggleButton), (int)Reconciler.FlyoutSlot.Attached)]
+    [InlineData(typeof(TextBlock), (int)Reconciler.FlyoutSlot.Attached)]
+    [InlineData(typeof(Border), (int)Reconciler.FlyoutSlot.Attached)]
+    [InlineData(typeof(FrameworkElement), (int)Reconciler.FlyoutSlot.Attached)]
+    // int, not FlyoutSlot: the enum is internal and an internal parameter type on a
+    // public test method is CS0051.
+    public void ResolveFlyoutSlot_Maps_TargetType_To_Slot(global::System.Type targetType, int expectedSlot)
+    {
+        Assert.Equal((Reconciler.FlyoutSlot)expectedSlot, Reconciler.ResolveFlyoutSlot(targetType));
+    }
+
+    [Fact]
+    public void ResolveFlyoutSlot_Separates_Button_From_SplitButton()
+    {
+        // Differential: the two button families must NOT collapse onto the same
+        // slot, or one of them gets written to a property the reader never checks.
+        Assert.NotEqual(
+            Reconciler.ResolveFlyoutSlot(typeof(Button)),
+            Reconciler.ResolveFlyoutSlot(typeof(SplitButton)));
+    }
+
+    [Fact]
+    public void ResolveFlyoutSlot_Does_Not_Put_Buttons_In_The_Attached_Slot()
+    {
+        // The attached slot only opens via an explicit ShowAttachedFlyout call.
+        // A Button target landing there is the CommandBarFlyout "dead button" bug.
+        Assert.NotEqual(Reconciler.FlyoutSlot.Attached, Reconciler.ResolveFlyoutSlot(typeof(Button)));
+        Assert.NotEqual(Reconciler.FlyoutSlot.Attached, Reconciler.ResolveFlyoutSlot(typeof(SplitButton)));
+    }
+
+    [Fact]
+    public void CommandBarFlyout_Does_Not_Open_Itself_By_Default()
+    {
+        // IsOpen is an explicit opt-in trigger — defaulting it true would pop every
+        // CommandBarFlyout open on mount.
+        Assert.False(CommandBarFlyout(Button("target", null)).IsOpen);
+    }
+
+    [Fact]
+    public void CommandBarFlyout_IsOpen_Is_Settable_Via_With()
+    {
+        Assert.True((CommandBarFlyout(Button("target", null)) with { IsOpen = true }).IsOpen);
+    }
 }

--- a/tests/Reactor.Tests/FlyoutAttachmentTests.cs
+++ b/tests/Reactor.Tests/FlyoutAttachmentTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.UI.Reactor.Core;
+using Microsoft.UI.Reactor.Core.V1Protocol;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
@@ -396,5 +397,45 @@ public class FlyoutAttachmentTests
     public void CommandBarFlyout_IsOpen_Is_Settable_Via_With()
     {
         Assert.True((CommandBarFlyout(Button("target", null)) with { IsOpen = true }).IsOpen);
+    }
+
+    // ════════════════════════════════════════════════════════════════
+    //  Deferred-open guard (OverlayLifecycle.IsStillRequestingOpen)
+    //
+    //  A mount-time IsOpen=true defers the show to the target's Loaded.
+    //  Between those two points the element can be re-rendered with
+    //  IsOpen=false, replaced by a different element, or unmounted (the
+    //  pool clears the tag). The guard reads the target's *current* tag so
+    //  a stale request never pops a flyout.
+    // ════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void DeferredOpen_Honoured_While_Element_Still_Wants_Open()
+    {
+        Assert.True(OverlayLifecycle.IsStillRequestingOpen(
+            CommandBarFlyout(Button("t", null)) with { IsOpen = true }));
+    }
+
+    [Fact]
+    public void DeferredOpen_Dropped_When_Element_Rerendered_Closed()
+    {
+        Assert.False(OverlayLifecycle.IsStillRequestingOpen(
+            CommandBarFlyout(Button("t", null)) with { IsOpen = false }));
+    }
+
+    [Fact]
+    public void DeferredOpen_Dropped_When_Target_Untagged()
+    {
+        // Pool return calls ClearElementTag, so a recycled control reports no element.
+        Assert.False(OverlayLifecycle.IsStillRequestingOpen(null));
+    }
+
+    [Fact]
+    public void DeferredOpen_Dropped_When_Target_Now_Hosts_A_Different_Element()
+    {
+        // FlyoutElement.IsOpen is a different feature on a different element type —
+        // it must not satisfy the CommandBarFlyout deferred-open guard.
+        Assert.False(OverlayLifecycle.IsStillRequestingOpen(
+            Flyout(Button("t", null), TextBlock("content")) with { IsOpen = true }));
     }
 }


### PR DESCRIPTION
## Symptom

`CommandBarFlyout(Button("Show Commands"), primaryCommands: ...)` renders a button that does
nothing. Clicking it produces no flyout at all and the gallery sample's state text stays at
`Last action: (none)`.

## Root cause

`OverlayLifecycle.MountCommandBarFlyout` installed the flyout as *attached-flyout metadata* only:

```csharp
WinPrim.FlyoutBase.SetAttachedFlyout(targetFe, flyout);
```

An attached flyout only opens when something explicitly calls `FlyoutBase.ShowAttachedFlyout(target)`.
Nothing in Reactor ever does. The two sibling overlays both do the right thing already:

| Overlay | Wiring call |
|---|---|
| `MountFlyout` | `reconciler.SetFlyoutOnControl(targetFe, flyout)` |
| `MountMenuFlyout` | `reconciler.SetFlyoutOnControl(targetFe, menuFlyout)` |
| `MountCommandBarFlyout` | **`SetAttachedFlyout`** ← the bug |

`Reconciler.SetFlyoutOnControl` assigns `SplitButton.Flyout` / `Button.Flyout` for button targets
so a click opens the flyout natively, and only falls back to `SetAttachedFlyout` for other targets.

Two independent confirmations that the attached slot was simply the wrong choice:

- WinUI's own docs for the `AttachedFlyout` attached property say it outright:
  *"To attach a flyout to a Button, use `Button.Flyout` instead."*
- Our shipped docs already **claimed** the fixed behaviour —
  `docs/_pipeline/templates/dialogs-and-flyouts.md.dt` lists `CommandBarFlyoutElement`'s open/close
  as *"Auto on target click"*. This was code-vs-doc drift, not a design choice.

`UpdateCommandBarFlyout` had the matching half of the bug: it looked the existing flyout up with
`GetAttachedFlyout` only, so once mount stopped writing there every re-render would build a
*second* flyout in the slot nobody reads and leave the live one with stale commands.

## What changed

**`src/Reactor/Core/Reconciler.cs`**
- New `internal enum FlyoutSlot` + `ResolveFlyoutSlot(Type)` — one authority for the slot rule.
- `SetFlyoutOnControl` routes through it; added the symmetric `GetFlyoutOnControl` and
  `ClearFlyoutOnControl`. Four hand-copied `switch { SplitButton, Button, _ }` blocks collapsed
  into these; the missing fourth read is exactly what made the update path lose commands.
- New `ApplyFlyoutPlacement` (see the coupled fix below).

**`src/Reactor/Core/V1Protocol/OverlayLifecycle.cs`**
- `MountCommandBarFlyout` uses `SetFlyoutOnControl`; `UpdateCommandBarFlyout` reads back with
  `GetFlyoutOnControl` and re-installs with `SetFlyoutOnControl`.
- `UpdateFlyoutElement` / `UpdateMenuFlyout` now use the shared reader (identical logic).
- New `ShowFlyoutWhenReady` + `IsStillRequestingOpen` for the `IsOpen` support below.

**`src/Reactor/Core/Element.cs`** — new `CommandBarFlyoutElement.IsOpen`, honoured on mount and on
the rising edge of update. Same one-shot semantics as the existing `FlyoutElement.IsOpen`, so
`false` → `true` opens and the user dismisses from there. At mount the target has no `XamlRoot`
yet, so the show defers to its first `Loaded`, re-checking that the flyout is still installed
*and* that the target's current element still asks to be open.

It deliberately calls `flyout.ShowAt(target)` rather than `ShowAttachedFlyout`: by construction the
latter cannot see a flyout living in `Button.Flyout`.

**`src/Reactor/Core/V1Protocol/Handlers/OverlayDecoratorHandlers.cs`** — `CommandBarFlyoutHandler.Unmount`
now detaches the flyout (`ElementPool.CleanElement` nulls `Button.Flyout`, but nothing clears the
attached slot a non-button target uses). `FlyoutHandler.Unmount` routes through the shared helpers.

**Docs + generated indexes** — reference row updated, an `IsOpen` section added to the
`dialogs-and-flyouts` template and recompiled with `mur docs compile --topic dialogs-and-flyouts`;
both `reactor.api.txt` copies regenerated.

### One pre-existing assertion changed, and why

`CoreReconcilerRenderCoverageFixtures.OverlayCommandBarFlyoutUpdate` asserted that a **Button**
target's flyout was reachable via `FlyoutBase.GetAttachedFlyout` (two lookups). That assertion
encoded the buggy placement — it passed only because mount put the flyout somewhere a click can
never reach. Both were repointed at `Button.Flyout`. Its third lookup, for the **TextBlock**
target, deliberately stays on `GetAttachedFlyout`, because non-button targets still legitimately
use the attached slot. No allowlist or architecture guard was widened by this PR.

## Coupled fix (please read — it overlaps a sibling PR)

Fixing the wiring alone turns a **dead button into a fail-fast crash**. Once the flyout can
actually open, `FlyoutPlacementMode.Auto` (Reactor's default for `CommandBarFlyoutElement`)
reaches `FlyoutBase::ShowAtCore`, which rejects it. Observed on the real gallery after the wiring
fix but before this guard:

```
Faulting application name: ReactorGallery.exe
Faulting module name: Microsoft.UI.Xaml.dll
Exception code: 0xc000027b            (stowed exception / fail-fast)
WER P7: 80070057                      (E_INVALIDARG)
```

So `ApplyFlyoutPlacement` never writes `Auto`; it clears the DP instead, leaving WinUI's own
default. Clearing (rather than merely skipping the write, which is what the existing MenuFlyout
guard does) keeps an explicit → `Auto` update consistent with a fresh mount of the same element.

### ⚠ Direct conflict with #939 — please read before merging either

I touched only the three `CommandBarFlyout` placement sites and deliberately did **not** route
`FlyoutElement` / `ContentFlyoutElement` / `MenuFlyoutContentElement` through the new helper,
because #939 owns those exact lines.

But the two PRs **disagree on CommandBarFlyout specifically, and each has a test asserting the
opposite**:

| | #939 | this PR |
|---|---|---|
| CommandBarFlyout `Auto` | written through, guard **deliberately excluded** | never written; DP cleared |
| pinned by | `FlyoutPlacement_CommandBarFlyout_KeepsAuto` (asserts `Placement == Auto`) | `CbfAuto_PlacementNotAuto` (asserts `Placement != Auto`) |

#939's rationale is *"CommandBarFlyout resolves `Auto` itself and auto-positions today"*. That is
true only in the sense that made this PR necessary: **on `main` a CommandBarFlyout never opens**,
so `ShowAtCore` is never reached and `Auto` is never validated. Its fixture reads the DP after
mount and never opens the flyout, so it cannot observe the failure.

Once this PR makes the flyout openable, `Auto` reaches the same validator that kills `Flyout`:

- Real gallery, native click path — process fail-fast, WER `0xc000027b`, `P7=80070057`
  (E_INVALIDARG), faulting module `Microsoft.UI.Xaml.dll`. Same signature #939 itself attributes
  to `ValidateAndSetParameters` rejecting 13.
- Selftest, managed `ShowAt` path — mutation "write `Auto` through" fails 3 assertions incl.
  `CbfAuto_OpenedWithoutFailFast`.

**Falsifiable check for whoever adjudicates:** take #939's `CommandBarFlyout_KeepsAuto_Unguarded`
fixture and add a single line that actually opens the flyout. If `Auto` really is resolved, it
opens; it does not.

**Measured, not assumed:** an unset `CommandBarFlyout` placement resolves to **`Top`** — the
fixtures record it in their TAP names, `CbfAuto_PlacementNotAuto[Top]` and
`CbfReset_DefaultIsNotAuto[Top]`. Reactor's *element* default is `Auto` (13) and pre-fix that
was written onto the DP, so the DP was never in the unset state; 13 is exactly what
`ValidateAndSetParameters` rejects. Removing the guard flips the same check to
`CbfAuto_PlacementNotAuto[Auto]` and `CbfAuto_OpenedWithoutFailFast` fails.

On the "guarding it silently moves it to Top" concern: this PR uses `ClearValue`, so the DP falls
back to WinUI's own `FlyoutBase.Placement` default — the same value a XAML author gets by not
setting `Placement`. Nothing is pinned that the platform didn't already pin.

**Suggested resolution:** whichever merges second, `CommandBarFlyout` should be inside the guard
and #939's `KeepsAuto` assertion should invert. Happy to do that follow-up in either direction.

## Live verification on ReactorGallery

Baseline vs fixed, driven by one script per build so the locked sequence stays in a single
process (mutex ownership is per-thread). Each run: real `winapp ui click`, foreground forced via
`AttachThreadInput`, serialised on a shared input mutex, Escape-dismiss before each case, retries
on foreground refusal.

**Two detection methods, because neither alone can establish a negative.** Some WinUI flyouts open
a separate top-level `PopupHost`; others render inside the owning HWND:

- **A** — popup enumeration by process id (`winapp ui list-windows --json`)
- **B** — UIA content search against the main HWND (`winapp ui search "Paste" -w <mainHwnd>`)

Every run also probes the **MenuFlyout** page as a positive control. It is the ideal control: same
page group, same click path, same `Paste` probe string, and it differs from the subject only in
using `SetFlyoutOnControl` — the very call this PR adds to CommandBarFlyout.

| build | case | A: popups | B: `Paste` in main tree | opened |
|---|---|---|---|---|
| baseline `2117320c` | control — MenuFlyout "Open Menu" | 1 (178×181) | 2 | **yes** |
| baseline `2117320c` | subject — CommandBarFlyout "Show Commands" | **0** | **0** | **no** |
| this PR | control — MenuFlyout "Open Menu" | 1 (178×181) | 2 | **yes** |
| this PR | subject — CommandBarFlyout "Show Commands" | **2** (30×30 + 375×122) | **1** | **yes** |

Both methods agree, in both directions, with the control passing on the same build that the subject
fails — so the baseline negative is a real negative and not a measurement artifact. The split falls
exactly on the `SetFlyoutOnControl` vs `SetAttachedFlyout` line identified above. The process
survived every case, on both builds.

Also verified by hand on this branch: invoking the opened commands updates the sample state —
`Copy` → `Last action: Copy`, `Cut` → `Last action: Cut`, and the second card's **overflow**
secondary command `Select All` → `Last action: Select All`.
## Tests

**Unit — `tests/Reactor.Tests/FlyoutAttachmentTests.cs`** (headless, `typeof`-only so no WinUI
object is constructed): a table for `ResolveFlyoutSlot` (`Button`/`DropDownButton`/`AppBarButton` →
Button slot; `SplitButton`/`ToggleSplitButton` → SplitButton slot; `HyperlinkButton`/
`AppBarToggleButton`/`TextBlock`/`Border` → attached), two differential facts, and four for the
deferred-open guard.

**Selftests — `tests/Reactor.AppTests.Host/SelfTest/Fixtures/CommandBarFlyoutWiringFixtures.cs`**
(10 fixtures, registered in both `AllFixtures` and the `Create()` switch): `TargetWiring` (incl.
click-to-open), `NonButtonTargetUsesAttachedSlot`, `IsOpenOnUpdate`, `IsOpenOnMount`,
`DefaultPlacementOpens`, `SplitButtonTargetWiring`, `PlacementExplicitToAutoResets`,
`UnmountDetachesFlyout`, `KeyedReorderKeepsSiblingFlyouts`, `TargetKeepsItsOwnCallbacks`.

### Revert-proof — each product change reverted in isolation, re-run against the FINAL test set

Selftest counts are `--filter CmdBarFlyout` (the 10 new fixtures) plus
`--filter CoreRRC_OverlayCommandBarFlyoutUpdate` (the pre-existing one). Unit counts are
`--filter FullyQualifiedName~FlyoutAttachmentTests` (50 tests).

| Reverted | Failing assertions | Notable |
|---|---|---|
| mount → `SetAttachedFlyout` | **29** (25 new + 4 pre-existing) | the core bug |
| update lookup → `GetAttachedFlyout` | **6** (5 + 1) | incl. `CbfWire_FlyoutReusedInPlace`, `CbfSplit_FlyoutReusedInPlace` — a duplicate flyout is built every re-render |
| `ApplyFlyoutPlacement`: write `Auto` through (what `main` effectively does) | **3** | `CbfAuto_PlacementNotAuto[Auto]`, `CbfAuto_OpenedWithoutFailFast`, `CbfReset_AutoRestoresDefaultPlacement` — the TAP name records the value: `[Top]` with the guard, `[Auto]` without |
| `ApplyFlyoutPlacement`: skip `Auto` instead of clearing the DP | **1** | `CbfReset_AutoRestoresDefaultPlacement` |
| `CommandBarFlyoutHandler.Unmount` detach disabled | **1** | `CbfUnmount_FlyoutDetached` |
| `ResolveFlyoutSlot` → always `Attached` | **7 of 50** unit tests | 5 theory rows + both differential facts |
| `IsStillRequestingOpen` → drop the `IsOpen` check | **1 of 50** unit tests | `DeferredOpen_Dropped_When_Element_Rerendered_Closed` |

### Suites (on the rebased head)

- `dotnet test tests/Reactor.Tests` — 12542 passed, 0 failed.
- Full selftest suite — 1352 fixtures, 0 failures. (`WindowLevel_RuntimeFlip_Topmost` flaked once;
  I rebuilt a clean `origin/main` tree and confirmed it fails there too — pre-existing, unrelated.)
- `dotnet build Reactor.slnx -c Release` — 0 errors, re-run after rebasing onto post-#932 `main`
  (the `TreatWarningsAsErrors` + sample-analyzer configuration).

## Known gap, deliberately not fixed here

While testing I found that **all three** target-wrapping decorators (`Flyout`, `MenuFlyout`,
`CommandBarFlyout`) silently disable the *target's own* callbacks — they retag the target control
with the decorator's element, which is the same `ReactorState` slot the target's event trampolines
resolve through. `MenuFlyout`, whose tagging this branch does not touch, reproduces it identically
while a plain `Button` passes, so it is pre-existing and belongs in its own change. Filed as #942.
`TargetKeepsItsOwnCallbacks` pins what does work and `H.Skip`s the two blocked assertions so the
gap stays visible in the TAP log instead of being silently dropped.

Separately: `FlyoutElement.IsOpen` is dead for Button/SplitButton targets for the original reason —
`MountFlyout` installs into `Button.Flyout` but then calls `ShowAttachedFlyout`. Out of scope here;
reported to the coordinating session.

## Review

Ran the repo's `.github/skills/pr-review` skill (8 dimensions incl. a multi-model cross-check on a
different model family). Every finding was fixed or investigated; the two dismissals — hoisting the
placement guard across all flyout paths (collision with the sibling PR) and the
`FlyoutElement.IsOpen` gap (separate bug) — are explained above. The cross-check's two "high"
findings were each reproduced or refuted with a dedicated fixture rather than argued.



