### PR TITLE
fix(gallery): stop the title bar's right-header glyphs from clipping

### DIFF
--- a/samples/ReactorGallery/GalleryShell.cs
+++ b/samples/ReactorGallery/GalleryShell.cs
@@ -187,8 +187,9 @@ class GalleryShell : Component
                 RightHeader = HStack(4,
                     Component<CopyDeepLinkButton, string>(
                         GalleryRoutes.UriForCurrentView(selectedTag, searchQuery)),
-                    Button(Icon(isDark ? "\uE706" : "\uE708"), () => setIsDark(!isDark))
-                        .Width(40).Height(36)
+                    Button(Icon(FontIcon(isDark ? "\uE706" : "\uE708",
+                        fontSize: GalleryControls.TitleBarGlyphSize)), () => setIsDark(!isDark))
+                        .Width(40).Height(36).Padding(0)
                         .ToolTip(isDark ? "Switch to Light" : "Switch to Dark")
                         .AutomationName(isDark ? "Switch to Light theme" : "Switch to Dark theme")
                 ),

--- a/samples/ReactorGallery/UserControls/GalleryControls.cs
+++ b/samples/ReactorGallery/UserControls/GalleryControls.cs
@@ -100,7 +100,11 @@ internal sealed class CopyDeepLinkButton : Component<string>
             return () => isMounted.Current = false;
         });
 
-        return Button(Icon(copied ? "\uE73E" : "\uE71B"))
+        // 16 DIP glyph + zero padding: the default Button padding (11,5,11,6) leaves
+        // only 18 DIP of content width on a 40 DIP button, which clips the 20 DIP
+        // default FontIcon. 16 also matches the title bar's own back / pane-toggle
+        // glyphs.
+        return Button(Icon(FontIcon(copied ? "\uE73E" : "\uE71B", fontSize: GalleryControls.TitleBarGlyphSize)))
             .Click(() =>
             {
                 try
@@ -123,7 +127,7 @@ internal sealed class CopyDeepLinkButton : Component<string>
                     // copy button swallows.
                 }
             })
-            .Width(40).Height(36)
+            .Width(40).Height(36).Padding(0)
             .ToolTip(copied ? "Link copied" : $"Copy link to this page\n{uri}")
             .AutomationName("Copy link to this page");
     }
@@ -258,6 +262,13 @@ internal sealed class SourceCodeView : Component<string>
 /// </summary>
 public static class GalleryControls
 {
+    /// <summary>
+    /// Glyph size for the title-bar command buttons. Matches the 16 DIP the WinUI
+    /// <c>TitleBar</c> template uses for its own back / pane-toggle glyphs; the
+    /// <c>FontIcon</c> default of 20 DIP overflows a 40 DIP button and gets clipped.
+    /// </summary>
+    internal const double TitleBarGlyphSize = 16;
+
     static CornerRadius ControlRadiusCR => ThemeResource.CornerRadius("ControlCornerRadius");
     static CornerRadius OverlayRadiusCR => ThemeResource.CornerRadius("OverlayCornerRadius");
     static double ControlRadius => ControlRadiusCR.TopLeft;

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ReconcilerBigCoverageFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ReconcilerBigCoverageFixtures.cs
@@ -1041,6 +1041,127 @@ internal static class ReconcilerBigCoverageFixtures
     }
 
     // ════════════════════════════════════════════════════════════════════
