### PR TITLE
docs: compress the verification section and give it a stopping rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -201,133 +201,31 @@ Hard-won specifics that repeatedly cost sessions time. Prefer these exact comman
 
 ### Checks that actually prove something
 
-Applies to anything whose output you would act on: xUnit assertions, selftest
-`H.Check`s, and the ad-hoc commands you verify state with — log greps, freshness
-checks, CI queries. The failure mode is identical in all three, and the last one is
-the one that bites hardest, because a broken instrument is trusted by default.
+Applies to xUnit assertions, selftest `H.Check`s, **and the ad-hoc commands you verify
+state with**. A broken instrument is trusted by default, so the last one bites hardest.
 
-- **Every assertion must fail if its target code is deleted / no-op'd / returns default.**
-  Bare non-null, "no throw" on a `void`, and always-emitted shape markers are vacuous.
-  Use throw-position/arity, differential-isolation (`Assert.NotEqual` between two variants
-  differing only by the setter), structural counts, reflection `DeclaringType`, or
-  corrupt-then-recompute oracles. **Copilot review does not catch vacuous assertions** —
-  run the `.github/skills/pr-review/` multi-model dimension (different model family, high
-  reasoning) on the *final* commit and fix every finding.
-- **A value oracle proves nothing where its healthy and broken branches coincide.**
-  This is the shared failure behind deleting a "redundant" guard and citing a passing but
-  non-differential check as an oracle. Before either, identify where both branches produce
-  the same value; preserve a guard or use a structural/differential oracle that cannot.
-- **Mutation testing does not reach an assertion whose *inputs* are environment-derived.**
-  It perturbs the code under test, so it only exposes an oracle whose value depends on that
-  code. `double preOffset = sv.VerticalOffset;` … `Math.Abs(sv.VerticalOffset - preOffset)
-  <= 3.0` passes identically in a healthy and a degraded environment when both sides are
-  `0.00` — no product mutation separates them. **Log the input once, not just the verdict:**
-  if a value read from live state is `0`, `NaN`, empty, or equal to the thing it is compared
-  against, the assertion is a tautology regardless of what the product does. Same shape as a
-  `-1` "not found" sentinel satisfying `bodyOn > bodyOff * 3` (`-1 > -3`) — prefer
-  `double.NaN`, which makes every comparison false. The bug is upstream of the comparison.
-- **The obvious remediation can itself be the vacuous one.** `Harness.WaitFor(P)` establishes
-  P *at the moment it returns* and nothing more — it evaluates P **before** its first
-  `Render`. So converting a fixed delay to a `WaitFor` is correct for an *eventual* assertion
-  (false at t=0, converges) and silently vacuous for a *survival* assertion ("still visible"),
-  which is true at t=0 and short-circuits at zero elapsed time. Before converting, ask: **if
-  the predicate is true the instant `WaitFor` is called, does the next assertion still mean
-  what I think it means?** Same question for a precondition `throw`: report-and-return when
-  the fixture's other checks remain meaningful, throw loudly when it is structurally invalid
-  (a renamed reflection target) and they do not.
-- **This applies to your verification tooling, not just to tests.** A check that cannot fail
-  loudly will eventually report something false with total confidence, and the direction is
-  arbitrary — it can manufacture an alarm or an all-clear, and nobody audits the one that says
-  what they hoped. A malformed `gh --jq` expression exits non-zero to stderr while a pipeline
-  reading stdout sees an empty string indistinguishable from a legitimate zero. Prefer
-  parameterised GraphQL (`-f`/`-F`, no interpolation), or fetch JSON and filter in the host
-  language so a parse failure throws. **The tell is implausible uniformity:** an identical
-  value across subjects that have nothing in common is a bug report about the instrument.
-  The unifying question for a test and a tool alike is the same — **could this have come out
-  the other way?** If the answer is "no — it always passes", that is the finding, not
-  confirmation. **A no-match result is not a measurement** until a positive control proves
-  the same probe, wrapping, and file set can produce a match.
-- **Historical searches need historical vocabulary.** A rename or unit change makes a grep for
-  the current identifier/value structurally blind to earlier revisions. Before trusting a zero,
-  establish when the identifier first existed; use `git log --follow -p -- <file>` or pickaxe
-  searches over the changed value rather than projecting today's name backward through history.
-- **Self-consistency does not prove currency.** Counts from one stale checkout can corroborate
-  each other perfectly. Attach the commit OID and timestamp to measurements and compare against
-  a live remote ref when identity matters. `git rev-parse` identifies a commit; a tree OID only
-  identifies content and can remain unchanged after a message-only amend.
-- **Fixture registration is two-place.** Selftest: add to `AllFixtures` **and** the
-  `Create()` switch in `tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs`.
-  E2E: add to `AllFixtures` **and** the `Build` switch in
-  `tests/Reactor.AppTests.Host/FixtureRegistry.cs`.
-- **…which makes searching for a TAP name unsafe unless you search the whole tree.** TAP
-  carries two kinds of name and they live in different files: *fixture* names (registry only,
-  and the class they map to is often spelled differently — `CenterOnCurrent_UsesCursorMonitor`
-  → `CenterOnCurrentUsesCursorMonitor`) and *check* names (string literals in `H.Check(...)`
-  inside `Fixtures/`). Neither location is a superset:
+- **An assertion must fail when its target is broken.** Delete or no-op the code and
+  confirm it reddens. Bare non-null, "no throw" on a `void`, and always-emitted shape
+  markers are vacuous. Prefer differential oracles, structural counts, or
+  corrupt-then-recompute.
+- **An oracle proves nothing where its healthy and broken branches coincide.** If a live
+  value is `0`, `NaN`, empty, or already equal to what it's compared against, the
+  comparison is a tautology regardless of the product. Log the input, not just the verdict
+  — mutation testing cannot catch this, because the defect is upstream of the code it
+  perturbs.
+- **A no-match is not a measurement until a positive control shows the probe can match.**
+  Zero from a broken grep and zero from a clean repo are the same character on screen.
+  Applies to greps, `gh --jq`, CI queries — anything whose output you act on. Renames make
+  today's identifier structurally blind to older revisions.
+- **Self-consistency is not currency.** Counts from one stale checkout corroborate each
+  other perfectly. Pin measurements to a commit OID and compare against a live remote ref.
+- **Green runs corroborate a fix; a mechanism establishes it.** At a 25% failure rate,
+  three clean passes happen 42% of the time.
 
