### PR TITLE
Stop keyed ListView/GridView rows announcing Reactor's internal row identity

### DIFF
--- a/docs/_pipeline/templates/accessibility.md.dt
+++ b/docs/_pipeline/templates/accessibility.md.dt
@@ -331,6 +331,33 @@ satisfied without sprinkling regions through the tree, and message
 ordering is sequential because the underlying
 `RaiseNotificationEvent` queues at the automation peer.
 
+### Naming list and grid rows
+
+A `ListView` / `GridView` row is its own automation node, separate from
+the item view you render into it. When the item view is a single piece
+of text, WinUI composes the row's name from that text and there is
+nothing to do. When it is a composite — an `HStack` of an icon, a title
+and a subtitle, or a card `Border` — WinUI has no single string to use
+and the row is left unnamed, so Narrator falls through to reading the
+descendants one by one.
+
+To give the row a single spoken name, put `.AutomationName(...)` on the
+**root of the item view**; Reactor forwards it to the generated
+`ListViewItem` / `GridViewItem` container and keeps it in sync as rows
+are added, renamed, reordered and recycled:
+
+```csharp
+ListView(contacts, c => c.Id, (contact, i) =>
+    HStack(
+        Image(contact.AvatarUrl).AccessibilityHidden(),
+        VStack(TextBlock(contact.Name).Bold(), TextBlock(contact.Role))
+    ).AutomationName($"{contact.Name}, {contact.Role}"))
+```
+
+Leave it off when the composite already reads well descendant by
+descendant — an unnamed row is the correct, standard result, not a bug.
+Reactor never derives the row name from its own internal bookkeeping.
+
 ### Custom-control semantics
 
 Composite controls (a star rating built from `Button` children, a

--- a/docs/guide/accessibility.md
+++ b/docs/guide/accessibility.md
@@ -517,6 +517,33 @@ satisfied without sprinkling regions through the tree, and message
 ordering is sequential because the underlying
 `RaiseNotificationEvent` queues at the automation peer.
 
+### Naming list and grid rows
+
+A `ListView` / `GridView` row is its own automation node, separate from
+the item view you render into it. When the item view is a single piece
+of text, WinUI composes the row's name from that text and there is
+nothing to do. When it is a composite — an `HStack` of an icon, a title
+and a subtitle, or a card `Border` — WinUI has no single string to use
+and the row is left unnamed, so Narrator falls through to reading the
+descendants one by one.
+
+To give the row a single spoken name, put `.AutomationName(...)` on the
+**root of the item view**; Reactor forwards it to the generated
+`ListViewItem` / `GridViewItem` container and keeps it in sync as rows
+are added, renamed, reordered and recycled:
+
+```csharp
+ListView(contacts, c => c.Id, (contact, i) =>
+    HStack(
+        Image(contact.AvatarUrl).AccessibilityHidden(),
+        VStack(TextBlock(contact.Name).Bold(), TextBlock(contact.Role))
+    ).AutomationName($"{contact.Name}, {contact.Role}"))
+```
+
+Leave it off when the composite already reads well descendant by
+descendant — an unnamed row is the correct, standard result, not a bug.
+Reactor never derives the row name from its own internal bookkeeping.
+
 ### Custom-control semantics
 
 Composite controls (a star rating built from `Button` children, a

--- a/src/Reactor/Core/Internal/ReactorListState.cs
+++ b/src/Reactor/Core/Internal/ReactorListState.cs
@@ -1,4 +1,5 @@
 using System.Collections.ObjectModel;
+using System.Diagnostics;
 
 namespace Microsoft.UI.Reactor.Core.Internal;
 
@@ -11,6 +12,7 @@ namespace Microsoft.UI.Reactor.Core.Internal;
 /// is what lets WinUI distinguish "this item moved" from
 /// "removed + inserted." See spec 042 §4.
 /// </summary>
+[DebuggerDisplay("{DebugDescription,nq}")]
 internal sealed class ReactorRow
 {
     /// <summary>
@@ -36,7 +38,37 @@ internal sealed class ReactorRow
     /// </summary>
     public AnimationKind? PendingEnterAnimation { get; set; }
 
-    public override string ToString() => $"Row[{Index}]={Key}";
+    /// <summary>
+    /// Human-readable identity for debugger watch windows, the
+    /// <see cref="DebuggerDisplayAttribute"/> on this type, and diagnostic
+    /// logging. Deliberately kept off <see cref="ToString"/> — see the
+    /// remarks there.
+    /// </summary>
+    public string DebugDescription => $"Row[{Index}]={Key}";
+
+    /// <summary>
+    /// Deliberately empty — this string reaches assistive technology.
+    /// </summary>
+    /// <remarks>
+    /// <para>Rows are the items of the <see cref="ObservableCollection{T}"/>
+    /// bound to a templated <c>ListView</c> / <c>GridView</c>, so WinUI builds
+    /// one <c>ItemAutomationPeer</c> (<c>ListViewItemDataAutomationPeer</c> /
+    /// <c>GridViewItemDataAutomationPeer</c>) per row <em>from the data item</em>.
+    /// That peer resolves its UIA <c>Name</c> as: the container peer's name when
+    /// non-empty, otherwise the data item's string representation. A container
+    /// peer composes a name only when the realized item view has plain text at
+    /// its root (a bare <c>TextBlock</c>); for a composite item view — a stack,
+    /// a border, a card — the container name is empty and the data item's
+    /// string representation becomes the announced name.</para>
+    /// <para>Returning the old <c>$"Row[{Index}]={Key}"</c> debug form therefore
+    /// made every item in a keyed list announce Reactor's internal bookkeeping,
+    /// down to a raw GUID when the author's key selector produced one
+    /// (issue #951). An empty string leaves the item unnamed, so assistive
+    /// technology falls through to the item's own content — the same behaviour
+    /// an author gets from a plain WinUI list whose data item has no string
+    /// representation. Use <see cref="DebugDescription"/> for diagnostics.</para>
+    /// </remarks>
+    public override string ToString() => string.Empty;
 }
 
 /// <summary>

--- a/src/Reactor/Core/Reconciler.Mount.cs
+++ b/src/Reactor/Core/Reconciler.Mount.cs
@@ -595,6 +595,9 @@ public sealed partial class Reconciler
     {
         if (args.InRecycleQueue)
         {
+            // Issue #951 — drop any name this container carried for its
+            // previous row before WinUI hands the container to a new one.
+            PropagateItemAutomationName(args.ItemContainer, null);
             if (args.ItemContainer.ContentTemplateRoot is ContentControl oldCc)
             {
                 if (oldCc.Content is UIElement oldCtrl)
@@ -620,6 +623,8 @@ public sealed partial class Reconciler
             cc.Content = ctrl;
             SetElementTag(cc, itemElement); // Store for later reconciliation
 
+            PropagateItemAutomationName(args.ItemContainer, ctrl);
+
             // Spec 042 §6 — if this container is materializing a row that
             // the keyed diff tagged as inserted under an active
             // Animations.Animate transaction, fire a one-shot enter
@@ -631,6 +636,37 @@ public sealed partial class Reconciler
                 ApplyAmbientEnterAnimation(args.ItemContainer, kind);
             }
         }
+    }
+
+    /// <summary>
+    /// Issue #951 — forwards an author-declared automation name from the item
+    /// view's root onto its generated <c>ListViewItem</c> / <c>GridViewItem</c>.
+    /// </summary>
+    /// <remarks>
+    /// WinUI exposes each row of a templated items control through an
+    /// <c>ItemAutomationPeer</c> built from the <em>data item</em>, and that peer
+    /// resolves its UIA <c>Name</c> as: the container peer's name when non-empty,
+    /// otherwise the data item's string representation. The container peer in turn
+    /// composes a name only from plain text at the root of the realized item view —
+    /// a bare <c>TextBlock</c> works, a composite (stack / border / card) does not,
+    /// and an <c>AutomationProperties.Name</c> set on the item view's root is not
+    /// consulted at all. So without this forwarding an author has no way to name a
+    /// row: <c>.AutomationName(...)</c> on the item view lands on an element WinUI
+    /// never reads for the list item.
+    /// <para>Nothing is invented here — the name is copied only when the author set
+    /// one, and the container's local value is cleared otherwise so a recycled
+    /// container can't announce the previous row's name.</para>
+    /// </remarks>
+    internal static void PropagateItemAutomationName(WinPrim.SelectorItem container, UIElement? itemRoot)
+    {
+        var name = itemRoot is null
+            ? null
+            : global::Microsoft.UI.Xaml.Automation.AutomationProperties.GetName(itemRoot);
+
+        if (string.IsNullOrEmpty(name))
+            container.ClearValue(global::Microsoft.UI.Xaml.Automation.AutomationProperties.NameProperty);
+        else
+            global::Microsoft.UI.Xaml.Automation.AutomationProperties.SetName(container, name);
     }
 
     /// <summary>

--- a/src/Reactor/Core/Reconciler.Update.cs
+++ b/src/Reactor/Core/Reconciler.Update.cs
@@ -1203,6 +1203,11 @@ public sealed partial class Reconciler
                 cc.Content = Mount(newItemElement, requestRerender);
             }
             SetElementTag(cc, newItemElement);
+
+            // Issue #951 — the container survives re-renders, so its automation
+            // name has to track the row it now shows. Without this a reorder or
+            // a renamed item would keep announcing the previous row's name.
+            PropagateItemAutomationName(container, cc.Content as UIElement);
         }
     }
 