+    //  11c. Standalone IconElement → FontIcon projection, sized.
+    //     The gallery's title-bar buttons render an icon-only Button whose
+    //     glyph swaps on state (theme toggle, copied checkmark) and whose
+    //     glyph must stay inside a 40x36 box. That leans on two things this
+    //     fixture pins, neither of which had live coverage:
+    //
+    //     1. FontIconData(glyph, FontFamily: null, FontSize: n) is a safe
+    //        substitute for the string form. Icon("\uE71B") resolves through
+    //        ResolveIconString, which assigns ResolveSymbolFontFamily() BY
+    //        HAND; Icon(FontIcon(...)) resolves through CreateFontIcon, which
+    //        assigns FontFamily only when the author supplied one and
+    //        otherwise leans on the WinUI FontIcon default style. If those two
+    //        ever land on different families, typed glyph icons render tofu.
+    //     2. The glyph re-projects on update while the explicit FontSize
+    //        survives — a rebuild that dropped the size would silently restore
+    //        the 20 DIP default and overflow a fixed-size button. Mount and
+    //        update are genuinely different code paths here (IconResolver's
+    //        CreateFontIcon vs IconElement.PatchIcon's same-subtype patch), so
+    //        both are driven: phase 1 swaps the glyph at a constant size (the
+    //        gallery's shape) and phase 2 changes the size itself.
+    // ════════════════════════════════════════════════════════════════════
+    internal class IconElementFontIconSizing(Harness h) : SelfTestFixtureBase(h)
+    {
+        const double Sized = 16;
+        const double Resized = 28;
+
+        public override async Task RunAsync()
+        {
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                var (phase, set) = ctx.UseState(0);
+                return VStack(
+                    Button("IconSizePhase", () => set(phase + 1)),
+                    // The exact shape the gallery title bar uses.
+                    Button(Icon(FontIcon(
+                            phase == 0 ? "\uE71B" : "\uE73E",
+                            fontSize: phase < 2 ? Sized : Resized)))
+                        .Width(40).Height(36).Padding(0),
+                    // Differential control: identical but for the omitted size.
+                    Border(Icon(FontIcon("\uE700")))
+                );
+            });
+
+            await Harness.Render();
+
+            var sized = FindSizedIcon();
+            var unsized = H.FindControl<WinXC.FontIcon>(f => f.Glyph == "\uE700");
+
+            // Mount path. Glyph and FontSize both land — paired with the unsized
+            // control so dropping the `if (fi.FontSize.HasValue)` write in
+            // CreateFontIcon fails here instead of passing on a coincidental
+            // control default.
+            H.Check("IconFontSize_GlyphAndSizeProjected",
+                sized?.Glyph == "\uE71B"
+                && sized?.FontSize == Sized
+                && unsized is not null
+                && unsized.FontSize != Sized);
+
+            // The divergence that makes Icon(FontIcon(glyph, fontSize:)) usable
+            // wherever Icon(glyph) was: with no family supplied, the mounted
+            // control must resolve to the SAME family ResolveIconString assigns
+            // explicitly. "\uE700" is not a Symbol enum name, so that call takes
+            // the glyph arm and is the honest comparand. Retarget
+            // ResolveSymbolFontFamily and the two sides part company here.
+            var handAssigned =
+                (IconResolver.ResolveIconString("\uE700") as WinXC.FontIcon)?.FontFamily?.Source;
+            H.Check("IconFontSize_DefaultFamilyMatchesGlyphResolver",
+                handAssigned is not null
+                && sized?.FontFamily?.Source == handAssigned);
+
+            // …and an author-supplied family still wins over that default. This
+            // is the arm that traps deleting the `if (fi.FontFamily is not null)`
+            // assignment: without it the icon falls back to the symbol font,
+            // which the inequality below catches.
+            var explicitFamily = IconResolver.CreateFontIcon(
+                new FontIconData("\uE700", "Segoe MDL2 Assets", Sized));
+            H.Check("IconFontSize_ExplicitFamilyWins",
+                explicitFamily.FontFamily?.Source == "Segoe MDL2 Assets"
+                && explicitFamily.FontFamily?.Source != handAssigned);
+
+            // Padding(0) must actually reach the control. A modifier pipeline
+            // that treated the 0 as "unset" would leave the WinUI default
+            // ButtonPadding (11,5,11,6) — precisely what clipped the 20 DIP
+            // default glyph inside a 40 DIP button.
+            var iconButton = H.FindControl<WinXC.Button>(b => b.Content is WinXC.FontIcon);
+            H.Check("IconFontSize_ZeroPaddingApplied",
+                iconButton is not null
+                && iconButton.Padding is { Left: 0, Top: 0, Right: 0, Bottom: 0 });
+
+            H.ClickButton("IconSizePhase");
+            await Harness.Render();
+
+            // Update path, glyph only: PatchIcon rewrites Glyph in place and the
+            // explicit size rides through unchanged.
+            var afterGlyphSwap = FindSizedIcon();
+            H.Check("IconFontSize_GlyphSwapKeepsSize",
+                afterGlyphSwap?.Glyph == "\uE73E"
+                && afterGlyphSwap?.FontSize == Sized
+                && H.FindControl<WinXC.FontIcon>(f => f.Glyph == "\uE71B") is null);
+
+            H.ClickButton("IconSizePhase");
+            await Harness.Render();
+
+            // Update path, size only: the same-subtype patch must carry a changed
+            // FontSize too. Without that write the control keeps the mounted 16
+            // and an author resizing an icon across renders silently gets nothing.
+            var afterResize = FindSizedIcon();
+            H.Check("IconFontSize_SizeChangePatched",
+                afterResize?.FontSize == Resized
+                && afterResize?.Glyph == "\uE73E");
+        }
+
+        // The differential control deliberately uses a third glyph, so match on
+        // "is one of the sized button's two glyphs" rather than on size —
+        // matching on FontSize would make the size assertions circular.
+        private WinXC.FontIcon? FindSizedIcon() =>
+            H.FindControl<WinXC.FontIcon>(f => f.Glyph is "\uE71B" or "\uE73E");
+    }
+
+    // ════════════════════════════════════════════════════════════════════
     //  12. Frame mount (rarely-used element).
     //     Targets Mount.cs MountFrame. MapControl is intentionally not exercised
     //     here because it crashes natively without a map service token.

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ReconcilerBigCoverageFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ReconcilerBigCoverageFixtures.cs
@@ -1112,8 +1112,17 @@ internal static class ReconcilerBigCoverageFixtures
             // wherever Icon(glyph) was: with no family supplied, the mounted
             // control must resolve to the SAME family ResolveIconString assigns
             // explicitly. "\uE700" is not a Symbol enum name, so that call takes