-  | probe | blind spot |
-  |---|---|
-  | grep `SelfTest/Fixtures/` only | fixture names whose class name differs |
-  | grep `SelfTestFixtureRegistry.cs` only | check-only names — e.g. `WindowLevel_RuntimeFlip_Topmost`, `TabViewFill_Mounted`, `ExitTr_Removed` are all registry=0 |
-  | **grep `tests/Reactor.AppTests.Host/` whole** | **none — use this** |
-
-  Both narrow probes return a *confident zero*, which reads as "this fixture doesn't exist"
-  and invites re-attributing a real flake as branch-local or renamed. Both directions were hit
-  during one flakiness audit, and the check-only example above is the assertion at the centre
-  of issue #927 — a rule that silently fails on the most-discussed flake in the audit is worse
-  than no rule, because its user has no reason to doubt the answer. Two probes with
-  complementary blind spots don't compose into coverage unless you run both, and if you're
-  running both the whole-tree grep is cheaper than remembering why.
-- **Coverage** starts from `tools/coverage/run-coverage.ps1` (`-UnitOnly`, `-SkipBuild`);
-  output `coverage/merged.cobertura.xml`. The script **aborts before the merge step on any
-  test failure** — if a known flake trips it (`CenterOnCurrent_UsesCursorMonitor`,
-  `PersistPlacement_FallbackWhenEmpty`), merge the legs manually with
-  `dotnet-coverage merge coverage\unit.cobertura.xml coverage\selftest.cobertura.xml --output coverage\merged.cobertura.xml --output-format cobertura`.
-  Both are **selftest** fixtures (`Phase1WindowingFixtures.cs` / `Phase3WindowingFixtures.cs`),
-  not unit tests — don't go hunting for them in `Reactor.Tests`. They are the
-  *same assertion twice*: both open a `WindowStartPosition.CenterOnCurrent` window and check
-  its centre lands in the work area of the monitor under the mouse, so they fail as a **pair**
-  — seeing only one of them is the surprise, not seeing both. Neither is a render-timing race,
-  so `WaitFor` will not help. **Two different mechanisms in two different environments — check
-  which one you are in before theorising:**
-  - **Non-interactive session (CI agents, RDP-disconnected, locked, headless).**
-    `GetCursorPos` returns **ACCESS_DENIED (err 5)** and never writes its `out` param, so the
-    cursor monitor cannot be determined at all. This is a **100% deterministic failure, not a
-    flake** — the pair simply cannot pass there. Confirmed by direct P/Invoke probe on two
-    separate machines. Fixed by skipping rather than asserting when the cursor is
-    undeterminable; if you see these fail, probe first:
-    `GetCursorPos(out p)` → `False` / `LastError=5` means you are in this case and the fixtures
-    are innocent. Note `System.Windows.Forms.Cursor.Position` **hides** this — it surfaces the
-    uninitialised `(0,0)` instead of the failure.
-  - **Interactive multi-monitor box.** A TOCTOU: `GetCursorPos` is sampled *before*
-    `OpenAndSettle`, so a cursor crossing a monitor boundary while the window opens invalidates
-    the captured work rect. Intermittent, and **structurally impossible on a single display** —
-    if you are on one virtual desktop with no boundary to cross, this is not your mechanism.
-  Do not assume "quiet machine ⇒ passes": that holds only in the interactive case.
-- **Don't co-locate the E2E and selftest tiers.** CI runs them as separate jobs on separate
-  runners today, and that isolation is load-bearing rather than incidental. E2E drives real
-  pointer input, foregrounds windows and changes Z-order; several selftest fixtures read live
-  desktop state (the two `CenterOnCurrent`-based ones above read the cursor's monitor;
-  `UseIsCovered_RerendersOnZOrderChange` reads Z-order). Running E2E first on one machine and
-  then `--self-test` took a clean unmodified tree from 0 to 8 failures — reproducible, and the
-  standing repro for those fixtures. So if you consolidate jobs to save runner minutes, or run
-  both tiers locally back-to-back, expect selftest reds that are an artefact of tier ordering
-  and not of your change. Fix the fixtures' desktop-state dependence before merging the jobs,
-  not after.
-- **Judging whether a flake fix worked.** N clean runs only supports a fix if `(1-p)^N` is
-  small for an observed failure rate with `0 < p < 1`. At `p = 0.25`, three consecutive
-  passes happen **42%** of the time, and roughly `N = 10` is needed for ~95% confidence.
-  Synthetic-input E2E tests for timing defects often have `p` fixed at `0` or `1` by queue
-  ordering; reruns then have zero statistical power, so mutation-test the detector instead.
-  Prefer a *mechanism* that explains the observed failure text over any number of green runs;
-  run counts corroborate a cause, they don't establish one.
-- **Budget increases only refute one class of race.** Raising a poll/wait budget and still
-  failing rules out "we sampled too early". It does not rule out an event that never fires,
-  an ordering race decided before the first poll, or a lost wakeup — all budget-insensitive.
-  The sound conclusion is "not a *too-short-poll* problem", which is narrower than "not a
-  race". Don't let the narrower finding promote a fixture into an "environmental" bucket it
-  then stops being investigated in; confirm that label by running it on a quiet machine with
-  a known window-manager state, and only apply it if it goes clean there.
+**When to stop.** One positive control per instrument is enough. Verify the assertion that
+gates correctness — not the verifier of the verifier. If you are writing a check about a
+check, or correcting the wording of a comment rather than the behaviour of code, you are
+past the point of return: stop and ship.
 
 ### Analyzers, CLI checks, docs & public API
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -222,10 +222,10 @@ state with**. A broken instrument is trusted by default, so the last one bites h
 - **Green runs corroborate a fix; a mechanism establishes it.** At a 25% failure rate,
   three clean passes happen 42% of the time.
 
