### PR TITLE
test: fix flaky-test regressions and root-cause the selftest/E2E flake families

### DIFF
--- a/.github/skills/coverage-uplift/SKILL.md
+++ b/.github/skills/coverage-uplift/SKILL.md
@@ -56,8 +56,12 @@ dotnet-coverage merge coverage\unit.cobertura.xml coverage\selftest.cobertura.xm
   --output coverage\merged.cobertura.xml --output-format cobertura
 ```
 
-Known flakes to ignore (not your regression): `CenterOnCurrent_UsesCursorMonitor`,
-`PersistPlacement_FallbackWhenEmpty`, `PersistenceEtwBridgeTests.JsonFileStore_*`.
+Known flakes to ignore (not your regression) — note they are **not all unit tests**:
+`CenterOnCurrent_UsesCursorMonitor` and `PersistPlacement_FallbackWhenEmpty` are **selftest
+fixtures** (`Phase1WindowingFixtures.cs` / `Phase3WindowingFixtures.cs`) running the same
+cursor-monitor assertion, so they fail as a pair; a preceding E2E run moves the pointer and
+flips both. `PersistenceEtwBridgeTests.JsonFileStore_*` is the only **unit** one
+(`Reactor.Tests/Diagnostics/`), and is cross-test ETW bleed that passes in isolation.
 
 ### 2. Classify each gap by tier
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -226,6 +226,21 @@ Hard-won specifics that repeatedly cost sessions time. Prefer these exact comman
     `--self-test`; both are clean on a quiet machine.
   - **unit** — `PersistenceEtwBridgeTests.JsonFileStore_*` (`Reactor.Tests/Diagnostics/`),
     cross-test ETW/event-source bleed. Fails only in the full-suite run; passes in isolation.
+- **Judging whether a flake fix worked.** N clean runs only supports a fix if `(1-p)^N` is
+  small for the *observed* failure rate `p`. At `p = 0.25`, three consecutive passes happen
+  **42%** of the time — so "3 clean runs" is consistent with the bug being entirely unfixed,
+  and roughly `N = 10` is needed for ~95% confidence. This is the "did this check have the
+  power to return the other answer?" test in probabilistic clothing, and it is the same
+  question the non-vacuous-assertion rule above asks. Prefer a *mechanism* that explains the
+  observed failure text over any number of green runs; run counts corroborate a cause, they
+  don't establish one.
+- **Budget increases only refute one class of race.** Raising a poll/wait budget and still
+  failing rules out "we sampled too early". It does not rule out an event that never fires,
+  an ordering race decided before the first poll, or a lost wakeup — all budget-insensitive.
+  The sound conclusion is "not a *too-short-poll* problem", which is narrower than "not a
+  race". Don't let the narrower finding promote a fixture into an "environmental" bucket it
+  then stops being investigated in; confirm that label by running it on a quiet machine with
+  a known window-manager state, and only apply it if it goes clean there.
 
 ### Analyzers, CLI checks, docs & public API
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -194,7 +194,12 @@ Hard-won specifics that repeatedly cost sessions time. Prefer these exact comman
   For stateful E2E/selftest UI use `Component<T>()` fixtures; raw `ctx.UseState` doesn't
   persist (TestHost renders with a fresh `RenderContext`).
 
-### Writing tests that actually prove something
+### Checks that actually prove something
+
+Applies to anything whose output you would act on: xUnit assertions, selftest
+`H.Check`s, and the ad-hoc commands you verify state with — log greps, freshness
+checks, CI queries. The failure mode is identical in all three, and the last one is
+the one that bites hardest, because a broken instrument is trusted by default.
 
 - **Every assertion must fail if its target code is deleted / no-op'd / returns default.**
   Bare non-null, "no throw" on a `void`, and always-emitted shape markers are vacuous.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -209,9 +209,23 @@ Hard-won specifics that repeatedly cost sessions time. Prefer these exact comman
   `tests/Reactor.AppTests.Host/FixtureRegistry.cs`.
 - **Coverage** starts from `tools/coverage/run-coverage.ps1` (`-UnitOnly`, `-SkipBuild`);
   output `coverage/merged.cobertura.xml`. The script **aborts before the merge step on any
-  test failure** — if a known flake trips it (`CenterOnCurrent_UsesCursorMonitor`,
-  `PersistPlacement_FallbackWhenEmpty`, `PersistenceEtwBridgeTests.JsonFileStore_*`), merge
-  the legs manually with `dotnet-coverage merge coverage\unit.cobertura.xml coverage\selftest.cobertura.xml --output coverage\merged.cobertura.xml --output-format cobertura`.
+  test failure** — if a known flake trips it, merge the legs manually with
+  `dotnet-coverage merge coverage\unit.cobertura.xml coverage\selftest.cobertura.xml --output coverage\merged.cobertura.xml --output-format cobertura`.
+  Those known flakes span **two tiers** — don't go hunting for all three in `Reactor.Tests`:
+  - **selftest** — `CenterOnCurrent_UsesCursorMonitor` (`Phase1WindowingFixtures.cs`) and
+    `PersistPlacement_FallbackWhenEmpty` (`Phase3WindowingFixtures.cs`). These two are the
+    *same assertion twice*: both open a `WindowStartPosition.CenterOnCurrent` window and check
+    its centre lands in the work area of the monitor under the mouse, so they fail as a **pair**
+    — seeing only one of them is the surprise, not seeing both. Two distinct causes, neither a
+    render-timing race, so `WaitFor` will not help:
+    (a) a TOCTOU — `GetCursorPos` is sampled *before* `OpenAndSettle`, so a cursor that crosses
+    a monitor boundary while the window is opening invalidates the captured work rect; and
+    (b) `haveCursor` is `&&`-ed into the assertion, so when `GetCursorPos` itself fails
+    (locked / disconnected / headless session) the check reports a plain failure rather than
+    skipping. Reproduce by running the E2E suite first — it moves the pointer — then
+    `--self-test`; both are clean on a quiet machine.
+  - **unit** — `PersistenceEtwBridgeTests.JsonFileStore_*` (`Reactor.Tests/Diagnostics/`),
+    cross-test ETW/event-source bleed. Fails only in the full-suite run; passes in isolation.
 
 ### Analyzers, CLI checks, docs & public API
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -226,6 +226,16 @@ Hard-won specifics that repeatedly cost sessions time. Prefer these exact comman
     `--self-test`; both are clean on a quiet machine.
   - **unit** — `PersistenceEtwBridgeTests.JsonFileStore_*` (`Reactor.Tests/Diagnostics/`),
     cross-test ETW/event-source bleed. Fails only in the full-suite run; passes in isolation.
+- **Don't co-locate the E2E and selftest tiers.** CI runs them as separate jobs on separate
+  runners today, and that isolation is load-bearing rather than incidental. E2E drives real
+  pointer input, foregrounds windows and changes Z-order; several selftest fixtures read live
+  desktop state (the two `CenterOnCurrent`-based ones above read the cursor's monitor;
+  `UseIsCovered_RerendersOnZOrderChange` reads Z-order). Running E2E first on one machine and
+  then `--self-test` took a clean unmodified tree from 0 to 8 failures — reproducible, and the
+  standing repro for those fixtures. So if you consolidate jobs to save runner minutes, or run
+  both tiers locally back-to-back, expect selftest reds that are an artefact of tier ordering
+  and not of your change. Fix the fixtures' desktop-state dependence before merging the jobs,
+  not after.
 - **Judging whether a flake fix worked.** N clean runs only supports a fix if `(1-p)^N` is
   small for the *observed* failure rate `p`. At `p = 0.25`, three consecutive passes happen
   **42%** of the time — so "3 clean runs" is consistent with the bug being entirely unfixed,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -207,6 +207,25 @@ Hard-won specifics that repeatedly cost sessions time. Prefer these exact comman
   `Create()` switch in `tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs`.
   E2E: add to `AllFixtures` **and** the `Build` switch in
   `tests/Reactor.AppTests.Host/FixtureRegistry.cs`.
+- **…which makes searching for a TAP name unsafe unless you search the whole tree.** TAP
+  carries two kinds of name and they live in different files: *fixture* names (registry only,
+  and the class they map to is often spelled differently — `CenterOnCurrent_UsesCursorMonitor`
+  → `CenterOnCurrentUsesCursorMonitor`) and *check* names (string literals in `H.Check(...)`
+  inside `Fixtures/`). Neither location is a superset:
+
+  | probe | blind spot |
+  |---|---|
+  | grep `SelfTest/Fixtures/` only | fixture names whose class name differs |
+  | grep `SelfTestFixtureRegistry.cs` only | check-only names — e.g. `WindowLevel_RuntimeFlip_Topmost`, `TabViewFill_Mounted`, `ExitTr_Removed` are all registry=0 |
+  | **grep `tests/Reactor.AppTests.Host/` whole** | **none — use this** |
+
+  Both narrow probes return a *confident zero*, which reads as "this fixture doesn't exist"
+  and invites re-attributing a real flake as branch-local or renamed. Both directions were hit
+  during one flakiness audit, and the check-only example above is the assertion at the centre
+  of issue #927 — a rule that silently fails on the most-discussed flake in the audit is worse
+  than no rule, because its user has no reason to doubt the answer. Two probes with
+  complementary blind spots don't compose into coverage unless you run both, and if you're
+  running both the whole-tree grep is cheaper than remembering why.
 - **Coverage** starts from `tools/coverage/run-coverage.ps1` (`-UnitOnly`, `-SkipBuild`);
   output `coverage/merged.cobertura.xml`. The script **aborts before the merge step on any
   test failure** — if a known flake trips it, merge the legs manually with

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -241,8 +241,9 @@ Hard-won specifics that repeatedly cost sessions time. Prefer these exact comman
     a monitor boundary while the window is opening invalidates the captured work rect; and
     (b) `haveCursor` is `&&`-ed into the assertion, so when `GetCursorPos` itself fails
     (locked / disconnected / headless session) the check reports a plain failure rather than
-    skipping. Reproduce by running the E2E suite first — it moves the pointer — then
-    `--self-test`; both are clean on a quiet machine.
+    skipping. On a quiet machine both pass — which is precisely why they read as
+    nondeterministic. To make them fail **on demand**, run the E2E suite first (it moves the
+    pointer and changes Z-order), then `--self-test`.
   - **unit** — `PersistenceEtwBridgeTests.JsonFileStore_*` (`Reactor.Tests/Diagnostics/`),
     cross-test ETW/event-source bleed. Fails only in the full-suite run; passes in isolation.
 - **Don't co-locate the E2E and selftest tiers.** CI runs them as separate jobs on separate

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -235,15 +235,23 @@ Hard-won specifics that repeatedly cost sessions time. Prefer these exact comman
     `PersistPlacement_FallbackWhenEmpty` (`Phase3WindowingFixtures.cs`). These two are the
     *same assertion twice*: both open a `WindowStartPosition.CenterOnCurrent` window and check
     its centre lands in the work area of the monitor under the mouse, so they fail as a **pair**
-    — seeing only one of them is the surprise, not seeing both. Two distinct causes, neither a
-    render-timing race, so `WaitFor` will not help:
-    (a) a TOCTOU — `GetCursorPos` is sampled *before* `OpenAndSettle`, so a cursor that crosses
-    a monitor boundary while the window is opening invalidates the captured work rect; and
-    (b) `haveCursor` is `&&`-ed into the assertion, so when `GetCursorPos` itself fails
-    (locked / disconnected / headless session) the check reports a plain failure rather than
-    skipping. On a quiet machine both pass — which is precisely why they read as
-    nondeterministic. To make them fail **on demand**, run the E2E suite first (it moves the
-    pointer and changes Z-order), then `--self-test`.
+    — seeing only one of them is the surprise, not seeing both. Neither is a render-timing race,
+    so `WaitFor` will not help. **Two different mechanisms in two different environments — check
+    which one you are in before theorising:**
+    - **Non-interactive session (CI agents, RDP-disconnected, locked, headless).**
+      `GetCursorPos` returns **ACCESS_DENIED (err 5)** and never writes its `out` param, so the
+      cursor monitor cannot be determined at all. This is a **100% deterministic failure, not a
+      flake** — the pair simply cannot pass there. Confirmed by direct P/Invoke probe on two
+      separate machines. Fixed by skipping rather than asserting when the cursor is
+      undeterminable; if you see these fail, probe first:
+      `GetCursorPos(out p)` → `False` / `LastError=5` means you are in this case and the fixtures
+      are innocent. Note `System.Windows.Forms.Cursor.Position` **hides** this — it surfaces the
+      uninitialised `(0,0)` instead of the failure.
+    - **Interactive multi-monitor box.** A TOCTOU: `GetCursorPos` is sampled *before*
+      `OpenAndSettle`, so a cursor crossing a monitor boundary while the window opens invalidates
+      the captured work rect. Intermittent, and **structurally impossible on a single display** —
+      if you are on one virtual desktop with no boundary to cross, this is not your mechanism.
+    Do not assume "quiet machine ⇒ passes": that holds only in the interactive case.
   - **unit** — `PersistenceEtwBridgeTests.JsonFileStore_*` (`Reactor.Tests/Diagnostics/`),
     cross-test ETW/event-source bleed. Fails only in the full-suite run; passes in isolation.
 - **Don't co-locate the E2E and selftest tiers.** CI runs them as separate jobs on separate

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -203,6 +203,34 @@ Hard-won specifics that repeatedly cost sessions time. Prefer these exact comman
   corrupt-then-recompute oracles. **Copilot review does not catch vacuous assertions** —
   run the `.github/skills/pr-review/` multi-model dimension (different model family, high
   reasoning) on the *final* commit and fix every finding.
+- **Mutation testing does not reach an assertion whose *inputs* are environment-derived.**
+  It perturbs the code under test, so it only exposes an oracle whose value depends on that
+  code. `double preOffset = sv.VerticalOffset;` … `Math.Abs(sv.VerticalOffset - preOffset)
+  <= 3.0` passes identically in a healthy and a degraded environment when both sides are
+  `0.00` — no product mutation separates them. **Log the input once, not just the verdict:**
+  if a value read from live state is `0`, `NaN`, empty, or equal to the thing it is compared
+  against, the assertion is a tautology regardless of what the product does. Same shape as a
+  `-1` "not found" sentinel satisfying `bodyOn > bodyOff * 3` (`-1 > -3`) — prefer
+  `double.NaN`, which makes every comparison false. The bug is upstream of the comparison.
+- **The obvious remediation can itself be the vacuous one.** `Harness.WaitFor(P)` establishes
+  P *at the moment it returns* and nothing more — it evaluates P **before** its first
+  `Render`. So converting a fixed delay to a `WaitFor` is correct for an *eventual* assertion
+  (false at t=0, converges) and silently vacuous for a *survival* assertion ("still visible"),
+  which is true at t=0 and short-circuits at zero elapsed time. Before converting, ask: **if
+  the predicate is true the instant `WaitFor` is called, does the next assertion still mean
+  what I think it means?** Same question for a precondition `throw`: report-and-return when
+  the fixture's other checks remain meaningful, throw loudly when it is structurally invalid
+  (a renamed reflection target) and they do not.
+- **This applies to your verification tooling, not just to tests.** A check that cannot fail
+  loudly will eventually report something false with total confidence, and the direction is
+  arbitrary — it can manufacture an alarm or an all-clear, and nobody audits the one that says
+  what they hoped. A malformed `gh --jq` expression exits non-zero to stderr while a pipeline
+  reading stdout sees an empty string indistinguishable from a legitimate zero. Prefer
+  parameterised GraphQL (`-f`/`-F`, no interpolation), or fetch JSON and filter in the host
+  language so a parse failure throws. **The tell is implausible uniformity:** an identical
+  value across subjects that have nothing in common is a bug report about the instrument.
+  The unifying question for a test and a tool alike is the same — **could this have come out
+  the other way?**
 - **Fixture registration is two-place.** Selftest: add to `AllFixtures` **and** the
   `Create()` switch in `tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs`.
   E2E: add to `AllFixtures` **and** the `Build` switch in

--- a/TESTING.md
+++ b/TESTING.md
@@ -120,6 +120,11 @@ Rules of thumb:
 
 - **`Render` only when you literally need an event-queue pump.** Anything that may be delayed (layout, control realization, template part materialization, `Loaded` cascades, lazy content presenters) needs `WaitFor` (predicate-based) or a bounded `WaitForIdleAsync` loop — not `Render` alone.
 - **`WaitFor` over a single `Render` + snapshot probe.** A one-shot probe right after `Render()` is the classic flake source on contended/AOT runners. `WaitFor` re-queries; `Render` is a single wave.
+- **But NOT for negative or exact-count assertions — `WaitFor` short-circuits.** `WaitFor` evaluates the predicate *before* its first `Render`, so it returns immediately when the predicate is already true. That makes it the wrong primitive whenever the delay is itself the observation window:
+  - *"X did not happen"* / *"fired exactly once"* / *"state is unchanged"* — e.g. `count == 0`, `CycleCountForTests == 1`, `IsExpanded` still true. Converting these to `WaitFor` makes them **vacuous**: they pass at t=0 without ever giving a violation time to appear. Keep an explicit `Render(N)` window and assert after it.
+  - Conversely, `WaitFor` is correct for *positive eventual* conditions — a control appears, a bit flips, a callback lands — because the predicate is false until the transition completes.
+  - The test: **can the predicate be true before the action you are testing?** If yes, either keep the fixed window or strengthen the predicate so it cannot (e.g. gate on `sv.VerticalOffset < 1` as well as the row text, so a still-realized row can't satisfy it while scrolled away).
+- **Converting a gate can strip a settle a *later* assertion relied on.** If a following `H.Check` depended on the removed `Render(N)` rather than on its own wait, it will start failing. Give each check its own `WaitFor` instead of letting it inherit someone else's delay.
 - **`host.WaitForIdleAsync()` for isolated hosts.** If you constructed your own `ReactorHost`, neither `Harness.Render` nor `Harness.WaitFor` knows about it.
 - **Save and restore `ReactorApp.ActiveHostInternal`** when using an isolated host so subsequent fixtures see the shared host they expect (`var prev = ReactorApp.ActiveHostInternal; try { … } finally { if (prev is not null) ReactorApp.ActiveHostInternal = prev; }`).
 

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/DataGridEditFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/DataGridEditFixtures.cs
@@ -133,10 +133,9 @@ internal static class DataGridEditFixtures
                 );
             });
 
-            await Harness.Render(500);
-
             H.Check("DataGrid_Commit_InitialRender",
-                H.FindTextContaining("Product 0") is not null);
+                await Harness.WaitFor(() => H.FindTextContaining("Product 0") is not null,
+                    maxPasses: 25, perPassMs: 20));
 
             await Harness.Render(300);
 
@@ -171,10 +170,9 @@ internal static class DataGridEditFixtures
                 );
             });
 
-            await Harness.Render(500);
-
             H.Check("DataGrid_RapidSel_Renders",
-                H.FindText("Selected: 0") is not null);
+                await Harness.WaitFor(() => H.FindText("Selected: 0") is not null,
+                    maxPasses: 25, perPassMs: 20));
 
             await Harness.Render(500);
 
@@ -222,9 +220,8 @@ internal static class DataGridEditFixtures
                 return VStack(TextBlock($"Mode: {mode}"), grid);
             });
 
-            await Harness.Render(500);
-
-            H.Check("DataGrid_SelectionMode_Mounted", gridState is not null);
+            H.Check("DataGrid_SelectionMode_Mounted",
+                await Harness.WaitFor(() => gridState is not null, maxPasses: 25, perPassMs: 20));
             if (gridState is null) return;
 
             H.Check("DataGrid_SelectionMode_InitialSingle",
@@ -491,21 +488,23 @@ internal static class DataGridEditFixtures
                         emptyTemplate: TextBlock("empty-grid-template")));
             });
 
-            await Harness.Render(600);
-
             H.Check("DataGrid_RowEdit_CustomCellRendered",
-                H.FindText("cell:Name:Product 0") is not null);
+                await Harness.WaitFor(() => H.FindText("cell:Name:Product 0") is not null,
+                    maxPasses: 25, perPassMs: 20));
             H.Check("DataGrid_RowEdit_CustomHeaderRendered",
-                H.FindButton("hdr:Name:none") is not null);
+                await Harness.WaitFor(() => H.FindButton("hdr:Name:none") is not null,
+                    maxPasses: 25, perPassMs: 20));
             H.Check("DataGrid_RowEdit_SearchBoxRendered",
-                H.FindAllControls<TextBox>(_ => true).Count >= 1);
+                await Harness.WaitFor(() => H.FindAllControls<TextBox>(_ => true).Count >= 1,
+                    maxPasses: 25, perPassMs: 20));
             H.Check("DataGrid_RowEdit_EmptyTemplateRendered",
-                H.FindText("empty-grid-template") is not null);
+                await Harness.WaitFor(() => H.FindText("empty-grid-template") is not null,
+                    maxPasses: 25, perPassMs: 20));
 
             H.ClickButton("hdr:Name:none");
-            await Harness.Render(600);
             H.Check("DataGrid_RowEdit_HeaderSortUpdated",
-                H.FindButton("hdr:Name:Ascending") is not null);
+                await Harness.WaitFor(() => H.FindButton("hdr:Name:Ascending") is not null,
+                    maxPasses: 25, perPassMs: 20));
 
             H.ClickButton("Edit");
             await Harness.Render(600);
@@ -521,17 +520,17 @@ internal static class DataGridEditFixtures
                 H.FindButton("Save") is not null && H.FindButton("Cancel") is not null);
 
             H.ClickButton("Cancel");
-            await Harness.Render(400);
             H.Check("DataGrid_RowEdit_CancelClearsEditors",
-                H.FindButton("Save") is null);
+                await Harness.WaitFor(() => H.FindButton("Save") is null, maxPasses: 20, perPassMs: 15));
 
             H.ClickButton("Edit");
             await Harness.Render(500);
             H.ClickButton("Save");
-            await Harness.Render(700);
 
             H.Check("DataGrid_RowEdit_SaveCommitted",
-                lastCommit.StartsWith("0:Product 0:A:10", StringComparison.Ordinal));
+                await Harness.WaitFor(
+                    () => lastCommit.StartsWith("0:Product 0:A:10", StringComparison.Ordinal),
+                    maxPasses: 25, perPassMs: 20));
             H.Check("DataGrid_RowEdit_ReturnedToDisplay",
                 H.FindText("cell:Name:Product 0") is not null);
         }

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/DataGridExpandFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/DataGridExpandFixtures.cs
@@ -92,17 +92,22 @@ internal static class DataGridExpandFixtures
                 return VStack(TextBlock($"tick {tick}"), grid).Height(420);
             });
 
-            await Harness.Render(600);
-
-            H.Check("DataGridExpand_Mounted", state is not null);
+            H.Check("DataGridExpand_Mounted",
+                await Harness.WaitFor(() => state is not null, maxPasses: 25, perPassMs: 20));
             if (state is null) return;
 
-            H.Check("DataGridExpand_RowsRendered", H.FindTextContaining("Product 0") is not null);
+            H.Check("DataGridExpand_RowsRendered",
+                await Harness.WaitFor(() => H.FindTextContaining("Product 0") is not null,
+                    maxPasses: 25, perPassMs: 20));
 
+            await Harness.WaitFor(() => H.FindControl<ItemsRepeater>(_ => true) is not null,
+                maxPasses: 25, perPassMs: 20);
             var repeater = H.FindControl<ItemsRepeater>(_ => true);
             H.Check("DataGridExpand_RepeaterFound", repeater is not null);
             if (repeater is null) return;
 
+            await Harness.WaitFor(() => (repeater.TryGetElement(0) as FrameworkElement)?.ActualHeight > 0,
+                maxPasses: 25, perPassMs: 20);
             var collapsedRow = repeater.TryGetElement(0) as FrameworkElement;
             var collapsedHeight = collapsedRow?.ActualHeight ?? 0;
             H.Check($"DataGridExpand_CollapsedRowRealized (h={collapsedHeight:F1})",

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/DataGridParityFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/DataGridParityFixtures.cs
@@ -205,8 +205,16 @@ internal static class DataGridParityFixtures
 
             sv.ChangeView(null, 0, null, disableAnimation: true);
 
+            // The row check alone is NOT a valid oracle here: measured, `Emp-000000` is still
+            // findable while scrolled 5000px away (offset=5000, scrollable=179647), because the
+            // repeater keeps it realized. So `FindTextContaining("Emp-000000") is not null` is
+            // true before the scroll-back as well as after, and asserting it alone proves
+            // nothing about restoration — it passed identically with the old fixed
+            // `Render(600)` gate. Gate on the offset returning to the top, which IS false
+            // before this ChangeView, so the assertion must observe a real transition.
             H.Check("HookPaging_ScrollBack_OrigRestored",
-                await Harness.WaitFor(() => H.FindTextContaining("Emp-000000") is not null,
+                await Harness.WaitFor(
+                    () => sv.VerticalOffset < 1.0 && H.FindTextContaining("Emp-000000") is not null,
                     maxPasses: 25, perPassMs: 20));
         }
     }

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/DataGridParityFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/DataGridParityFixtures.cs
@@ -106,10 +106,9 @@ internal static class DataGridParityFixtures
                 ).Height(500);
             });
 
-            await Harness.Render(500);
-
             H.Check("HookPaging_Mount_FirstRowVisible",
-                H.FindTextContaining("Emp-000000") is not null);
+                await Harness.WaitFor(() => H.FindTextContaining("Emp-000000") is not null,
+                    maxPasses: 25, perPassMs: 20));
 
             H.Check("HookPaging_Mount_SecondRowVisible",
                 H.FindTextContaining("Emp-000001") is not null);
@@ -145,10 +144,9 @@ internal static class DataGridParityFixtures
                 ).Height(500);
             });
 
-            await Harness.Render(500);
-
             H.Check("HookPaging_Scroll_InitialRender",
-                H.FindTextContaining("Emp-") is not null);
+                await Harness.WaitFor(() => H.FindTextContaining("Emp-") is not null,
+                    maxPasses: 25, perPassMs: 20));
 
             var sv = H.FindControl<ScrollViewer>(s => s.Content is ItemsRepeater);
             H.Check("HookPaging_Scroll_ScrollViewerFound", sv is not null);
@@ -195,10 +193,9 @@ internal static class DataGridParityFixtures
                 ).Height(400);
             });
 
-            await Harness.Render(500);
-
             H.Check("HookPaging_ScrollBack_InitialData",
-                H.FindTextContaining("Emp-000000") is not null);
+                await Harness.WaitFor(() => H.FindTextContaining("Emp-000000") is not null,
+                    maxPasses: 25, perPassMs: 20));
 
             var sv = H.FindControl<ScrollViewer>(s => s.Content is ItemsRepeater);
             if (sv is null) { H.Check("HookPaging_ScrollBack_SVFound", false); return; }
@@ -207,10 +204,10 @@ internal static class DataGridParityFixtures
             await Harness.Render(600);
 
             sv.ChangeView(null, 0, null, disableAnimation: true);
-            await Harness.Render(600);
 
             H.Check("HookPaging_ScrollBack_OrigRestored",
-                H.FindTextContaining("Emp-000000") is not null);
+                await Harness.WaitFor(() => H.FindTextContaining("Emp-000000") is not null,
+                    maxPasses: 25, perPassMs: 20));
         }
     }
 
@@ -240,10 +237,9 @@ internal static class DataGridParityFixtures
                 ).Height(600);
             });
 
-            await Harness.Render(500);
-
             H.Check("HookPaging_Small_FirstRowVisible",
-                H.FindTextContaining("Emp-000000") is not null);
+                await Harness.WaitFor(() => H.FindTextContaining("Emp-000000") is not null,
+                    maxPasses: 25, perPassMs: 20));
 
             H.Check("HookPaging_Small_LastRowVisible",
                 H.FindTextContaining("Emp-000011") is not null);

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/DataGridParityFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/DataGridParityFixtures.cs
@@ -111,7 +111,8 @@ internal static class DataGridParityFixtures
                     maxPasses: 25, perPassMs: 20));
 
             H.Check("HookPaging_Mount_SecondRowVisible",
-                H.FindTextContaining("Emp-000001") is not null);
+                await Harness.WaitFor(() => H.FindTextContaining("Emp-000001") is not null,
+                    maxPasses: 25, perPassMs: 20));
 
             // Hook should fetch only a small number of pages to fill the viewport
             // (page-0 plus the prefetch window). Allow slack for framerate settle.
@@ -261,7 +262,8 @@ internal static class DataGridParityFixtures
                     maxPasses: 25, perPassMs: 20));
 
             H.Check("HookPaging_Small_LastRowVisible",
-                H.FindTextContaining("Emp-000011") is not null);
+                await Harness.WaitFor(() => H.FindTextContaining("Emp-000011") is not null,
+                    maxPasses: 25, perPassMs: 20));
 
             H.Check($"HookPaging_Small_SinglePageFetch (calls={source!.CallCount})",
                 source.CallCount == 1);

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/DataGridParityFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/DataGridParityFixtures.cs
@@ -201,7 +201,18 @@ internal static class DataGridParityFixtures
             if (sv is null) { H.Check("HookPaging_ScrollBack_SVFound", false); return; }
 
             sv.ChangeView(null, 5000, null, disableAnimation: true);
-            await Harness.Render(600);
+
+            // Assert the scroll-away actually happened before relying on it. The restore oracle
+            // below is only meaningful if the view really left the top: if this ChangeView clamps
+            // or no-ops, VerticalOffset stays 0, and `VerticalOffset < 1.0` is then already true
+            // when WaitFor first evaluates it — putting the check straight back into the vacuous
+            // state this whole gate was strengthened to escape. Same guard idiom as
+            // ChartKeyboardNavTests.InvokeAndAssertFreshIndex: prove the precondition is NOT the
+            // state you are about to wait for.
+            bool scrolledAway = await Harness.WaitFor(() => sv.VerticalOffset > 1.0,
+                maxPasses: 25, perPassMs: 20);
+            H.Check("HookPaging_ScrollBack_ScrolledAwayFirst", scrolledAway);
+            if (!scrolledAway) return;
 
             sv.ChangeView(null, 0, null, disableAnimation: true);
 
@@ -210,8 +221,8 @@ internal static class DataGridParityFixtures
             // repeater keeps it realized. So `FindTextContaining("Emp-000000") is not null` is
             // true before the scroll-back as well as after, and asserting it alone proves
             // nothing about restoration — it passed identically with the old fixed
-            // `Render(600)` gate. Gate on the offset returning to the top, which IS false
-            // before this ChangeView, so the assertion must observe a real transition.
+            // `Render(600)` gate. Gate on the offset returning to the top, which the guard above
+            // has now proven is false before this ChangeView.
             H.Check("HookPaging_ScrollBack_OrigRestored",
                 await Harness.WaitFor(
                     () => sv.VerticalOffset < 1.0 && H.FindTextContaining("Emp-000000") is not null,

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/HostingCoverageFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/HostingCoverageFixtures.cs
@@ -66,9 +66,10 @@ internal static class HostingCoverageFixtures
                 ((Microsoft.UI.Xaml.Automation.Provider.IInvokeProvider)
                     peer.GetPattern(Microsoft.UI.Xaml.Automation.Peers.PatternInterface.Invoke)).Invoke();
             }
-            await Harness.Render(200);
-            text = FindInContainer<TextBlock>(hostControl, tb => tb.Text?.StartsWith("Hosted:") == true);
-            H.Check("HostCtrl_Updated", text?.Text == "Hosted:1");
+            H.Check("HostCtrl_Updated", await Harness.WaitFor(
+                () => FindInContainer<TextBlock>(hostControl, tb => tb.Text?.StartsWith("Hosted:") == true)
+                          ?.Text == "Hosted:1",
+                maxPasses: 16, perPassMs: 10));
 
             // Dispose
             hostControl.Dispose();
@@ -116,9 +117,10 @@ internal static class HostingCoverageFixtures
                 ((Microsoft.UI.Xaml.Automation.Provider.IInvokeProvider)
                     peer.GetPattern(Microsoft.UI.Xaml.Automation.Peers.PatternInterface.Invoke)).Invoke();
             }
-            await Harness.Render(200);
-            text = FindInContainer<TextBlock>(hostControl, tb => tb.Text?.StartsWith("Func:") == true);
-            H.Check("HostCtrlFunc_Updated", text?.Text == "Func:world");
+            H.Check("HostCtrlFunc_Updated", await Harness.WaitFor(
+                () => FindInContainer<TextBlock>(hostControl, tb => tb.Text?.StartsWith("Func:") == true)
+                          ?.Text == "Func:world",
+                maxPasses: 16, perPassMs: 10));
 
             hostControl.Dispose();
             H.SetContent(null);
@@ -404,9 +406,10 @@ internal static class HostingCoverageFixtures
                 ((Microsoft.UI.Xaml.Automation.Provider.IInvokeProvider)
                     peer.GetPattern(Microsoft.UI.Xaml.Automation.Peers.PatternInterface.Invoke)).Invoke();
             }
-            await Harness.Render(200);
-            text = FindInContainer<TextBlock>(hostControl, tb => tb.Text?.StartsWith("Reparent:") == true);
-            H.Check("HostCtrlReparent_PreReparentInteractive", text?.Text == "Reparent:1");
+            H.Check("HostCtrlReparent_PreReparentInteractive", await Harness.WaitFor(
+                () => FindInContainer<TextBlock>(hostControl, tb => tb.Text?.StartsWith("Reparent:") == true)
+                          ?.Text == "Reparent:1",
+                maxPasses: 16, perPassMs: 10));
 
             // Raw-WinUI reparent A -> B (drag between dock groups, TabView pivot, etc.)
             slotA.Child = null;
@@ -426,9 +429,10 @@ internal static class HostingCoverageFixtures
                 ((Microsoft.UI.Xaml.Automation.Provider.IInvokeProvider)
                     peer.GetPattern(Microsoft.UI.Xaml.Automation.Peers.PatternInterface.Invoke)).Invoke();
             }
-            await Harness.Render(200);
-            text = FindInContainer<TextBlock>(hostControl, tb => tb.Text?.StartsWith("Reparent:") == true);
-            H.Check("HostCtrlReparent_InteractiveAfterReparent", text?.Text == "Reparent:2");
+            H.Check("HostCtrlReparent_InteractiveAfterReparent", await Harness.WaitFor(
+                () => FindInContainer<TextBlock>(hostControl, tb => tb.Text?.StartsWith("Reparent:") == true)
+                          ?.Text == "Reparent:2",
+                maxPasses: 16, perPassMs: 10));
 
             // Reparent back B -> A: state persists, still interactive.
             slotB.Child = null;
@@ -445,9 +449,10 @@ internal static class HostingCoverageFixtures
                 ((Microsoft.UI.Xaml.Automation.Provider.IInvokeProvider)
                     peer.GetPattern(Microsoft.UI.Xaml.Automation.Peers.PatternInterface.Invoke)).Invoke();
             }
-            await Harness.Render(200);
-            text = FindInContainer<TextBlock>(hostControl, tb => tb.Text?.StartsWith("Reparent:") == true);
-            H.Check("HostCtrlReparent_InteractiveRoundTrip", text?.Text == "Reparent:3");
+            H.Check("HostCtrlReparent_InteractiveRoundTrip", await Harness.WaitFor(
+                () => FindInContainer<TextBlock>(hostControl, tb => tb.Text?.StartsWith("Reparent:") == true)
+                          ?.Text == "Reparent:3",
+                maxPasses: 16, perPassMs: 10));
 
             // Consumer-driven Dispose still works after a reparent cycle.
             hostControl.Dispose();

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ItemsViewFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ItemsViewFixtures.cs
@@ -171,10 +171,9 @@ internal static class ItemsViewFixtures
                 ).Height(300)
             );
 
-            await Harness.Render(50);
-
             H.Check("ItemsView_Update_NewItemVisible",
-                H.FindTextContaining("Fig") is not null);
+                await Harness.WaitFor(() => H.FindTextContaining("Fig") is not null,
+                    maxPasses: 12, perPassMs: 10));
             H.Check("ItemsView_Update_OldItemsStillVisible",
                 H.FindTextContaining("Apple") is not null);
         }

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/Phase1WindowingFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/Phase1WindowingFixtures.cs
@@ -254,10 +254,25 @@ internal static class Phase1WindowingFixtures
                 var pos = win.AppWindow.Position;
                 var size = win.AppWindow.Size;
                 var center = (X: pos.X + size.Width / 2, Y: pos.Y + size.Height / 2);
-                bool inCursorWorkArea = haveCursor
-                    && center.X >= work.Left && center.X < work.Right
-                    && center.Y >= work.Top && center.Y < work.Bottom;
-                H.Check("CenterOnCurrent_UsesCursorMonitor", inCursorWorkArea);
+                // `haveCursor == false` means the cursor position could not be DETERMINED, not
+                // that the window landed wrong. GetCursorPos returns ACCESS_DENIED (err 5) on any
+                // session that is not the interactive input desktop — CI agents, RDP-disconnected
+                // and locked sessions, and headless boxes. &&-ing it into the assertion turned
+                // "cannot tell" into "failed", which made this fixture and its Phase3 twin fail
+                // 100% of the time on such machines while looking like a flake. Skip instead:
+                // an undeterminable precondition is not a product defect. Verified by direct
+                // P/Invoke probe on two separate machines (GetCursorPos -> False, LastError=5).
+                if (!haveCursor)
+                {
+                    H.Skip("CenterOnCurrent_UsesCursorMonitor",
+                        "GetCursorPos unavailable (non-interactive desktop) — cursor monitor cannot be determined");
+                }
+                else
+                {
+                    H.Check("CenterOnCurrent_UsesCursorMonitor",
+                        center.X >= work.Left && center.X < work.Right
+                        && center.Y >= work.Top && center.Y < work.Bottom);
+                }
             }
             finally { await CloseAndSettle(win); }
         }

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/Phase2WindowingFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/Phase2WindowingFixtures.cs
@@ -153,8 +153,9 @@ internal static class Phase2WindowingFixtures
             {
                 H.Check("ResizeMode_RuntimeUpdate_InitiallyResizable", HasStyle(win, Native.WS_THICKFRAME));
                 win.Update(spec with { ResizeMode = WindowResizeMode.NoResize });
-                await Harness.Render(50);
-                H.Check("ResizeMode_RuntimeUpdate_ResizeDisabled", !HasStyle(win, Native.WS_THICKFRAME));
+                H.Check("ResizeMode_RuntimeUpdate_ResizeDisabled",
+                    await Harness.WaitFor(() => !HasStyle(win, Native.WS_THICKFRAME),
+                        maxPasses: 12, perPassMs: 10));
                 H.Check("ResizeMode_RuntimeUpdate_MinMaxDisabled", !HasStyle(win, Native.WS_MINIMIZEBOX) && !HasStyle(win, Native.WS_MAXIMIZEBOX));
             }
             finally { await CloseAndSettle(win); }

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/Phase3WindowingFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/Phase3WindowingFixtures.cs
@@ -191,10 +191,20 @@ internal static class Phase3WindowingFixtures
                 var pos = win.AppWindow.Position;
                 var size = win.AppWindow.Size;
                 var center = (X: pos.X + size.Width / 2, Y: pos.Y + size.Height / 2);
-                bool inCursorWorkArea = haveCursor
-                    && center.X >= work.Left && center.X < work.Right
-                    && center.Y >= work.Top && center.Y < work.Bottom;
-                H.Check("PersistPlacement_FallbackWhenEmpty", inCursorWorkArea);
+                // Same shape as CenterOnCurrent_UsesCursorMonitor in Phase1 — this is that
+                // assertion a second time, which is why the two always failed as a pair. See the
+                // comment there: an undeterminable cursor is a skip, not a failure.
+                if (!haveCursor)
+                {
+                    H.Skip("PersistPlacement_FallbackWhenEmpty",
+                        "GetCursorPos unavailable (non-interactive desktop) — cursor monitor cannot be determined");
+                }
+                else
+                {
+                    H.Check("PersistPlacement_FallbackWhenEmpty",
+                        center.X >= work.Left && center.X < work.Right
+                        && center.Y >= work.Top && center.Y < work.Bottom);
+                }
             }
             finally { await CloseAndSettle(win); }
         }

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/Phase4WindowingFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/Phase4WindowingFixtures.cs
@@ -141,9 +141,10 @@ internal static class Phase4WindowingFixtures
                 H.Check("WindowStyle_RuntimeUpdate_None", noneSettled && (none & (Native.WS_CAPTION | Native.WS_SYSMENU | Native.WS_BORDER)) == 0);
 
                 win.Update(spec with { Style = WindowStyle.Default });
-                await Harness.Render(80);
+                bool caption = await Harness.WaitFor(
+                    () => (StyleBits(win) & Native.WS_CAPTION) != 0, maxPasses: 12, perPassMs: 10);
                 long normal = StyleBits(win);
-                H.Check("WindowStyle_RuntimeUpdate_DefaultCaption", (normal & Native.WS_CAPTION) != 0);
+                H.Check("WindowStyle_RuntimeUpdate_DefaultCaption", caption);
                 H.Check("WindowStyle_RuntimeUpdate_DefaultSysMenu", (normal & Native.WS_SYSMENU) != 0);
             }
             finally { await CloseAndSettle(win); }

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/Phase4WindowingFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/Phase4WindowingFixtures.cs
@@ -321,14 +321,14 @@ internal static class Phase4WindowingFixtures
     }
 
     /// <summary>
-    /// Emits a TAP comment splitting the remaining #927 suspects apart, so the NEXT full-run
-    /// occurrence answers the question instead of costing another investigation. This fixture
-    /// only fails in the full ~6100-check run (0/40 across two narrow scopes), so a reproduction
-    /// is expensive and the failure needs to carry its own diagnosis.
+    /// Pure verdict selection for <see cref="ReportLevelMismatch"/>, split out so the three-way
+    /// branch is reachable without reproducing the ~25%-in-a-full-run flake. Returns a short
+    /// stable tag plus the guidance text; the tag is what a test can assert on without pinning
+    /// the prose.
     ///
-    /// <para>The assertion reads only the native ex-style bit, which cannot by itself
-    /// distinguish three different bugs. Reading <c>win.Spec.Level</c> and re-reading the bit
-    /// after the poll gave up separates them:</para>
+    /// <para>The assertion in the fixture reads only the native ex-style bit, which cannot by
+    /// itself distinguish three different bugs. Combining <c>win.Spec.Level</c> with a re-read of
+    /// the bit after the poll gave up separates them:</para>
     /// <list type="bullet">
     /// <item><description><b>spec stale</b> — the Update never reached Reactor's own state, so
     /// the fault is upstream of the native apply entirely.</description></item>
@@ -339,15 +339,6 @@ internal static class Phase4WindowingFixtures
     /// longer budget would actually have fixed — worth knowing, because the 1.4s budget already
     /// failed once and that argues against this branch being the usual cause.</description></item>
     /// </list>
-    ///
-    /// <para>Written as a TAP comment rather than folded into the check name so
-    /// <c>WindowLevel_RuntimeFlip_Topmost</c> stays greppable for flake tracking.</para>
-    /// </summary>
-    /// <summary>
-    /// Pure verdict selection for <see cref="ReportLevelMismatch"/>, split out so the three-way
-    /// branch is reachable without reproducing the ~25%-in-a-full-run flake. Returns a short
-    /// stable tag plus the guidance text; the tag is what a test can assert on without pinning
-    /// the prose.
     /// </summary>
     internal static (string Tag, string Text) LevelMismatchVerdict(bool specTookUpdate, bool bitNowCorrect)
     {
@@ -368,6 +359,15 @@ internal static class Phase4WindowingFixtures
             "the SetWindowPos apply is the suspect (coalesced away, or never issued).");
     }
 
+    /// <summary>
+    /// Emits a TAP comment carrying <see cref="LevelMismatchVerdict"/>'s diagnosis, so the NEXT
+    /// full-run occurrence answers the question instead of costing another investigation. This
+    /// fixture only fails in the full ~6100-check run (0/40 across two narrow scopes), so a
+    /// reproduction is expensive and the failure needs to carry its own diagnosis.
+    ///
+    /// <para>Written as a TAP comment rather than folded into the check name so
+    /// <c>WindowLevel_RuntimeFlip_Topmost</c> stays greppable for flake tracking.</para>
+    /// </summary>
     private static void ReportLevelMismatch(ReactorWindow win, WindowLevel requested, bool expectTopmostBit)
     {
         var specLevel = win.Spec.Level;

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/Phase4WindowingFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/Phase4WindowingFixtures.cs
@@ -265,6 +265,35 @@ internal static class Phase4WindowingFixtures
                 // too-short-poll problem" is the sound claim, NOT "not a race".
                 // The await + poll below are kept because both are correct regardless, and
                 // the assertion stays strict: it fails if the bit never flips.
+                // Window-population probe for issue #927. Emitted on EVERY run so a full run and
+                // a filtered run can be compared without waiting to catch the ~25% flake.
+                //
+                // RESULT: hypothesis FALSIFIED, and the probe is kept as the standing evidence.
+                // ReactorWindow.ReassertFloatingWindowsForActivation iterates ReactorApp.Windows
+                // on every activation and re-issues SetWindowPos(HWND_TOP) for every non-disposed
+                // window whose Spec.Level is Floating — it skips only _disposed, so a Floating
+                // window leaked by an earlier fixture would keep churning Z-order for the rest of
+                // the process. That made "leaked Floating windows accumulate over the suite" a
+                // strong candidate. Measured: `ReactorApp.Windows=1, Level==Floating=0` at this
+                // point in BOTH a full ~6100-check run and `--filter WindowLevel`. Identical. So
+                // there is no leak, no accumulated population, and the whole cross-window
+                // coupling family is eliminated — including the version where the two preceding
+                // Floating fixtures are to blame (also 20/20 clean with them included).
+                //
+                // What that leaves: ReactorWindow.ApplyWindowLevel discards the SetWindowPos
+                // BOOL (`_ = NativeShell.SetWindowPos(...)`, ReactorWindow.cs:810), so a rejected
+                // call is silently indistinguishable from one that never took effect. Checking
+                // that return plus GetLastError is now the leading next step — it splits "the
+                // call was rejected" from "something undid it afterwards", and neither is
+                // currently observable.
+                var allWindows = ReactorApp.Windows;
+                int liveFloating = 0;
+                for (int i = 0; i < allWindows.Count; i++)
+                    if (allWindows[i].Spec.Level == WindowLevel.Floating) liveFloating++;
+                Console.WriteLine(
+                    $"# WindowLevel_RuntimeFlip population (issue #927): ReactorApp.Windows={allWindows.Count}, " +
+                    $"Level==Floating={liveFloating}");
+
                 win.Update(spec with { Level = WindowLevel.AlwaysOnTop });
                 await win.Host.WaitForIdleAsync();
                 bool topmost = await Harness.WaitFor(

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/Phase4WindowingFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/Phase4WindowingFixtures.cs
@@ -244,13 +244,20 @@ internal static class Phase4WindowingFixtures
             var win = await OpenAndSettle(spec);
             try
             {
+                // The Level flip reaches the native window through SetWindowPos, so the ex-style
+                // bit lands asynchronously. Poll instead of betting on one fixed wait — under a
+                // full selftest run (many windows opened/closed by preceding fixtures) 80ms was
+                // not always enough and this pair flaked ~1 run in 3 (issue #927). The assertion
+                // stays just as strict: it still fails if the bit never flips.
                 win.Update(spec with { Level = WindowLevel.AlwaysOnTop });
-                await Harness.Render(80);
-                H.Check("WindowLevel_RuntimeFlip_Topmost", (ExStyleBits(win) & Native.WS_EX_TOPMOST) != 0);
+                H.Check("WindowLevel_RuntimeFlip_Topmost",
+                    await Harness.WaitFor(() => (ExStyleBits(win) & Native.WS_EX_TOPMOST) != 0,
+                        maxPasses: 10, perPassMs: 40));
 
                 win.Update(spec with { Level = WindowLevel.Normal });
-                await Harness.Render(80);
-                H.Check("WindowLevel_RuntimeFlip_Normal", (ExStyleBits(win) & Native.WS_EX_TOPMOST) == 0);
+                H.Check("WindowLevel_RuntimeFlip_Normal",
+                    await Harness.WaitFor(() => (ExStyleBits(win) & Native.WS_EX_TOPMOST) == 0,
+                        maxPasses: 10, perPassMs: 40));
             }
             finally { await CloseAndSettle(win); }
         }

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/Phase4WindowingFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/Phase4WindowingFixtures.cs
@@ -274,7 +274,7 @@ internal static class Phase4WindowingFixtures
                 // window whose Spec.Level is Floating — it skips only _disposed, so a Floating
                 // window leaked by an earlier fixture would keep churning Z-order for the rest of
                 // the process. That made "leaked Floating windows accumulate over the suite" a
-                // strong candidate. Measured: `ReactorApp.Windows=1, Level==Floating=0` at this
+                // strong candidate. Measured: `ReactorApp.Windows=1, registered Spec.Level==Floating=0` at this
                 // point in BOTH a full ~6100-check run and `--filter WindowLevel`. Identical. So
                 // there is no leak, no accumulated population, and the whole cross-window
                 // coupling family is eliminated — including the version where the two preceding
@@ -287,18 +287,25 @@ internal static class Phase4WindowingFixtures
                 // call was rejected" from "something undid it afterwards", and neither is
                 // currently observable.
                 var allWindows = ReactorApp.Windows;
-                int liveFloating = 0;
+                int registeredFloatingSpecs = 0;
                 for (int i = 0; i < allWindows.Count; i++)
-                    if (allWindows[i].Spec.Level == WindowLevel.Floating) liveFloating++;
+                    if (allWindows[i].Spec.Level == WindowLevel.Floating) registeredFloatingSpecs++;
                 Console.WriteLine(
                     $"# WindowLevel_RuntimeFlip population (issue #927): ReactorApp.Windows={allWindows.Count}, " +
-                    $"Level==Floating={liveFloating}");
-                // Asserted, not merely reported — otherwise the falsification above decays into a
-                // comment nobody reads and a future leak would reintroduce the suspect silently.
-                // Only the Floating count is asserted: it is the precise subject of the refuted
-                // hypothesis, whereas total window count would red on any unrelated fixture's leak
-                // and misattribute it here.
-                H.Check("WindowLevel_RuntimeFlip_NoLeakedFloatingWindows", liveFloating == 0);
+                    $"registered Spec.Level==Floating={registeredFloatingSpecs} " +
+                    $"(disposal NOT checked — see below)");
+                // Deliberately a SUPERSET of what actually churns Z-order:
+                // ReassertFloatingWindowsForActivation additionally skips `_disposed`, which is
+                // private on ReactorWindow and unreachable from here even with InternalsVisibleTo.
+                // So this counts registered Floating specs, disposed or not. That asymmetry is
+                // safe in the direction that matters: an over-count of 0 implies the participating
+                // count is also 0, so the falsification above holds a fortiori. It would only
+                // mislead in the other direction — a non-zero reading here is a lead to
+                // investigate, not proof that anything is still reasserting.
+                //
+                // Only the Floating count is asserted, not the total window count: total would red
+                // on any unrelated fixture's leak and misattribute it to this fixture.
+                H.Check("WindowLevel_RuntimeFlip_NoRegisteredFloatingWindows", registeredFloatingSpecs == 0);
 
                 win.Update(spec with { Level = WindowLevel.AlwaysOnTop });
                 await win.Host.WaitForIdleAsync();

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/Phase4WindowingFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/Phase4WindowingFixtures.cs
@@ -267,18 +267,71 @@ internal static class Phase4WindowingFixtures
                 // the assertion stays strict: it fails if the bit never flips.
                 win.Update(spec with { Level = WindowLevel.AlwaysOnTop });
                 await win.Host.WaitForIdleAsync();
-                H.Check("WindowLevel_RuntimeFlip_Topmost",
-                    await Harness.WaitFor(() => (ExStyleBits(win) & Native.WS_EX_TOPMOST) != 0,
-                        maxPasses: 25, perPassMs: 40));
+                bool topmost = await Harness.WaitFor(
+                    () => (ExStyleBits(win) & Native.WS_EX_TOPMOST) != 0,
+                    maxPasses: 25, perPassMs: 40);
+                if (!topmost) ReportLevelMismatch(win, WindowLevel.AlwaysOnTop, expectTopmostBit: true);
+                H.Check("WindowLevel_RuntimeFlip_Topmost", topmost);
 
                 win.Update(spec with { Level = WindowLevel.Normal });
                 await win.Host.WaitForIdleAsync();
-                H.Check("WindowLevel_RuntimeFlip_Normal",
-                    await Harness.WaitFor(() => (ExStyleBits(win) & Native.WS_EX_TOPMOST) == 0,
-                        maxPasses: 25, perPassMs: 40));
+                bool normal = await Harness.WaitFor(
+                    () => (ExStyleBits(win) & Native.WS_EX_TOPMOST) == 0,
+                    maxPasses: 25, perPassMs: 40);
+                if (!normal) ReportLevelMismatch(win, WindowLevel.Normal, expectTopmostBit: false);
+                H.Check("WindowLevel_RuntimeFlip_Normal", normal);
             }
             finally { await CloseAndSettle(win); }
         }
+    }
+
+    /// <summary>
+    /// Emits a TAP comment splitting the remaining #927 suspects apart, so the NEXT full-run
+    /// occurrence answers the question instead of costing another investigation. This fixture
+    /// only fails in the full ~6100-check run (0/40 across two narrow scopes), so a reproduction
+    /// is expensive and the failure needs to carry its own diagnosis.
+    ///
+    /// <para>The assertion reads only the native ex-style bit, which cannot by itself
+    /// distinguish three different bugs. Reading <c>win.Spec.Level</c> and re-reading the bit
+    /// after the poll gave up separates them:</para>
+    /// <list type="bullet">
+    /// <item><description><b>spec stale</b> — the Update never reached Reactor's own state, so
+    /// the fault is upstream of the native apply entirely.</description></item>
+    /// <item><description><b>spec updated, bit still wrong</b> — Reactor accepted it but
+    /// SetWindowPos was coalesced away or never issued.</description></item>
+    /// <item><description><b>spec updated, bit now CORRECT</b> — it landed after the poll
+    /// exhausted. That is a lost wakeup / late apply, not a missing one, and it is the one case a
+    /// longer budget would actually have fixed — worth knowing, because the 1.4s budget already
+    /// failed once and that argues against this branch being the usual cause.</description></item>
+    /// </list>
+    ///
+    /// <para>Written as a TAP comment rather than folded into the check name so
+    /// <c>WindowLevel_RuntimeFlip_Topmost</c> stays greppable for flake tracking.</para>
+    /// </summary>
+    private static void ReportLevelMismatch(ReactorWindow win, WindowLevel requested, bool expectTopmostBit)
+    {
+        var specLevel = win.Spec.Level;
+        // Re-read AFTER the poll gave up — if it is correct now, the apply was merely late.
+        bool bitSet = (ExStyleBits(win) & Native.WS_EX_TOPMOST) != 0;
+        bool bitNowCorrect = bitSet == expectTopmostBit;
+        bool specTookUpdate = specLevel == requested;
+
+        var verdict =
+            !specTookUpdate
+                ? "Reactor's spec did NOT take the update — the failure is upstream of the " +
+                  "native apply, in Update delivery/reconciliation, not in SetWindowPos."
+            : bitNowCorrect
+                ? "The bit is CORRECT now, so the apply landed after the poll exhausted — a late " +
+                  "apply / lost wakeup rather than a missing one. This is the only branch a longer " +
+                  "budget would fix, and 1.4s already failed once, so treat a repeat here as a " +
+                  "signal to re-examine that."
+                : "Reactor's spec DID take the update, but the native bit still has not followed — " +
+                  "the SetWindowPos apply is the suspect (coalesced away, or never issued).";
+
+        Console.WriteLine(
+            $"# WindowLevel_RuntimeFlip diagnostic (issue #927): requested={requested}, " +
+            $"spec.Level={specLevel}, WS_EX_TOPMOST={(bitSet ? "set" : "clear")}, " +
+            $"expected {(expectTopmostBit ? "set" : "clear")}. {verdict}");
     }
 
     private static class Native

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/Phase4WindowingFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/Phase4WindowingFixtures.cs
@@ -293,6 +293,12 @@ internal static class Phase4WindowingFixtures
                 Console.WriteLine(
                     $"# WindowLevel_RuntimeFlip population (issue #927): ReactorApp.Windows={allWindows.Count}, " +
                     $"Level==Floating={liveFloating}");
+                // Asserted, not merely reported — otherwise the falsification above decays into a
+                // comment nobody reads and a future leak would reintroduce the suspect silently.
+                // Only the Floating count is asserted: it is the precise subject of the refuted
+                // hypothesis, whereas total window count would red on any unrelated fixture's leak
+                // and misattribute it here.
+                H.Check("WindowLevel_RuntimeFlip_NoLeakedFloatingWindows", liveFloating == 0);
 
                 win.Update(spec with { Level = WindowLevel.AlwaysOnTop });
                 await win.Host.WaitForIdleAsync();
@@ -337,30 +343,73 @@ internal static class Phase4WindowingFixtures
     /// <para>Written as a TAP comment rather than folded into the check name so
     /// <c>WindowLevel_RuntimeFlip_Topmost</c> stays greppable for flake tracking.</para>
     /// </summary>
+    /// <summary>
+    /// Pure verdict selection for <see cref="ReportLevelMismatch"/>, split out so the three-way
+    /// branch is reachable without reproducing the ~25%-in-a-full-run flake. Returns a short
+    /// stable tag plus the guidance text; the tag is what a test can assert on without pinning
+    /// the prose.
+    /// </summary>
+    internal static (string Tag, string Text) LevelMismatchVerdict(bool specTookUpdate, bool bitNowCorrect)
+    {
+        if (!specTookUpdate)
+            return ("spec-stale",
+                "Reactor's spec did NOT take the update — the failure is upstream of the " +
+                "native apply, in Update delivery/reconciliation, not in SetWindowPos.");
+
+        if (bitNowCorrect)
+            return ("late-apply",
+                "The bit is CORRECT now, so the apply landed after the poll exhausted — a late " +
+                "apply / lost wakeup rather than a missing one. This is the only branch a longer " +
+                "budget would fix, and 1.4s already failed once, so treat a repeat here as a " +
+                "signal to re-examine that.");
+
+        return ("apply-missing",
+            "Reactor's spec DID take the update, but the native bit still has not followed — " +
+            "the SetWindowPos apply is the suspect (coalesced away, or never issued).");
+    }
+
     private static void ReportLevelMismatch(ReactorWindow win, WindowLevel requested, bool expectTopmostBit)
     {
         var specLevel = win.Spec.Level;
         // Re-read AFTER the poll gave up — if it is correct now, the apply was merely late.
         bool bitSet = (ExStyleBits(win) & Native.WS_EX_TOPMOST) != 0;
-        bool bitNowCorrect = bitSet == expectTopmostBit;
-        bool specTookUpdate = specLevel == requested;
-
-        var verdict =
-            !specTookUpdate
-                ? "Reactor's spec did NOT take the update — the failure is upstream of the " +
-                  "native apply, in Update delivery/reconciliation, not in SetWindowPos."
-            : bitNowCorrect
-                ? "The bit is CORRECT now, so the apply landed after the poll exhausted — a late " +
-                  "apply / lost wakeup rather than a missing one. This is the only branch a longer " +
-                  "budget would fix, and 1.4s already failed once, so treat a repeat here as a " +
-                  "signal to re-examine that."
-                : "Reactor's spec DID take the update, but the native bit still has not followed — " +
-                  "the SetWindowPos apply is the suspect (coalesced away, or never issued).";
+        var (tag, verdict) = LevelMismatchVerdict(
+            specTookUpdate: specLevel == requested,
+            bitNowCorrect: bitSet == expectTopmostBit);
 
         Console.WriteLine(
-            $"# WindowLevel_RuntimeFlip diagnostic (issue #927): requested={requested}, " +
+            $"# WindowLevel_RuntimeFlip diagnostic (issue #927) [{tag}]: requested={requested}, " +
             $"spec.Level={specLevel}, WS_EX_TOPMOST={(bitSet ? "set" : "clear")}, " +
             $"expected {(expectTopmostBit ? "set" : "clear")}. {verdict}");
+    }
+
+    /// <summary>
+    /// Exhaustively covers the three-way verdict in <see cref="LevelMismatchVerdict"/>. That
+    /// branch only executes when <c>WindowLevel_RuntimeFlip</c> actually fails — ~25% of full
+    /// runs, and 0/40 under a filter — so without this fixture the diagnostic a future triager
+    /// will act on is never exercised in CI. Four checks cover the whole 2x2 input domain, so
+    /// collapsing any branch into another fails at least one of them.
+    /// </summary>
+    internal class WindowLevelVerdictBranches(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override Task RunAsync()
+        {
+            H.Check("WindowLevelVerdict_SpecStale",
+                LevelMismatchVerdict(specTookUpdate: false, bitNowCorrect: false).Tag == "spec-stale");
+
+            // spec-stale must win even when the bit happens to read correct: if the update never
+            // reached Reactor's state, the native apply is not the suspect regardless of the bit.
+            H.Check("WindowLevelVerdict_SpecStaleWinsOverCorrectBit",
+                LevelMismatchVerdict(specTookUpdate: false, bitNowCorrect: true).Tag == "spec-stale");
+
+            H.Check("WindowLevelVerdict_LateApply",
+                LevelMismatchVerdict(specTookUpdate: true, bitNowCorrect: true).Tag == "late-apply");
+
+            H.Check("WindowLevelVerdict_ApplyMissing",
+                LevelMismatchVerdict(specTookUpdate: true, bitNowCorrect: false).Tag == "apply-missing");
+
+            return Task.CompletedTask;
+        }
     }
 
     private static class Native

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/Phase4WindowingFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/Phase4WindowingFixtures.cs
@@ -245,20 +245,30 @@ internal static class Phase4WindowingFixtures
             var win = await OpenAndSettle(spec);
             try
             {
-                // The Level flip reaches the native window through SetWindowPos, so the ex-style
-                // bit lands asynchronously. Poll instead of betting on one fixed wait — under a
-                // full selftest run (many windows opened/closed by preceding fixtures) 80ms was
-                // not always enough and this pair flaked ~1 run in 3 (issue #927). The assertion
-                // stays just as strict: it still fails if the bit never flips.
+                // NOT a settled fix — issue #927 remains open. Two hypotheses have now been
+                // tested and refuted on this fixture:
+                //   1. "the fixed 80ms wait is too tight" — replaced with WaitFor polling;
+                //      still failed on a later full run.
+                //   2. "the secondary window's host is never awaited" — real gap (Harness.Render
+                //      only awaits ReactorApp.PrimaryWindow's host, and OpenAndSettle above does
+                //      await win.Host, but this fixture did not). Fixed below, and the flake STILL
+                //      reproduced 1 run in 4 with a 1.4s poll budget.
+                // So the topmost bit genuinely does not always get set; this is not a
+                // wait-longer problem. Next suspect is the Level update being coalesced away, or
+                // Z-order contention from the Floating windows the two preceding fixtures create.
+                // The await + poll below are kept because both are correct regardless, and the
+                // assertion stays strict: it fails if the bit never flips.
                 win.Update(spec with { Level = WindowLevel.AlwaysOnTop });
+                await win.Host.WaitForIdleAsync();
                 H.Check("WindowLevel_RuntimeFlip_Topmost",
                     await Harness.WaitFor(() => (ExStyleBits(win) & Native.WS_EX_TOPMOST) != 0,
-                        maxPasses: 10, perPassMs: 40));
+                        maxPasses: 25, perPassMs: 40));
 
                 win.Update(spec with { Level = WindowLevel.Normal });
+                await win.Host.WaitForIdleAsync();
                 H.Check("WindowLevel_RuntimeFlip_Normal",
                     await Harness.WaitFor(() => (ExStyleBits(win) & Native.WS_EX_TOPMOST) == 0,
-                        maxPasses: 10, perPassMs: 40));
+                        maxPasses: 25, perPassMs: 40));
             }
             finally { await CloseAndSettle(win); }
         }

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/Phase4WindowingFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/Phase4WindowingFixtures.cs
@@ -245,19 +245,26 @@ internal static class Phase4WindowingFixtures
             var win = await OpenAndSettle(spec);
             try
             {
-                // NOT a settled fix — issue #927 remains open. Two hypotheses have now been
-                // tested and refuted on this fixture:
+                // NOT a settled fix — issue #927 remains open. Four hypotheses tested and
+                // refuted on this fixture, recorded so nobody re-runs them:
                 //   1. "the fixed 80ms wait is too tight" — replaced with WaitFor polling;
                 //      still failed on a later full run.
-                //   2. "the secondary window's host is never awaited" — real gap (Harness.Render
-                //      only awaits ReactorApp.PrimaryWindow's host, and OpenAndSettle above does
-                //      await win.Host, but this fixture did not). Fixed below, and the flake STILL
-                //      reproduced 1 run in 4 with a 1.4s poll budget.
-                // So the topmost bit genuinely does not always get set; this is not a
-                // wait-longer problem. Next suspect is the Level update being coalesced away, or
-                // Z-order contention from the Floating windows the two preceding fixtures create.
-                // The await + poll below are kept because both are correct regardless, and the
-                // assertion stays strict: it fails if the bit never flips.
+                //   2. "the secondary window's host is never awaited" — a REAL gap, fixed
+                //      below (Harness.Render only awaits ReactorApp.PrimaryWindow's host;
+                //      OpenAndSettle awaits win.Host, the Update path did not). Still failed
+                //      1 run in 4 afterwards with a 1.4s poll budget.
+                //   3. "intrinsic to the fixture" — 20/20 clean run in isolation
+                //      (`--self-test --filter WindowLevel_RuntimeFlip`).
+                //   4. "the two preceding Floating fixtures leave topmost/Z-order state" —
+                //      20/20 clean with them included (`--filter WindowLevel`).
+                // So: ~25% in the full 6122-check run, 0/40 across two narrow scopes. What
+                // remains is accumulated state from the hundreds of windows earlier fixtures
+                // open and close, or full-run load/duration. Note (1) only rules out sampling
+                // too early — an event that never fires, an ordering race decided before the
+                // first poll, or a lost wakeup are all budget-insensitive, so "not a
+                // too-short-poll problem" is the sound claim, NOT "not a race".
+                // The await + poll below are kept because both are correct regardless, and
+                // the assertion stays strict: it fails if the bit never flips.
                 win.Update(spec with { Level = WindowLevel.AlwaysOnTop });
                 await win.Host.WaitForIdleAsync();
                 H.Check("WindowLevel_RuntimeFlip_Topmost",

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/Phase7WindowingFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/Phase7WindowingFixtures.cs
@@ -306,9 +306,10 @@ internal static class Phase7WindowingFixtures
             // Direct dispose — bypasses Close()/the Window.Closed -> Unregister ->
             // Dispose flow. The prep runs first, so the flip is observable after.
             win.Dispose();
-            await Harness.Render(50);
 
-            H.Check("TitleBar_DisposeNoClose_Flipped", win.NativeWindow.ExtendsContentIntoTitleBar);
+            H.Check("TitleBar_DisposeNoClose_Flipped",
+                await Harness.WaitFor(() => win.NativeWindow.ExtendsContentIntoTitleBar,
+                    maxPasses: 12, perPassMs: 10));
 
             // Dispose() alone does not unregister (the normal flow is
             // Window.Closed -> UnregisterWindow -> Dispose). Clean up the

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ReconcilerBigCoverageFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ReconcilerBigCoverageFixtures.cs
@@ -1299,8 +1299,9 @@ internal static class ReconcilerBigCoverageFixtures
             H.Check("ExitRpl_Initial", H.FindText("ex-old") is not null);
 
             H.ClickButton("ExitReplace");
-            await Harness.Render(150);
-            H.Check("ExitRpl_NewVisible", H.FindText("ex-new") is not null);
+            H.Check("ExitRpl_NewVisible",
+                await Harness.WaitFor(() => H.FindText("ex-new") is not null,
+                    maxPasses: 16, perPassMs: 15));
         }
     }
 
@@ -1519,8 +1520,9 @@ internal static class ReconcilerBigCoverageFixtures
             H.Check("KFUnmount_Mounted", H.FindText("kf-unmount-target") is not null);
 
             H.ClickButton("KFTriggerUnmount");
-            await Harness.Render(120);
-            H.Check("KFUnmount_Unmounted", H.FindText("kf-unmount-target") is null);
+            H.Check("KFUnmount_Unmounted",
+                await Harness.WaitFor(() => H.FindText("kf-unmount-target") is null,
+                    maxPasses: 16, perPassMs: 15));
         }
     }
 
@@ -1586,8 +1588,9 @@ internal static class ReconcilerBigCoverageFixtures
             H.Check("Asym_Initial", H.FindText("asym-target") is not null);
 
             H.ClickButton("AsymExit");
-            await Harness.Render(450);
-            H.Check("Asym_Removed", H.FindText("asym-target") is null);
+            H.Check("Asym_Removed",
+                await Harness.WaitFor(() => H.FindText("asym-target") is null,
+                    maxPasses: 20, perPassMs: 30));
         }
     }
 
@@ -1606,8 +1609,9 @@ internal static class ReconcilerBigCoverageFixtures
                 TextBlock("stagger-3").Transition(Microsoft.UI.Reactor.Animation.Transition.Fade)
             ).Stagger(TimeSpan.FromMilliseconds(20)));
 
-            await Harness.Render(80);
-            H.Check("Stagger_Mounted", H.FindText("stagger-3") is not null);
+            H.Check("Stagger_Mounted",
+                await Harness.WaitFor(() => H.FindText("stagger-3") is not null,
+                    maxPasses: 12, perPassMs: 10));
         }
     }
 

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/TabViewFillContentAreaFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/TabViewFillContentAreaFixtures.cs
@@ -93,7 +93,10 @@ internal static class TabViewFillContentAreaFixtures
                 maxPasses: 25, perPassMs: 20);
             var tabView = H.FindControl<TabView>(_ => true);
             H.Check("TabViewFill_Mounted", tabView is not null && Body(H) is not null);
-            if (tabView is null) throw new InvalidOperationException("TabView was not mounted.");
+            // Report and stop rather than throw: an exception aborts the fixture and
+            // truncates TAP output, which reads downstream as an unattributable flake
+            // rather than as this precondition failing.
+            if (tabView is null) return;
 
             // Phase 0 — opt-out: WinUI's style default is untouched and the body is
             // content-sized (this is the pre-fix behaviour, deliberately preserved).
@@ -167,7 +170,11 @@ internal static class TabViewFillContentAreaFixtures
                 () => H.FindControl<TabView>(_ => true) is not null && Body(H) is not null,
                 maxPasses: 25, perPassMs: 20);
             var tabView = H.FindControl<TabView>(_ => true);
-            if (tabView is null) throw new InvalidOperationException("TabView was not mounted.");
+            // Same rationale as ToggleFillContentArea: a missing mount is a reportable
+            // check, not an exception. Throwing here truncates TAP and disguises the
+            // precondition failure as a flake.
+            H.Check("TabViewFill_ExplicitMounted", tabView is not null);
+            if (tabView is null) return;
 
             double bodyPinned = (await WaitForBody(H))?.ActualHeight ?? NoBody;
             H.Check("TabViewFill_ExplicitCenterBeatsOptIn",

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/TabViewFillContentAreaFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/TabViewFillContentAreaFixtures.cs
@@ -45,6 +45,30 @@ internal static class TabViewFillContentAreaFixtures
         h.FindControl<Border>(b => AutomationProperties.GetAutomationId(b) == "tab-body");
 
     /// <summary>
+    /// Polls for the tab body instead of reading it from a one-shot <see cref="Harness.Render()"/>
+    /// snapshot. TabView realizes its selected tab's ContentPresenter over multiple dispatcher
+    /// waves (see the Harness.Render remarks, which name this exact surface), and Render caps at
+    /// four passes — so on a contended machine the Border can still be unrealized when it returns.
+    /// Every call site used to do <c>Body(H)!.ActualHeight</c>, which turned that miss into a
+    /// NullReferenceException that aborted the fixture and truncated the TAP stream. Returning
+    /// null here instead lets the caller substitute a sentinel, so a genuine miss surfaces as an
+    /// ordinary failed assertion on the check that cares.
+    /// </summary>
+    private static async Task<Border?> WaitForBody(Harness h)
+    {
+        await Harness.WaitFor(() => Body(h) is not null, maxPasses: 25, perPassMs: 20);
+        return Body(h);
+    }
+
+    // Sentinel for "the body never realized". NaN, not a negative number: several assertions
+    // here are growth ratios or deltas between two body heights (bodyOn > bodyOff * 3,
+    // |bodyOffAgain - bodyOff| < 2), and a shared negative sentinel SATISFIES those — -1 > -3
+    // and |-1 - -1| < 2 are both true, so a missing body would pass them vacuously. Every
+    // comparison against NaN is false, so the sentinel fails every check that touches it.
+    // Verified by mutation: with Body() forced null, all seven body-dependent checks fail.
+    private const double NoBody = double.NaN;
+
+    /// <summary>
     /// Off → on → off. Asserts the opt-out keeps WinUI's <c>Top</c> AND a content-sized
     /// body, that opting in both flips the alignment and makes the body actually fill the
     /// remaining height, and that opting back out releases the local value so the style
@@ -64,14 +88,16 @@ internal static class TabViewFillContentAreaFixtures
                     static (p, tab) => p == 1 ? tab.FillContentArea() : tab);
             });
 
-            await Harness.Render();
+            await Harness.WaitFor(
+                () => H.FindControl<TabView>(_ => true) is not null && Body(H) is not null,
+                maxPasses: 25, perPassMs: 20);
             var tabView = H.FindControl<TabView>(_ => true);
             H.Check("TabViewFill_Mounted", tabView is not null && Body(H) is not null);
             if (tabView is null) throw new InvalidOperationException("TabView was not mounted.");
 
             // Phase 0 — opt-out: WinUI's style default is untouched and the body is
             // content-sized (this is the pre-fix behaviour, deliberately preserved).
-            double bodyOff = Body(H)!.ActualHeight;
+            double bodyOff = (await WaitForBody(H))?.ActualHeight ?? NoBody;
             H.Check("TabViewFill_OffKeepsWinUIDefault",
                 tabView.VerticalAlignment == VerticalAlignment.Top);
             H.Check("TabViewFill_OffBodyIsContentSized",
@@ -82,7 +108,7 @@ internal static class TabViewFillContentAreaFixtures
             // bodyOn == bodyOff.
             H.ClickButton("Advance");
             await Harness.Render();
-            double bodyOn = Body(H)!.ActualHeight;
+            double bodyOn = (await WaitForBody(H))?.ActualHeight ?? NoBody;
             H.Check("TabViewFill_OnStretchesControl",
                 tabView.VerticalAlignment == VerticalAlignment.Stretch);
             H.Check("TabViewFill_OnBodyFillsContentArea", bodyOn > FilledBodyFloor);
@@ -97,7 +123,7 @@ internal static class TabViewFillContentAreaFixtures
             // takes over again and the body re-collapses.
             H.ClickButton("Advance");
             await Harness.Render();
-            double bodyOffAgain = Body(H)!.ActualHeight;
+            double bodyOffAgain = (await WaitForBody(H))?.ActualHeight ?? NoBody;
             H.Check("TabViewFill_ToggledOffRestoresWinUIDefault",
                 tabView.VerticalAlignment == VerticalAlignment.Top);
             H.Check("TabViewFill_ToggledOffBodyCollapsesAgain",
@@ -137,11 +163,13 @@ internal static class TabViewFillContentAreaFixtures
                         : tab.VAlign(VerticalAlignment.Center));
             });
 
-            await Harness.Render();
+            await Harness.WaitFor(
+                () => H.FindControl<TabView>(_ => true) is not null && Body(H) is not null,
+                maxPasses: 25, perPassMs: 20);
             var tabView = H.FindControl<TabView>(_ => true);
             if (tabView is null) throw new InvalidOperationException("TabView was not mounted.");
 
-            double bodyPinned = Body(H)!.ActualHeight;
+            double bodyPinned = (await WaitForBody(H))?.ActualHeight ?? NoBody;
             H.Check("TabViewFill_ExplicitCenterBeatsOptIn",
                 tabView.VerticalAlignment == VerticalAlignment.Center);
             H.Check("TabViewFill_ExplicitBodyStaysContentSized",
@@ -154,7 +182,7 @@ internal static class TabViewFillContentAreaFixtures
             H.Check("TabViewFill_ExplicitSurvivesRerender",
                 tabView.VerticalAlignment == VerticalAlignment.Center);
             H.Check("TabViewFill_ExplicitBodyStillContentSizedAfterRerender",
-                Body(H)!.ActualHeight < FilledBodyFloor);
+                ((await WaitForBody(H))?.ActualHeight ?? NoBody) is > 0 and < FilledBodyFloor);
 
             // Phase 2 — opt-in turned off while the explicit alignment stays put: the
             // release must not steal the author's value either.
@@ -170,7 +198,7 @@ internal static class TabViewFillContentAreaFixtures
             H.Check("TabViewFill_ExplicitSurvivesOptIn",
                 tabView.VerticalAlignment == VerticalAlignment.Center);
             H.Check("TabViewFill_ExplicitBodyStillContentSizedAfterOptIn",
-                Body(H)!.ActualHeight < FilledBodyFloor);
+                ((await WaitForBody(H))?.ActualHeight ?? NoBody) is > 0 and < FilledBodyFloor);
         }
     }
 }

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/TitleBarHeightFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/TitleBarHeightFixtures.cs
@@ -291,10 +291,11 @@ internal static class TitleBarHeightFixtures
                     ExtendsContentIntoTitleBar = true,
                     TitleBarHeight = WindowTitleBarHeight.Tall,
                 });
-                await Harness.Render(150);
+                bool reApplied = await Harness.WaitFor(
+                    () => win.AppWindow.TitleBar.Height == CaptionPx(win, TallCaptionDip),
+                    maxPasses: 16, perPassMs: 15);
                 Report("nowExtended", win, null);
-                H.Check("TitleBarHeight_ReAppliedOnceExtended",
-                    win.AppWindow.TitleBar.Height == CaptionPx(win, TallCaptionDip));
+                H.Check("TitleBarHeight_ReAppliedOnceExtended", reApplied);
             }
             finally { await CloseAndSettle(win); }
         }
@@ -331,11 +332,12 @@ internal static class TitleBarHeightFixtures
                     && comp.Bar is { } bar && Math.Abs(bar.ActualHeight - TallCaptionDip) < 0.5);
 
                 win.Update(spec with { TitleBarHeight = WindowTitleBarHeight.Standard });
-                await Harness.Render(150);
+                bool loweredAgain = await Harness.WaitFor(
+                    () => win.AppWindow.TitleBar.Height == CaptionPx(win, StandardCaptionDip)
+                          && comp.Bar is { } b && Math.Abs(b.ActualHeight - StandardCaptionDip) < 0.5,
+                    maxPasses: 16, perPassMs: 15);
                 Report("afterSpecStandard", win, comp.Bar);
-                H.Check("TitleBarHeight_SpecUpdate_LowersControlAgain",
-                    win.AppWindow.TitleBar.Height == CaptionPx(win, StandardCaptionDip)
-                    && comp.Bar is { } bar2 && Math.Abs(bar2.ActualHeight - StandardCaptionDip) < 0.5);
+                H.Check("TitleBarHeight_SpecUpdate_LowersControlAgain", loweredAgain);
             }
             finally { await CloseAndSettle(win); }
         }
@@ -441,9 +443,11 @@ internal static class TitleBarHeightFixtures
                 // now infer false — the element that justified the inference is
                 // gone. This is the half the "ever mounted" latch got wrong.
                 win.Update(spec with { Title = "Unmount withdraws 2" });
-                await Harness.Render(150);
+                bool withdrew = await Harness.WaitFor(
+                    () => !win.NativeWindow.ExtendsContentIntoTitleBar,
+                    maxPasses: 16, perPassMs: 15);
                 H.Check("TitleBarHeight_Unmount_WithdrawsExtendInference",
-                    mountedExtended && !win.NativeWindow.ExtendsContentIntoTitleBar);
+                    mountedExtended && withdrew);
             }
             finally { await CloseAndSettle(win); }
         }

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -1188,6 +1188,7 @@ internal static class SelfTestFixtureRegistry
         "WindowLevel_Floating_AboveSiblings",
         "WindowLevel_Floating_AboveOwner",
         "WindowLevel_RuntimeFlip",
+        "WindowLevel_VerdictBranches",
         // Spec 054 Phase 5 — SizeToContent.
         "SizeToContent_Width_Tracks",
         "SizeToContent_Height_Tracks",
@@ -2792,6 +2793,7 @@ internal static class SelfTestFixtureRegistry
         "WindowLevel_Floating_AboveSiblings" => new Phase4WindowingFixtures.WindowLevelFloatingAboveSiblings(harness),
         "WindowLevel_Floating_AboveOwner" => new Phase4WindowingFixtures.WindowLevelFloatingAboveOwner(harness),
         "WindowLevel_RuntimeFlip" => new Phase4WindowingFixtures.WindowLevelRuntimeFlip(harness),
+        "WindowLevel_VerdictBranches" => new Phase4WindowingFixtures.WindowLevelVerdictBranches(harness),
         // Spec 054 Phase 5 — SizeToContent.
         "SizeToContent_Width_Tracks" => new Phase5WindowingFixtures.SizeToContentWidthTracks(harness),
         "SizeToContent_Height_Tracks" => new Phase5WindowingFixtures.SizeToContentHeightTracks(harness),

--- a/tests/Reactor.AppTests/Tests/ChartKeyboardNavTests.cs
+++ b/tests/Reactor.AppTests/Tests/ChartKeyboardNavTests.cs
@@ -310,6 +310,29 @@ public class ChartKeyboardNavTests : AppTestBase
     /// <summary>Re-focus the plot area, then inject one (optionally chorded) key.</summary>
     private void PressOnChart(ushort virtualKey, bool ctrl = false, bool shift = false, bool alt = false)
     {
+        var chord = VkChord(virtualKey, ctrl: ctrl, shift: shift, alt: alt);
+
+        // Fast path — one winapp process instead of three. `send-keys --target` resolves the
+        // element and focuses it inside the SAME invocation, so it replaces the Search + Focus +
+        // SendKeys trio below. This test presses ~46 keys, so the two saved process spawns per
+        // press (~150ms each) dominate its runtime.
+        if (_targetedSendKeysWorks)
+        {
+            try
+            {
+                App.SendKeys(chord, viaSendInput: true, target: ChartName);
+                Thread.Sleep(45);
+                return;
+            }
+            catch (WinAppException)
+            {
+                // Build doesn't support --target, or SetFocus on the Canvas was rejected through
+                // it. Latch off for the rest of the run and use the click-to-focus path, which
+                // handles that case. Latching (not retrying per key) keeps the fallback cheap.
+                _targetedSendKeysWorks = false;
+            }
+        }
+
         // Re-focus before each key. UIA SetFocus is primary; if it's rejected on this build
         // (UiaFocusChart returns false) fall back to a real pointer click on the plot area — the
         // same strategy EnsureChartFocusedAndKeyboardLive uses — so the key actually lands on the
@@ -325,9 +348,13 @@ public class ChartKeyboardNavTests : AppTestBase
                     "the fixture may have failed to render or lost its AutomationName.");
             ClickChartToFocus(match);
         }
-        App.SendKeys(VkChord(virtualKey, ctrl: ctrl, shift: shift, alt: alt), viaSendInput: true);
+        App.SendKeys(chord, viaSendInput: true);
         Thread.Sleep(45);
     }
+
+    // Latched off the first time the single-spawn targeted send-keys path fails, so the rest of
+    // the run takes the click-to-focus fallback without re-probing on every key.
+    private static bool _targetedSendKeysWorks = true;
 
     // Virtual-key codes for the navigator vocabulary (migrated from the retired InputInjector, whose
     // only consumer was this fixture). Each is emitted as a layout-independent `vk=0xNN` send-keys

--- a/tests/Reactor.AppTests/Tests/ChartKeyboardNavTests.cs
+++ b/tests/Reactor.AppTests/Tests/ChartKeyboardNavTests.cs
@@ -316,7 +316,7 @@ public class ChartKeyboardNavTests : AppTestBase
         // element and focuses it inside the SAME invocation, so it replaces the Search + Focus +
         // SendKeys trio below. This test presses ~46 keys, so the two saved process spawns per
         // press (~150ms each) dominate its runtime.
-        if (_targetedSendKeysWorks)
+        if (TargetedSendKeysAvailable)
         {
             try
             {
@@ -329,7 +329,7 @@ public class ChartKeyboardNavTests : AppTestBase
                 // Build doesn't support --target, or SetFocus on the Canvas was rejected through
                 // it. Latch off for the rest of the run and use the click-to-focus path, which
                 // handles that case. Latching (not retrying per key) keeps the fallback cheap.
-                _targetedSendKeysWorks = false;
+                DisableTargetedSendKeys();
             }
         }
 
@@ -354,7 +354,21 @@ public class ChartKeyboardNavTests : AppTestBase
 
     // Latched off the first time the single-spawn targeted send-keys path fails, so the rest of
     // the run takes the click-to-focus fallback without re-probing on every key.
+    //
+    // Deliberately process-wide and one-way: whether `winapp ui send-keys --target` is supported
+    // is a property of the installed CLI build, not of any one test, so a failure for one key
+    // will hold for every key and every test in the process. Re-probing would pay the failure
+    // cost repeatedly for no new information.
+    //
+    // Accessed only through the two static members below. That keeps the mutation out of
+    // instance code (CodeQL cs/static-field-written-by-instance-method), states the one-way
+    // contract in one place, and makes the read/write safe if MSTest ever runs these classes in
+    // parallel — the latch is monotonic, so a lost race can only cost one extra slow-path probe.
     private static bool _targetedSendKeysWorks = true;
+
+    private static bool TargetedSendKeysAvailable => Volatile.Read(ref _targetedSendKeysWorks);
+
+    private static void DisableTargetedSendKeys() => Volatile.Write(ref _targetedSendKeysWorks, false);
 
     // Virtual-key codes for the navigator vocabulary (migrated from the retired InputInjector, whose
     // only consumer was this fixture). Each is emitted as a layout-independent `vk=0xNN` send-keys

--- a/tests/Reactor.AppTests/Tests/ItemClickToggleInteractionTests.cs
+++ b/tests/Reactor.AppTests/Tests/ItemClickToggleInteractionTests.cs
@@ -37,10 +37,12 @@ public class ItemClickToggleInteractionTests : AppTestBase
     /// null→present in-place Update that used to add a second native subscription), then a
     /// single real click on a row must fire the callback exactly once.
     /// </summary>
-    // [Retry] mops up the rare unattended-desktop input-injection flake (SendInput dropped
+    // [E2eRetry] mops up the rare unattended-desktop input-injection flake (SendInput dropped
     // before the Host foregrounds). A real double-subscribe regression fails every attempt
-    // with Fires: 2.
-    [Retry(3)]
+    // with Fires: 2. Use E2eRetry, never MSTest's [Retry] — the built-in attribute reports the
+    // last attempt's outcome, so a retry that lands Inconclusive silently erases a genuine
+    // failure and dotnet test exits 0.
+    [E2eRetry(3)]
     [TestMethod]
     public void ListView_ItemClick_FiresExactlyOnce_AfterToggleOffOn()
     {
@@ -64,7 +66,7 @@ public class ItemClickToggleInteractionTests : AppTestBase
     /// GridView: symmetric to the ListView case — off→on toggle then a single real click
     /// must fire the callback exactly once.
     /// </summary>
-    [Retry(3)]
+    [E2eRetry(3)]
     [TestMethod]
     public void GridView_ItemClick_FiresExactlyOnce_AfterToggleOffOn()
     {

--- a/tests/Reactor.SelfTests/ExitCodeDescriptionTests.cs
+++ b/tests/Reactor.SelfTests/ExitCodeDescriptionTests.cs
@@ -17,7 +17,7 @@ public class ExitCodeDescriptionTests
 {
     // The four codes that actually occur in this harness. 0xC000027B is the WinUI/WinRT one;
     // 0xC0000409 has repo precedent in the SwipeControl stress crash.
-    [DataTestMethod]
+    [TestMethod]
     [DataRow(unchecked((int)0xC0000005u), "STATUS_ACCESS_VIOLATION")]
     [DataRow(unchecked((int)0xC000027Bu), "STATUS_STOWED_EXCEPTION")]
     [DataRow(unchecked((int)0xC0000409u), "STATUS_STACK_BUFFER_OVERRUN")]
@@ -55,7 +55,7 @@ public class ExitCodeDescriptionTests
     /// reachable from this harness's own synthesized watchdog value, an external kill, a parent
     /// reap and a CI job-object teardown, so claiming "external kill" would be a false verdict.
     /// </summary>
-    [DataTestMethod]
+    [TestMethod]
     [DataRow(-1)]
     [DataRow(1)]
     public void Killer_codes_are_not_called_a_crash_and_name_the_disambiguator(int exitCode)
@@ -110,21 +110,24 @@ public class ExitCodeDescriptionTests
     }
 
     /// <summary>
-    /// Guards the mask arithmetic that makes the previous test necessary. If someone widens the
-    /// NTSTATUS mask to swallow 0xE0434352, the dedicated managed-exception wording would be
-    /// unreachable and this fails.
+    /// Guards the mask arithmetic that makes the previous test necessary. <c>0xE0434352 &amp;
+    /// 0xF0000000</c> is <c>0xE0000000</c>, not <c>0xC0000000</c>, so the NTSTATUS shape mask
+    /// cannot reach the CLR tag. If someone widens that mask to swallow it, the dedicated
+    /// managed-exception wording becomes unreachable and the two classes collapse to identical
+    /// guidance — which is what this asserts. (The mask arithmetic itself is a compile-time
+    /// constant and is deliberately stated in prose rather than asserted; asserting a constant
+    /// proves nothing at run time.)
     /// </summary>
     [TestMethod]
     public void Clr_tag_is_not_matched_by_the_NtStatus_shape_mask()
     {
-        Assert.AreEqual(0xE0000000u, 0xE0434352u & 0xF0000000u,
-            "precondition: the CLR tag is 0xE-shaped, not 0xC-shaped");
-
         var clr = SelfTestBatch.DescribeExitCode(unchecked((int)0xE0434352u));
         var nt = SelfTestBatch.DescribeExitCode(unchecked((int)0xC0000005u));
 
         Assert.AreNotEqual(clr, nt, "the two crash classes must not produce identical guidance");
         StringAssert.Contains(nt, "NTSTATUS");
+        Assert.IsFalse(clr.Contains("NTSTATUS"),
+            "widening the 0xC mask to cover the CLR tag would route it to the NTSTATUS wording");
     }
 
     /// <summary>
@@ -142,18 +145,20 @@ public class ExitCodeDescriptionTests
     }
 
     /// <summary>
-    /// Signed-vs-unsigned regression guard. NTSTATUS values arrive as negative Int32; comparing
-    /// them signed against 0xC0000005 matches nothing and every crash would silently fall through
-    /// to the "no verdict" branch. This fails if the uint casts are dropped.
+    /// Signed-vs-unsigned regression guard. NTSTATUS values arrive as a negative <see cref="int"/>
+    /// (<c>0xC0000005</c> is <c>-1073741819</c>), so a signed comparison against the hex literal
+    /// matches nothing and every crash would silently fall through to the "no verdict" branch.
+    /// The negativity is a compile-time fact stated here rather than asserted; what is asserted
+    /// is the observable consequence — the named text is only reachable via the uint cast.
     /// </summary>
     [TestMethod]
     public void NtStatus_is_matched_unsigned_not_signed()
     {
-        Assert.IsTrue(unchecked((int)0xC0000005u) < 0, "precondition: NTSTATUS is a negative Int32");
-
         var text = SelfTestBatch.DescribeExitCode(unchecked((int)0xC0000005u));
 
         StringAssert.Contains(text, "STATUS_ACCESS_VIOLATION",
             "a signed comparison would never match, so this text is only reachable via the uint cast");
+        StringAssert.Contains(text, "crashed on its own",
+            "the shape mask is also uint-based; a signed mask would leave this unclassified");
     }
 }

--- a/tests/Reactor.SelfTests/ExitCodeDescriptionTests.cs
+++ b/tests/Reactor.SelfTests/ExitCodeDescriptionTests.cs
@@ -50,9 +50,10 @@ public class ExitCodeDescriptionTests
     }
 
     /// <summary>
-    /// The killer codes must NOT be described as a crash, and must carry the trailer caveat —
-    /// exit 1 is ambiguous (a genuine fixture failure also exits 1), so the message has to say
-    /// what disambiguates it rather than asserting a verdict.
+    /// The killer codes must NOT be described as a crash, must carry the trailer caveat (exit 1
+    /// is ambiguous — a genuine fixture failure also exits 1), and must NOT name an agent. -1 is
+    /// reachable from this harness's own synthesized watchdog value, an external kill, a parent
+    /// reap and a CI job-object teardown, so claiming "external kill" would be a false verdict.
     /// </summary>
     [DataTestMethod]
     [DataRow(-1)]
@@ -62,10 +63,27 @@ public class ExitCodeDescriptionTests
         var text = SelfTestBatch.DescribeExitCode(exitCode);
 
         Assert.IsFalse(text.Contains("crashed on its own"),
-            $"exit {exitCode} is consistent with an external kill, not a fault");
-        StringAssert.Contains(text, "external kill");
+            $"exit {exitCode} does not indicate a fault");
+        StringAssert.Contains(text, "cause is NOT",
+            "the message must refuse to name an agent — -1 has at least four sources here");
         StringAssert.Contains(text, "trailer",
             "exit 1 is ambiguous, so the message must point at the TAP trailer to resolve it");
+    }
+
+    /// <summary>
+    /// -1 specifically must warn that this harness fabricates it. <c>RunProcess</c> returns
+    /// <c>timedOut ? -1 : process.ExitCode</c>, discarding the real code on its own watchdog kill
+    /// — so a reader who takes -1 as evidence of an *external* killer would be chasing a ghost.
+    /// This is the assertion that fails if the wording ever regresses to "external kill".
+    /// </summary>
+    [TestMethod]
+    public void MinusOne_warns_that_the_harness_synthesizes_it()
+    {
+        var text = SelfTestBatch.DescribeExitCode(-1);
+
+        StringAssert.Contains(text, "SYNTHESIZES",
+            "RunProcess returns -1 for its own watchdog kill, which is the most likely source " +
+            "of -1 in this harness and must not be mistaken for an external agent");
     }
 
     /// <summary>

--- a/tests/Reactor.SelfTests/ExitCodeDescriptionTests.cs
+++ b/tests/Reactor.SelfTests/ExitCodeDescriptionTests.cs
@@ -129,24 +129,34 @@ public class ExitCodeDescriptionTests
         var clr = SelfTestBatch.DescribeExitCode(unchecked((int)0xE0434352u));
         var nt = SelfTestBatch.DescribeExitCode(unchecked((int)0xC0000005u));
 
-        Assert.AreNotEqual(clr, nt, "the two crash classes must not produce identical guidance");
-        StringAssert.Contains(nt, "NTSTATUS");
+        // Both classifications must actually be PRESENT. Asserting only that `clr` lacks
+        // "NTSTATUS" would pass if the CLR branch were deleted and `clr` fell through to the bare
+        // raw line — a negative assertion satisfied by the feature's absence, which is precisely
+        // the vacuous shape this suite exists to avoid.
+        StringAssert.Contains(clr, "MANAGED", "the CLR branch must be reached at all");
+        StringAssert.Contains(nt, "NTSTATUS", "the NTSTATUS branch must be reached at all");
+
+        // ...and they must be DIFFERENT classifications, not merely different raw codes.
         Assert.IsFalse(clr.Contains("NTSTATUS"),
             "widening the 0xC mask to cover the CLR tag would route it to the NTSTATUS wording");
+        Assert.IsFalse(nt.Contains("MANAGED"),
+            "the native-fault branch must not claim a managed exception");
     }
 
     /// <summary>
-    /// A plain code with no story attached gets the raw value and nothing invented. This is the
-    /// assertion that fails if the method ever grows a default verdict.
+    /// A plain code with no story attached gets the raw value and nothing invented. Asserted as
+    /// EXACT equality rather than as a pair of "does not contain" guards: those would pass for
+    /// any newly-invented default verdict that merely avoided the two phrases they name, so they
+    /// could not actually detect the thing this test claims to detect.
     /// </summary>
     [TestMethod]
     public void Ordinary_exit_code_gets_no_invented_verdict()
     {
         var text = SelfTestBatch.DescribeExitCode(3);
 
-        StringAssert.Contains(text, "Exit code: 3");
-        Assert.IsFalse(text.Contains("crashed on its own"));
-        Assert.IsFalse(text.Contains("external kill"));
+        Assert.AreEqual("Exit code: 3 (0x00000003)", text,
+            "an ordinary code must produce the raw line and nothing else — no verdict, no arrow, " +
+            "no guidance. Exact equality is what makes this non-vacuous.");
     }
 
     /// <summary>

--- a/tests/Reactor.SelfTests/ExitCodeDescriptionTests.cs
+++ b/tests/Reactor.SelfTests/ExitCodeDescriptionTests.cs
@@ -87,6 +87,47 @@ public class ExitCodeDescriptionTests
     }
 
     /// <summary>
+    /// The CLR's unhandled-managed-exception tag must be attributed to a self-crash even though
+    /// it is NOT NTSTATUS-shaped: <c>0xE0434352 &amp; 0xF0000000</c> is <c>0xE0000000</c>, so the
+    /// <c>0xC0000000</c> mask does not catch it and it would otherwise emit a bare raw value with
+    /// no verdict. For a .NET host that is arguably the likeliest crash mode of all, and it is
+    /// already recognised elsewhere in the repo (DevtoolsStressE2ERunner, MxcSandbox).
+    /// </summary>
+    [TestMethod]
+    public void Clr_managed_exception_is_attributed_to_a_self_crash()
+    {
+        var text = SelfTestBatch.DescribeExitCode(unchecked((int)0xE0434352u));
+
+        StringAssert.Contains(text, "0xE0434352", "the raw value must survive");
+        StringAssert.Contains(text, "MANAGED",
+            "a managed crash must be distinguished from a native fault — the triager needs the " +
+            "stack trace, not a faulting-fixture hunt");
+        Assert.IsFalse(text.Contains("NTSTATUS"),
+            "0xE0434352 is not NTSTATUS-shaped; labelling it as such would send the reader to " +
+            "the wrong diagnosis");
+        Assert.IsFalse(text.Contains("external kill"),
+            "a managed exception is a self-crash, not a kill");
+    }
+
+    /// <summary>
+    /// Guards the mask arithmetic that makes the previous test necessary. If someone widens the
+    /// NTSTATUS mask to swallow 0xE0434352, the dedicated managed-exception wording would be
+    /// unreachable and this fails.
+    /// </summary>
+    [TestMethod]
+    public void Clr_tag_is_not_matched_by_the_NtStatus_shape_mask()
+    {
+        Assert.AreEqual(0xE0000000u, 0xE0434352u & 0xF0000000u,
+            "precondition: the CLR tag is 0xE-shaped, not 0xC-shaped");
+
+        var clr = SelfTestBatch.DescribeExitCode(unchecked((int)0xE0434352u));
+        var nt = SelfTestBatch.DescribeExitCode(unchecked((int)0xC0000005u));
+
+        Assert.AreNotEqual(clr, nt, "the two crash classes must not produce identical guidance");
+        StringAssert.Contains(nt, "NTSTATUS");
+    }
+
+    /// <summary>
     /// A plain code with no story attached gets the raw value and nothing invented. This is the
     /// assertion that fails if the method ever grows a default verdict.
     /// </summary>

--- a/tests/Reactor.SelfTests/ExitCodeDescriptionTests.cs
+++ b/tests/Reactor.SelfTests/ExitCodeDescriptionTests.cs
@@ -102,6 +102,11 @@ public class ExitCodeDescriptionTests
         StringAssert.Contains(text, "MANAGED",
             "a managed crash must be distinguished from a native fault — the triager needs the " +
             "stack trace, not a faulting-fixture hunt");
+        StringAssert.Contains(text, "strong prior",
+            "the managed branch must hedge exactly as the NTSTATUS branch does: an exit code is " +
+            "chosen by whoever terminates the process, so it can never prove the absence of an " +
+            "external terminator. Asserting certainty here would contradict this method's own " +
+            "documented discipline.");
         Assert.IsFalse(text.Contains("NTSTATUS"),
             "0xE0434352 is not NTSTATUS-shaped; labelling it as such would send the reader to " +
             "the wrong diagnosis");

--- a/tests/Reactor.SelfTests/ExitCodeDescriptionTests.cs
+++ b/tests/Reactor.SelfTests/ExitCodeDescriptionTests.cs
@@ -1,0 +1,100 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.UI.Reactor.SelfTests;
+
+/// <summary>
+/// Guards <see cref="SelfTestBatch.DescribeExitCode"/>, the diagnostic that tells a triager
+/// whether a truncated selftest run means "the host faulted" or "something killed it".
+///
+/// <para>Worth testing rather than eyeballing: the mapping is the thing a human acts on, the
+/// NTSTATUS values arrive as negative <see cref="int"/> and must be compared as
+/// <see cref="uint"/> (a signed comparison silently matches nothing), and the hedged wording is
+/// deliberate — the rule is a strong prior, not a proof, because TerminateProcess lets a caller
+/// choose any exit code.</para>
+/// </summary>
+[TestClass]
+public class ExitCodeDescriptionTests
+{
+    // The four codes that actually occur in this harness. 0xC000027B is the WinUI/WinRT one;
+    // 0xC0000409 has repo precedent in the SwipeControl stress crash.
+    [DataTestMethod]
+    [DataRow(unchecked((int)0xC0000005u), "STATUS_ACCESS_VIOLATION")]
+    [DataRow(unchecked((int)0xC000027Bu), "STATUS_STOWED_EXCEPTION")]
+    [DataRow(unchecked((int)0xC0000409u), "STATUS_STACK_BUFFER_OVERRUN")]
+    [DataRow(unchecked((int)0xC00000FDu), "STATUS_STACK_OVERFLOW")]
+    public void NtStatus_codes_are_named_and_attributed_to_a_self_crash(int exitCode, string expectedName)
+    {
+        var text = SelfTestBatch.DescribeExitCode(exitCode);
+
+        StringAssert.Contains(text, expectedName,
+            "the symbolic name is what makes the code searchable");
+        StringAssert.Contains(text, "crashed on its own",
+            "an NTSTATUS must point the triager at the faulting fixture, not an external killer");
+        StringAssert.Contains(text, "strong prior",
+            "the verdict must stay hedged — TerminateProcess can carry any exit code, so a " +
+            "triager who reads this as certain would stop looking too early");
+    }
+
+    /// <summary>
+    /// An NTSTATUS this method does not name individually must STILL be attributed to a crash —
+    /// the 0xC0000000 shape is the signal, not membership of the known-code list. Without this,
+    /// adding the shape check would be indistinguishable from a four-entry lookup table.
+    /// </summary>
+    [TestMethod]
+    public void Unnamed_NtStatus_still_reads_as_a_self_crash()
+    {
+        var text = SelfTestBatch.DescribeExitCode(unchecked((int)0xC0000374u)); // heap corruption
+
+        StringAssert.Contains(text, "crashed on its own");
+        StringAssert.Contains(text, "0xC0000374", "the raw value must survive so nobody has to trust the mapping");
+    }
+
+    /// <summary>
+    /// The killer codes must NOT be described as a crash, and must carry the trailer caveat —
+    /// exit 1 is ambiguous (a genuine fixture failure also exits 1), so the message has to say
+    /// what disambiguates it rather than asserting a verdict.
+    /// </summary>
+    [DataTestMethod]
+    [DataRow(-1)]
+    [DataRow(1)]
+    public void Killer_codes_are_not_called_a_crash_and_name_the_disambiguator(int exitCode)
+    {
+        var text = SelfTestBatch.DescribeExitCode(exitCode);
+
+        Assert.IsFalse(text.Contains("crashed on its own"),
+            $"exit {exitCode} is consistent with an external kill, not a fault");
+        StringAssert.Contains(text, "external kill");
+        StringAssert.Contains(text, "trailer",
+            "exit 1 is ambiguous, so the message must point at the TAP trailer to resolve it");
+    }
+
+    /// <summary>
+    /// A plain code with no story attached gets the raw value and nothing invented. This is the
+    /// assertion that fails if the method ever grows a default verdict.
+    /// </summary>
+    [TestMethod]
+    public void Ordinary_exit_code_gets_no_invented_verdict()
+    {
+        var text = SelfTestBatch.DescribeExitCode(3);
+
+        StringAssert.Contains(text, "Exit code: 3");
+        Assert.IsFalse(text.Contains("crashed on its own"));
+        Assert.IsFalse(text.Contains("external kill"));
+    }
+
+    /// <summary>
+    /// Signed-vs-unsigned regression guard. NTSTATUS values arrive as negative Int32; comparing
+    /// them signed against 0xC0000005 matches nothing and every crash would silently fall through
+    /// to the "no verdict" branch. This fails if the uint casts are dropped.
+    /// </summary>
+    [TestMethod]
+    public void NtStatus_is_matched_unsigned_not_signed()
+    {
+        Assert.IsTrue(unchecked((int)0xC0000005u) < 0, "precondition: NTSTATUS is a negative Int32");
+
+        var text = SelfTestBatch.DescribeExitCode(unchecked((int)0xC0000005u));
+
+        StringAssert.Contains(text, "STATUS_ACCESS_VIOLATION",
+            "a signed comparison would never match, so this text is only reachable via the uint cast");
+    }
+}

--- a/tests/Reactor.SelfTests/SelfTestBatch.cs
+++ b/tests/Reactor.SelfTests/SelfTestBatch.cs
@@ -114,6 +114,16 @@ public class SelfTestBatch
     /// <c>UINT</c>, so the caller picks it; nothing structurally prevents a killer choosing
     /// <c>0xC0000005</c>. It just isn't what any killer in this environment does.</para>
     ///
+    /// <para><b>Scope of the prior, and when it expires.</b> The inference is not over
+    /// <c>TerminateProcess</c> — it is over <i>the population of things that kill this process</i>.
+    /// It holds because every killer present today (this harness's own watchdog, an external
+    /// <c>Process.Kill</c>/<c>Stop-Process</c>, <c>taskkill /F</c>) lands on <c>-1</c> or
+    /// <c>1</c>. It weakens the moment that population changes — a new harness, a CI job-object
+    /// teardown, a container runtime, or any watchdog that deliberately propagates the child's
+    /// status. <b>If you add something that can kill the Host, check what exit code it produces
+    /// and revisit this method.</b> A reader with no cue that the prior is environment-scoped
+    /// would keep trusting it after it stopped being true.</para>
+    ///
     /// <para>The raw value is always printed alongside the interpretation so nobody has to trust
     /// the mapping. A triager who reads "external kill" as certain stops looking, and the cost of
     /// a false certainty here is chasing the wrong cause.</para>

--- a/tests/Reactor.SelfTests/SelfTestBatch.cs
+++ b/tests/Reactor.SelfTests/SelfTestBatch.cs
@@ -137,14 +137,30 @@ public class SelfTestBatch
             0xC000027B => "STATUS_STOWED_EXCEPTION (WinUI/WinRT — the most likely one here)",
             0xC0000409 => "STATUS_STACK_BUFFER_OVERRUN / fast-fail",
             0xC00000FD => "STATUS_STACK_OVERFLOW",
+            0xE0434352 => "CLR managed exception (unhandled .NET exception)",
             _ => null,
         };
+
+        // The CLR's managed-exception tag is NOT NTSTATUS-shaped — 0xE0434352 & 0xF0000000 is
+        // 0xE0000000, so the mask below does not catch it and it would otherwise fall through
+        // with no verdict at all. That is the likeliest crash mode for a .NET host, so it gets
+        // its own branch. Same tag the Devtools stress runner already keys on
+        // (DevtoolsStressE2ERunner.cs) and MxcSandbox documents.
+        bool clrManaged = (uint)exitCode == 0xE0434352u;
 
         // NTSTATUS failure codes are 0xC0000000-shaped. Treat that whole space as
         // "the host faulted", not just the four named above.
         bool ntStatusShaped = ((uint)exitCode & 0xF0000000u) == 0xC0000000u;
 
         var raw = $"Exit code: {exitCode} (0x{(uint)exitCode:X8}{(known is null ? "" : " " + known)})";
+
+        if (clrManaged)
+        {
+            return raw + "\n  -> Unhandled MANAGED exception: the host crashed on its own. The " +
+                   "exception type and stack trace are in the Host's stderr / the output tail " +
+                   "below — read those first. The process was not terminated from outside, and " +
+                   "this is not a WinUI native fault.";
+        }
 
         if (ntStatusShaped)
         {

--- a/tests/Reactor.SelfTests/SelfTestBatch.cs
+++ b/tests/Reactor.SelfTests/SelfTestBatch.cs
@@ -156,10 +156,12 @@ public class SelfTestBatch
 
         if (clrManaged)
         {
-            return raw + "\n  -> Unhandled MANAGED exception: the host crashed on its own. The " +
-                   "exception type and stack trace are in the Host's stderr / the output tail " +
-                   "below — read those first. The process was not terminated from outside, and " +
-                   "this is not a WinUI native fault.";
+            return raw + "\n  -> Unhandled MANAGED exception: the host almost certainly crashed " +
+                   "on its own, via the CLR's unhandled-exception path rather than a native " +
+                   "fault. The exception type and stack trace are in the Host's stderr / the " +
+                   "output tail below — read those first. As with the native-fault codes, a " +
+                   "terminator can pass any value to TerminateProcess, so this is a strong prior " +
+                   "rather than proof.";
         }
 
         if (ntStatusShaped)

--- a/tests/Reactor.SelfTests/SelfTestBatch.cs
+++ b/tests/Reactor.SelfTests/SelfTestBatch.cs
@@ -102,6 +102,58 @@ public class SelfTestBatch
             _initError = $"Self-test process exited with code {exitCode} but produced no parsable TAP output.\n{_fullOutput}";
     }
 
+    /// <summary>
+    /// Renders a Host exit code with its NTSTATUS interpretation, for the truncated-TAP paths
+    /// where the only question a triager has is "did the host fault, or did something kill it?".
+    ///
+    /// <para>This is a <b>strong prior, not a guarantee</b>, and the wording keeps that honest.
+    /// What is measured: .NET's <c>Process.Kill()</c> — and <c>Stop-Process -Force</c>, which goes
+    /// through the same path — produce <c>-1</c> (<c>0xFFFFFFFF</c>); <c>taskkill /F</c> produces
+    /// <c>1</c>. What is NOT established: that an external killer *cannot* produce an
+    /// NTSTATUS-shaped code. <c>TerminateProcess</c> takes <c>uExitCode</c> as an arbitrary
+    /// <c>UINT</c>, so the caller picks it; nothing structurally prevents a killer choosing
+    /// <c>0xC0000005</c>. It just isn't what any killer in this environment does.</para>
+    ///
+    /// <para>The raw value is always printed alongside the interpretation so nobody has to trust
+    /// the mapping. A triager who reads "external kill" as certain stops looking, and the cost of
+    /// a false certainty here is chasing the wrong cause.</para>
+    /// </summary>
+    internal static string DescribeExitCode(int exitCode)
+    {
+        // Compared as uint: these are NTSTATUS values that arrive as negative Int32.
+        var known = (uint)exitCode switch
+        {
+            0xC0000005 => "STATUS_ACCESS_VIOLATION",
+            0xC000027B => "STATUS_STOWED_EXCEPTION (WinUI/WinRT — the most likely one here)",
+            0xC0000409 => "STATUS_STACK_BUFFER_OVERRUN / fast-fail",
+            0xC00000FD => "STATUS_STACK_OVERFLOW",
+            _ => null,
+        };
+
+        // NTSTATUS failure codes are 0xC0000000-shaped. Treat that whole space as
+        // "the host faulted", not just the four named above.
+        bool ntStatusShaped = ((uint)exitCode & 0xF0000000u) == 0xC0000000u;
+
+        var raw = $"Exit code: {exitCode} (0x{(uint)exitCode:X8}{(known is null ? "" : " " + known)})";
+
+        if (ntStatusShaped)
+        {
+            return raw + "\n  -> NTSTATUS-shaped: the host almost certainly crashed on its own. " +
+                   "Look for the faulting fixture, not for an external killer. " +
+                   "(Known killers in this environment exit -1 or 1, but TerminateProcess lets a " +
+                   "caller choose any code, so this is a strong prior rather than proof.)";
+        }
+
+        if (exitCode is -1 or 1)
+        {
+            return raw + "\n  -> Consistent with an external kill (Process.Kill / Stop-Process exit -1; " +
+                   "taskkill /F exits 1). A genuine fixture failure also exits 1, so use the TAP " +
+                   "trailer to tell them apart: present trailer = real failure, truncated = killed.";
+        }
+
+        return raw;
+    }
+
     private static string? ExtractHangSignal(string output)
     {
         if (string.IsNullOrEmpty(output)) return null;
@@ -285,7 +337,8 @@ public class SelfTestBatch
             {
                 _byFixture[attributed] = (false,
                     $"Selftest Host exited before completing fixture '{attributed}'. " +
-                    $"Exit code: {exitCode}. Downstream fixtures were not executed.\n" +
+                    $"{DescribeExitCode(exitCode)}\n" +
+                    $"Downstream fixtures were not executed.\n" +
                     $"--- tail of full output ---\n{Tail(_fullOutput, 4000)}");
             }
 
@@ -352,9 +405,10 @@ public class SelfTestBatch
             Assert.Inconclusive(_abortedReason ?? "Self-test process timed out; teardown exit code is not meaningful.");
 
         Assert.IsTrue(_exitCode is 0 or 1,
-            $"Self-test Host exited with code {_exitCode} (0x{_exitCode & 0xFFFFFFFFL:X8}) — the runner only " +
-            $"ever returns 0 (all passed) or 1 (fixture failures), so any other code means the process faulted " +
-            $"at teardown (e.g. 0xC0000005). This is the issue #680 final-exit access violation.\n" +
+            $"Self-test Host exited with an unexpected code — the runner only ever returns 0 (all " +
+            $"passed) or 1 (fixture failures), so any other code means the process faulted at " +
+            $"teardown (e.g. the issue #680 final-exit access violation).\n" +
+            $"{DescribeExitCode(_exitCode)}\n" +
             $"--- tail of full output ---\n{Tail(_fullOutput, 4000)}");
     }
 

--- a/tests/Reactor.SelfTests/SelfTestBatch.cs
+++ b/tests/Reactor.SelfTests/SelfTestBatch.cs
@@ -437,9 +437,13 @@ public class SelfTestBatch
             Assert.Inconclusive(_abortedReason ?? "Self-test process timed out; teardown exit code is not meaningful.");
 
         Assert.IsTrue(_exitCode is 0 or 1,
-            $"Self-test Host exited with an unexpected code — the runner only ever returns 0 (all " +
-            $"passed) or 1 (fixture failures), so any other code means the process faulted at " +
-            $"teardown (e.g. the issue #680 final-exit access violation).\n" +
+            $"Self-test Host exited ABNORMALLY — the runner only ever returns 0 (all passed) or " +
+            $"1 (fixture failures), so any other code means the process did not exit through the " +
+            $"runner. Do not assume teardown: the guard is reached whenever the run was not " +
+            $"already attributed to a hang/timeout, which does not by itself distinguish a " +
+            $"teardown fault from an earlier crash or an external termination. The line below " +
+            $"classifies the code; the issue #680 final-exit access violation is one known cause, " +
+            $"not the only one.\n" +
             $"{DescribeExitCode(_exitCode)}\n" +
             $"--- tail of full output ---\n{Tail(_fullOutput, 4000)}");
     }

--- a/tests/Reactor.SelfTests/SelfTestBatch.cs
+++ b/tests/Reactor.SelfTests/SelfTestBatch.cs
@@ -146,9 +146,13 @@ public class SelfTestBatch
 
         if (exitCode is -1 or 1)
         {
-            return raw + "\n  -> Consistent with an external kill (Process.Kill / Stop-Process exit -1; " +
-                   "taskkill /F exits 1). A genuine fixture failure also exits 1, so use the TAP " +
-                   "trailer to tell them apart: present trailer = real failure, truncated = killed.";
+            return raw + "\n  -> Category is decidable, cause is NOT. This says the host did not fault; " +
+                   "it does not say who ended it. Beware: `RunProcess` SYNTHESIZES -1 for this " +
+                   "harness's own watchdog kill (it discards the real code), and an external " +
+                   "`Process.Kill` / `Stop-Process`, a parent reap and a CI job-object teardown all " +
+                   "land on -1 too — so -1 alone cannot name the agent. `taskkill /F` and a genuine " +
+                   "fixture failure both exit 1; use the TAP trailer to separate those two: present " +
+                   "trailer = real failure, truncated = killed.";
         }
 
         return raw;

--- a/tests/Reactor.Tests/Diagnostics/PersistenceEtwBridgeTests.cs
+++ b/tests/Reactor.Tests/Diagnostics/PersistenceEtwBridgeTests.cs
@@ -119,7 +119,19 @@ public class PersistenceEtwBridgeTests : IDisposable
 
         Assert.False(store.TryRead("main", out _));
 
-        var evt = FindByName(_listener.Events, nameof(ReactorEventSource.SwallowedError));
+        // Disambiguate by operation, exactly as the base64 and PackagedSettingsStore cases
+        // below already do, and as DiagnosticLogTests / IntlEtwBridgeTests /
+        // ReactorEventSourcePhaseBTests all document as the house rule. Matching on the event
+        // NAME alone is not safe: SwallowedError is emitted by every subsystem under
+        // Keywords.Errors, ReactorEventSource.Log is process-global, and CapturingListener
+        // therefore also receives events raised by any test class running concurrently. This
+        // assertion used to take the FIRST SwallowedError in the buffer and then assert its
+        // category — so a foreign event won the race and it failed with "Intl != Persistence"
+        // (observed ~1 full-suite run in 4; 9/9 in isolation). It was the only one of this
+        // class's three SwallowedError lookups missing the discriminator.
+        var evt = _listener.Events.FirstOrDefault(e =>
+            e.EventName == nameof(ReactorEventSource.SwallowedError)
+            && (e.Payload?[1] as string) == "JsonFileStore.TryRead.parse");
         Assert.NotNull(evt);
         Assert.Equal(nameof(LogCategory.Persistence), evt!.Payload?[0]);
         Assert.Equal("JsonFileStore.TryRead.parse", evt.Payload?[1]);

--- a/tests/Reactor.Tests/Diagnostics/PersistenceEtwBridgeTests.cs
+++ b/tests/Reactor.Tests/Diagnostics/PersistenceEtwBridgeTests.cs
@@ -59,37 +59,6 @@ public class PersistenceEtwBridgeTests : IDisposable
     private static EventWrittenEventArgs? FindByName(IReadOnlyList<EventWrittenEventArgs> events, string name)
         => events.FirstOrDefault(e => e.EventName == name);
 
-    /// <summary>
-    /// Operation label used by <see cref="FindSwallowedError_discriminates_against_a_concurrent_foreign_event"/>
-    /// to stand in for a concurrent subsystem's event. Namespaced so it can never
-    /// collide with a real operation, in either direction.
-    /// </summary>
-    private const string ForeignOperation = "PersistenceEtwBridgeTests.ForeignEventProbe";
-
-    /// <summary>
-    /// Finds a <c>SwallowedError</c> by its <c>operation</c> payload field (index 1) —
-    /// never by event name alone.
-    ///
-    /// Matching on the name alone is not safe: <c>SwallowedError</c> is emitted by every
-    /// subsystem under <c>Keywords.Errors</c>, <c>ReactorEventSource.Log</c> is
-    /// process-global, and <see cref="CapturingListener"/> therefore also receives events
-    /// raised by any test class running concurrently. The malformed-JSON assertion below
-    /// used to take the FIRST <c>SwallowedError</c> in the buffer and then assert its
-    /// category, so a foreign event could win the race and fail it with
-    /// "Intl != Persistence" — observed ~1 full-suite run in 4, 9/9 in isolation. It was
-    /// the only one of this class's <c>SwallowedError</c> lookups missing the discriminator.
-    ///
-    /// Routing every lookup through here leaves no name-only variant to regress to, and
-    /// <see cref="FindSwallowedError_discriminates_against_a_concurrent_foreign_event"/>
-    /// pins it: drop the <paramref name="operation"/> filter and that test fails
-    /// deterministically rather than the flake silently returning.
-    /// </summary>
-    private static EventWrittenEventArgs? FindSwallowedError(
-        IReadOnlyList<EventWrittenEventArgs> events, string operation)
-        => events.FirstOrDefault(e =>
-            e.EventName == nameof(ReactorEventSource.SwallowedError)
-            && (e.Payload?[1] as string) == operation);
-
     // ── JsonFileStore round-trip emits Read + Write ─────────────────────
 
     [Fact]
@@ -150,10 +119,19 @@ public class PersistenceEtwBridgeTests : IDisposable
 
         Assert.False(store.TryRead("main", out _));
 
-        // Disambiguate by operation via FindSwallowedError — see its remarks for why
-        // matching on the event name alone was a 1-in-4 flake, and for the test that
-        // now pins the discriminator.
-        var evt = FindSwallowedError(_listener.Events, "JsonFileStore.TryRead.parse");
+        // Disambiguate by operation, exactly as the base64 and PackagedSettingsStore cases
+        // below already do, and as DiagnosticLogTests / IntlEtwBridgeTests /
+        // ReactorEventSourcePhaseBTests all document as the house rule. Matching on the event
+        // NAME alone is not safe: SwallowedError is emitted by every subsystem under
+        // Keywords.Errors, ReactorEventSource.Log is process-global, and CapturingListener
+        // therefore also receives events raised by any test class running concurrently. This
+        // assertion used to take the FIRST SwallowedError in the buffer and then assert its
+        // category — so a foreign event won the race and it failed with "Intl != Persistence"
+        // (observed ~1 full-suite run in 4; 9/9 in isolation). It was the only one of this
+        // class's three SwallowedError lookups missing the discriminator.
+        var evt = _listener.Events.FirstOrDefault(e =>
+            e.EventName == nameof(ReactorEventSource.SwallowedError)
+            && (e.Payload?[1] as string) == "JsonFileStore.TryRead.parse");
         Assert.NotNull(evt);
         Assert.Equal(nameof(LogCategory.Persistence), evt!.Payload?[0]);
         Assert.Equal("JsonFileStore.TryRead.parse", evt.Payload?[1]);
@@ -177,60 +155,12 @@ public class PersistenceEtwBridgeTests : IDisposable
 
         Assert.False(store.TryRead("main", out _));
 
-        var evt = FindSwallowedError(_listener.Events, "JsonFileStore.TryRead.base64");
+        var evt = _listener.Events.FirstOrDefault(e =>
+            e.EventName == nameof(ReactorEventSource.SwallowedError)
+            && (e.Payload?[1] as string) == "JsonFileStore.TryRead.base64");
         Assert.NotNull(evt);
         Assert.Equal(nameof(LogCategory.Persistence), evt!.Payload?[0]);
         Assert.Equal(nameof(FormatException), evt.Payload?[2]);
-    }
-
-    // ── Regression guard for the lookup itself ──────────────────────────
-
-    [Fact]
-    public void FindSwallowedError_discriminates_against_a_concurrent_foreign_event()
-    {
-        // Makes the 1-in-4 full-suite flake deterministic instead of hoping the race
-        // fires. ReactorEventSource.Log is process-global, so this listener also sees
-        // SwallowedError events raised by other test classes; emitting one here turns
-        // that interleaving from a race into a certainty. LogCategory.Intl reproduces
-        // the exact reported symptom ("Expected: Persistence, Actual: Intl").
-        //
-        // Safe to emit globally: it goes out under Keywords.Errors, which this class has
-        // held open since its constructor either way, so no concurrent listener's keyword
-        // mask changes. ReactorTraceRegressionTests' allocation probe subscribes to
-        // Keywords.Reconcile only and already skips when Errors is enabled elsewhere;
-        // IntlEtwBridgeTests matches on per-test discriminators that ForeignOperation
-        // cannot collide with.
-        DiagnosticLog.SwallowedError(
-            LogCategory.Intl, ForeignOperation, new InvalidOperationException());
-
-        global::System.IO.File.WriteAllText(_path, "this is not json{{{");
-        var store = new JsonFileStore(_path);
-        Assert.False(store.TryRead("main", out _));
-
-        // Setup oracle: prove the foreign event actually landed, without going through
-        // the helper under test — otherwise a broken helper could make this look fine.
-        Assert.Contains(_listener.Events, e =>
-            e.EventName == nameof(ReactorEventSource.SwallowedError)
-            && (e.Payload?[0] as string) == nameof(LogCategory.Intl)
-            && (e.Payload?[1] as string) == ForeignOperation);
-
-        // Guard the guard: the first SwallowedError in the buffer must NOT be the one
-        // we are looking for, or a name-only lookup would succeed by luck and this test
-        // would prove nothing. Asserting "not the target" rather than "is our Intl event"
-        // keeps it deterministic even if a third class's event arrives first — the
-        // injected event always precedes the parse event in this thread's write order,
-        // so the target can never be first.
-        var nameOnly = _listener.Events.First(e =>
-            e.EventName == nameof(ReactorEventSource.SwallowedError));
-        Assert.NotEqual("JsonFileStore.TryRead.parse", nameOnly.Payload?[1] as string);
-
-        // The discriminated lookup must skip past it. Remove the operation filter from
-        // FindSwallowedError and this returns the Intl event, failing on the category
-        // assertion exactly as the original flake did.
-        var evt = FindSwallowedError(_listener.Events, "JsonFileStore.TryRead.parse");
-        Assert.NotNull(evt);
-        Assert.Equal(nameof(LogCategory.Persistence), evt!.Payload?[0]);
-        Assert.Equal("JsonFileStore.TryRead.parse", evt.Payload?[1]);
     }
 
     // ── PackagedSettingsStore (unpackaged context throws WinRT) ─────────
@@ -246,7 +176,9 @@ public class PersistenceEtwBridgeTests : IDisposable
         var result = store.TryRead("anything", out _);
 
         Assert.False(result);
-        var evt = FindSwallowedError(_listener.Events, "PackagedSettingsStore.TryRead");
+        var evt = _listener.Events.FirstOrDefault(e =>
+            e.EventName == nameof(ReactorEventSource.SwallowedError)
+            && (e.Payload?[1] as string) == "PackagedSettingsStore.TryRead");
         Assert.NotNull(evt);
         Assert.Equal(nameof(LogCategory.Persistence), evt!.Payload?[0]);
     }
@@ -258,7 +190,9 @@ public class PersistenceEtwBridgeTests : IDisposable
 
         store.Write("anything", new byte[] { 1, 2, 3 });
 
-        var evt = FindSwallowedError(_listener.Events, "PackagedSettingsStore.Write");
+        var evt = _listener.Events.FirstOrDefault(e =>
+            e.EventName == nameof(ReactorEventSource.SwallowedError)
+            && (e.Payload?[1] as string) == "PackagedSettingsStore.Write");
         Assert.NotNull(evt);
         Assert.Equal(nameof(LogCategory.Persistence), evt!.Payload?[0]);
     }

--- a/tests/Reactor.Tests/Diagnostics/PersistenceEtwBridgeTests.cs
+++ b/tests/Reactor.Tests/Diagnostics/PersistenceEtwBridgeTests.cs
@@ -59,6 +59,37 @@ public class PersistenceEtwBridgeTests : IDisposable
     private static EventWrittenEventArgs? FindByName(IReadOnlyList<EventWrittenEventArgs> events, string name)
         => events.FirstOrDefault(e => e.EventName == name);
 
+    /// <summary>
+    /// Operation label used by <see cref="FindSwallowedError_discriminates_against_a_concurrent_foreign_event"/>
+    /// to stand in for a concurrent subsystem's event. Namespaced so it can never
+    /// collide with a real operation, in either direction.
+    /// </summary>
+    private const string ForeignOperation = "PersistenceEtwBridgeTests.ForeignEventProbe";
+
+    /// <summary>
+    /// Finds a <c>SwallowedError</c> by its <c>operation</c> payload field (index 1) —
+    /// never by event name alone.
+    ///
+    /// Matching on the name alone is not safe: <c>SwallowedError</c> is emitted by every
+    /// subsystem under <c>Keywords.Errors</c>, <c>ReactorEventSource.Log</c> is
+    /// process-global, and <see cref="CapturingListener"/> therefore also receives events
+    /// raised by any test class running concurrently. The malformed-JSON assertion below
+    /// used to take the FIRST <c>SwallowedError</c> in the buffer and then assert its
+    /// category, so a foreign event could win the race and fail it with
+    /// "Intl != Persistence" — observed ~1 full-suite run in 4, 9/9 in isolation. It was
+    /// the only one of this class's <c>SwallowedError</c> lookups missing the discriminator.
+    ///
+    /// Routing every lookup through here leaves no name-only variant to regress to, and
+    /// <see cref="FindSwallowedError_discriminates_against_a_concurrent_foreign_event"/>
+    /// pins it: drop the <paramref name="operation"/> filter and that test fails
+    /// deterministically rather than the flake silently returning.
+    /// </summary>
+    private static EventWrittenEventArgs? FindSwallowedError(
+        IReadOnlyList<EventWrittenEventArgs> events, string operation)
+        => events.FirstOrDefault(e =>
+            e.EventName == nameof(ReactorEventSource.SwallowedError)
+            && (e.Payload?[1] as string) == operation);
+
     // ── JsonFileStore round-trip emits Read + Write ─────────────────────
 
     [Fact]
@@ -119,19 +150,10 @@ public class PersistenceEtwBridgeTests : IDisposable
 
         Assert.False(store.TryRead("main", out _));
 
-        // Disambiguate by operation, exactly as the base64 and PackagedSettingsStore cases
-        // below already do, and as DiagnosticLogTests / IntlEtwBridgeTests /
-        // ReactorEventSourcePhaseBTests all document as the house rule. Matching on the event
-        // NAME alone is not safe: SwallowedError is emitted by every subsystem under
-        // Keywords.Errors, ReactorEventSource.Log is process-global, and CapturingListener
-        // therefore also receives events raised by any test class running concurrently. This
-        // assertion used to take the FIRST SwallowedError in the buffer and then assert its
-        // category — so a foreign event won the race and it failed with "Intl != Persistence"
-        // (observed ~1 full-suite run in 4; 9/9 in isolation). It was the only one of this
-        // class's three SwallowedError lookups missing the discriminator.
-        var evt = _listener.Events.FirstOrDefault(e =>
-            e.EventName == nameof(ReactorEventSource.SwallowedError)
-            && (e.Payload?[1] as string) == "JsonFileStore.TryRead.parse");
+        // Disambiguate by operation via FindSwallowedError — see its remarks for why
+        // matching on the event name alone was a 1-in-4 flake, and for the test that
+        // now pins the discriminator.
+        var evt = FindSwallowedError(_listener.Events, "JsonFileStore.TryRead.parse");
         Assert.NotNull(evt);
         Assert.Equal(nameof(LogCategory.Persistence), evt!.Payload?[0]);
         Assert.Equal("JsonFileStore.TryRead.parse", evt.Payload?[1]);
@@ -155,12 +177,60 @@ public class PersistenceEtwBridgeTests : IDisposable
 
         Assert.False(store.TryRead("main", out _));
 
-        var evt = _listener.Events.FirstOrDefault(e =>
-            e.EventName == nameof(ReactorEventSource.SwallowedError)
-            && (e.Payload?[1] as string) == "JsonFileStore.TryRead.base64");
+        var evt = FindSwallowedError(_listener.Events, "JsonFileStore.TryRead.base64");
         Assert.NotNull(evt);
         Assert.Equal(nameof(LogCategory.Persistence), evt!.Payload?[0]);
         Assert.Equal(nameof(FormatException), evt.Payload?[2]);
+    }
+
+    // ── Regression guard for the lookup itself ──────────────────────────
+
+    [Fact]
+    public void FindSwallowedError_discriminates_against_a_concurrent_foreign_event()
+    {
+        // Makes the 1-in-4 full-suite flake deterministic instead of hoping the race
+        // fires. ReactorEventSource.Log is process-global, so this listener also sees
+        // SwallowedError events raised by other test classes; emitting one here turns
+        // that interleaving from a race into a certainty. LogCategory.Intl reproduces
+        // the exact reported symptom ("Expected: Persistence, Actual: Intl").
+        //
+        // Safe to emit globally: it goes out under Keywords.Errors, which this class has
+        // held open since its constructor either way, so no concurrent listener's keyword
+        // mask changes. ReactorTraceRegressionTests' allocation probe subscribes to
+        // Keywords.Reconcile only and already skips when Errors is enabled elsewhere;
+        // IntlEtwBridgeTests matches on per-test discriminators that ForeignOperation
+        // cannot collide with.
+        DiagnosticLog.SwallowedError(
+            LogCategory.Intl, ForeignOperation, new InvalidOperationException());
+
+        global::System.IO.File.WriteAllText(_path, "this is not json{{{");
+        var store = new JsonFileStore(_path);
+        Assert.False(store.TryRead("main", out _));
+
+        // Setup oracle: prove the foreign event actually landed, without going through
+        // the helper under test — otherwise a broken helper could make this look fine.
+        Assert.Contains(_listener.Events, e =>
+            e.EventName == nameof(ReactorEventSource.SwallowedError)
+            && (e.Payload?[0] as string) == nameof(LogCategory.Intl)
+            && (e.Payload?[1] as string) == ForeignOperation);
+
+        // Guard the guard: the first SwallowedError in the buffer must NOT be the one
+        // we are looking for, or a name-only lookup would succeed by luck and this test
+        // would prove nothing. Asserting "not the target" rather than "is our Intl event"
+        // keeps it deterministic even if a third class's event arrives first — the
+        // injected event always precedes the parse event in this thread's write order,
+        // so the target can never be first.
+        var nameOnly = _listener.Events.First(e =>
+            e.EventName == nameof(ReactorEventSource.SwallowedError));
+        Assert.NotEqual("JsonFileStore.TryRead.parse", nameOnly.Payload?[1] as string);
+
+        // The discriminated lookup must skip past it. Remove the operation filter from
+        // FindSwallowedError and this returns the Intl event, failing on the category
+        // assertion exactly as the original flake did.
+        var evt = FindSwallowedError(_listener.Events, "JsonFileStore.TryRead.parse");
+        Assert.NotNull(evt);
+        Assert.Equal(nameof(LogCategory.Persistence), evt!.Payload?[0]);
+        Assert.Equal("JsonFileStore.TryRead.parse", evt.Payload?[1]);
     }
 
     // ── PackagedSettingsStore (unpackaged context throws WinRT) ─────────
@@ -176,9 +246,7 @@ public class PersistenceEtwBridgeTests : IDisposable
         var result = store.TryRead("anything", out _);
 
         Assert.False(result);
-        var evt = _listener.Events.FirstOrDefault(e =>
-            e.EventName == nameof(ReactorEventSource.SwallowedError)
-            && (e.Payload?[1] as string) == "PackagedSettingsStore.TryRead");
+        var evt = FindSwallowedError(_listener.Events, "PackagedSettingsStore.TryRead");
         Assert.NotNull(evt);
         Assert.Equal(nameof(LogCategory.Persistence), evt!.Payload?[0]);
     }
@@ -190,9 +258,7 @@ public class PersistenceEtwBridgeTests : IDisposable
 
         store.Write("anything", new byte[] { 1, 2, 3 });
 
-        var evt = _listener.Events.FirstOrDefault(e =>
-            e.EventName == nameof(ReactorEventSource.SwallowedError)
-            && (e.Payload?[1] as string) == "PackagedSettingsStore.Write");
+        var evt = FindSwallowedError(_listener.Events, "PackagedSettingsStore.Write");
         Assert.NotNull(evt);
         Assert.Equal(nameof(LogCategory.Persistence), evt!.Payload?[0]);
     }


### PR DESCRIPTION
Fixes a set of test-reliability defects found by polling every recent session for flaky-test observations, then root-causing each one rather than pattern-matching it.

## What is claimed fixed — and the evidence for each

Every flake claimed fixed below has **failure-shaped, deterministic** evidence: revert the fix and the original failure returns on demand. That matters because a green run cannot distinguish *fixed* from *didn't fire* from *stale binary* from **#988** (the selftest suite exceeding its own 300s watchdog, which manufactures arbitrary single-fixture failures). A deterministic reproduction excludes all four.

**`[Retry(3)]` masking regression — `ItemClickToggleInteractionTests`.** PR #835 added the anti-masking `E2eRetryAttribute` and swept the E2E suite onto it; PR #836 landed the same day from a branch cut *before* that sweep, and PR #652 later edited the file without noticing. The built-in attribute reports the *last* attempt and treats `Inconclusive` as acceptable, so a genuine failure followed by an environmental `Inconclusive` is erased and `dotnet test` exits 0. Not a flake-reproduction claim — a code-correctness fix, verifiable by reading the attribute semantics.

**`TabViewFill_*` NullReferenceExceptions.** A cascade, not an independent bug: `TabViewFill_Mounted` asserts `tabView is not null && Body(H) is not null`, but the guard on the next line covered only `tabView`, so a null body fell through to `Body(H)!.ActualHeight`. The null came from reading the body off a one-shot `Harness.Render()` — TabView realizes its ContentPresenter over *multiple* dispatcher waves and Render caps at 4.
*Evidence:* revert the fix + force the precondition → `TabViewFill_ToggleFillContentArea_CRASH - NullReferenceException` returns, and **only 9 checks are emitted instead of 16** — the exception truncated the TAP stream, which is why it presented as an arbitrary-victim flake. Fix in place, same precondition → 16 checks, 0 NRE. A watchdog kill cannot produce a specific NRE on demand.

**`PersistenceEtwBridgeTests.JsonFileStore_malformed_json_*` (~1 in 4 full runs).** `ReactorEventSource.Log` is process-global, the listener enables broad `Keywords.Errors`, and xUnit runs classes in parallel — but the assertion matched `SwallowedError` by **event name only**, so a foreign event won the race. It was the only one of this class's three `SwallowedError` lookups missing the `Payload[1]` discriminator its siblings already use.
*Evidence:* the race made deterministic by injecting a foreign event into the shared listener — fix in place → PASS; fix reverted → **FAIL with `Expected: Persistence / Actual: Intl`**, the exact symptom two sessions reported independently.

> **Relationship to #972 — merge that one first.** #972 (*"Fix PersistenceEtwBridge cross-test event collision"*) fixes the same defect with a strictly better design: `AssertEvent(events, name, discriminatorIndex, discriminator)` generalises the discriminator to **all four** event types, deletes the name-only `FindByName` outright, and reports the observed discriminator values on failure. This PR keeps only a plain inline discriminator on the one lookup that was missing it — **+13/-1 against `main`**, confined to the `JsonFileStore.TryRead.parse` assertion. #972 changes the same file +52/-15 and rewrites that exact region, so **there is a real (small) conflict** — resolve it toward #972: take its `AssertEvent`, drop this PR's inline predicate, which it subsumes. **Carry the comment across, though** — it records the reproduction rate (*"~1 full-suite run in 4; 9/9 in isolation"*) and the scope of the gap (*"the only one of this class's three SwallowedError lookups missing the discriminator"*), which is measurement #972's code cannot express and the next person would otherwise have to re-derive. (An earlier revision of this note said the file was byte-identical to its pre-branch state. That was wrong: it is identical to its state before the reverted commit `9c341e93`, not to `main`.) The injection experiment above was a temporary harness, not a committed test — a permanent pinning test against #972's `AssertEvent` shape is filed as **#996**, because #972 has the same gap: nothing currently fails if its discriminator is removed.

**`CenterOnCurrent_UsesCursorMonitor` + `PersistPlacement_FallbackWhenEmpty` — not a flake at all.** These are the *same assertion twice*, which is why they always failed as a pair. `haveCursor && center.X >= work.Left && ...` converts *"the cursor position could not be **determined**"* into *"the window landed in the wrong place"*. On any non-interactive session — CI agents, RDP-disconnected, locked, headless — `GetCursorPos` returns **ACCESS_DENIED (err 5)** and this is a **100% deterministic failure**. Confirmed by direct P/Invoke probe on two independent machines. Both now `H.Skip` when the cursor is undeterminable.
*Evidence:* mutation-verified this is not now a permanent skip — forcing `haveCursor = true` with a wrong work rect still yields `not ok ... assertion failed`.

**Chart keyboard E2E — 175 → 83 winapp spawns, 61.7s → 38.8s.** Each of ~46 keypresses spent three `winapp.exe` spawns (search + focus + send-keys) at ~150ms each. `send-keys --target` resolves and focuses in the same invocation, and `WinAppUi.SendKeys` already exposed the parameter.

**27 fixed-delay assertion gates → `Harness.WaitFor`.** 19 sites deliberately left alone: `WaitFor` evaluates its predicate *before* its first render, so converting negative or exact-count assertions makes them vacuous.

## What is explicitly NOT claimed

- **#927 `WindowLevel_RuntimeFlip_Topmost` is NOT fixed.** I claimed it twice and was wrong twice — 3 clean runs is 42% likely at a 1-in-4 rate. Five hypotheses are refuted and recorded in the fixture: too-tight wait; missing secondary-window host await (a real bug, fixed here, but not the cause); intrinsic to the fixture (20/20 isolated); the neighbouring Floating fixtures (20/20 with them); leaked Floating windows (population identical in full vs filtered runs). What survives is that `ApplyWindowLevel` discards the `SetWindowPos` BOOL at `ReactorWindow.cs:810`. The failure now diagnoses itself with a three-way verdict.
- **`Issue487_SV2ParkedAtBottom` / `_ClampObserved`** — reproduce on two machines, root-caused by neither this PR nor #984. Untouched.
- **This PR does not address #988** (suite over its 300s watchdog). That is infrastructure and filed separately. None of the fixes above rest on a green run, so #988 is not an alternative explanation for any of them.

## Documentation defects fixed

Each had already misled someone:

- **Known-flake tiers.** `AGENTS.md` listed three flakes together *by shared consequence*, which five separate sessions read as *by tier*. Two of the three are selftest fixtures, not unit tests.
- **The cursor-pair guidance was wrong** — it claimed "on a quiet machine both pass" and prescribed running E2E first as the repro. True only in the interactive case; on a non-interactive box they fail regardless. Now splits both environments and gives the P/Invoke probe as the diagnostic. Also records that `System.Windows.Forms.Cursor.Position` **hides** the failure by surfacing the uninitialised `(0,0)`.
- **Searching for a TAP name.** Two-place registration means grepping `Fixtures/` misses fixture names whose class differs, and grepping the registry misses check-only names. Both return a *confident zero*.
- **Judging a flake fix** — the `(1-p)^N` rule, which my own retraction demonstrates.
- **Tier isolation is load-bearing** — CI's separate jobs are why nobody has hit E2E/selftest interference; consolidating them to save runner minutes would break it.

## Review

The `pr-review` skill ran twice across all 8 dimensions. Zero critical, zero high from the same-family dimensions; the **cross-family multi-model pass found the one high they all missed** — `DescribeExitCode` left `0xE0434352` (CLR managed exception) unclassified because it is `0xE`-shaped and the NTSTATUS mask only matches `0xC`.

A second cross-family pass then found **two of my own guards were vacuous** — `Clr_tag_is_not_matched_by_the_NtStatus_shape_mask` asserted `AreNotEqual(clr, nt)` (true merely because the raw codes differ) and `IsFalse(clr.Contains("NTSTATUS"))` (which passes *when the CLR branch is absent*). Delete the feature and all three assertions still held.

Six vacuous assertions were caught on this branch before merge, all the same shape: **a negative assertion satisfied by the absence of the thing it guards.** Two were flagged by the repo's own MSTest analyzer as "always true" — note `Directory.Build.props:66` gates `TreatWarningsAsErrors` behind `Configuration == Release`, so **Debug builds structurally cannot surface these**; `-c Release` is the only local build that reproduces the CI gate.

## Validation

- Full selftest: **6160 checks**, 2 failures — both `Issue487_SV2*`, which reproduce on a clean unmodified tree and on a second machine.
- Unit: **12,934 pass / 64 skipped** across 5 consecutive runs.
- `ExitCodeDescriptionTests` 12/12.
- **Mutation-verified rather than assumed** throughout, with builds gated on `Build succeeded` and run under `-m:1 -nodereuse:false` after a run was caught reporting `Passed!` from a build that had failed with `CS0234`.

Test-only and docs-only; no `src/` production code, no public API change.