-            // the glyph arm and is the honest comparand. Retarget
-            // ResolveSymbolFontFamily and the two sides part company here.
+            // the glyph arm and is the honest comparand.
+            //
+            // Scope, honestly: under a live app SymbolThemeFontFamily is present,
+            // so ResolveSymbolFontFamily returns from its theme-resource arm. This
+            // traps a retarget of THAT arm (verified by mutation) but NOT its
+            // `?? SymbolFontFallback` tail, which never executes in this host —
+            // PrivMount_SymbolFontFallbackStack in PrivateMountHotPaths is what
+            // pins the fallback constant. What this check adds is cross-path
+            // agreement: Reactor's hand-assigned family and the family the WinUI
+            // FontIcon default style supplies must not drift apart, or typed
+            // glyph icons render tofu while the string form keeps working.
             var handAssigned =
                 (IconResolver.ResolveIconString("\uE700") as WinXC.FontIcon)?.FontFamily?.Source;
             H.Check("IconFontSize_DefaultFamilyMatchesGlyphResolver",

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ReconcilerBigCoverageFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ReconcilerBigCoverageFixtures.cs
@@ -1067,6 +1067,13 @@ internal static class ReconcilerBigCoverageFixtures
         const double Sized = 16;
         const double Resized = 28;
 
+        // FontSize is a double, and a WinUI control default can be theme-resource
+        // derived rather than a literal, so compare with a tolerance instead of
+        // exact ==. The tolerance is far tighter than any DIP gap under test
+        // (16 vs 20 vs 28), so it cannot mask a real mismatch.
+        static bool IsSize(double actual, double expected) =>
+            global::System.Math.Abs(actual - expected) < 0.0001;
+
         public override async Task RunAsync()
         {
             var host = H.CreateHost();
@@ -1095,10 +1102,11 @@ internal static class ReconcilerBigCoverageFixtures
             // CreateFontIcon fails here instead of passing on a coincidental
             // control default.
             H.Check("IconFontSize_GlyphAndSizeProjected",
-                sized?.Glyph == "\uE71B"
-                && sized?.FontSize == Sized
+                sized is not null
+                && sized.Glyph == "\uE71B"
+                && IsSize(sized.FontSize, Sized)
                 && unsized is not null
-                && unsized.FontSize != Sized);
+                && !IsSize(unsized.FontSize, Sized));
 
             // The divergence that makes Icon(FontIcon(glyph, fontSize:)) usable
             // wherever Icon(glyph) was: with no family supplied, the mounted
@@ -1110,7 +1118,8 @@ internal static class ReconcilerBigCoverageFixtures
                 (IconResolver.ResolveIconString("\uE700") as WinXC.FontIcon)?.FontFamily?.Source;
             H.Check("IconFontSize_DefaultFamilyMatchesGlyphResolver",
                 handAssigned is not null
-                && sized?.FontFamily?.Source == handAssigned);
+                && sized is not null
+                && sized.FontFamily?.Source == handAssigned);
 
             // …and an author-supplied family still wins over that default. This
             // is the arm that traps deleting the `if (fi.FontFamily is not null)`
