### PR TITLE
docs: strengthen agent verification guidance

### DIFF
--- a/.github/skills/pr-review/SKILL.md
+++ b/.github/skills/pr-review/SKILL.md
@@ -233,11 +233,9 @@ Coverage block and include its short "what I checked" note in a final
   already catch. The Team Lead Test (see any dimension file) is mandatory.
 - **Cite evidence.** Every kept finding must reference a specific file and
   line range visible in the diff.
-- **Treat finding fixes as new code.** If a commit that fixes a review finding
-  asserts a fact about framework or repo behavior in prose, a comment, or docs,
-  require it to cite the in-repo test, call site, analyzer table, or other source
-  that establishes the claim. If no such source can be found, flag the claim
-  rather than accepting the fix at face value.
+- **Treat finding fixes as new code.** Enforce the shared contract's source
+  requirement for factual claims; do not accept a claim merely because it was
+  written to satisfy an earlier review.
 
 ## Sub-agent prompt template
 

--- a/.github/skills/pr-review/SKILL.md
+++ b/.github/skills/pr-review/SKILL.md
@@ -233,6 +233,11 @@ Coverage block and include its short "what I checked" note in a final
   already catch. The Team Lead Test (see any dimension file) is mandatory.
 - **Cite evidence.** Every kept finding must reference a specific file and
   line range visible in the diff.
+- **Treat finding fixes as new code.** If a commit that fixes a review finding
+  asserts a fact about framework or repo behavior in prose, a comment, or docs,
+  require it to cite the in-repo test, call site, analyzer table, or other source
+  that establishes the claim. If no such source can be found, flag the claim
+  rather than accepting the fix at face value.
 
 ## Sub-agent prompt template
 

--- a/.github/skills/pr-review/dimensions/_shared-contract.md
+++ b/.github/skills/pr-review/dimensions/_shared-contract.md
@@ -68,6 +68,12 @@ Specifically, **drop**:
   `IsAotCompatible=true` / trim-warning-as-error settings already flag. The core
   Reactor library treats IL trimming / AOT warnings as errors.
 
+Do not treat a comforting negative as evidence by itself. A no-match search,
+clean sweep, or deterministic pass is not a measurement until a positive control
+shows the probe could produce the opposite result. If the answer to "could this
+have come out the other way?" is "no -- it always passes", emit the finding; do
+not record that invariance as confirmation.
+
 **Keep**:
 
 - Bugs, logic errors, race conditions, missed edge cases.

--- a/.github/skills/pr-review/dimensions/_shared-contract.md
+++ b/.github/skills/pr-review/dimensions/_shared-contract.md
@@ -71,8 +71,15 @@ Specifically, **drop**:
 Do not treat a comforting negative as evidence by itself. A no-match search,
 clean sweep, or deterministic pass is not a measurement until a positive control
 shows the probe could produce the opposite result. If the answer to "could this
-have come out the other way?" is "no -- it always passes", emit the finding; do
-not record that invariance as confirmation.
+have come out the other way?" is "no — it always passes", the probe is
+inconclusive. Fix the probe; emit a finding only when validated evidence exposes
+a defect in the reviewed diff.
+
+Treat fixes for review findings as new code. When new prose, comments, or docs
+assert facts about framework or repo behavior, require the in-repo test, call
+site, analyzer table, or other source that establishes the claim. If no such
+source can be found, flag the unsupported claim rather than accepting it at face
+value.
 
 **Keep**:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -347,8 +347,10 @@ the one that bites hardest, because a broken instrument is trusted by default.
 ### Environment
 
 - Work in a clean worktree, not `main`: `git worktree add -b <branch> <path> origin/main`.
