### PR TITLE
deps: bump NuGet packages missed by (Linux) Dependabot

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -66,8 +66,8 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
-    <PackageVersion Include="MSTest.TestAdapter" Version="4.3.2" />
-    <PackageVersion Include="MSTest.TestFramework" Version="4.3.2" />
+    <PackageVersion Include="MSTest.TestAdapter" Version="4.3.3" />
+    <PackageVersion Include="MSTest.TestFramework" Version="4.3.3" />
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />
     <PackageVersion Include="SharpFuzz" Version="2.3.0" />
     <PackageVersion Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.2.5" />


### PR DESCRIPTION
## Summary

<!-- One or two sentences: what changes, and why. -->

## Linked issue / spec

Fixes #1070

## Test plan

<!-- Bulleted list of how this was verified. Examples:
- [ ] Added unit tests in tests/Reactor.Tests/...
- [ ] Added selftest fixture in tests/Reactor.AppTests.Host/SelfTest/Fixtures/...
- [ ] Ran `dotnet test tests/Reactor.Tests`
- [ ] Manually ran `dotnet run --project samples/Reactor.TestApp`
-->

## Risk / breaking changes

<!-- Any public-API change, behavior shift, or perf-sensitive path? Flag it here. -->