@@ -1138,8 +1147,9 @@ internal static class ReconcilerBigCoverageFixtures
             // explicit size rides through unchanged.
             var afterGlyphSwap = FindSizedIcon();
             H.Check("IconFontSize_GlyphSwapKeepsSize",
-                afterGlyphSwap?.Glyph == "\uE73E"
-                && afterGlyphSwap?.FontSize == Sized
+                afterGlyphSwap is not null
+                && afterGlyphSwap.Glyph == "\uE73E"
+                && IsSize(afterGlyphSwap.FontSize, Sized)
                 && H.FindControl<WinXC.FontIcon>(f => f.Glyph == "\uE71B") is null);
 
             H.ClickButton("IconSizePhase");
@@ -1150,8 +1160,9 @@ internal static class ReconcilerBigCoverageFixtures
             // and an author resizing an icon across renders silently gets nothing.
             var afterResize = FindSizedIcon();
             H.Check("IconFontSize_SizeChangePatched",
-                afterResize?.FontSize == Resized
-                && afterResize?.Glyph == "\uE73E");
+                afterResize is not null
+                && IsSize(afterResize.FontSize, Resized)
+                && afterResize.Glyph == "\uE73E");
         }
 
         // The differential control deliberately uses a third glyph, so match on

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -1130,6 +1130,7 @@ internal static class SelfTestFixtureRegistry
         "RBC_ExpanderTemplateTransitionEvents",
         "RBC_PrivateUpdateHotPaths",
         "RBC_PrivateMountHotPaths",
+        "RBC_IconElementFontIconSizing",
 
         // Issue #142 — controls with private static readonly DPs
         "Issue142_CustomControlPrivateDp_Renders",
@@ -2732,6 +2733,7 @@ internal static class SelfTestFixtureRegistry
         "RBC_ExpanderTemplateTransitionEvents" => new ReconcilerBigCoverageFixtures.ExpanderTemplateTransitionEvents(harness),
         "RBC_PrivateUpdateHotPaths" => new ReconcilerBigCoverageFixtures.PrivateUpdateHotPaths(harness),
         "RBC_PrivateMountHotPaths" => new ReconcilerBigCoverageFixtures.PrivateMountHotPaths(harness),
+        "RBC_IconElementFontIconSizing" => new ReconcilerBigCoverageFixtures.IconElementFontIconSizing(harness),
 
         "Issue142_CustomControlPrivateDp_Renders" => new Issue142Fixtures.CustomControlPrivateDp_Renders(harness),
         "Issue142_ThirdPartyControlPrivateDp_Renders" => new Issue142Fixtures.ThirdPartyControlPrivateDp_Renders(harness),


### PR DESCRIPTION
## The bug

The gallery title bar's two right-header buttons rendered clipped glyphs — the link icon lost its trailing half, the moon lost its right edge.

