### PR TITLE
Fix PersistenceEtwBridge cross-test event collision

### DIFF
--- a/.github/skills/coverage-uplift/SKILL.md
+++ b/.github/skills/coverage-uplift/SKILL.md
@@ -57,7 +57,7 @@ dotnet-coverage merge coverage\unit.cobertura.xml coverage\selftest.cobertura.xm
 ```
 
 Known flakes to ignore (not your regression): `CenterOnCurrent_UsesCursorMonitor`,
-`PersistPlacement_FallbackWhenEmpty`, `PersistenceEtwBridgeTests.JsonFileStore_*`.
+`PersistPlacement_FallbackWhenEmpty`.
 
 ### 2. Classify each gap by tier
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -210,8 +210,8 @@ Hard-won specifics that repeatedly cost sessions time. Prefer these exact comman
 - **Coverage** starts from `tools/coverage/run-coverage.ps1` (`-UnitOnly`, `-SkipBuild`);
   output `coverage/merged.cobertura.xml`. The script **aborts before the merge step on any
   test failure** — if a known flake trips it (`CenterOnCurrent_UsesCursorMonitor`,
-  `PersistPlacement_FallbackWhenEmpty`, `PersistenceEtwBridgeTests.JsonFileStore_*`), merge
-  the legs manually with `dotnet-coverage merge coverage\unit.cobertura.xml coverage\selftest.cobertura.xml --output coverage\merged.cobertura.xml --output-format cobertura`.
+  `PersistPlacement_FallbackWhenEmpty`), merge the legs manually with
+  `dotnet-coverage merge coverage\unit.cobertura.xml coverage\selftest.cobertura.xml --output coverage\merged.cobertura.xml --output-format cobertura`.
 
 ### Analyzers, CLI checks, docs & public API
 

--- a/tests/Reactor.Tests/Diagnostics/PersistenceEtwBridgeTests.cs
+++ b/tests/Reactor.Tests/Diagnostics/PersistenceEtwBridgeTests.cs
@@ -64,7 +64,11 @@ public class PersistenceEtwBridgeTests : IDisposable
     {
         var candidates = events.Where(e => e.EventName == name).ToArray();
         var match = candidates.FirstOrDefault(e =>
-            (e.Payload?[discriminatorIndex] as string) == discriminator);
+            e.Payload is { } payload
+            && discriminatorIndex >= 0
+            && discriminatorIndex < payload.Count
+            && payload[discriminatorIndex] is string value
+            && value == discriminator);
 
         if (match is null)
         {

--- a/tests/Reactor.Tests/Diagnostics/PersistenceEtwBridgeTests.cs
+++ b/tests/Reactor.Tests/Diagnostics/PersistenceEtwBridgeTests.cs
@@ -64,18 +64,21 @@ public class PersistenceEtwBridgeTests : IDisposable
     {
         var candidates = events.Where(e => e.EventName == name).ToArray();
         var match = candidates.FirstOrDefault(e =>
-            e.EventName == name
-            && (e.Payload?[discriminatorIndex] as string) == discriminator);
+            (e.Payload?[discriminatorIndex] as string) == discriminator);
 
         if (match is null)
         {
-            var observedPayloads = candidates.Length == 0
+            var observedDiscriminators = candidates.Length == 0
                 ? "<none>"
-                : string.Join("; ", candidates.Select(e =>
-                    $"[{string.Join(", ", e.Payload?.Select(value => value?.ToString() ?? "<null>") ?? [])}]"));
+                : string.Join(", ", candidates.Select(e =>
+                    e.Payload is { } payload
+                    && discriminatorIndex >= 0
+                    && discriminatorIndex < payload.Count
+                        ? payload[discriminatorIndex]?.ToString() ?? "<null>"
+                        : "<missing>"));
             Assert.Fail(
                 $"Expected {name} with payload[{discriminatorIndex}] = '{discriminator}'. "
-                + $"Same-name payloads: {observedPayloads}");
+                + $"Same-name payload[{discriminatorIndex}] values: {observedDiscriminators}");
         }
 
         return match;

--- a/tests/Reactor.Tests/Diagnostics/PersistenceEtwBridgeTests.cs
+++ b/tests/Reactor.Tests/Diagnostics/PersistenceEtwBridgeTests.cs
@@ -56,8 +56,14 @@ public class PersistenceEtwBridgeTests : IDisposable
         try { if (global::System.IO.File.Exists(_path)) global::System.IO.File.Delete(_path); } catch { }
     }
 
-    private static EventWrittenEventArgs? FindByName(IReadOnlyList<EventWrittenEventArgs> events, string name)
-        => events.FirstOrDefault(e => e.EventName == name);
+    private static EventWrittenEventArgs? FindByName(
+        IReadOnlyList<EventWrittenEventArgs> events,
+        string name,
+        int discriminatorIndex,
+        string discriminator)
+        => events.FirstOrDefault(e =>
+            e.EventName == name
+            && (e.Payload?[discriminatorIndex] as string) == discriminator);
 
     // ── JsonFileStore round-trip emits Read + Write ─────────────────────
 
@@ -68,7 +74,11 @@ public class PersistenceEtwBridgeTests : IDisposable
 
         store.Write("main", new byte[] { 1, 2, 3 });
 
-        var evt = FindByName(_listener.Events, nameof(ReactorEventSource.PersistenceWrite));
+        var evt = FindByName(
+            _listener.Events,
+            nameof(ReactorEventSource.PersistenceWrite),
+            0,
+            "json-file");
         Assert.NotNull(evt);
         Assert.Equal("json-file", evt!.Payload?[0]);
         Assert.True((int)(evt.Payload?[1] ?? 0) > 0);
@@ -87,7 +97,11 @@ public class PersistenceEtwBridgeTests : IDisposable
         Assert.True(store.TryRead("main", out var data));
         Assert.NotNull(data);
 
-        var evt = FindByName(_listener.Events, nameof(ReactorEventSource.PersistenceRead));
+        var evt = FindByName(
+            _listener.Events,
+            nameof(ReactorEventSource.PersistenceRead),
+            0,
+            "json-file");
         Assert.NotNull(evt);
         Assert.Equal("json-file", evt!.Payload?[0]);
     }
@@ -103,7 +117,11 @@ public class PersistenceEtwBridgeTests : IDisposable
         var store = new JsonFileStore(_path);
         Assert.False(store.TryRead("main", out _));
 
-        var evt = FindByName(_listener.Events, nameof(ReactorEventSource.PersistenceRejected));
+        var evt = FindByName(
+            _listener.Events,
+            nameof(ReactorEventSource.PersistenceRejected),
+            0,
+            "json-file");
         Assert.NotNull(evt);
         Assert.Equal("json-file", evt!.Payload?[0]);
         Assert.Equal("oversize-read", evt.Payload?[1]);
@@ -119,7 +137,11 @@ public class PersistenceEtwBridgeTests : IDisposable
 
         Assert.False(store.TryRead("main", out _));
 
-        var evt = FindByName(_listener.Events, nameof(ReactorEventSource.SwallowedError));
+        var evt = FindByName(
+            _listener.Events,
+            nameof(ReactorEventSource.SwallowedError),
+            1,
+            "JsonFileStore.TryRead.parse");
         Assert.NotNull(evt);
         Assert.Equal(nameof(LogCategory.Persistence), evt!.Payload?[0]);
         Assert.Equal("JsonFileStore.TryRead.parse", evt.Payload?[1]);

--- a/tests/Reactor.Tests/Diagnostics/PersistenceEtwBridgeTests.cs
+++ b/tests/Reactor.Tests/Diagnostics/PersistenceEtwBridgeTests.cs
@@ -56,14 +56,30 @@ public class PersistenceEtwBridgeTests : IDisposable
         try { if (global::System.IO.File.Exists(_path)) global::System.IO.File.Delete(_path); } catch { }
     }
 
-    private static EventWrittenEventArgs? FindByName(
+    private static EventWrittenEventArgs AssertEvent(
         IReadOnlyList<EventWrittenEventArgs> events,
         string name,
         int discriminatorIndex,
         string discriminator)
-        => events.FirstOrDefault(e =>
+    {
+        var candidates = events.Where(e => e.EventName == name).ToArray();
+        var match = candidates.FirstOrDefault(e =>
             e.EventName == name
             && (e.Payload?[discriminatorIndex] as string) == discriminator);
+
+        if (match is null)
+        {
+            var observedPayloads = candidates.Length == 0
+                ? "<none>"
+                : string.Join("; ", candidates.Select(e =>
+                    $"[{string.Join(", ", e.Payload?.Select(value => value?.ToString() ?? "<null>") ?? [])}]"));
+            Assert.Fail(
+                $"Expected {name} with payload[{discriminatorIndex}] = '{discriminator}'. "
+                + $"Same-name payloads: {observedPayloads}");
+        }
+
+        return match;
+    }
 
     // ── JsonFileStore round-trip emits Read + Write ─────────────────────
 
@@ -74,13 +90,11 @@ public class PersistenceEtwBridgeTests : IDisposable
 
         store.Write("main", new byte[] { 1, 2, 3 });
 
-        var evt = FindByName(
+        var evt = AssertEvent(
             _listener.Events,
             nameof(ReactorEventSource.PersistenceWrite),
             0,
             "json-file");
-        Assert.NotNull(evt);
-        Assert.Equal("json-file", evt!.Payload?[0]);
         Assert.True((int)(evt.Payload?[1] ?? 0) > 0);
         // PII: serialized payload size is on the event, but the file path
         // must not appear anywhere on the payload list.
@@ -97,13 +111,11 @@ public class PersistenceEtwBridgeTests : IDisposable
         Assert.True(store.TryRead("main", out var data));
         Assert.NotNull(data);
 
-        var evt = FindByName(
+        AssertEvent(
             _listener.Events,
             nameof(ReactorEventSource.PersistenceRead),
             0,
             "json-file");
-        Assert.NotNull(evt);
-        Assert.Equal("json-file", evt!.Payload?[0]);
     }
 
     // ── JsonFileStore explicit rejects → PersistenceRejected ────────────
@@ -117,13 +129,11 @@ public class PersistenceEtwBridgeTests : IDisposable
         var store = new JsonFileStore(_path);
         Assert.False(store.TryRead("main", out _));
 
-        var evt = FindByName(
+        var evt = AssertEvent(
             _listener.Events,
             nameof(ReactorEventSource.PersistenceRejected),
             0,
             "json-file");
-        Assert.NotNull(evt);
-        Assert.Equal("json-file", evt!.Payload?[0]);
         Assert.Equal("oversize-read", evt.Payload?[1]);
     }
 
@@ -137,14 +147,12 @@ public class PersistenceEtwBridgeTests : IDisposable
 
         Assert.False(store.TryRead("main", out _));
 
-        var evt = FindByName(
+        var evt = AssertEvent(
             _listener.Events,
             nameof(ReactorEventSource.SwallowedError),
             1,
             "JsonFileStore.TryRead.parse");
-        Assert.NotNull(evt);
-        Assert.Equal(nameof(LogCategory.Persistence), evt!.Payload?[0]);
-        Assert.Equal("JsonFileStore.TryRead.parse", evt.Payload?[1]);
+        Assert.Equal(nameof(LogCategory.Persistence), evt.Payload?[0]);
         // The payload carries ex.GetType().Name — the concrete runtime
         // type, which for malformed JSON is the JsonException-derived
         // JsonReaderException. Assert by IsAssignableFrom-style prefix


### PR DESCRIPTION
## Summary

Tightens four `PersistenceEtwBridgeTests` event lookups to match both the ETW event name and a discriminating payload field. This prevents parallel tests listening to the process-wide `ReactorEventSource.Log` singleton from selecting a foreign event with the same name.

The asserting helper reports captured values for the discriminator slot when no match exists, preserving actionable collision evidence without dumping unrelated ETW payload fields. Redundant assertions on the already-filtered slot were removed; independent size, reason, category, exception-type, and PII assertions remain.

The failure was surfaced by CI on #963, but this is intentionally a standalone test-reliability PR. The pre-fix combined-class loop failed 1/12 runs with `PhaseBTests.Persistence.placement-rejected`; the final loop passed 12/12.

Also removes the resolved test family from the known-flake guidance in `AGENTS.md` and the coverage-uplift skill. `CenterOnCurrent_UsesCursorMonitor` and `PersistPlacement_FallbackWhenEmpty` were inspected and left unchanged: they are interactive-desktop/cursor-monitor selftests and do not use the shared EventSource or unfiltered `FirstOrDefault` pattern.

## Linked issue / spec

Related to #963 (CI evidence only; deliberately separate from its samples-only changes).

## Test plan

- [x] Reproduced combined `PersistenceEtwBridgeTests` + `ReactorEventSourcePhaseBTests` loop before the fix: 1/12 failures
- [x] Re-ran the same loop after the final fix: 0/12 failures
- [x] Mutation-checked the discriminator with `json-file-WRONG`; the targeted test failed and reported `Same-name payload[0] values: json-file`
- [x] Ran the Diagnostics namespace: 96 passed
- [x] Ran the full `tests/Reactor.Tests` suite: 12,933 passed, 64 skipped, 0 failed
- [x] Re-ran the unrelated failed Merged coverage job; it passed

## Risk / breaking changes

Test-only oracle tightening and contributor guidance updates. No production or public API changes; xUnit parallelism remains enabled.