### PR TITLE
Fix the 5 genuine dropped-modifier sample sites; reclassify the other 7 to #950

### DIFF
--- a/samples/.editorconfig
+++ b/samples/.editorconfig
@@ -47,42 +47,45 @@
 ;
 ; REACTOR_MOD_003 is NOT in the list below. It is a correctness rule — a modifier the
 ; reconciler silently drops is an invisible control, not a style preference — so it stays
-; at `warning` across the sample tree, and a new one anywhere breaks the build. Its 90
-; pre-existing hits are exempted by PATH instead, in the scoped section at the bottom of
-; this file, exactly as the REACTOR_HOOKS_* debt is.
+; at `warning` across the sample tree, and a new one anywhere breaks the build. Its
+; remaining pre-existing hits are exempted by PATH instead, in the scoped section at the
+; bottom of this file, exactly as the REACTOR_HOOKS_* debt is.
 ;
-; The 90 are NOT one problem, and that is why they are not simply fixed in the samples.
-; Triaged by who is actually wrong:
+; The rule originally reported 90 hits. #961 fixed the 5 that were genuinely wrong in the
+; samples; every one of the 84 that remain is a FRAMEWORK gap (#950), not bad sample code.
+; Triaged by what the ApplyModifiers gate excludes:
 ;
-;   59  .Padding(...)    on TextBlockElement    framework — issue #950
-;   18  .Padding(...)    on FlexElement         framework — same class as #950
-;    1  .Foreground(...) on RichTextBlockElement framework — missing ThemeRef overload, #961
-;   12  everything else                          the samples — issue #961
+;   58  .Padding(...)      on TextBlockElement     WinUI declares TextBlock.Padding
+;   18  .Padding(...)      on FlexElement          FlexPanel has Yoga padding semantics
+;    3  .CornerRadius(...) on StackElement         WinUI declares StackPanel.CornerRadius
+;    2  .CornerRadius(...) on GridElement          WinUI declares Grid.CornerRadius
+;    2  .Padding(...)      on GridElement          WinUI declares Grid.Padding
+;    1  .Foreground(...)   on RichTextBlockElement missing ThemeRef overload
+;   ──  84 sites, every one of them #950
 ;
-; 78 of the 90 (87%) are a reconciler/DSL gap, not bad sample code. WinUI declares Padding
-; on TextBlock and FlexPanel has real padding semantics via Yoga, but the ApplyModifiers
-; gate is Control/Border/StackPanel, so both are dropped. Rewriting those 78 call sites
-; would be fixing the wrong layer and would have to be reverted when the gate is widened —
-; if #950 is fixed by widening, the rule simply stops firing on them and they disappear
-; without a single sample edit. The RichTextBlock one is the same shape one level up: the
-; sample correctly passes a theme token, and ElementExtensions has string and Brush
-; overloads but no ThemeRef one, so the call falls through to the gated generic modifier.
+; None of these is a sample bug. The property exists on the mounted control in every case,
+; but the ApplyModifiers gate is Control/Border/StackPanel, so the write is skipped.
+; Rewriting these call sites would be fixing the wrong layer and would have to be reverted
+; when the gate is widened — if #950 is fixed by widening, the rule simply stops firing on
+; them and they disappear without a single sample edit. The RichTextBlock one is the same
+; shape one level up: the sample correctly passes a theme token, and ElementExtensions has
+; string and Brush overloads but no ThemeRef one, so the call falls through to the gated
+; generic modifier.
 ;
-; The remaining 12 ARE genuine sample bugs — Grid/StackPanel/TextBlock/Rectangle/Border do
-; not declare the property at all, so no widening helps. They are enumerated with file:line
-; in #961. Their fix is structural (wrap in a Border), which makes a currently-invisible
-; modifier start rendering, so each needs a visual check rather than a mechanical rewrite.
+; The Grid and StackPanel rows were originally filed as sample bugs in #961, on the premise
+; that WinUI does not declare those properties. It does: Microsoft.WinUI.xml (from
+; Microsoft.WindowsAppSDK.WinUI 2.3.0) declares Grid.Padding, Grid.CornerRadius,
+; StackPanel.Padding and StackPanel.CornerRadius, and apps/regedit/Components/ValueList.cs
+; already sets `g.Padding` imperatively on a Grid under a comment describing this exact
+; gate. Those 7 sites were therefore reclassified to #950 rather than rewritten.
 ;
-; Full breakdown, re-measured after PR #941 merged, over the whole sample tree
-; (Reactor.slnx, Debug, severity flipped to `warning`), deduplicated on file:line:col:
+; What #961 did fix, and why those five were different — Border, TextBlock and Rectangle do
+; not declare the property at all, so no widening could ever have helped:
 ;
-;   59  .Padding(...)      on TextBlockElement
-;   18  .Padding(...)      on FlexElement        (14 carry a .FlexPadding(...) auto-fix)
-;    3  .CornerRadius(...) on StackElement
-;    2  .Background(...)   on TextBlockElement
-;    2  .CornerRadius(...) on GridElement
-;    2  .Padding(...)      on GridElement
-;    1  each: .CornerRadius on Rectangle/TextBlock, .Foreground on Border/RichTextBlock
+;    2  .Background + .CornerRadius on TextBlockElement  → wrapped in a Border
+;    1  .Background(...)            on TextBlockElement  → wrapped in a Border
+;    1  .Foreground(...)            on BorderElement     → moved onto the TextBlock inside
+;    1  .CornerRadius(...)          on RectangleElement  → `with { RadiusX, RadiusY }`
 ;
 ; The `.Background(...) on RectangleElement` row that used to head this list — the Canvas
 ; gallery bug this rule was written to prevent — is now GONE: #941 rewrote those call sites
@@ -110,23 +113,22 @@ dotnet_diagnostic.REACTOR_HOOKS_011.severity = suggestion
 dotnet_diagnostic.REACTOR_HOOKS_013.severity = suggestion
 
 
-; REACTOR_MOD_003 debt, scoped to the 36 files that already carry it. Deliberately a file
+; REACTOR_MOD_003 debt, scoped to the 32 files that still carry it. Deliberately a file
 ; list and not a `**/*.cs` glob, matching the REACTOR_HOOKS_* treatment above: this is a
 ; correctness rule, so a silent modifier drop in any other sample — or in a new one — must
 ; still break the build. Delete a path once its file is clean; delete the whole section once
 ; the list is empty.
 ;
-; This list has two owners, both tracked (see the triage above): #950 covers the 78 hits
-; that are a reconciler/DSL gap and will clear WITHOUT editing any sample, and #961
-; enumerates the 12 genuine sample bugs with file:line. It is scheduled work, not a
-; standing exemption.
+; Every path below is now owned by #950 alone (see the triage above): all 84 remaining hits
+; are a reconciler/DSL gate gap that will clear WITHOUT editing any sample. It is scheduled
+; work, not a standing exemption.
 ;
-; Pruned once already: PR #941 rewrote CanvasPage.cs's Rectangle().Background(...) calls to
-; .Fill(...), and ParallaxViewPage.cs came clean with it, so both paths are gone from the
-; list below. That was the whole of the `Background on RectangleElement` category — the bug
-; this rule was written to prevent no longer occurs anywhere in samples. Re-run the sweep
-; after any sample fix and drop whatever has gone clean; the remaining GridViewPage /
-; NavigationViewPage / TabViewPage entries were checked at the same time and are still dirty
-; for unrelated hits.
-[{apps/animated-list-demo/App.cs,apps/chat/Chat.UI/ChatTimeline.cs,apps/chat/Chat.UI/InputBar.cs,apps/chat/Chat.UI/LandingPage.cs,apps/chat/Chat.UI/Sidebar.cs,apps/command-palette-window/Program.cs,apps/demo-script-tool/App/Components/StepCard.cs,apps/demo-script-tool/App/DemoScriptShell.cs,apps/headtrax/HeadTrax/Components/EmployeeGrid.cs,apps/minesweeper/Components/StatusPanel.cs,apps/monaco-editor/App.cs,apps/regedit/Components/ValueList.cs,apps/widget-creator/WidgetCreatorShell.cs,CommandingDemo/App.cs,Reactor.TestApp/Demos/DataGridDemo.cs,Reactor.TestApp/Demos/IntegratedDataDemo.cs,Reactor.TestApp/Demos/SpecializedEditorsDemo.cs,Reactor.TestApp/Demos/TransitionsDemo.cs,ReactorCharting.Gallery/Program.cs,ReactorCharting.Gallery/Samples/MultiLineChart.cs,ReactorCharting.Gallery/Samples/WeeklyForecast.cs,ReactorGallery/ControlPages/Collections/GridViewPage.cs,ReactorGallery/ControlPages/Collections/RefreshContainerPage.cs,ReactorGallery/ControlPages/Collections/SemanticZoomPage.cs,ReactorGallery/ControlPages/DesignGuidance/SpacingPage.cs,ReactorGallery/ControlPages/DialogsAndFlyouts/FlyoutPage.cs,ReactorGallery/ControlPages/Layout/BorderPage.cs,ReactorGallery/ControlPages/Layout/GridPage.cs,ReactorGallery/ControlPages/Layout/RelativePanelPage.cs,ReactorGallery/ControlPages/Layout/ScrollViewPage.cs,ReactorGallery/ControlPages/Navigation/NavigationViewPage.cs,ReactorGallery/ControlPages/Navigation/PivotPage.cs,ReactorGallery/ControlPages/Navigation/TabViewPage.cs,ReactorGallery/ControlPages/Styles/AcrylicPage.cs,StylingGallery/App.cs,TodoApp/Program.cs}]
+; Pruned twice. PR #941 rewrote CanvasPage.cs's Rectangle().Background(...) calls to
+; .Fill(...), and ParallaxViewPage.cs came clean with it. Then #961 fixed the 5 genuine
+; sample bugs and four more files went clean with them: command-palette-window/Program.cs,
+; ReactorCharting.Gallery/Samples/WeeklyForecast.cs, GridViewPage.cs and SpacingPage.cs.
+; Note GridViewPage.cs — an earlier revision of this comment claimed it was "still dirty for
+; unrelated hits"; it was not. Re-run the sweep after any sample fix and drop whatever has
+; gone clean, and measure rather than trusting a note.
+[{apps/animated-list-demo/App.cs,apps/chat/Chat.UI/ChatTimeline.cs,apps/chat/Chat.UI/InputBar.cs,apps/chat/Chat.UI/LandingPage.cs,apps/chat/Chat.UI/Sidebar.cs,apps/demo-script-tool/App/Components/StepCard.cs,apps/demo-script-tool/App/DemoScriptShell.cs,apps/headtrax/HeadTrax/Components/EmployeeGrid.cs,apps/minesweeper/Components/StatusPanel.cs,apps/monaco-editor/App.cs,apps/regedit/Components/ValueList.cs,apps/widget-creator/WidgetCreatorShell.cs,CommandingDemo/App.cs,Reactor.TestApp/Demos/DataGridDemo.cs,Reactor.TestApp/Demos/IntegratedDataDemo.cs,Reactor.TestApp/Demos/SpecializedEditorsDemo.cs,Reactor.TestApp/Demos/TransitionsDemo.cs,ReactorCharting.Gallery/Program.cs,ReactorCharting.Gallery/Samples/MultiLineChart.cs,ReactorGallery/ControlPages/Collections/RefreshContainerPage.cs,ReactorGallery/ControlPages/Collections/SemanticZoomPage.cs,ReactorGallery/ControlPages/DialogsAndFlyouts/FlyoutPage.cs,ReactorGallery/ControlPages/Layout/BorderPage.cs,ReactorGallery/ControlPages/Layout/GridPage.cs,ReactorGallery/ControlPages/Layout/RelativePanelPage.cs,ReactorGallery/ControlPages/Layout/ScrollViewPage.cs,ReactorGallery/ControlPages/Navigation/NavigationViewPage.cs,ReactorGallery/ControlPages/Navigation/PivotPage.cs,ReactorGallery/ControlPages/Navigation/TabViewPage.cs,ReactorGallery/ControlPages/Styles/AcrylicPage.cs,StylingGallery/App.cs,TodoApp/Program.cs}]
 dotnet_diagnostic.REACTOR_MOD_003.severity = suggestion

--- a/samples/ReactorCharting.Gallery/Samples/WeeklyForecast.cs
+++ b/samples/ReactorCharting.Gallery/Samples/WeeklyForecast.cs
@@ -36,7 +36,7 @@ public sealed class WeeklyForecastSample : GallerySample
                 (TextBlock("day") with { FontSize = 8 }).Foreground(ChartMutedForeground))
                 .HAlign(HorizontalAlignment.Center))
             .YTickLabelView(t => HStack(4,
-                Rectangle().Width(10).Height(10).CornerRadius(2).Fill(SwatchFor(t)),
+                (Rectangle() with { RadiusX = 2, RadiusY = 2 }).Width(10).Height(10).Fill(SwatchFor(t)),
                 (TextBlock($"{Math.Round(t):F0}°") with { FontSize = 11 })
                     .Foreground(ChartAxis))
                 .VAlign(VerticalAlignment.Center))