![before and after](https://github.com/user-attachments/assets/3cdfa82c-23c6-4c06-88a5-54c09a8a16bb)

## Root cause

Both buttons are `40×36`. WinUI's default `Button` padding is `11,5,11,6`, leaving **18 DIP** of content width. `Icon("\uE71B")` resolves (via `IconResolver.ResolveIconString`) to a `FontIcon` at its default **20 DIP** size, so the glyph overflowed the content box and was clipped on the right.

Measured on the live window: glyph ink spanned `x:1654..1669`, terminating exactly on the `1653..1670` content boundary — while the title bar's own back / pane-toggle glyphs render at 16 DIP.

## Fix

Size both glyphs to 16 DIP (what the WinUI `TitleBar` template already uses for its own chrome) and zero the button padding so the icon centres in the full `40×36` box.

| | before | after |
|---|---|---|
| link ink | 16×11, cut on right | 16×9, complete + centred |
| moon ink | 14×20, cut on right | 15×16, complete + centred |

Also verified in dark theme (the `\uE706` sun arm) and for the transient "copied" checkmark state:

![dark theme](https://github.com/user-attachments/assets/2232e3c2-bccd-4f53-80fd-8a1e576fe305)

## Test

The fix moves both buttons onto the standalone `Icon(FontIcon(glyph, fontSize:))` path, which had **no** coverage. Two distinct code paths carry it:

- **mount** — `IconResolver.CreateFontIcon`, which assigns `FontFamily` only when the author supplied one, unlike `ResolveIconString` which assigns `ResolveSymbolFontFamily()` by hand. If those two ever land on different families, typed glyph icons render tofu.
- **update** — `IconElement.PatchIcon`'s same-subtype patch, which rewrites `Glyph` and `FontSize` in place.

`RBC_IconElementFontIconSizing` mounts the gallery's exact shape, swaps the glyph at a constant size, then changes the size, and also pins the zero padding the fix depends on.

Every check was **mutation-verified** against product code — one oracle each. Each mutation failed exactly its own check and no others:

| check | mutated product code |
|---|---|
| `GlyphAndSizeProjected` | `CreateFontIcon` FontSize write |
| `ExplicitFamilyWins` | `CreateFontIcon` FontFamily write |
| `DefaultFamilyMatchesGlyphResolver` | `ResolveSymbolFontFamily` theme-resource arm |
| `ZeroPaddingApplied` | `ApplyModifiers` padding write |
| `GlyphSwapKeepsSize` | `PatchIcon` Glyph write |
| `SizeChangePatched` | `PatchIcon` FontSize write |

## Commits

| | |
|---|---|
| `b5a2f09` | the gallery fix |
| `4a930b3` | the selftest fixture |
| `31f19cb` | code-quality review: tolerance-based FontSize comparison + hoisted null guards |
| `d4d5468` | second review pass: scope the default-family check's claim honestly |

## Review trail

Two full passes of the repo's `pr-review` skill (8 dimensions each, multi-model cross-check on a different model family), plus three Copilot review rounds.

- **Pass 1** (over `b5a2f09`) — 0 critical, 0 high, 1 medium: the `Icon(FontIcon(..., fontSize:))` path had no coverage. Closed by the fixture.
- **Pass 2** (over the full branch, since the fixture landed after pass 1) — 1 medium: the comment on `DefaultFamilyMatchesGlyphResolver` overclaimed. Under a live app `ResolveSymbolFontFamily` returns from its theme-resource arm, so the check traps a retarget of *that* arm — what the mutation run exercised — but not the `?? SymbolFontFallback` tail, which never executes in this host. Comment rewritten to say so, in the style of the existing "Scope, honestly:" note in `PrivateMountHotPaths`.
- **Declined:** pass 2 also raised two `high` findings alleging `Button("\uE713")` renders tofu in `ControlPages/Navigation/TitleBarPage.cs` and `docs/_pipeline/templates/windows.md.dt`. Both files are outside this diff, and the claim rests on Windows PUA font fallback, which is unverified — the multi-model cross-check disputed both and also found the paired `⚙` is U+2699, which *is* in normal text fonts. Filed as #979 instead of expanding this PR.
- **Copilot rounds:** round 1 → no comments from Copilot; `github-code-quality[bot]` raised 4 (one float-equality, three constant-condition), all fixed in `31f19cb`, each replied to and resolved. Rounds 2 and 3 → no new comments.

## Validation

- `--self-test --filter "RBC_"` green locally; CI **18 pass / 2 skipped / 0 fail**, including Selftests, AOT Selftests, AOT Trim Proof, E2E, and Docs build
- `samples/ReactorGallery` builds clean (0 errors, no `REACTOR_*` diagnostics)
- `dotnet run --project tools/Reactor.SearchIndex` — no drift; the generator reads only `ControlRegistry.cs`, `PageRouter.cs` and `ControlPages/**`, none of which this touches
- No public API change, so `skills/reactor.api.txt` needs no regeneration