-- Don't build under deep or OneDrive-synced paths — WinUI can fail with `MSB3073`/`PRI210`;
-  prefer a short local path (e.g. `C:\src\`).
+- Don't build under deep or OneDrive-synced paths — WinUI can fail with `MSB3073`/`PRI210`
+  or XAML compiler `WMC1006`/`WMC9999`, sometimes naming an unrelated project such as
+  `Reactor.AppTests.ThirdPartyControls`. Before concluding your branch broke the build, check
+  out the same HEAD at a short path (e.g. `C:\src\probe`); if it passes, the path was the cause.
 
 ### Repo skills (`.github/skills/`)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -178,7 +178,8 @@ Hard-won specifics that repeatedly cost sessions time. Prefer these exact comman
 - **A green Debug build does not clear the `Build solution` CI job.**
   `TreatWarningsAsErrors` is Release-only and CI builds Release, so verify with
   `dotnet build Reactor.slnx -c Release`. If `WMC0110` / `WMC1509` follows a C# error,
-  fix the earlier error; those markup errors are a cascade, not the root cause.
+  treat the markup errors as a likely cascade: fix the earlier error first, then confirm
+  they disappear before investigating them independently.
 - **Add `-p:SkipSignaturesGen=true` to local `tests/Reactor.Tests` builds** to avoid the
   XAML-markup/SignaturesGen race: `CSC error CS2012: Cannot open '...\obj\...\intermediatexaml\Reactor.dll' ... used by another process`. If it still races under
   parallel WinUI builds, prebuild `src/Reactor` alone first, then add `-m:1`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -247,6 +247,14 @@ the one that bites hardest, because a broken instrument is trusted by default.
   the other way?** If the answer is "no — it always passes", that is the finding, not
   confirmation. **A no-match result is not a measurement** until a positive control proves
   the same probe, wrapping, and file set can produce a match.
+- **Historical searches need historical vocabulary.** A rename or unit change makes a grep for
+  the current identifier/value structurally blind to earlier revisions. Before trusting a zero,
+  establish when the identifier first existed; use `git log --follow -p -- <file>` or pickaxe
+  searches over the changed value rather than projecting today's name backward through history.
+- **Self-consistency does not prove currency.** Counts from one stale checkout can corroborate
+  each other perfectly. Attach the commit OID and timestamp to measurements and compare against
+  a live remote ref when identity matters. `git rev-parse` identifies a commit; a tree OID only
+  identifies content and can remain unchanged after a message-only amend.
 - **Fixture registration is two-place.** Selftest: add to `AllFixtures` **and** the
   `Create()` switch in `tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs`.
   E2E: add to `AllFixtures` **and** the `Build` switch in

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -175,6 +175,10 @@ Hard-won specifics that repeatedly cost sessions time. Prefer these exact comman
   `Reactor.AppTests`, `Reactor.AppTests.Host`, etc. fail with *"WindowsAppSDKSelfContained
   requires a supported Windows architecture"*. (`dotnet build Reactor.slnx` handles the
   solution defaults; single app/test projects usually do not.)
+- **A green Debug build does not clear the `Build solution` CI job.**
+  `TreatWarningsAsErrors` is Release-only and CI builds Release, so verify with
+  `dotnet build Reactor.slnx -c Release`. If `WMC0110` / `WMC1509` follows a C# error,
+  fix the earlier error; those markup errors are a cascade, not the root cause.
 - **Add `-p:SkipSignaturesGen=true` to local `tests/Reactor.Tests` builds** to avoid the
   XAML-markup/SignaturesGen race: `CSC error CS2012: Cannot open '...\obj\...\intermediatexaml\Reactor.dll' ... used by another process`. If it still races under
   parallel WinUI builds, prebuild `src/Reactor` alone first, then add `-m:1`
@@ -208,6 +212,10 @@ the one that bites hardest, because a broken instrument is trusted by default.
   corrupt-then-recompute oracles. **Copilot review does not catch vacuous assertions** —
   run the `.github/skills/pr-review/` multi-model dimension (different model family, high
   reasoning) on the *final* commit and fix every finding.
+- **A value oracle proves nothing where its healthy and broken branches coincide.**
+  This is the shared failure behind deleting a "redundant" guard and citing a passing but
+  non-differential check as an oracle. Before either, identify where both branches produce
+  the same value; preserve a guard or use a structural/differential oracle that cannot.
 - **Mutation testing does not reach an assertion whose *inputs* are environment-derived.**
   It perturbs the code under test, so it only exposes an oracle whose value depends on that
   code. `double preOffset = sv.VerticalOffset;` … `Math.Abs(sv.VerticalOffset - preOffset)
@@ -235,7 +243,9 @@ the one that bites hardest, because a broken instrument is trusted by default.
   language so a parse failure throws. **The tell is implausible uniformity:** an identical
   value across subjects that have nothing in common is a bug report about the instrument.
   The unifying question for a test and a tool alike is the same — **could this have come out
-  the other way?**
+  the other way?** If the answer is "no — it always passes", that is the finding, not
+  confirmation. **A no-match result is not a measurement** until a positive control proves
+  the same probe, wrapping, and file set can produce a match.
 - **Fixture registration is two-place.** Selftest: add to `AllFixtures` **and** the
   `Create()` switch in `tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs`.
   E2E: add to `AllFixtures` **and** the `Build` switch in
@@ -296,13 +306,12 @@ the one that bites hardest, because a broken instrument is trusted by default.
   and not of your change. Fix the fixtures' desktop-state dependence before merging the jobs,
   not after.
 - **Judging whether a flake fix worked.** N clean runs only supports a fix if `(1-p)^N` is
-  small for the *observed* failure rate `p`. At `p = 0.25`, three consecutive passes happen
-  **42%** of the time — so "3 clean runs" is consistent with the bug being entirely unfixed,
-  and roughly `N = 10` is needed for ~95% confidence. This is the "did this check have the
-  power to return the other answer?" test in probabilistic clothing, and it is the same
-  question the non-vacuous-assertion rule above asks. Prefer a *mechanism* that explains the
-  observed failure text over any number of green runs; run counts corroborate a cause, they
-  don't establish one.
+  small for an observed failure rate with `0 < p < 1`. At `p = 0.25`, three consecutive
+  passes happen **42%** of the time, and roughly `N = 10` is needed for ~95% confidence.
+  Synthetic-input E2E tests for timing defects often have `p` fixed at `0` or `1` by queue
+  ordering; reruns then have zero statistical power, so mutation-test the detector instead.
+  Prefer a *mechanism* that explains the observed failure text over any number of green runs;
+  run counts corroborate a cause, they don't establish one.
 - **Budget increases only refute one class of race.** Raising a poll/wait budget and still
   failing rules out "we sampled too early". It does not rule out an event that never fires,
   an ordering race decided before the first poll, or a lost wakeup — all budget-insensitive.

--- a/TESTING.md
+++ b/TESTING.md
@@ -55,6 +55,16 @@ dotnet test tests/Reactor.Tests --filter "FullyQualifiedName~ReconcilerMountUpda
 
 Tests that write to `Console.Out`/`Console.Error` must be grouped with `[Collection("ConsoleTests")]` to prevent cross-test interference.
 
+### Mutation checks must prove the mutation ran
+
+Before interpreting a green mutation run, verify the intended edit is present at exactly the
+target site and that the rebuilt assembly is newer than it. Check each build/test process exit
+code directly; do not infer success by matching stdout, because pipelines can swallow failures
+and stale binaries can still report `Passed`. CRLF-sensitive replacements, ambiguous anchors,
+failed compilation, node races, and timestamp-preserving restores can all make a mutation look
+tested when it was absent or applied elsewhere. After restoring, require a clean `git diff`
+rather than treating the expected post-mutation test failure as proof of the restore.
+
 ### Repo lints ride in this tier
 
 Some tests here parse repo *sources* with Roslyn rather than exercising Reactor at runtime, so a gallery or docs edit can fail `dotnet test tests/Reactor.Tests` with no code change at all. The ones under `Tooling/`:
@@ -209,6 +219,11 @@ dotnet test tests/Reactor.AppTests --filter "ClassName=Reactor.AppTests.Tests.Ac
 > **Requires:** the **winapp CLI** (`winapp ui`). Install it with `winget install Microsoft.WinAppCli` (or run `./bootstrap.ps1`, which installs it for you). The harness resolves it from `%LOCALAPPDATA%\Microsoft\WindowsApps\winapp.exe` or `winapp` on PATH. Unit and selftest runs don't need it.
 >
 > **WinForms tests** also require `Reactor.WinFormsTests.Host` to build. It launches a separate WinForms app with a XAML Island.
+
+When `viaSendInput: true` injects a modifier chord, the key messages arrive with no human-scale
+gap. If the defect is *when* state is read rather than *whether* input arrived, fixed queue
+ordering may make the race always won or always lost (`p` is `0` or `1`). Prove that detector
+with a mutation before counting repeated green E2E runs as evidence.
 
 ---
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -36,6 +36,17 @@ Both `Reactor.SelfTests` and `Reactor.AppTests` declare a `ProjectReference` to 
 
 Rule of thumb: start with a unit test. Drop to selftest only when you need a live control. Reach for E2E only when you need cross-process UIA — E2E is the slowest and flakiest tier.
 
+### Mutation checks must prove the mutation ran
+
+Before interpreting a green mutation run, verify the source diff contains the intended edit at
+exactly the target site, the build and test processes both exited successfully, and the product
+assembly containing that source was rebuilt after the edit. Do not infer success by matching
+stdout: pipelines can swallow failures and stale binaries can still report `Passed`.
+CRLF-sensitive replacements, ambiguous anchors, failed compilation, node races, and
+timestamp-preserving restores can all make a mutation look tested when it was absent or applied
+elsewhere. After restoring, require `git status --porcelain` to match the pre-mutation state
+rather than treating a subsequent passing test as proof of the restore.
+
 ---
 
 ## 1. Unit tests (`tests/Reactor.Tests`) — xUnit
@@ -54,16 +65,6 @@ dotnet test tests/Reactor.Tests --filter "FullyQualifiedName~ReconcilerMountUpda
 ### Console-mutating tests need collection isolation
 
 Tests that write to `Console.Out`/`Console.Error` must be grouped with `[Collection("ConsoleTests")]` to prevent cross-test interference.
-
-### Mutation checks must prove the mutation ran
-
-Before interpreting a green mutation run, verify the intended edit is present at exactly the
-target site and that the rebuilt assembly is newer than it. Check each build/test process exit
-code directly; do not infer success by matching stdout, because pipelines can swallow failures
-and stale binaries can still report `Passed`. CRLF-sensitive replacements, ambiguous anchors,
-failed compilation, node races, and timestamp-preserving restores can all make a mutation look
-tested when it was absent or applied elsewhere. After restoring, require a clean `git diff`
-rather than treating the expected post-mutation test failure as proof of the restore.
 
 ### Repo lints ride in this tier
 
@@ -220,10 +221,11 @@ dotnet test tests/Reactor.AppTests --filter "ClassName=Reactor.AppTests.Tests.Ac
 >
 > **WinForms tests** also require `Reactor.WinFormsTests.Host` to build. It launches a separate WinForms app with a XAML Island.
 
-When `viaSendInput: true` injects a modifier chord, the key messages arrive with no human-scale
-gap. If the defect is *when* state is read rather than *whether* input arrived, fixed queue
-ordering may make the race always won or always lost (`p` is `0` or `1`). Prove that detector
-with a mutation before counting repeated green E2E runs as evidence.
+When `viaSendInput: true` injects a modifier chord, it can compress the gap between key messages
+enough that queue ordering makes a timing-sensitive race always won or always lost (`p` is `0`
+or `1`) for that environment and tool version. If the defect is *when* state is read rather than
+*whether* input arrived, prove the detector with a mutation before counting repeated green E2E
+runs as evidence.
 
 ---
 


### PR DESCRIPTION
## Summary
- document Release-only warnings-as-errors and markup-error cascades
- make mutation, oracle, and negative-result checks prove their instruments worked
- strengthen PR-review guidance for factual fix claims and comforting negatives
- qualify flake rerun math for deterministic synthetic-input timing

## Validation
- Not run (markdown-only guidance changes)

Fixes #991
Fixes #992
Fixes #993
Fixes #997
Fixes #1023
Fixes #1043
Fixes #1049