@@ -63,7 +63,7 @@ public sealed class WeeklyForecastSample : GallerySample
                 (TextBlock("day") with { FontSize = 8 }).Foreground(ChartMutedForeground)
             ).HAlign(HorizontalAlignment.Center))
             .YTickLabelView(t => HStack(4,
-                Rectangle().Width(10).Height(10).CornerRadius(2).Fill(SwatchFor(t)),
+                (Rectangle() with { RadiusX = 2, RadiusY = 2 }).Width(10).Height(10).Fill(SwatchFor(t)),
                 (TextBlock($"{Math.Round(t):F0}°") with { FontSize = 11 })
                     .Foreground(ChartAxis)
             ).VAlign(VerticalAlignment.Center));

--- a/samples/ReactorGallery/ControlPages/Collections/GridViewPage.cs
+++ b/samples/ReactorGallery/ControlPages/Collections/GridViewPage.cs
@@ -52,9 +52,8 @@ class GridViewPage : Component
                     GridView(
                         items.Select(i => i.ToString()).ToArray().AsReadOnly(),
                         s => s,
-                        (s, i) => Border(TextBlock(s).Center().Bold())
+                        (s, i) => Border(TextBlock(s).Center().Bold().Foreground("#FFFFFF"))
                             .Background(i % 2 == 0 ? "#335588" : "#885533")
-                            .Foreground("#FFFFFF")
                             .Size(80, 80).CornerRadius(ThemeResource.CornerRadius("OverlayCornerRadius").TopLeft)
                     ),
                     """

--- a/samples/ReactorGallery/ControlPages/DesignGuidance/SpacingPage.cs
+++ b/samples/ReactorGallery/ControlPages/DesignGuidance/SpacingPage.cs
@@ -257,12 +257,15 @@ Border(child).Padding(4, 8, 16, 24)");
         VStack(2,
             TextBlock(label).FontSize(12).Foreground(Theme.SecondaryText),
             Border(
-                TextBlock($"{l}, {t}, {r}, {b}")
-                    .FontSize(11)
-                    .Foreground(Theme.PrimaryText)
-                    .HAlign(HorizontalAlignment.Center)
-                    .VAlign(VerticalAlignment.Center)
-                    .Background(Theme.Accent)
+                Border(
+                    TextBlock($"{l}, {t}, {r}, {b}")
+                        .FontSize(11)
+                        .Foreground(Theme.PrimaryText)
+                        .HAlign(HorizontalAlignment.Center)
+                        .VAlign(VerticalAlignment.Center)
+                )
+                .Background(Theme.Accent)
+                .CornerRadius(4)
             )
             .Background(Theme.SubtleFill)
             .WithBorder(Theme.DividerStroke)

--- a/samples/apps/command-palette-window/Program.cs
+++ b/samples/apps/command-palette-window/Program.cs
@@ -34,7 +34,7 @@ internal sealed class PaletteApp(IReadOnlyList<string> commands) : Component
         var filtered = commands
             .Where(c => query.Length == 0 || c.Contains(query, StringComparison.OrdinalIgnoreCase))
             .Take(5)
-            .Select(c => TextBlock(c).Padding(12).Background(SubtleFill).CornerRadius(6))
+            .Select(c => Border(TextBlock(c)).Padding(12).Background(SubtleFill).CornerRadius(6))
             .Cast<Element>()
             .ToArray();
 


### PR DESCRIPTION
Fixes the sample-side half of #961 — but the issue's triage needed correcting first, so the scope here is 5 sites rather than 12.

## The premise in #961 is wrong for 7 of the 12

#961 classifies 12 sites as genuine sample bugs because *"WinUI's `Grid`, `StackPanel`, `TextBlock`, `Rectangle` and `Border` do not declare the property being set at all, so no framework widening helps."*

That is false for `Grid` and `StackPanel`. `Microsoft.WinUI.xml` (from `Microsoft.WindowsAppSDK.WinUI` 2.3.0) declares:

```
P:Microsoft.UI.Xaml.Controls.Grid.Padding
P:Microsoft.UI.Xaml.Controls.Grid.CornerRadius
P:Microsoft.UI.Xaml.Controls.StackPanel.Padding
P:Microsoft.UI.Xaml.Controls.StackPanel.CornerRadius
```

The repo already proves it: `samples/apps/regedit/Components/ValueList.cs:42` compiles `g.Padding = new Thickness(8, 0, 8, 0)` on a `Grid`, under a comment describing this exact gate.

So 7 of the 12 are the **same** `Control`/`Border`/`StackPanel` gate gap as #950 — widening the gate clears them with zero sample edits — and only 5 are genuine, where the property does not exist on the mounted control under any gate. Corrected split: **85 framework / 5 sample**.

| | modifier · element | WinUI declares it? |
|---|---|---|
| **fixed here** | `Background`, `CornerRadius` · TextBlock | no |
| **fixed here** | `Foreground` · Border | no |
| **fixed here** | `CornerRadius` · Rectangle | no — it has `RadiusX`/`RadiusY` |
| **→ #950** | `Padding`, `CornerRadius` · Grid / StackPanel | **yes** |

## The 5 fixed

**`apps/command-palette-window/Program.cs:37`** — `Background` + `CornerRadius` on `TextBlockElement`. Wrapped the per-command row in a `Border` so the subtle-fill rounded pill renders. `.Padding(12)` moved onto the Border with them: leaving it behind would have made this fix *introduce* a visible defect — a pill painting a background with zero inset. The Border now owns the box, so nothing reverts when the gate widens.

**`ReactorGallery/ControlPages/DesignGuidance/SpacingPage.cs:265`** — `Background` on `TextBlockElement`. `PaddingDemo` is the helper on the page that **teaches padding**, and the accent block that makes the padding visible was the dropped modifier — the demo has been rendering a plain subtle-fill box with centred text. Wrapped in an inner `Border`, matching the same file's `MarginDemo` at lines 91-102, plus `.CornerRadius(4)` so the two read as a pair.

**`ReactorGallery/ControlPages/Collections/GridViewPage.cs:57`** — `Foreground` on `BorderElement`. Moved onto the `TextBlock` inside it, which declares it and is inside the gate. No wrap.

**`ReactorCharting.Gallery/Samples/WeeklyForecast.cs:66`** — `CornerRadius` on `RectangleElement`. Shapes round via `RadiusX`/`RadiusY`. Switched to `with { RadiusX = 2, RadiusY = 2 }`, the repo-wide idiom — `RectangleElement` already generates both props and no fluent modifier exists. Also updated the mirrored `SourceCode` display string so the gallery stops teaching the bug.

## The 7 deliberately not fixed

`minesweeper/StatusPanel.cs:45`, `regedit/ValueList.cs:82`, `CommandingDemo/App.cs:257,264`, `TransitionsDemo.cs:105,153`, `StylingGallery/App.cs:139` — reclassified to #950, paths kept in the exemption list.

Rewriting them would be fixing the wrong layer, for exactly the reason the other 78 are being left alone. `TransitionsDemo` makes the point sharpest: line 96 documents that `BrushTransition` only works on Panel types, so `Background` and `BackgroundTransition` must stay on the Grid — widening the gate is the only clean fix there.

## `samples/.editorconfig`

Pruned the 4 paths that **measured** clean — `command-palette-window/Program.cs`, `WeeklyForecast.cs`, `GridViewPage.cs`, `SpacingPage.cs` — 36 → 32, and rewrote the triage comment with the corrected classification.

An earlier revision of that comment asserted `GridViewPage.cs` was "still dirty for unrelated hits". It was not; the file has zero other hits. The note now says to measure rather than trust it.

## Verification

- **Sweep** (scoped severity flipped to `warning`, Debug): 90 → **84** unique sites — the 5 fixed plus the one TextBlock `Padding` that moved onto a Border. Paths normalised to repo-relative *before* dedup, because MSBuild double-prints each diagnostic and mixes absolute and relative forms in a single log. Severity restored, `git status` clean.
- **Release build** of `Reactor.slnx`: **0 errors** (2 pre-existing `WIN2D0001` AnyCPU warnings). Release is the one that matters — `TreatWarningsAsErrors` is Release-only.
- **The pruned list still bites**: removing minesweeper's path turns `StatusPanel.cs(45,11)` into a hard `error REACTOR_MOD_003` in a Release build. Restored.
- `NoOpModifierAnalyzerTests` + `ModifierTableIntegrityTests` — **75 passed**.
- `SearchIndexGeneratorTests` — **16 passed**; the gallery index is not stale, so no regeneration needed.

## Also found, reported not fixed

`REACTOR_MOD_003` is blind to modifier **aliases**. `StylingGallery/App.cs:140`'s `.WithBorder(Theme.CardStroke)` on an `HStack` writes `BorderBrush`/`BorderThickness` through the same `Control`/`Border` gate and is dropped today — but the analyzer's syntactic gate keys on the invoked *method name* (`NoOpModifierAnalyzer.cs:217-220`) and `WithBorder` is not in `ModifierTable.Properties`, so it is never reported. The rule under-counts. Worth folding into #950.

Separately, `NoOpModifierAnalyzer.ShapeReplacements` has no `CornerRadius` → `RadiusX`/`RadiusY` entry, so the Rectangle site got no did-you-mean hint. It is a one-to-many replacement, which the existing code-fix shape does not accommodate.

Refs #961, #950