-**When to stop.** One positive control per instrument is enough. Verify the assertion that
-gates correctness — not the verifier of the verifier. If you are writing a check about a
-check, or correcting the wording of a comment rather than the behaviour of code, you are
-past the point of return: stop and ship.
+**When to stop.** Validate each instrument once — then stop. Verify the assertion that gates
+correctness, not the verifier of the verifier. If you are adding a *second* layer of checking,
+or correcting the wording of a comment rather than the behaviour of code, you are past the
+point of return: stop and ship.
 
 ### Analyzers, CLI checks, docs & public API
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -211,12 +211,12 @@ state with**. A broken instrument is trusted by default, so the last one bites h
 - **An oracle proves nothing where its healthy and broken branches coincide.** If a live
   value is `0`, `NaN`, empty, or already equal to what it's compared against, the
   comparison is a tautology regardless of the product. Log the input, not just the verdict
-  — mutation testing cannot catch this, because the defect is upstream of the code it
-  perturbs.
-- **A no-match is not a measurement until a positive control shows the probe can match.**
-  Zero from a broken grep and zero from a clean repo are the same character on screen.
-  Applies to greps, `gh --jq`, CI queries — anything whose output you act on. Renames make
-  today's identifier structurally blind to older revisions.
+  — mutation testing cannot catch an environment-derived oracle, because the defect is
+  upstream of the code it perturbs.
+- **A no-match is not a measurement** until a positive control — same probe, same wrapping,
+  same file set — shows it can match. Zero from a broken grep and zero from a clean repo are
+  the same character on screen. Applies to greps, `gh --jq`, CI queries. Renames make today's
+  identifier structurally blind to older revisions.
 - **Self-consistency is not currency.** Counts from one stale checkout corroborate each
   other perfectly. Pin measurements to a commit OID and compare against a live remote ref.
 - **Green runs corroborate a fix; a mechanism establishes it.** At a 25% failure rate,

--- a/TESTING.md
+++ b/TESTING.md
@@ -120,9 +120,10 @@ dotnet run --project tests/Reactor.AppTests.Host -- --self-test --filter "Flex"
 ### Fixture registration is two-place — and what that does to name searches
 
 Selftest: add the fixture to `AllFixtures` **and** to the `Create()` switch in