--- a/src/Reactor/Core/V1Protocol/Handlers/GridViewHandler.cs
+++ b/src/Reactor/Core/V1Protocol/Handlers/GridViewHandler.cs
@@ -43,6 +43,7 @@ internal sealed class GridViewHandler : IElementHandler<GridViewElement, WinUI.G
         {
             if (args.InRecycleQueue)
             {
+                Reconciler.PropagateItemAutomationName(args.ItemContainer, null);
                 if (args.ItemContainer.ContentTemplateRoot is ContentControl oldCc)
                 {
                     if (oldCc.Content is UIElement oldCtrl)
@@ -59,6 +60,9 @@ internal sealed class GridViewHandler : IElementHandler<GridViewElement, WinUI.G
             {
                 var ctrl = reconciler.Mount(items[args.ItemIndex], requestRerender);
                 cc.Content = ctrl;
+                // Issue #951 — keep .AutomationName(...) on an item view working
+                // the same way it does on the keyed overload.
+                Reconciler.PropagateItemAutomationName(args.ItemContainer, ctrl);
             }
         };
 

--- a/src/Reactor/Core/V1Protocol/Handlers/ListViewHandler.cs
+++ b/src/Reactor/Core/V1Protocol/Handlers/ListViewHandler.cs
@@ -45,6 +45,7 @@ internal sealed class ListViewHandler : IElementHandler<ListViewElement, WinUI.L
         {
             if (args.InRecycleQueue)
             {
+                Reconciler.PropagateItemAutomationName(args.ItemContainer, null);
                 if (args.ItemContainer.ContentTemplateRoot is ContentControl oldCc)
                 {
                     if (oldCc.Content is UIElement oldCtrl)
@@ -61,6 +62,9 @@ internal sealed class ListViewHandler : IElementHandler<ListViewElement, WinUI.L
             {
                 var ctrl = reconciler.Mount(items[args.ItemIndex], requestRerender);
                 cc.Content = ctrl;
+                // Issue #951 — keep .AutomationName(...) on an item view working
+                // the same way it does on the keyed overload.
+                Reconciler.PropagateItemAutomationName(args.ItemContainer, ctrl);
             }
         };
 

--- a/tests/Reactor.AppTests.Host/FixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/FixtureRegistry.cs
@@ -60,6 +60,9 @@ internal static class FixtureRegistry
 
         // Collections
         "ListView_TypedRendering",
+        // Issue #951 — keyed list rows must not announce Reactor's internal row
+        // identity, and must honor an author-declared item name (UIA-verified).
+        "KeyedList_ItemNames",
 
         // ItemClick once-fire guard (issue #679 (a) — E2E real-pointer-click coverage of
         // the ListViewHandler once-subscribe contract across re-renders + items change)
@@ -231,6 +234,7 @@ internal static class FixtureRegistry
 
         // Collections
         "ListView_TypedRendering" => CollectionFixtures.ListViewTyped(ctx),
+        "KeyedList_ItemNames" => CollectionFixtures.KeyedListItemNames(ctx),
 
         // ItemClick once-fire guard (issue #679 (a))
         "ItemClick_OnceFire" => ItemClickE2EFixtures.OnceFire(ctx),

--- a/tests/Reactor.AppTests.Host/Fixtures/CollectionFixtures.cs
+++ b/tests/Reactor.AppTests.Host/Fixtures/CollectionFixtures.cs
@@ -30,4 +30,42 @@ internal static class CollectionFixtures
                     )
             ).Height(300).AutomationId("AnimalsList")
         );
+
+    // Issue #951 — keyed rows used to announce Reactor's internal identity
+    // ("Row[0]=<key>") as their UIA Name. The keys below are literal GUID text,
+    // matching the report's worst case: a key selector over database ids, whose
+    // leak is both unreadable and unique per row. Item views are composite on
+    // purpose — a bare TextBlock lets the container compose its own name from
+    // the text and hides the bug entirely.
+    private record Fruit(string Id, string Label);
+
+    internal const string LeakKeyPrefix = "e951a000000000000000000000000";
+
+    private static readonly Fruit[] Fruits =
+    [
+        new($"{LeakKeyPrefix}001", "Apples"),
+        new($"{LeakKeyPrefix}002", "Bananas"),
+        new($"{LeakKeyPrefix}003", "Carrots"),
+    ];
+
+    private static Element FruitRow(Fruit f, int idx) =>
+        HStack(
+            Border(TextBlock($"{idx + 1}")).Size(28, 28),
+            TextBlock(f.Label)
+        );
+
+    internal static Element KeyedListItemNames(RenderContext ctx) =>
+        VStack(
+            TextBlock("Keyed item names").AutomationId("KeyedNamesTitle"),
+            // No author-declared name: rows must simply be unnamed, never named
+            // after the row's key.
+            ListView(Fruits, keySelector: f => f.Id, viewBuilder: FruitRow)
+                .Height(160).AutomationId("KeyedUnnamedList"),
+            // Author-declared name: .AutomationName on the item view is the
+            // supported way to name a row, and it has to survive to the real
+            // cross-process UIA tree.
+            ListView(Fruits, keySelector: f => f.Id,
+                viewBuilder: (f, idx) => FruitRow(f, idx).AutomationName($"Fruit {f.Label}"))
+                .Height(160).AutomationId("KeyedNamedList")
+        );
 }

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/KeyedListItemAutomationNameFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/KeyedListItemAutomationNameFixtures.cs
@@ -1,0 +1,300 @@
+using Microsoft.UI.Reactor.AppTests.Host.SelfTest;
+using Microsoft.UI.Reactor.Core;
+using Microsoft.UI.Xaml.Automation.Peers;
+using static Microsoft.UI.Reactor.Factories;
+using WinXC = Microsoft.UI.Xaml.Controls;
+
+namespace Microsoft.UI.Reactor.AppTests.Host.SelfTest.Fixtures;
+
+// Issue #951 — the UIA Name of a keyed ListView/GridView row.
+//
+// The oracle here is deliberately the *item* peer, not the container peer:
+// WinUI builds each row's UIA node as a ListViewItemDataAutomationPeer /
+// GridViewItemDataAutomationPeer constructed from the **data item**, and that
+// peer resolves its name as "container peer's name if non-empty, else the data
+// item's string representation". Querying
+// CreatePeerForElement(lvb.ContainerFromIndex(i)) returns the *container* peer
+// and does NOT reproduce the bug — it never consults the data item. The only
+// faithful in-process read is CreatePeerForElement(lvb).GetChildren()[i].
+//
+// The item views below are deliberately **composite** (a stack, not a bare
+// TextBlock). A container peer composes a name from plain text at the root of
+// the realized template; a bare TextBlock therefore masks the leak entirely,
+// which is exactly why the bug survived the existing keyed-list coverage.
+internal static class KeyedListItemAutomationNameFixtures
+{
+    private record Fruit(string Id, string Label);
+
+    private static Element Composite(Fruit f, int index) => HStack(8,
+        Border(TextBlock($"{index + 1}")).Size(28, 28),
+        TextBlock(f.Label));
+
+    private static IReadOnlyList<Fruit> GuidKeyed(params string[] labels) => labels
+        .Select(l => new Fruit(global::System.Guid.NewGuid().ToString("N"), l))
+        .ToList();
+    /// <summary>Name of the row at <paramref name="index"/> as UIA sees it.</summary>
+    private static string ItemPeerName(WinXC.ListViewBase lvb, int index)
+    {
+        var children = FrameworkElementAutomationPeer.CreatePeerForElement(lvb)?.GetChildren();
+        if (children is null || index >= children.Count) return "<no item peer>";
+        return children[index].GetName() ?? string.Empty;
+    }
+
+    // ── Leak ────────────────────────────────────────────────────────────
+
+    internal class NoRowIdentityLeak(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var fruits = GuidKeyed("Apples", "Bananas", "Carrots");
+
+            var host = H.CreateHost();
+            host.Mount(_ => VStack(
+                ListView<Fruit>(fruits, f => f.Id, Composite).Height(140),
+                GridView<Fruit>(fruits, f => f.Id, Composite).Height(160)
+            ));
+            await Harness.Render();
+            await Harness.Render();
+
+            var lv = H.FindControl<WinXC.ListView>(_ => true);
+            var gv = H.FindControl<WinXC.GridView>(_ => true);
+            if (lv is null || gv is null) { H.Check("KLIA_ListsRealized", false); return; }
+
+            // Keys are GUIDs, so a leak is unmistakable: the row's internal
+            // identity renders as "Row[<index>]=<key>".
+            for (int i = 0; i < 2; i++)
+            {
+                var lvName = ItemPeerName(lv, i);
+                var gvName = ItemPeerName(gv, i);
+                Console.WriteLine($"# KLIA leak: lv[{i}]=<{lvName}> gv[{i}]=<{gvName}>");
+
+                H.Check($"KLIA_ListView_Item{i}_NoRowPrefix", !lvName.Contains("Row[", StringComparison.Ordinal));
+                H.Check($"KLIA_ListView_Item{i}_NoKeyText", !lvName.Contains(fruits[i].Id, StringComparison.OrdinalIgnoreCase));
+                H.Check($"KLIA_GridView_Item{i}_NoRowPrefix", !gvName.Contains("Row[", StringComparison.Ordinal));
+                H.Check($"KLIA_GridView_Item{i}_NoKeyText", !gvName.Contains(fruits[i].Id, StringComparison.OrdinalIgnoreCase));
+            }
+        }
+    }
+
+    // ── Differential oracle ─────────────────────────────────────────────
+
+    // Characterization guard, not a regression test for the leak: with a bare
+    // TextBlock item view the container composes a name from its plain text, and
+    // that composed name outranks the data item's string representation — which
+    // is precisely why the leak went unnoticed for so long and why every other
+    // fixture here uses a composite item view. What this pins down is that the
+    // keyed overload still agrees with the element-array reference for the
+    // simple case, so a future change to row naming can't silently desync them.
+    internal class MatchesElementArray(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var labels = new[] { "Apples", "Bananas", "Carrots" };
+            var keyed = labels.Select(l => new Fruit(l, l)).ToList();
+
+            var host = H.CreateHost();
+            host.Mount(_ => VStack(
+                ListView(labels.Select(l => TextBlock(l) as Element).ToArray()).Height(140),
+                ListView<Fruit>(keyed, f => f.Id, (f, _) => TextBlock(f.Label)).Height(140)
+            ));
+            await Harness.Render();
+            await Harness.Render();
+
+            var lists = H.FindAllControls<WinXC.ListView>(_ => true);
+            if (lists.Count < 2) { H.Check("KLIA_BothListsRealized", false); return; }
+
+            for (int i = 0; i < 2; i++)
+            {
+                var reference = ItemPeerName(lists[0], i);
+                var keyedName = ItemPeerName(lists[1], i);
+                Console.WriteLine($"# KLIA diff: array[{i}]=<{reference}> keyed[{i}]=<{keyedName}>");
+
+                H.Check($"KLIA_ElementArray_Item{i}_NamedByContent", reference == labels[i]);
+                H.Check($"KLIA_Keyed_Item{i}_MatchesElementArray", keyedName == reference);
+            }
+        }
+    }
+
+    // The real cross-overload differential. Both overloads realize rows through
+    // their own container hook, so an author-declared name has to be forwarded in
+    // both places or the two DSL shapes disagree about how a row is named. With
+    // composite item views neither overload composes a name on its own — the
+    // element-array path falls back to the boxed index ("0", "1") and the keyed
+    // path to nothing — so agreement here can only come from the forwarding.
+    //
+    // All four forwarding call sites are exercised: the element-array
+    // ListViewHandler and GridViewHandler realize hooks, and the shared keyed
+    // realize hook for both control types. Deleting any one of them fails this
+    // fixture.
+    internal class AuthorNameParityAcrossOverloads(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var labels = new[] { "Apples", "Bananas", "Carrots" };
+            var keyed = GuidKeyed(labels);
+            Element[] Array() => labels
+                .Select((l, ix) => Composite(new Fruit(l, l), ix).AutomationName($"Fruit {l}") as Element)
+                .ToArray();
+
+            var host = H.CreateHost();
+            host.Mount(_ => VStack(
+                ListView(Array()).Height(140),
+                ListView<Fruit>(keyed, f => f.Id,
+                    (f, ix) => Composite(f, ix).AutomationName($"Fruit {f.Label}")).Height(140),
+                GridView(Array()).Height(160),
+                GridView<Fruit>(keyed, f => f.Id,
+                    (f, ix) => Composite(f, ix).AutomationName($"Fruit {f.Label}")).Height(160)
+            ));
+            await Harness.Render();
+            await Harness.Render();
+
+            // GridView derives from ListViewBase, not ListView, so the two
+            // lookups do not overlap.
+            var lists = H.FindAllControls<WinXC.ListView>(_ => true);
+            var grids = H.FindAllControls<WinXC.GridView>(_ => true);
+            if (lists.Count < 2 || grids.Count < 2)
+            {
+                H.Check("KLIA_Parity_AllFourRealized", false);
+                return;
+            }
+
+            for (int i = 0; i < 2; i++)
+            {
+                var expected = $"Fruit {labels[i]}";
+                var arrayList = ItemPeerName(lists[0], i);
+                var keyedList = ItemPeerName(lists[1], i);
+                var arrayGrid = ItemPeerName(grids[0], i);
+                var keyedGrid = ItemPeerName(grids[1], i);
+                Console.WriteLine(
+                    $"# KLIA parity[{i}]: lv-array=<{arrayList}> lv-keyed=<{keyedList}> " +
+                    $"gv-array=<{arrayGrid}> gv-keyed=<{keyedGrid}> expected=<{expected}>");
+
+                H.Check($"KLIA_Parity_ElementArray_Item{i}", arrayList == expected);
+                H.Check($"KLIA_Parity_Keyed_Item{i}", keyedList == expected);
+                H.Check($"KLIA_Parity_GridElementArray_Item{i}", arrayGrid == expected);
+                H.Check($"KLIA_Parity_GridKeyed_Item{i}", keyedGrid == expected);
+            }
+        }
+    }
+
+    // ── Author-declared names ───────────────────────────────────────────
+
+    // A composite row has no plain text at its template root, so WinUI composes
+    // no name for it — and an AutomationProperties.Name set on the item view's
+    // own root is not consulted for the row either. Reactor forwards it to the
+    // generated container so .AutomationName(...) on an item view actually names
+    // the row. Without that forwarding these names come back empty.
+    internal class AuthorNameReachesItem(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var fruits = GuidKeyed("Apples", "Bananas", "Carrots");
+
+            var host = H.CreateHost();
+            host.Mount(_ => VStack(
+                ListView<Fruit>(fruits, f => f.Id,
+                    (f, ix) => Composite(f, ix).AutomationName($"Fruit {f.Label}")).Height(140),
+                GridView<Fruit>(fruits, f => f.Id,
+                    (f, ix) => Composite(f, ix).AutomationName($"Fruit {f.Label}")).Height(160)
+            ));
+            await Harness.Render();
+            await Harness.Render();
+
+            var lv = H.FindControl<WinXC.ListView>(_ => true);
+            var gv = H.FindControl<WinXC.GridView>(_ => true);
+            if (lv is null || gv is null) { H.Check("KLIA_AuthorName_ListsRealized", false); return; }
+
+            for (int i = 0; i < 2; i++)
+            {
+                var expected = $"Fruit {fruits[i].Label}";
+                var lvName = ItemPeerName(lv, i);
+                var gvName = ItemPeerName(gv, i);
+                Console.WriteLine($"# KLIA author: lv[{i}]=<{lvName}> gv[{i}]=<{gvName}> expected=<{expected}>");
+
+                H.Check($"KLIA_ListView_Item{i}_UsesAuthorName", lvName == expected);
+                H.Check($"KLIA_GridView_Item{i}_UsesAuthorName", gvName == expected);
+            }
+        }
+    }
+
+    // A container outlives the row it was realized for. If the forwarded name
+    // were written only at realize time, re-rendering the list with reordered or
+    // renamed items would leave each container announcing its previous row —
+    // a worse failure than no name at all, because it is confidently wrong.
+    internal class AuthorNameTracksUpdates(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var initial = GuidKeyed("Apples", "Bananas", "Carrots");
+            // Same keys, so the diff reuses the realized containers instead of
+            // recycling them — this exercises the update path, not the realize path.
+            var renamed = initial.Select(f => f with { Label = f.Label + " (organic)" }).ToList();
+
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                var (phase, setPhase) = ctx.UseState(0);
+                var data = phase == 0 ? initial : renamed;
+                return VStack(
+                    Button("Rename", () => setPhase(1)),
+                    ListView<Fruit>(data, f => f.Id,
+                        (f, ix) => Composite(f, ix).AutomationName($"Fruit {f.Label}")).Height(140)
+                );
+            });
+            await Harness.Render();
+            await Harness.Render();
+
+            var lv = H.FindControl<WinXC.ListView>(_ => true);
+            if (lv is null) { H.Check("KLIA_Update_ListRealized", false); return; }
+
+            H.Check("KLIA_Update_InitialName", ItemPeerName(lv, 0) == "Fruit Apples");
+
+            H.ClickButton("Rename");
+            await Harness.Render();
+            await Harness.Render();
+
+            var after = ItemPeerName(lv, 0);
+            Console.WriteLine($"# KLIA update: after=<{after}>");
+            H.Check("KLIA_Update_NameFollowsItem", after == "Fruit Apples (organic)");
+        }
+    }
+
+    // The mirror of the update case: when the author drops the name, the stale
+    // one must not survive on the recycled/reused container.
+    internal class AuthorNameClearedWhenRemoved(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var fruits = GuidKeyed("Apples", "Bananas", "Carrots");
+
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                var (named, setNamed) = ctx.UseState(true);
+                return VStack(
+                    Button("DropName", () => setNamed(false)),
+                    ListView<Fruit>(fruits, f => f.Id, (f, ix) =>
+                        named ? Composite(f, ix).AutomationName($"Fruit {f.Label}") : Composite(f, ix)).Height(140)
+                );
+            });
+            await Harness.Render();
+            await Harness.Render();
+
+            var lv = H.FindControl<WinXC.ListView>(_ => true);
+            if (lv is null) { H.Check("KLIA_Clear_ListRealized", false); return; }
+
+            H.Check("KLIA_Clear_NamedFirst", ItemPeerName(lv, 0) == "Fruit Apples");
+
+            H.ClickButton("DropName");
+            await Harness.Render();
+            await Harness.Render();
+
+            var after = ItemPeerName(lv, 0);
+            Console.WriteLine($"# KLIA clear: after=<{after}>");
+            H.Check("KLIA_Clear_NoStaleName", after != "Fruit Apples");
+            H.Check("KLIA_Clear_NoRowIdentityLeak",
+                !after.Contains("Row[", StringComparison.Ordinal)
+                && !after.Contains(fruits[0].Id, StringComparison.OrdinalIgnoreCase));
+        }
+    }
+}

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -9,8 +9,7 @@ internal static class SelfTestFixtureRegistry
 {
     public static readonly string[] AllFixtures =
     [
-        "ErrorBoundary_CatchesRenderError",
-        "ErrorBoundary_Recovery",
+        "ErrorBoundary_CatchesRenderError",        "ErrorBoundary_Recovery",
         "Reconciler_MountText",
         "Reconciler_UpdateText",
         "Reconciler_AddRemoveChildren",
@@ -179,8 +178,7 @@ internal static class SelfTestFixtureRegistry
         "ItemsView_Rerender_DoesNotMarkContainersModified",
         "ItemsView_MultiSelect_CheckmarkDoesNotFlicker",
         // Spec 042 Phase 1 — keyed-list reconciliation end-to-end fixtures.
-        "KLR_ListView_MountsOcSource",
-        "KLR_ListView_InsertAtZero_EmitsSingleAdd",
+        "KLR_ListView_MountsOcSource",        "KLR_ListView_InsertAtZero_EmitsSingleAdd",
         "KLR_ListView_RemoveFromEnd_EmitsSingleRemove",
         "KLR_ListView_MoveOne_EmitsSingleMove",
         "KLR_ListView_BulkReplace_TriggersBailout",
@@ -198,6 +196,14 @@ internal static class SelfTestFixtureRegistry
         "KLR_FlexColumn_KeyedChildren_Swap_SurvivorsKeepIdentity",
         "KLR_FlexColumn_KeyedChildren_Reverse_SurvivorsKeepIdentity",
         "KLR_FlexColumn_WithKeyItem_PreservesIdentityAcrossInsert",
+        // Issue #951 — keyed ListView/GridView rows must not announce Reactor's
+        // internal row identity, and must honor an author-declared item name.
+        "KLIA_NoRowIdentityLeak",
+        "KLIA_MatchesElementArray",
+        "KLIA_AuthorNameParityAcrossOverloads",
+        "KLIA_AuthorNameReachesItem",
+        "KLIA_AuthorNameTracksUpdates",
+        "KLIA_AuthorNameClearedWhenRemoved",
         // Spec 047 §14 — panel descriptor migration: keyed reconcile identity,
         // lockstep attached-prop reapply, stale-state clears, unmount cleanup.
         "PDM_Stack_KeyedSwap_PreservesIdentity",
@@ -1817,6 +1823,13 @@ internal static class SelfTestFixtureRegistry
         "KLR_FlexColumn_KeyedChildren_Swap_SurvivorsKeepIdentity" => new KeyedListReconciliationFixtures.FlexColumn_KeyedChildren_Swap_SurvivorsKeepIdentity(harness),
         "KLR_FlexColumn_KeyedChildren_Reverse_SurvivorsKeepIdentity" => new KeyedListReconciliationFixtures.FlexColumn_KeyedChildren_Reverse_SurvivorsKeepIdentity(harness),
         "KLR_FlexColumn_WithKeyItem_PreservesIdentityAcrossInsert" => new KeyedListReconciliationFixtures.FlexColumn_WithKeyItem_PreservesIdentityAcrossInsert(harness),
+        // Issue #951 — keyed list/grid row automation names.
+        "KLIA_NoRowIdentityLeak" => new KeyedListItemAutomationNameFixtures.NoRowIdentityLeak(harness),
+        "KLIA_MatchesElementArray" => new KeyedListItemAutomationNameFixtures.MatchesElementArray(harness),
+        "KLIA_AuthorNameParityAcrossOverloads" => new KeyedListItemAutomationNameFixtures.AuthorNameParityAcrossOverloads(harness),
+        "KLIA_AuthorNameReachesItem" => new KeyedListItemAutomationNameFixtures.AuthorNameReachesItem(harness),
+        "KLIA_AuthorNameTracksUpdates" => new KeyedListItemAutomationNameFixtures.AuthorNameTracksUpdates(harness),
+        "KLIA_AuthorNameClearedWhenRemoved" => new KeyedListItemAutomationNameFixtures.AuthorNameClearedWhenRemoved(harness),
         "PDM_Stack_KeyedSwap_PreservesIdentity" => new PanelDescriptorMigrationFixtures.Stack_KeyedSwap_PreservesIdentity(harness),
         "PDM_Grid_KeyedSwap_PreservesIdentity_And_RowFollows" => new PanelDescriptorMigrationFixtures.Grid_KeyedSwap_PreservesIdentity_And_RowFollows(harness),
         "PDM_Canvas_KeyedReorder_PreservesIdentity_And_PositionFollows" => new PanelDescriptorMigrationFixtures.Canvas_KeyedReorder_PreservesIdentity_And_PositionFollows(harness),

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -9,7 +9,8 @@ internal static class SelfTestFixtureRegistry
 {
     public static readonly string[] AllFixtures =
     [
-        "ErrorBoundary_CatchesRenderError",        "ErrorBoundary_Recovery",
+        "ErrorBoundary_CatchesRenderError",
+        "ErrorBoundary_Recovery",
         "Reconciler_MountText",
         "Reconciler_UpdateText",
         "Reconciler_AddRemoveChildren",
@@ -178,7 +179,8 @@ internal static class SelfTestFixtureRegistry
         "ItemsView_Rerender_DoesNotMarkContainersModified",
         "ItemsView_MultiSelect_CheckmarkDoesNotFlicker",
         // Spec 042 Phase 1 — keyed-list reconciliation end-to-end fixtures.
-        "KLR_ListView_MountsOcSource",        "KLR_ListView_InsertAtZero_EmitsSingleAdd",
+        "KLR_ListView_MountsOcSource",
+        "KLR_ListView_InsertAtZero_EmitsSingleAdd",
         "KLR_ListView_RemoveFromEnd_EmitsSingleRemove",
         "KLR_ListView_MoveOne_EmitsSingleMove",
         "KLR_ListView_BulkReplace_TriggersBailout",

--- a/tests/Reactor.AppTests/Tests/KeyedListItemNameTests.cs
+++ b/tests/Reactor.AppTests/Tests/KeyedListItemNameTests.cs
@@ -1,0 +1,97 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.UI.Reactor.AppTests.Infrastructure;
+
+namespace Microsoft.UI.Reactor.AppTests.Tests;
+
+/// <summary>
+/// Issue #951 — the accessible name of a row in a keyed (data-driven)
+/// <c>ListView</c> / <c>GridView</c>, measured through the real cross-process
+/// UIA tree.
+///
+/// <para>This is the tier the bug was reported at. Reactor binds keyed items
+/// controls to an internally-owned collection of <c>ReactorRow</c> records, and
+/// WinUI builds each row's UIA node from that <em>data item</em>. When the row
+/// had no name of its own, the data item's string representation became the
+/// announced name — so Narrator read out <c>"Row[0]=&lt;guid&gt;"</c> instead of
+/// the row's visible content. The in-process selftests (<c>KLIA_*</c>) pin the
+/// automation peers directly; these tests confirm the same thing survives to an
+/// out-of-process UIA client, which is what assistive technology actually
+/// uses.</para>
+/// </summary>
+[TestClass]
+public class KeyedListItemNameTests : AppTestBase
+{
+    // Must match CollectionFixtures.LeakKeyPrefix — the fixture keys are literal
+    // GUID text so a leak is unambiguous rather than coincidentally readable.
+    private const string LeakKeyPrefix = "e951a000000000000000000000000";
+
+    [ClassInitialize]
+    public static void StartAppSession(TestContext context) => TestSession.AssemblyInit(context);
+
+    [ClassCleanup]
+    public static void StopAppSession() => TestSession.AssemblyCleanup();
+
+    private void NavigateToKeyedListFixture() => NavigateToFixture("KeyedList_ItemNames");
+
+    [TestMethod]
+    public void KeyedListRows_DoNotExposeInternalRowIdentity()
+    {
+        NavigateToKeyedListFixture();
+
+        // Guard the guard: if the fixture didn't render, the two searches below
+        // would trivially find nothing and the test would pass for the wrong
+        // reason.
+        Assert.IsNotNull(FindById("KeyedUnnamedList"), "Keyed list fixture did not render.");
+
+        var rowIdentityMatches = App.Search("Row[")
+            .Where(m => m.Name?.Contains("Row[", StringComparison.Ordinal) == true)
+            .ToList();
+
+        Assert.AreEqual(0, rowIdentityMatches.Count,
+            "Keyed list rows must not announce Reactor's internal row identity. Leaked names: "
+            + string.Join(", ", rowIdentityMatches.Select(m => $"{m.Type}:'{m.Name}'")));
+    }
+
+    [TestMethod]
+    public void KeyedListRows_DoNotExposeTheirKey()
+    {
+        NavigateToKeyedListFixture();
+
+        Assert.IsNotNull(FindById("KeyedUnnamedList"), "Keyed list fixture did not render.");
+
+        // The key is the author's opaque identifier — a database id or GUID. It
+        // is never something a user should hear, whatever wrapping it comes in.
+        var keyMatches = App.Search(LeakKeyPrefix)
+            .Where(m => m.Name?.Contains(LeakKeyPrefix, StringComparison.OrdinalIgnoreCase) == true)
+            .ToList();
+
+        Assert.AreEqual(0, keyMatches.Count,
+            "Keyed list rows must not announce their key. Leaked names: "
+            + string.Join(", ", keyMatches.Select(m => $"{m.Type}:'{m.Name}'")));
+    }
+
+    [TestMethod]
+    public void KeyedListRows_ExposeAuthorDeclaredName()
+    {
+        NavigateToKeyedListFixture();
+
+        // A composite row (stack / border / card) has no plain text at its
+        // template root, so WinUI composes no name for it. .AutomationName(...)
+        // on the item view is the supported way to name such a row, and this is
+        // the assertion that it reaches a real UIA client — without it the row
+        // is silently unnamed, which is how the original bug hid.
+        foreach (var label in new[] { "Apples", "Bananas", "Carrots" })
+        {
+            var expected = $"Fruit {label}";
+            var row = App.Search(expected)
+                .FirstOrDefault(m =>
+                    string.Equals(m.Name, expected, StringComparison.Ordinal) &&
+                    string.Equals(m.Type, "ListItem", StringComparison.Ordinal));
+
+            Assert.IsNotNull(row,
+                $"Expected a list row (ListItem) named '{expected}' in the UIA tree — "
+                + ".AutomationName on a keyed item view must name the row itself, not just "
+                + "an element inside it.");
+        }
+    }
+}

--- a/tests/Reactor.AppTests/Tests/KeyedListItemNameTests.cs
+++ b/tests/Reactor.AppTests/Tests/KeyedListItemNameTests.cs
@@ -80,9 +80,8 @@ public class KeyedListItemNameTests : AppTestBase
         // on the item view is the supported way to name such a row, and this is
         // the assertion that it reaches a real UIA client — without it the row
         // is silently unnamed, which is how the original bug hid.
-        foreach (var label in new[] { "Apples", "Bananas", "Carrots" })
+        foreach (var expected in new[] { "Apples", "Bananas", "Carrots" }.Select(label => $"Fruit {label}"))
         {
-            var expected = $"Fruit {label}";
             var row = App.Search(expected)
                 .FirstOrDefault(m =>
                     string.Equals(m.Name, expected, StringComparison.Ordinal) &&

--- a/tests/Reactor.Tests/Internal/ReactorListStateTests.cs
+++ b/tests/Reactor.Tests/Internal/ReactorListStateTests.cs
@@ -154,10 +154,14 @@ public class ReactorListStateTests
     }
 
     [Fact]
-    public void Row_ToString_Includes_Index_And_Key_For_Diagnostics()
+    public void Row_DebugDescription_Includes_Index_And_Key_For_Diagnostics()
     {
+        // Issue #951 — this used to assert on ToString(). That string is what
+        // WinUI announces for an unnamed keyed list row, so the diagnostic form
+        // moved to DebugDescription and ToString() is now deliberately empty
+        // (see the ToString_* tests below).
         var row = new ReactorRow { Index = 7, Key = "hello" };
-        var text = row.ToString();
+        var text = row.DebugDescription;
         Assert.Contains("7", text);
         Assert.Contains("hello", text);
     }
@@ -186,5 +190,59 @@ public class ReactorListStateTests
         Assert.True(state.ByKey.ContainsKey("A"));
         Assert.True(state.ByKey.ContainsKey("a"));
         Assert.NotSame(state.ByKey["A"], state.ByKey["a"]);
+    }
+
+    // ── Issue #951 — ReactorRow's string form reaches assistive technology ──
+    //
+    // Rows are the data items of the collection bound to a keyed ListView /
+    // GridView, and WinUI resolves an unnamed row's UIA Name from the data
+    // item's string representation. Anything ToString() returns is therefore
+    // announced verbatim by Narrator, so it has to stay empty. The live UIA
+    // measurement is in the KLIA_* selftest fixtures (headless tests can't
+    // construct AutomationPeers); these pin the contract at its source.
+
+    [Fact]
+    public void ToString_Is_Empty_So_Rows_Do_Not_Name_Their_List_Item()
+    {
+        var row = new ReactorRow { Index = 3, Key = "cb9f480f03954faaa2f8d69b739d31b8" };
+
+        // Not IsNullOrEmpty: object.ToString() (i.e. the override deleted)
+        // returns the type name, and any debug-ish form reintroduces the leak.
+        Assert.Equal(string.Empty, row.ToString());
+    }
+
+    [Fact]
+    public void ToString_Stays_Empty_For_Every_Row_In_A_Populated_State()
+    {
+        // Reset is the mount/bulk-replace path that builds the bound collection,
+        // so this covers the rows a real list actually hands to WinUI.
+        var state = new ReactorListState();
+        state.Reset([(0, "Apples"), (1, "Bananas"), (2, "Carrots")]);
+
+        Assert.All(state.Source, row => Assert.Equal(string.Empty, row.ToString()));
+    }
+
+    [Fact]
+    public void DebugDescription_Still_Carries_Index_And_Key()
+    {
+        // The identity string didn't disappear, it moved off ToString() —
+        // debugger display and diagnostics keep the readable form.
+        var row = new ReactorRow { Index = 3, Key = "beta" };
+
+        Assert.Equal("Row[3]=beta", row.DebugDescription);
+    }
+
+    [Fact]
+    public void DebugDescription_Tracks_Index_Reassignment()
+    {
+        // Rows are reused across diffs and their Index is rewritten in place;
+        // a cached/const string would silently drift from the row's real slot.
+        var row = new ReactorRow { Index = 0, Key = "beta" };
+        var before = row.DebugDescription;
+
+        row.Index = 7;
+
+        Assert.Equal("Row[0]=beta", before);
+        Assert.Equal("Row[7]=beta", row.DebugDescription);
     }
 }


### PR DESCRIPTION
Fixes #951.

Items of a keyed/data-driven `ListView`/`GridView` announced Reactor's internal row identity — `Row[0]=<key>`, down to a raw GUID when the key selector produced one — instead of their content.

## Root cause (measured, not inferred)

The issue flagged the automation-name rule as "inferred, not verified", so I measured it with a throwaway live-WinUI spike before writing any fix.

The keyed path binds `ItemsSource` to an internally-owned `ObservableCollection<ReactorRow>`, so WinUI builds each row's UIA node as an `ItemAutomationPeer` **from the data item**. That peer resolves its `Name` as: *the container peer's name when non-empty, otherwise the data item's string representation*. A container peer composes a name **only** when the realized item view has plain text at its root — a bare `TextBlock` works, a composite (stack / border / card) does not. So every composite keyed row fell through to `ReactorRow.ToString()`, a debug aid that was never meant to reach assistive technology.

Measured item-peer names, before → after:

| Case | Before | After |
|---|---|---|
| element-array + simple `TextBlock` | `Apples` | `Apples` |
| element-array + composite | `0`, `1` (boxed index) | `0`, `1` — or the author name |
| keyed + simple `TextBlock` | `Apples` | `Apples` |
| keyed + composite (GUID keys) | `Row[0]=<guid>` | *empty* ✅ |
| keyed `GridView` + composite | `Row[0]=<guid>` | *empty* ✅ |
| keyed + composite + `.AutomationName(...)` | *empty* | the author's name ✅ |

## The fix

**1. `ReactorRow.ToString()` returns `string.Empty`.** The readable form moves to a `DebugDescription` property surfaced via `[DebuggerDisplay]`, so the debugging affordance is preserved. One change covers `ListView`, `GridView`, `ItemsRepeater`, `ItemsView` and `Lazy*Stack` — they all share `ReactorRow`. Nothing else consumed the string.

An empty name is the correct, standard result: the row is left unnamed, so assistive technology reads its content, exactly as a plain WinUI list behaves for a data item with no string representation.

**2. Author-declared names now reach the row.** Step 1 alone would leave composite rows permanently unnameable — `.AutomationName(...)` on an item view lands on an element WinUI never consults for the list item. Reactor now forwards a non-empty name from the item view's root onto the generated container, and clears it otherwise so a recycled container can't strand the previous row's name.

Wired at all four realize/recycle sites — keyed mount, keyed update, and the element-array `ListView`/`GridView` handlers — so both DSL overloads behave identically. The update-path call matters most: realized containers survive re-renders, so without it a reorder or rename would *confidently announce the wrong row*, which is worse than no name at all.

## Testing

All three tiers, every oracle mutation-verified (patch product code → rebuild → re-run → restore):

| Mutation | Result |
|---|---|
| Revert `ToString()` | 9 selftest failures ✅ |
| Remove both propagation calls | 7 failures ✅ |
| Remove only the `Update.cs` call | 2 failures, both showing the stale-name symptom ✅ |
| Remove only the `GridViewHandler` call | exactly the 2 new grid checks ✅ |
| Revert the fix, then run E2E | 6 `ListItem`s named `Row[N]=<key>` ✅ |

- **Unit** — `ToString()` / `DebugDescription` contract. A pre-existing test pinned the old behaviour and was converted rather than deleted.
- **Selftest** — 6 live-WinUI fixtures. Two traps are documented in the file header: the reproducing oracle is the **item** peer (`CreatePeerForElement(listView).GetChildren()[i]`), not the container peer, and the item view must be **composite** — a bare `TextBlock` masks the bug entirely, which is why existing keyed-list coverage missed it.
- **E2E** — cross-process `winapp ui` UIA assertions, the tier the bug was reported at. Skipped locally by the non-interactive-session guard, so I validated by hand: `Row[` → 0 matches, key prefix → 0 matches, `Fruit Apples` → a `ListItem` with that name.

One weak test is called out honestly rather than papered over: `MatchesElementArray` is a characterization guard, not a leak regression test — `SetName(container, " ")` and `ClearValue` are indistinguishable at the peer level. `AuthorNameParityAcrossOverloads` is the genuine cross-overload differential.

Verification: 12,937 unit tests, 6,170 selftests, full `Reactor.slnx` build — all green.

## Review

Ran the repo's `.github/skills/pr-review` fan-out (8 dimensions). Two findings were fixed in this branch: an invalid DSL sample in the new doc section (`Text(...)` isn't a factory), and a missing non-vacuous test for the element-array `GridView` path. A low-severity security suggestion was disputed and the dispute upheld by the multi-model cross-check.

## Notes

- `TreeView<T>` is out of scope — its node content is the *user's* own object, not `ReactorRow`.
- Accepted deliberately: `ListViewBase` type-ahead loses its search string on keyed lists. It was already the useless `"Row[0]=…"`.
- An explicit `.ItemAutomationName(Func<T,string>)` API would be a reasonable follow-up; this change keeps the surface implicit and opt-in.