-`tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs`. E2E: add it to `AllFixtures`
-**and** to the `Build` switch in `tests/Reactor.AppTests.Host/FixtureRegistry.cs`. Miss the
-second place and `--list-fixtures` reports a name the run cannot produce.
+`tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs`; miss the second and
+`--list-fixtures` reports a name the run cannot produce. E2E: add it to `AllFixtures` **and**
+to the `Build` switch in `tests/Reactor.AppTests.Host/FixtureRegistry.cs` — `--list-fixtures`
+is selftest-only, so nothing warns you about the E2E half.
 
 That split also makes searching for a TAP name unsafe unless you search the whole tree. TAP
 carries two kinds of name and they live in different files: *fixture* names (registry only, and
@@ -261,29 +262,30 @@ Before converting a fixed wait you find that way, re-read the `WaitFor` short-ci
 >
 > An **earlier** measurement of the same change showed a 14.4 % win. It was wrong: the "legacy" arm it compared against still subscribed the frame counter before checking the opt-out flag, so the baseline carried the continuous-frame cost and the win was mostly the instrument. If you re-attempt this, verify the control arm is byte-for-byte the shipping path before believing any number it produces.
 
-### The two `CenterOnCurrent` fixtures fail as a pair — for two different reasons
+### The two `CenterOnCurrent` fixtures fail — or skip — as a pair, for two different reasons
 
 `CenterOnCurrent_UsesCursorMonitor` (`Phase1WindowingFixtures.cs`) and
 `PersistPlacement_FallbackWhenEmpty` (`Phase3WindowingFixtures.cs`) are **selftest** fixtures,
 not unit tests — don't go hunting for them in `Reactor.Tests`. They are the *same assertion
 twice*: both open a `WindowStartPosition.CenterOnCurrent` window and check its centre lands in
-the work area of the monitor under the mouse, so they fail as a **pair** — seeing only one of
+the work area of the monitor under the mouse, so they move as a **pair** — seeing only one of
 them is the surprise, not seeing both. Neither is a render-timing race, so `WaitFor` will not
 help. **Two different mechanisms in two different environments — check which one you are in
 before theorising:**
 
 - **Non-interactive session (CI agents, RDP-disconnected, locked, headless).** `GetCursorPos`
   returns **ACCESS_DENIED (err 5)** and never writes its `out` param, so the cursor monitor
-  cannot be determined at all. This is a **100% deterministic failure, not a flake** — the pair
-  simply cannot pass there. Confirmed by direct P/Invoke probe on two separate machines. Fixed
-  by skipping rather than asserting when the cursor is undeterminable; if you see these fail,
-  probe first: `GetCursorPos(out p)` returning `False` with `LastError=5` means you are in this
-  case and the fixtures are innocent. Note `System.Windows.Forms.Cursor.Position` **hides**
-  this — it surfaces the uninitialised `(0,0)` instead of the failure.
+  cannot be determined at all — a **100% deterministic** condition, not a flake. Confirmed by
+  direct P/Invoke probe on two separate machines. Both fixtures now `H.Skip` here rather than
+  assert, so the expected symptom on such a machine is a **skip, not a red**; a red means this
+  is not your mechanism. Note `System.Windows.Forms.Cursor.Position` **hides** the condition —
+  it surfaces the uninitialised `(0,0)` instead of the failure, so probe `GetCursorPos(out p)`
+  directly (`False` / `LastError=5`) rather than through it.
 - **Interactive multi-monitor box.** A TOCTOU: `GetCursorPos` is sampled *before*
   `OpenAndSettle`, so a cursor crossing a monitor boundary while the window opens invalidates
   the captured work rect. Intermittent, and **structurally impossible on a single display** —
   if you are on one virtual desktop with no boundary to cross, this is not your mechanism.
+  This is the only one of the two that still produces a red.
 
 Do not assume "quiet machine ⇒ passes": that holds only in the interactive case.
 
@@ -417,9 +419,8 @@ Replace `$(RuntimeIdentifier)` with `ARM64` or `x64`, or omit the platform segme
 
 `tools/coverage/run-coverage.ps1` (`-UnitOnly`, `-SkipBuild`) drives the recipe above and writes
 `coverage/merged.cobertura.xml`. It **aborts before the merge step on any test failure**, so a
-known flake — `CenterOnCurrent_UsesCursorMonitor` or `PersistPlacement_FallbackWhenEmpty`, both
-selftest fixtures covered in §2 above — leaves you with both legs collected and no merged file.
-Merge them by hand:
+red selftest fixture — the `CenterOnCurrent` pair in §2 above is the usual one — leaves you with
+both legs collected and no merged file. Merge them by hand:
 
 ```powershell
 dotnet-coverage merge coverage\unit.cobertura.xml coverage\selftest.cobertura.xml --output coverage\merged.cobertura.xml --output-format cobertura

--- a/TESTING.md
+++ b/TESTING.md
@@ -135,7 +135,11 @@ the class they map to is often spelled differently — `CenterOnCurrent_UsesCurs
 |---|---|
 | grep `SelfTest/Fixtures/` only | fixture names whose class name differs |
 | grep `SelfTestFixtureRegistry.cs` only | check-only names — e.g. `WindowLevel_RuntimeFlip_Topmost`, `TabViewFill_Mounted`, `ExitTr_Removed` are all registry=0 |
-| **grep `tests/Reactor.AppTests.Host/` whole** | **none — use this** |
+| **grep `tests/Reactor.AppTests.Host/` whole** | **literal names: none — use this** |
+
+One blind spot survives even the whole-tree grep: check names built by interpolation —
+`H.Check($"A11y_Role_{role}_Mounted", …)` — match no literal anywhere, so grepping the TAP name
+you actually saw returns zero. Search the invariant stem (`A11y_Role_`) instead.
 
 Both narrow probes return a *confident zero*, which reads as "this fixture doesn't exist" and
 invites re-attributing a real flake as branch-local or renamed. Both directions were hit during
@@ -369,13 +373,12 @@ runs as evidence.
 
 CI runs them as separate jobs on separate runners today, and that isolation is load-bearing
 rather than incidental. E2E drives real pointer input, foregrounds windows and changes Z-order;
-several selftest fixtures read live desktop state (the two `CenterOnCurrent`-based ones read the
-cursor's monitor; `UseIsCovered_RerendersOnZOrderChange` reads Z-order). Running E2E first on one
-machine and then `--self-test` took a clean unmodified tree from 0 to 8 failures — reproducible,
-and the standing repro for those fixtures. So if you consolidate jobs to save runner minutes, or
-run both tiers locally back-to-back, expect selftest reds that are an artefact of tier ordering
-and not of your change. Fix the fixtures' desktop-state dependence before merging the jobs, not
-after.
+some selftest fixtures read live desktop state — the two `CenterOnCurrent`-based ones sample the
+cursor's monitor while opening a real window. Running E2E first on one machine and then
+`--self-test` took a clean unmodified tree from 0 to 8 failures — reproducible, and the standing
+repro for those fixtures. So if you consolidate jobs to save runner minutes, or run both tiers
+locally back-to-back, expect selftest reds that are an artefact of tier ordering and not of your
+change. Fix the fixtures' desktop-state dependence before merging the jobs, not after.
 
 ---
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -47,6 +47,23 @@ timestamp-preserving restores can all make a mutation look tested when it was ab
 elsewhere. After restoring, require `git status --porcelain` to match the pre-mutation state
 rather than treating a subsequent passing test as proof of the restore.
 
+### Judging whether a flake fix worked
+
+N clean runs only support a fix if `(1-p)^N` is small for an observed failure rate with
+`0 < p < 1`. At `p = 0.25`, three consecutive passes happen **42%** of the time, and roughly
+`N = 10` is needed for ~95% confidence. Synthetic-input E2E tests for timing defects often have
+`p` fixed at `0` or `1` by queue ordering; reruns then have zero statistical power, so
+mutation-test the detector instead. Prefer a *mechanism* that explains the observed failure text
+over any number of green runs; run counts corroborate a cause, they don't establish one.
+
+**Budget increases only refute one class of race.** Raising a poll/wait budget and still failing
+rules out "we sampled too early". It does not rule out an event that never fires, an ordering
+race decided before the first poll, or a lost wakeup — all budget-insensitive. The sound
+conclusion is "not a *too-short-poll* problem", which is narrower than "not a race". Don't let
+the narrower finding promote a fixture into an "environmental" bucket it then stops being
+investigated in; confirm that label by running it on a quiet machine with a known
+window-manager state, and only apply it if it goes clean there.
+
 ---
 
 ## 1. Unit tests (`tests/Reactor.Tests`) — xUnit
@@ -100,6 +117,33 @@ dotnet run --project tests/Reactor.AppTests.Host -- --self-test
 dotnet run --project tests/Reactor.AppTests.Host -- --self-test --filter "Flex"
 ```
 
+### Fixture registration is two-place — and what that does to name searches
+
+Selftest: add the fixture to `AllFixtures` **and** to the `Create()` switch in
+`tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs`. E2E: add it to `AllFixtures`
+**and** to the `Build` switch in `tests/Reactor.AppTests.Host/FixtureRegistry.cs`. Miss the
+second place and `--list-fixtures` reports a name the run cannot produce.
+
+That split also makes searching for a TAP name unsafe unless you search the whole tree. TAP
+carries two kinds of name and they live in different files: *fixture* names (registry only, and
+the class they map to is often spelled differently — `CenterOnCurrent_UsesCursorMonitor` →
+`CenterOnCurrentUsesCursorMonitor`) and *check* names (string literals in `H.Check(...)` inside
+`Fixtures/`). Neither location is a superset:
+
+| probe | blind spot |
+|---|---|
+| grep `SelfTest/Fixtures/` only | fixture names whose class name differs |
+| grep `SelfTestFixtureRegistry.cs` only | check-only names — e.g. `WindowLevel_RuntimeFlip_Topmost`, `TabViewFill_Mounted`, `ExitTr_Removed` are all registry=0 |
+| **grep `tests/Reactor.AppTests.Host/` whole** | **none — use this** |
+
+Both narrow probes return a *confident zero*, which reads as "this fixture doesn't exist" and
+invites re-attributing a real flake as branch-local or renamed. Both directions were hit during
+one flakiness audit, and the check-only example above is the assertion at the centre of issue
+#927 — a rule that silently fails on the most-discussed flake in the audit is worse than no
+rule, because its user has no reason to doubt the answer. Two probes with complementary blind
+spots don't compose into coverage unless you run both, and if you're running both the
+whole-tree grep is cheaper than remembering why.
+
 ### Selftest waiting patterns — `Render` vs `WaitFor` vs `WaitForIdleAsync`
 
 Selftests run against a real WinUI dispatcher: most user-visible work (template realization, layout, content-presenter materialization, control intrinsic `Loaded` handlers) lands on *later* dispatcher waves, not synchronously with the mount call. Always wait on a concrete idle signal — never `Task.Delay(<n>)` — and pick the right primitive for the host you're driving:
@@ -147,6 +191,8 @@ Rules of thumb:
   - *"X did not happen"* / *"fired exactly once"* / *"state is unchanged"* — e.g. `count == 0`, `CycleCountForTests == 1`, `IsExpanded` still true. Converting these to `WaitFor` makes them **vacuous**: they pass at t=0 without ever giving a violation time to appear. Keep an explicit `Render(N)` window and assert after it.
   - Conversely, `WaitFor` is correct for *positive eventual* conditions — a control appears, a bit flips, a callback lands — because the predicate is false until the transition completes.
   - The test: **can the predicate be true before the action you are testing?** If yes, either keep the fixed window or strengthen the predicate so it cannot (e.g. gate on `sv.VerticalOffset < 1` as well as the row text, so a still-realized row can't satisfy it while scrolled away).
+- **Converting a fixed delay to `WaitFor` is not a safe default — the remediation can itself be the vacuous one.** Because `WaitFor` establishes its predicate *at the moment it returns* and nothing more, the conversion is correct for an *eventual* assertion (false at t=0, converges) and silently vacuous for a *survival* assertion — "still visible", "still expanded" — which is true at t=0 and short-circuits at zero elapsed time. Before converting, ask: **if the predicate is true the instant `WaitFor` is called, does the next assertion still mean what I think it means?**
+- **Ask the same of a precondition `throw`.** Report-and-return when the fixture's other checks remain meaningful; throw loudly when the fixture is structurally invalid (a renamed reflection target) and they do not.
 - **Converting a gate can strip a settle a *later* assertion relied on.** If a following `H.Check` depended on the removed `Render(N)` rather than on its own wait, it will start failing. Give each check its own `WaitFor` instead of letting it inherit someone else's delay.
 - **`host.WaitForIdleAsync()` for isolated hosts.** If you constructed your own `ReactorHost`, neither `Harness.Render` nor `Harness.WaitFor` knows about it.
 - **Save and restore `ReactorApp.ActiveHostInternal`** when using an isolated host so subsequent fixtures see the shared host they expect (`var prev = ReactorApp.ActiveHostInternal; try { … } finally { if (prev is not null) ReactorApp.ActiveHostInternal = prev; }`).
@@ -214,6 +260,32 @@ Before converting a fixed wait you find that way, re-read the `WaitFor` short-ci
 > Interleaved on one machine, alternating arms, three pairs: **≈0–3 %**, inside the run-to-run noise. The reason it doesn't pay is the same reason it looks attractive — subscribing to `CompositionTarget.Rendering` makes the UI thread produce frames continuously, so the frame arm buys back most of the delay it saves. And the delay is not arbitrary padding: it is a documented guard against fixture transitions outpacing the compositor and faulting natively, which is what the truncated run above looks like.
 >
 > An **earlier** measurement of the same change showed a 14.4 % win. It was wrong: the "legacy" arm it compared against still subscribed the frame counter before checking the opt-out flag, so the baseline carried the continuous-frame cost and the win was mostly the instrument. If you re-attempt this, verify the control arm is byte-for-byte the shipping path before believing any number it produces.
+
+### The two `CenterOnCurrent` fixtures fail as a pair — for two different reasons
+
+`CenterOnCurrent_UsesCursorMonitor` (`Phase1WindowingFixtures.cs`) and
+`PersistPlacement_FallbackWhenEmpty` (`Phase3WindowingFixtures.cs`) are **selftest** fixtures,
+not unit tests — don't go hunting for them in `Reactor.Tests`. They are the *same assertion
+twice*: both open a `WindowStartPosition.CenterOnCurrent` window and check its centre lands in
+the work area of the monitor under the mouse, so they fail as a **pair** — seeing only one of
+them is the surprise, not seeing both. Neither is a render-timing race, so `WaitFor` will not
+help. **Two different mechanisms in two different environments — check which one you are in
+before theorising:**
+
+- **Non-interactive session (CI agents, RDP-disconnected, locked, headless).** `GetCursorPos`
+  returns **ACCESS_DENIED (err 5)** and never writes its `out` param, so the cursor monitor
+  cannot be determined at all. This is a **100% deterministic failure, not a flake** — the pair
+  simply cannot pass there. Confirmed by direct P/Invoke probe on two separate machines. Fixed
+  by skipping rather than asserting when the cursor is undeterminable; if you see these fail,
+  probe first: `GetCursorPos(out p)` returning `False` with `LastError=5` means you are in this
+  case and the fixtures are innocent. Note `System.Windows.Forms.Cursor.Position` **hides**
+  this — it surfaces the uninitialised `(0,0)` instead of the failure.
+- **Interactive multi-monitor box.** A TOCTOU: `GetCursorPos` is sampled *before*
+  `OpenAndSettle`, so a cursor crossing a monitor boundary while the window opens invalidates
+  the captured work rect. Intermittent, and **structurally impossible on a single display** —
+  if you are on one virtual desktop with no boundary to cross, this is not your mechanism.
+
+Do not assume "quiet machine ⇒ passes": that holds only in the interactive case.
 
 ### Running selftests under NativeAOT
 
@@ -291,6 +363,18 @@ or `1`) for that environment and tool version. If the defect is *when* state is 
 *whether* input arrived, prove the detector with a mutation before counting repeated green E2E
 runs as evidence.
 
+### Don't co-locate the E2E and selftest tiers
+
+CI runs them as separate jobs on separate runners today, and that isolation is load-bearing
+rather than incidental. E2E drives real pointer input, foregrounds windows and changes Z-order;
+several selftest fixtures read live desktop state (the two `CenterOnCurrent`-based ones read the
+cursor's monitor; `UseIsCovered_RerendersOnZOrderChange` reads Z-order). Running E2E first on one
+machine and then `--self-test` took a clean unmodified tree from 0 to 8 failures — reproducible,
+and the standing repro for those fixtures. So if you consolidate jobs to save runner minutes, or
+run both tiers locally back-to-back, expect selftest reds that are an artefact of tier ordering
+and not of your change. Fix the fixtures' desktop-state dependence before merging the jobs, not
+after.
+
 ---
 
 ## Code coverage
@@ -328,6 +412,18 @@ dotnet-coverage merge unit.cobertura.xml selftest.cobertura.xml \
 ```
 
 Replace `$(RuntimeIdentifier)` with `ARM64` or `x64`, or omit the platform segment if you used the default platform from `Directory.Build.props`. The `coverage.settings.xml` file in the repo root controls which modules are included and excludes generated code (`obj/`, `*.g.cs`) and test-host scaffolding exercised only by the winapp/E2E runner.
+
+### When `run-coverage.ps1` aborts before the merge
+
+`tools/coverage/run-coverage.ps1` (`-UnitOnly`, `-SkipBuild`) drives the recipe above and writes
+`coverage/merged.cobertura.xml`. It **aborts before the merge step on any test failure**, so a
+known flake — `CenterOnCurrent_UsesCursorMonitor` or `PersistPlacement_FallbackWhenEmpty`, both
+selftest fixtures covered in §2 above — leaves you with both legs collected and no merged file.
+Merge them by hand:
+
+```powershell
+dotnet-coverage merge coverage\unit.cobertura.xml coverage\selftest.cobertura.xml --output coverage\merged.cobertura.xml --output-format cobertura
+```
 
 ### Running coverage in CI
 


### PR DESCRIPTION
## What this does

`AGENTS.md` § "Checks that actually prove something" was **130 lines of a 368-line file** — larger than the Architecture + Key Conventions sections combined (110). This compresses it to **28 lines** and relocates the **59 lines of repo-specific test lore** it had accumulated into `TESTING.md`, where the rest of the testing guide lives.

**Nothing is deleted.** Every mechanism, command, symbol name, and issue reference in the removed block is either preserved in the compressed rules or moved to `TESTING.md`.

| | before | after |
|---|---|---|
| `AGENTS.md` | 368 lines (section: 130) | 266 lines (section: 28) |
| `TESTING.md` | 366 lines | 466 lines |

## Why — the section only ever ratcheted one way

The section grew through a series of agent-authored `docs:` commits — `81592c2d` "generalise the rule past mutation testing", `1d2a1130` "retitle so the rule transfers past tests", `c5492afd`, `419fd99c` — plus `a078de2e` "strengthen agent verification guidance". **Every one of them widened its scope. None ever narrowed it.** That is structural, not accidental: agents edit the file that governs agents, and "be more rigorous" always sounds defensible, so there is no natural force pushing the other way.

The consequence was observed live. A PR whose actual fix was one commit accumulated **28 more**, many of them corrections to *the wording of comments* rather than to behaviour — because `a078de2e` added a clause turning every negative result into an obligation to run another check, **with no base case**.

The rule itself is good and stays; it has caught real vacuous assertions. What was missing is a stopping condition, and what was misfiled is 59 lines of repo test lore that belongs in the testing guide.

So the only substantive *addition* here is the closing paragraph:

> **When to stop.** Validate each instrument once — then stop. Verify the assertion that gates correctness, not the verifier of the verifier. If you are adding a *second* layer of checking, or correcting the wording of a comment rather than the behaviour of code, you are past the point of return: stop and ship.

## Where each block went

| moved out of `AGENTS.md` | into `TESTING.md` |
|---|---|
| `WaitFor` conversion hazards (eventual vs *survival* assertions) + precondition-`throw` guidance | `### Selftest waiting patterns` |
| Two-place fixture registration + the TAP name-search blind-spot table | `## 2. Selftest` |
| The `CenterOnCurrent` / `PersistPlacement` pair and its two distinct mechanisms | `## 2. Selftest` |
| `run-coverage.ps1` abort-before-merge + the manual `dotnet-coverage merge` | `## Code coverage` |
| E2E/selftest tier isolation (0 → 8 failures when co-located) | `## 3. E2E tests` |
| Flake-fix statistics `(1-p)^N` + the budget-increase rule | `### Judging whether a flake fix worked` |

The historical-vocabulary rule (renames make today's identifier blind to older revisions) is folded into the compressed no-match bullet rather than moved twice.

## Six factual corrections found while relocating

Review surfaced six wrong claims. Three I introduced while rewording; **three were inherited verbatim from `main`** but ship in this diff, so they're fixed here:

- `--list-fixtures` is **selftest-only** (`Program.cs` prints `SelfTestFixtureRegistry.AllFixtures`), so it cannot warn you about the E2E half of two-place registration.
- Both `CenterOnCurrent` fixtures now call `H.Skip` when `GetCursorPos` fails (`Phase1WindowingFixtures.cs:267`, `Phase3WindowingFixtures.cs:199`) — so the non-interactive symptom is a **skip, not a red**. The old text still described the pre-fix world and was internally inconsistent on `main` (it said "fixed by skipping" and then "if you see these fail"). Only the interactive TOCTOU mechanism still produces a failure.
- The TAP-name table claimed the whole-tree grep has **no** blind spot. It has one: interpolated check names — `H.Check($"A11y_Role_{role}_Mounted", …)` at `AccessibilityFixtures.cs:277` — match no literal anywhere, so grepping the TAP name you actually saw returns a confident zero. Fittingly, the table telling you which probe is trustworthy was itself overstating.
- `UseIsCovered_RerendersOnZOrderChange` does **not** read live Z-order — `Phase7WindowingFixtures.cs:519` synthesises it via `RaiseZOrderChangedForTests`. Dropped as evidence for tier isolation; the measured 0 → 8 regression stands on the `CenterOnCurrent` pair.
- The compressed positive-control rule had dropped the original's "same probe, wrapping, and file set" qualifier — without it, a control over a different file set satisfies the rule while proving nothing. Restored.
- The stopping rule originally read "if you are writing a check about a check … stop and ship", which could be read as licence to skip the first-order validation `TESTING.md` requires (prove the mutation ran). Narrowed to a *second* layer.

## Verification

Deliberately minimal — this is a documentation move, and building verification machinery for it would reproduce the exact failure mode being fixed.

- `dotnet test tests/Reactor.Tests --filter "FullyQualifiedName~Tooling"` → **203 passed, 0 failed** at final head.
- No reference in the repo depends on the removed text. No line-anchored (`AGENTS.md:197`-style) references exist anywhere; all references are by filename and survive. `OutputPathContainmentTests.cs:393` cites "the environment-derived-oracle shape from `AGENTS.md`" — that concept is retained and is now named explicitly so the citation stays greppable.
- Neither file is generated (`docs/guide/**` is compiled from `docs/_pipeline/templates/*.md.dt`; these two are hand-written roots), packed into any shipped artifact, or asserted on by any test or lint.
- `docs/specs/052-controlrod.md` passes full `AGENTS.md` into a model prompt as repo policy — shrinking it only lowers token cost, and no checked-in copy of the text exists to go stale.
- `git merge-tree --write-tree origin/main HEAD` → exit 0 (clean against `1b7da00b`).

Reviewed with the repo `pr-review` skill across docs-and-samples, correctness, packaging, test-coverage, and a multi-model cross-check on a different model family. Two findings recommending the removed prose be restored were rejected under the Team Lead Test — restoring generic verification advice is the ratchet this PR exists to break — and the cross-check upheld both rejections.