### PR TITLE
Fix bootstrap CI failure on VS 18.8 runners (#1074)

### DIFF
--- a/.github/workflows/vs-reactor-lib-tests.yml
+++ b/.github/workflows/vs-reactor-lib-tests.yml
@@ -1,0 +1,49 @@
+# Fast, headless tests for the PowerShell that installs the Reactor VS extension:
+#   - src/vs-reactor/VsProcessLib.ps1  (devenv /updateconfiguration timeout + tree kill)
+#   - src/vs-reactor/Reinstall-Vsix.ps1 + bootstrap.ps1 (the exit-code handshake)
+# No build, no dotnet, no Visual Studio — the "devenv" under test is a renamed
+# copy of cmd.exe. Runs on windows-latest because the process semantics being
+# tested (tree kill, taskkill fallback, Get-Process by name) are Windows-specific.
+#
+# Guards issue #1074: on VS 18.8 `devenv /updateconfiguration` never returns, and
+# a bare Process.Kill() orphaned its child, poisoning every later VSIX install on
+# the machine. Each test script exits non-zero on any failed assertion.
+name: VS extension script tests
+
+on:
+  push:
+    paths:
+      - 'bootstrap.ps1'
+      - 'src/vs-reactor/VsProcessLib.ps1'
+      - 'src/vs-reactor/Reinstall-Vsix.ps1'
+      - 'tests/vs_reactor/ci/**'
+      - '.github/workflows/vs-reactor-lib-tests.yml'
+  pull_request:
+    paths:
+      - 'bootstrap.ps1'
+      - 'src/vs-reactor/VsProcessLib.ps1'
+      - 'src/vs-reactor/Reinstall-Vsix.ps1'
+      - 'tests/vs_reactor/ci/**'
+      - '.github/workflows/vs-reactor-lib-tests.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  vs-reactor-scripts:
+    name: VsProcessLib + bootstrap exit-code tests
+    runs-on: windows-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Run VsProcessLib tests
+        shell: pwsh
+        run: ./tests/vs_reactor/ci/VsProcessLib.Tests.ps1
+
+      - name: Run bootstrap exit-code tests
+        shell: pwsh
+        run: ./tests/vs_reactor/ci/BootstrapExitCode.Tests.ps1

--- a/.github/workflows/vs-reactor-lib-tests.yml
+++ b/.github/workflows/vs-reactor-lib-tests.yml
@@ -3,19 +3,30 @@
 #   - src/vs-reactor/Reinstall-Vsix.ps1 + bootstrap.ps1 (the exit-code handshake)
 # No build, no dotnet, no Visual Studio — the "devenv" under test is a renamed
 # copy of cmd.exe. Runs on windows-latest because the process semantics being
-# tested (tree kill, taskkill fallback, Get-Process by name) are Windows-specific.
+# tested (tree kill, taskkill, Get-Process by name, Win32_Process parentage) are
+# Windows-specific.
+#
+# Both suites run twice: once under pwsh (PowerShell 7) and once under Windows
+# PowerShell 5.1. 5.1 is a real entry point, not a formality — bootstrap.ps1
+# re-launches Reinstall-Vsix.ps1 with the *current* host, and `mur upgrade`
+# falls back to powershell.exe when pwsh is absent. Testing only pwsh would
+# leave that half of the shipped path unexercised.
 #
 # Guards issue #1074: on VS 18.8 `devenv /updateconfiguration` never returns, and
 # a bare Process.Kill() orphaned its child, poisoning every later VSIX install on
 # the machine. Each test script exits non-zero on any failed assertion.
 name: VS extension script tests
 
+# Note: the two path lists are duplicated because GitHub Actions does not
+# support YAML anchors. Keep them in sync.
 on:
   push:
     paths:
       - 'bootstrap.ps1'
       - 'src/vs-reactor/VsProcessLib.ps1'
       - 'src/vs-reactor/Reinstall-Vsix.ps1'
+      - 'src/vs-reactor/TESTING.md'
+      - 'src/Reactor.Cli/Upgrade/UpgradeCommand.cs'
       - 'tests/vs_reactor/ci/**'
       - '.github/workflows/vs-reactor-lib-tests.yml'
   pull_request:
@@ -23,6 +34,8 @@ on:
       - 'bootstrap.ps1'
       - 'src/vs-reactor/VsProcessLib.ps1'
       - 'src/vs-reactor/Reinstall-Vsix.ps1'
+      - 'src/vs-reactor/TESTING.md'
+      - 'src/Reactor.Cli/Upgrade/UpgradeCommand.cs'
       - 'tests/vs_reactor/ci/**'
       - '.github/workflows/vs-reactor-lib-tests.yml'
 
@@ -33,17 +46,30 @@ jobs:
   vs-reactor-scripts:
     name: VsProcessLib + bootstrap exit-code tests
     runs-on: windows-latest
-    timeout-minutes: 10
+    # These tests deliberately start hanging processes. A stuck runner should
+    # fail the job, not sit for six hours — this PR is about a hang, after all.
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
-      - name: Run VsProcessLib tests
+      - name: Run VsProcessLib tests (PowerShell 7)
         shell: pwsh
         run: ./tests/vs_reactor/ci/VsProcessLib.Tests.ps1
 
-      - name: Run bootstrap exit-code tests
+      - name: Run bootstrap exit-code tests (PowerShell 7)
         shell: pwsh
+        run: ./tests/vs_reactor/ci/BootstrapExitCode.Tests.ps1
+
+      # `shell: powershell` is Windows PowerShell 5.1 — the host `mur upgrade`
+      # falls back to. Its Process type has no Kill(bool) and it has no
+      # $IsWindows, so this step is what keeps the shipped scripts 5.1-clean.
+      - name: Run VsProcessLib tests (Windows PowerShell 5.1)
+        shell: powershell
+        run: ./tests/vs_reactor/ci/VsProcessLib.Tests.ps1
+
+      - name: Run bootstrap exit-code tests (Windows PowerShell 5.1)
+        shell: powershell
         run: ./tests/vs_reactor/ci/BootstrapExitCode.Tests.ps1

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -604,7 +604,11 @@ Write-Host ''
 Write-Host 'Visual Studio preview (if VS installed): View -> Other Windows -> Reactor Preview'
 
 # Every hard failure above exits via Fail (exit 1), so reaching here means
-# success. Say so explicitly: any best-effort step that shelled out to a native
-# command leaves its code in $LASTEXITCODE, and PowerShell propagates that to
-# the caller when a -File script falls off the end (issue #1074).
+# success. Say so explicitly: bootstrap.yml runs this script *in-process* and
+# checks $LASTEXITCODE on the next line, and $LASTEXITCODE is a global — so a
+# code left behind by any best-effort step that shelled out to a native command
+# survives to that check (issue #1074). Measured: in-process, a leaked 7 is
+# still readable afterwards; `pwsh -File` returns 0 on fall-through and does
+# not reproduce it. This line makes the outcome independent of which one the
+# caller used.
 exit 0

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -561,7 +561,7 @@ if ($SkipVsExtension) {
                     # either — the extension is installed and usable.
                     if ($vsixExit -eq 3) {
                         Write-Host ''
-                        Write-Host "    [warn] VS extension installed into $($target.displayName), but 'devenv /updateconfiguration' timed out and was terminated. Launch VS once to finish the menu merge; if View -> Other Windows -> Reactor Preview is missing, re-run src\vs-reactor\Reinstall-Vsix.ps1." -ForegroundColor Yellow
+                        Write-Host "    [warn] VS extension installed into $($target.displayName), but 'devenv /updateconfiguration' did not complete. Launch VS once to finish the menu merge; if View -> Other Windows -> Reactor Preview is missing, re-run src\vs-reactor\Reinstall-Vsix.ps1." -ForegroundColor Yellow
                     } elseif ($vsixExit -ne 0) {
                         # Don't fail the whole bootstrap — the rest of the install is
                         # usable without the VS extension. Surface the failure clearly

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -554,15 +554,28 @@ if ($SkipVsExtension) {
                     # the next launch. -VsInstanceId pins to the same instance we probed.
                     $powerShellExe = (Get-Process -Id $PID).Path
                     & $powerShellExe -NoLogo -NoProfile -ExecutionPolicy Bypass -File $reinstall -Configuration $Configuration -VsInstanceId $target.instanceId
-                    if ($LASTEXITCODE -ne 0) {
+                    $vsixExit = $LASTEXITCODE
+                    # Reinstall-Vsix.ps1's exit-code contract (see its .OUTPUTS):
+                    # 3 == VSIX installed but `devenv /updateconfiguration`
+                    # timed out. Don't claim [ok] for that, and don't fail
+                    # either — the extension is installed and usable.
+                    if ($vsixExit -eq 3) {
+                        Write-Host ''
+                        Write-Host "    [warn] VS extension installed into $($target.displayName), but 'devenv /updateconfiguration' timed out and was terminated. Launch VS once to finish the menu merge; if View -> Other Windows -> Reactor Preview is missing, re-run src\vs-reactor\Reinstall-Vsix.ps1." -ForegroundColor Yellow
+                    } elseif ($vsixExit -ne 0) {
                         # Don't fail the whole bootstrap — the rest of the install is
                         # usable without the VS extension. Surface the failure clearly
                         # so users debugging install issues see it.
                         Write-Host ''
-                        Write-Host "    [warn] VS extension install reported a non-zero exit code ($LASTEXITCODE). The rest of the bootstrap completed; re-run src\vs-reactor\Reinstall-Vsix.ps1 directly to retry." -ForegroundColor Yellow
+                        Write-Host "    [warn] VS extension install reported a non-zero exit code ($vsixExit). The rest of the bootstrap completed; re-run src\vs-reactor\Reinstall-Vsix.ps1 directly to retry." -ForegroundColor Yellow
                     } else {
                         Write-Ok "VS extension installed into $($target.displayName) — launch VS, then View -> Other Windows -> Reactor Preview."
                     }
+                    # Write-Host does NOT clear $LASTEXITCODE, so without this
+                    # the child's non-zero code survives to the end of the
+                    # script and fails callers that check it (issue #1074:
+                    # bootstrap.yml's `if ($LASTEXITCODE -ne 0) { throw }`).
+                    $global:LASTEXITCODE = 0
                 }
             }
         }
@@ -589,3 +602,9 @@ Write-Host 'Run the E2E UI tests (needs the winapp CLI installed above):'
 Write-Host "    dotnet test tests/Reactor.AppTests -c Debug -p:Platform=$hostArch"
 Write-Host ''
 Write-Host 'Visual Studio preview (if VS installed): View -> Other Windows -> Reactor Preview'
+
+# Every hard failure above exits via Fail (exit 1), so reaching here means
+# success. Say so explicitly: any best-effort step that shelled out to a native
+# command leaves its code in $LASTEXITCODE, and PowerShell propagates that to
+# the caller when a -File script falls off the end (issue #1074).
+exit 0

--- a/src/Reactor.Cli/Upgrade/UpgradeCommand.cs
+++ b/src/Reactor.Cli/Upgrade/UpgradeCommand.cs
@@ -225,7 +225,16 @@ public static class UpgradeCommand
                 return;
             }
             proc.WaitForExit();
-            if (proc.ExitCode != 0)
+            // Reinstall-Vsix.ps1's exit-code contract (see its .OUTPUTS): 3 means
+            // the VSIX installed but `devenv /updateconfiguration` timed out and
+            // was terminated. That's a partial success, not a failure — report it
+            // on stdout so it doesn't read as a broken upgrade.
+            if (proc.ExitCode == 3)
+            {
+                Console.WriteLine("  VS extension installed, but `devenv /updateconfiguration` timed out and was terminated.");
+                Console.WriteLine("  Launch Visual Studio once to finish the menu merge.");
+            }
+            else if (proc.ExitCode != 0)
             {
                 Console.Error.WriteLine($"  VS extension reinstall exited with code {proc.ExitCode}; the rest of the upgrade completed.");
             }

--- a/src/Reactor.Cli/Upgrade/UpgradeCommand.cs
+++ b/src/Reactor.Cli/Upgrade/UpgradeCommand.cs
@@ -165,6 +165,12 @@ public static class UpgradeCommand
         };
         probe.ArgumentList.Add("-all");
         probe.ArgumentList.Add("-prerelease");
+        // -latest so the instance we probe for is the instance we install into.
+        // Without it this call only answered "does *some* VS have the workload?"
+        // while Reinstall-Vsix.ps1 went on to pick the highest-version instance
+        // from an unfiltered list — which can be a different, workload-less VS,
+        // failing the build for a reason the probe was meant to rule out.
+        probe.ArgumentList.Add("-latest");
         probe.ArgumentList.Add("-requires");
         probe.ArgumentList.Add("Microsoft.VisualStudio.Workload.VisualStudioExtension");
         probe.ArgumentList.Add("-property");
@@ -213,8 +219,12 @@ public static class UpgradeCommand
         psi.ArgumentList.Add("Bypass");
         psi.ArgumentList.Add("-File");
         psi.ArgumentList.Add(reinstall);
-        // Pick the highest-version instance the script finds (matches the
-        // default behavior of Reinstall-Vsix.ps1 when no -VsInstanceId is set).
+        // Pin the install to the instance we just verified has the workload.
+        // bootstrap.ps1 already does this; leaving it off here let the script
+        // fall back to "highest version found", which is chosen from an
+        // unfiltered vswhere list and need not be the one we probed.
+        psi.ArgumentList.Add("-VsInstanceId");
+        psi.ArgumentList.Add(instanceLines[0]);
 
         try
         {

--- a/src/Reactor.Cli/Upgrade/UpgradeCommand.cs
+++ b/src/Reactor.Cli/Upgrade/UpgradeCommand.cs
@@ -226,12 +226,13 @@ public static class UpgradeCommand
             }
             proc.WaitForExit();
             // Reinstall-Vsix.ps1's exit-code contract (see its .OUTPUTS): 3 means
-            // the VSIX installed but `devenv /updateconfiguration` timed out and
-            // was terminated. That's a partial success, not a failure — report it
-            // on stdout so it doesn't read as a broken upgrade.
+            // the VSIX installed but `devenv /updateconfiguration` did not complete
+            // (it timed out and was terminated, or devenv.exe was missing). That's
+            // a partial success, not a failure — report it on stdout so it doesn't
+            // read as a broken upgrade.
             if (proc.ExitCode == 3)
             {
-                Console.WriteLine("  VS extension installed, but `devenv /updateconfiguration` timed out and was terminated.");
+                Console.WriteLine("  VS extension installed, but `devenv /updateconfiguration` did not complete.");
                 Console.WriteLine("  Launch Visual Studio once to finish the menu merge.");
             }
             else if (proc.ExitCode != 0)

--- a/src/vs-reactor/Reinstall-Vsix.ps1
+++ b/src/vs-reactor/Reinstall-Vsix.ps1
@@ -12,10 +12,16 @@
 .OUTPUTS
     Exit codes:
       0  VSIX installed and `devenv /updateconfiguration` completed.
-      1  Install failed (build, vswhere, VSIXInstaller, or VS already running).
-      3  VSIX installed, but `devenv /updateconfiguration` did not complete —
-         it timed out and was terminated. The extension is usable; the menu
-         merge may need one manual VS launch.
+      1  The script did not reach a good state and needs developer action —
+         build / vswhere / VSIXInstaller failure, VS already running, or
+         duplicate installs detected (VS silently disables all of them).
+      3  VSIX installed, but `devenv /updateconfiguration` did not complete:
+         it timed out and was terminated, or devenv.exe was not found. The
+         extension is usable; the menu merge needs one manual VS launch.
+
+    Every path that skips or abandons `/updateconfiguration` exits 3, and every
+    path that leaves work for the developer exits 1 — so `0` really does mean
+    "installed and merged", which is what bootstrap.ps1 prints [ok] for.
 #>
 [CmdletBinding()]
 param(
@@ -24,6 +30,10 @@ param(
     [ValidateSet('Debug', 'Release')]
     [string]$Configuration = 'Debug',
     [string]$VsInstanceId,
+    # Upper bound is a sanity rail, not a policy: anything past an hour is a
+    # typo. 0 or negative would make the very first WaitForExit time out and
+    # kill devenv instantly.
+    [ValidateRange(1, 3600)]
     [int]$UpdateConfigurationTimeoutSec = 120
 )
 
@@ -182,6 +192,7 @@ Write-Host ""
 Write-Host "=== Result ==="
 $installedFoldersArray = @($installedFolders)
 $skipUpdateConfig = $false
+$installIncomplete = $false
 if ($installedFoldersArray.Count -eq 0) {
     Write-Warning "Install reported success (VSIXInstaller exit 0) but no Reactor.VsExtension folder appeared within 30s. Proceeding with /updateconfiguration anyway. If VS still doesn't show the menus, inspect %TEMP%\dd_VSIXInstaller_*.log."
 } elseif ($installedFoldersArray.Count -gt 1) {
@@ -189,8 +200,12 @@ if ($installedFoldersArray.Count -eq 0) {
     $installedFoldersArray | ForEach-Object { Write-Warning "  $($_.FullName)" }
     Write-Warning "Skipping /updateconfiguration; clean up duplicates and re-run."
     $skipUpdateConfig = $true
-} else {
-    $folder = $installedFoldersArray[0]
+    # Not a success: the extension is installed but very likely disabled, and
+    # only a human can resolve which copy to keep. Exiting 0 here would make
+    # bootstrap.ps1 print [ok] over the exact failure mode this script exists
+    # to prevent.
+    $installIncomplete = $true
+} else {    $folder = $installedFoldersArray[0]
     [xml]$m = Get-Content (Join-Path $folder.FullName 'extension.vsixmanifest')
     Write-Host ("Installed v{0} at {1}" -f $m.PackageManifest.Metadata.Identity.Version, $folder.FullName)
 }
@@ -220,6 +235,8 @@ if (-not $skipUpdateConfig) {
         Write-Host ("  /updateconfiguration exit code: {0} ({1:0.0}s)" -f $exitText, $r.DurationSeconds)
     } else {
         Write-Warning "devenv.exe not found at $devenv. Run /updateconfiguration manually before launching VS."
+        # Same observable outcome as a timeout: installed, not merged.
+        $updateConfigTimedOut = $true
     }
     Write-Host ""
     Write-Host "Next steps:"
@@ -227,8 +244,10 @@ if (-not $skipUpdateConfig) {
     Write-Host "  2. View -> Other Windows -> Reactor Preview."
 }
 
-# See .OUTPUTS in the header for the exit-code contract. 3 means "the VSIX is
-# installed, but the pkgdef merge didn't finish" — callers warn instead of
-# claiming success, and instead of failing outright.
+# See .OUTPUTS in the header for the exit-code contract.
+#   1 — the developer has to do something before this can work.
+#   3 — installed, but the pkgdef merge didn't finish; one VS launch fixes it.
+# Callers warn on both instead of printing [ok], and neither fails the build.
+if ($installIncomplete) { exit 1 }
 if ($updateConfigTimedOut) { exit 3 }
 exit 0

--- a/src/vs-reactor/Reinstall-Vsix.ps1
+++ b/src/vs-reactor/Reinstall-Vsix.ps1
@@ -1,13 +1,35 @@
+<#
+.SYNOPSIS
+    Clean rebuild + reinstall of the Reactor Preview VSIX into a local Visual
+    Studio instance.
+
+.PARAMETER UpdateConfigurationTimeoutSec
+    How long to wait for `devenv /updateconfiguration` before terminating it
+    and its children. Healthy runs take 27-99s; the default leaves headroom.
+    Visual Studio 18.8 never returns from this call (issue #1074), so the
+    timeout is the normal path there, not an error.
+
+.OUTPUTS
+    Exit codes:
+      0  VSIX installed and `devenv /updateconfiguration` completed.
+      1  Install failed (build, vswhere, VSIXInstaller, or VS already running).
+      3  VSIX installed, but `devenv /updateconfiguration` did not complete —
+         it timed out and was terminated. The extension is usable; the menu
+         merge may need one manual VS launch.
+#>
 [CmdletBinding()]
 param(
     [switch]$SkipBuild,
     [switch]$NoRestore,
     [ValidateSet('Debug', 'Release')]
     [string]$Configuration = 'Debug',
-    [string]$VsInstanceId
+    [string]$VsInstanceId,
+    [int]$UpdateConfigurationTimeoutSec = 120
 )
 
 $ErrorActionPreference = 'Stop'
+
+. (Join-Path $PSScriptRoot 'VsProcessLib.ps1')
 
 # 1. Build the VSIX unless caller asks us to skip it.
 if (-not $SkipBuild) {
@@ -64,9 +86,17 @@ Write-Host "Target VS: $($target.displayName) ($instanceHash, $instanceVersion)"
 Write-Host "Per-user extension root: $extRoot"
 
 # 3. Make sure VS is closed (a running devenv locks the extension DLL).
-$vsRunning = Get-Process devenv -ErrorAction SilentlyContinue
+$vsRunning = @(Get-Process devenv -ErrorAction SilentlyContinue)
 if ($vsRunning) {
-    Write-Error "Visual Studio is running (PIDs: $($vsRunning.Id -join ', ')). Close it and re-run."
+    # Report start times too: a devenv that started seconds ago is almost
+    # always a leftover from a previous /updateconfiguration on this machine
+    # (issue #1074), not a developer's open IDE. Knowing which it is turns a
+    # confusing CI failure into a one-line diagnosis.
+    $detail = ($vsRunning | ForEach-Object {
+        $started = try { $_.StartTime.ToString('u') } catch { 'unknown start time' }
+        "$($_.Id) (started $started)"
+    }) -join ', '
+    Write-Error "Visual Studio is running (PIDs: $detail). Close it and re-run."
     exit 1
 }
 
@@ -165,6 +195,7 @@ if ($installedFoldersArray.Count -eq 0) {
     Write-Host ("Installed v{0} at {1}" -f $m.PackageManifest.Metadata.Identity.Version, $folder.FullName)
 }
 
+$updateConfigTimedOut = $false
 if (-not $skipUpdateConfig) {
     Write-Host ""
     Write-Host "Running 'devenv /updateconfiguration' to force the menu/pkgdef merge synchronously."
@@ -172,13 +203,21 @@ if (-not $skipUpdateConfig) {
     Write-Host "and our menu entry never appears. This step blocks until the merge completes (~10-30s)."
     $devenv = Join-Path $installationPath 'Common7\IDE\devenv.exe'
     if (Test-Path -LiteralPath $devenv) {
-        $psi = New-Object System.Diagnostics.ProcessStartInfo
-        $psi.FileName = $devenv
-        $psi.Arguments = '/updateconfiguration'
-        $psi.UseShellExecute = $false
-        $proc = [System.Diagnostics.Process]::Start($psi)
-        if (-not $proc.WaitForExit(120000)) { $proc.Kill(); Write-Warning "/updateconfiguration timed out after 2 min." }
-        Write-Host ("  /updateconfiguration exit code: {0} ({1:0.0}s)" -f $proc.ExitCode, ($proc.ExitTime - $proc.StartTime).TotalSeconds)
+        $r = Invoke-DevenvUpdateConfiguration -DevenvPath $devenv -TimeoutSeconds $UpdateConfigurationTimeoutSec
+        if ($r.TimedOut) {
+            $updateConfigTimedOut = $true
+            Write-Warning ("/updateconfiguration timed out after {0}s and was terminated (tree kill). This is the known Visual Studio 18.8 hang - see issue #1074." -f $UpdateConfigurationTimeoutSec)
+            if ($r.KilledPids.Count -gt 0) {
+                Write-Warning ("  Reaped leftover devenv PIDs: {0}" -f ($r.KilledPids -join ', '))
+            }
+            if (-not $r.Drained) {
+                # The next invocation's "Visual Studio is running" guard will
+                # fail. Say so here rather than letting it look like a fresh bug.
+                Write-Warning "  A devenv process is still running after the sweep. Close it before re-running this script."
+            }
+        }
+        $exitText = if ($null -ne $r.ExitCode) { $r.ExitCode } else { 'unknown' }
+        Write-Host ("  /updateconfiguration exit code: {0} ({1:0.0}s)" -f $exitText, $r.DurationSeconds)
     } else {
         Write-Warning "devenv.exe not found at $devenv. Run /updateconfiguration manually before launching VS."
     }
@@ -187,3 +226,9 @@ if (-not $skipUpdateConfig) {
     Write-Host "  1. Launch Visual Studio (no special flags needed)."
     Write-Host "  2. View -> Other Windows -> Reactor Preview."
 }
+
+# See .OUTPUTS in the header for the exit-code contract. 3 means "the VSIX is
+# installed, but the pkgdef merge didn't finish" — callers warn instead of
+# claiming success, and instead of failing outright.
+if ($updateConfigTimedOut) { exit 3 }
+exit 0

--- a/src/vs-reactor/Reinstall-Vsix.ps1
+++ b/src/vs-reactor/Reinstall-Vsix.ps1
@@ -216,7 +216,8 @@ if (-not $skipUpdateConfig) {
     Write-Host ""
     Write-Host "Running 'devenv /updateconfiguration' to force the menu/pkgdef merge synchronously."
     Write-Host "Without this step, the first VS launch on VS 2026 sometimes silently skips the merge"
-    Write-Host "and our menu entry never appears. This step blocks until the merge completes (~10-30s)."
+    Write-Host "and our menu entry never appears. This step blocks until the merge completes — 27-99s on"
+    Write-Host "a healthy VS. VS 18.8 never returns (issue #1074), so it is bounded by -UpdateConfigurationTimeoutSec."
     $devenv = Join-Path $installationPath 'Common7\IDE\devenv.exe'
     if (Test-Path -LiteralPath $devenv) {
         $r = Invoke-DevenvUpdateConfiguration -DevenvPath $devenv -TimeoutSeconds $UpdateConfigurationTimeoutSec

--- a/src/vs-reactor/Reinstall-Vsix.ps1
+++ b/src/vs-reactor/Reinstall-Vsix.ps1
@@ -205,7 +205,8 @@ if ($installedFoldersArray.Count -eq 0) {
     # bootstrap.ps1 print [ok] over the exact failure mode this script exists
     # to prevent.
     $installIncomplete = $true
-} else {    $folder = $installedFoldersArray[0]
+} else {
+    $folder = $installedFoldersArray[0]
     [xml]$m = Get-Content (Join-Path $folder.FullName 'extension.vsixmanifest')
     Write-Host ("Installed v{0} at {1}" -f $m.PackageManifest.Metadata.Identity.Version, $folder.FullName)
 }

--- a/src/vs-reactor/Reinstall-Vsix.ps1
+++ b/src/vs-reactor/Reinstall-Vsix.ps1
@@ -215,7 +215,12 @@ if ($installedFoldersArray.Count -eq 0) {
     Write-Host ("Installed v{0} at {1}" -f $m.PackageManifest.Metadata.Identity.Version, $folder.FullName)
 }
 
-$updateConfigTimedOut = $false
+# True when the pkgdef merge did not run to completion, whatever the reason —
+# the 18.8 hang and a missing devenv.exe both land here, because they are
+# indistinguishable to the caller: the VSIX is installed and one manual VS
+# launch finishes the job. Deliberately not named after the timeout; a future
+# edit reading this as timeout-only would drop the devenv-missing path.
+$updateConfigIncomplete = $false
 if (-not $skipUpdateConfig) {
     Write-Host ""
     Write-Host "Running 'devenv /updateconfiguration' to force the menu/pkgdef merge synchronously."
@@ -226,7 +231,7 @@ if (-not $skipUpdateConfig) {
     if (Test-Path -LiteralPath $devenv) {
         $r = Invoke-DevenvUpdateConfiguration -DevenvPath $devenv -TimeoutSeconds $UpdateConfigurationTimeoutSec
         if ($r.TimedOut) {
-            $updateConfigTimedOut = $true
+            $updateConfigIncomplete = $true
             Write-Warning ("/updateconfiguration timed out after {0}s and was terminated (tree kill). This is the known Visual Studio 18.8 hang - see issue #1074." -f $UpdateConfigurationTimeoutSec)
             if ($r.KilledPids.Count -gt 0) {
                 Write-Warning ("  Reaped leftover devenv PIDs: {0}" -f ($r.KilledPids -join ', '))
@@ -242,7 +247,7 @@ if (-not $skipUpdateConfig) {
     } else {
         Write-Warning "devenv.exe not found at $devenv. Run /updateconfiguration manually before launching VS."
         # Same observable outcome as a timeout: installed, not merged.
-        $updateConfigTimedOut = $true
+        $updateConfigIncomplete = $true
     }
     Write-Host ""
     Write-Host "Next steps:"
@@ -255,5 +260,5 @@ if (-not $skipUpdateConfig) {
 #   3 — installed, but the pkgdef merge didn't finish; one VS launch fixes it.
 # Callers warn on both instead of printing [ok], and neither fails the build.
 if ($installIncomplete) { exit 1 }
-if ($updateConfigTimedOut) { exit 3 }
+if ($updateConfigIncomplete) { exit 3 }
 exit 0

--- a/src/vs-reactor/Reinstall-Vsix.ps1
+++ b/src/vs-reactor/Reinstall-Vsix.ps1
@@ -19,9 +19,13 @@
          it timed out and was terminated, or devenv.exe was not found. The
          extension is usable; the menu merge needs one manual VS launch.
 
-    Every path that skips or abandons `/updateconfiguration` exits 3, and every
-    path that leaves work for the developer exits 1 — so `0` really does mean
-    "installed and merged", which is what bootstrap.ps1 prints [ok] for.
+    Which code wins when a path qualifies for both: `1` outranks `3`. The
+    duplicate-install branch skips `/updateconfiguration` *and* needs a human,
+    so it exits 1 — "you must act" is more useful to the caller than "the merge
+    didn't run". `3` is therefore the code for paths that skip or abandon the
+    merge but leave nothing for the developer to fix beyond launching VS. `0` is
+    reached only when the merge actually completed, which is the sole case
+    bootstrap.ps1 prints [ok] for.
 #>
 [CmdletBinding()]
 param(

--- a/src/vs-reactor/TESTING.md
+++ b/src/vs-reactor/TESTING.md
@@ -89,10 +89,13 @@ It exits with:
 | Code | Meaning |
 | --- | --- |
 | `0` | VSIX installed and `devenv /updateconfiguration` completed. |
-| `1` | Install failed (build, `vswhere`, `VSIXInstaller`, or VS already running). |
-| `3` | VSIX installed, but `devenv /updateconfiguration` timed out and was terminated. The extension is usable; the menu merge may need one manual VS launch. |
+| `1` | Needs developer action — build, `vswhere`, or `VSIXInstaller` failure; VS already running; or duplicate installs detected (VS silently disables all of them, so this is *not* a success). |
+| `3` | VSIX installed, but `devenv /updateconfiguration` did not complete — it timed out and was terminated, or `devenv.exe` was not found. The extension is usable; the menu merge needs one manual VS launch. |
 
-`bootstrap.ps1` and `mur upgrade` both treat `3` as a warning and carry on.
+`bootstrap.ps1` and `mur upgrade` both treat `3` as a warning and carry on, and
+neither prints `[ok]` for it. `0` therefore really does mean "installed and
+merged". `tests/vs_reactor/ci/BootstrapExitCode.Tests.ps1` fails if this table
+and the script's exit statements ever disagree.
 
 After it completes, launch VS once with `devenv /updateconfiguration` if the
 menu still does not appear — that forces a synchronous pkgdef merge before the
@@ -110,9 +113,14 @@ during its window, waits for the name to clear, and exits `3`.
 That sweep matters. `Process.Kill()` with no argument kills only the top process
 and returns without waiting, so the second `devenv` that `/updateconfiguration`
 spawns used to survive and make every later run of this script fail its
-"Visual Studio is running" guard (issue #1074). The logic lives in
-`VsProcessLib.ps1` and is covered by `tests/vs_reactor/ci/VsProcessLib.Tests.ps1`
-(run by the *VS extension script tests* workflow).
+"Visual Studio is running" guard (issue #1074). The sweep is **attributed, not
+name-matched**: it acts only on processes it recorded as descendants of the
+`devenv` it started, so an IDE you opened during the wait is never touched. A
+`devenv` it cannot attribute is *reported* — that is what the "still running
+after the sweep" warning is. The logic lives in `VsProcessLib.ps1` and is
+covered by `tests/vs_reactor/ci/VsProcessLib.Tests.ps1` (run by the *VS
+extension script tests* workflow, under both PowerShell 7 and Windows
+PowerShell 5.1).
 
 If you see `Visual Studio is running (PIDs: ...)` on a machine where you have no
 IDE open, check the reported start times: a process seconds old is a leftover

--- a/src/vs-reactor/TESTING.md
+++ b/src/vs-reactor/TESTING.md
@@ -84,9 +84,39 @@ VSIX silently into the highest-version VS instance reported by `vswhere`. Pass
 `-VsInstanceId <id>` to target a specific install. Skip `-SkipBuild` if the
 VSIX is already current.
 
+It exits with:
+
+| Code | Meaning |
+| --- | --- |
+| `0` | VSIX installed and `devenv /updateconfiguration` completed. |
+| `1` | Install failed (build, `vswhere`, `VSIXInstaller`, or VS already running). |
+| `3` | VSIX installed, but `devenv /updateconfiguration` timed out and was terminated. The extension is usable; the menu merge may need one manual VS launch. |
+
+`bootstrap.ps1` and `mur upgrade` both treat `3` as a warning and carry on.
+
 After it completes, launch VS once with `devenv /updateconfiguration` if the
 menu still does not appear — that forces a synchronous pkgdef merge before the
 shell starts.
+
+### `devenv /updateconfiguration` hangs on Visual Studio 18.8
+
+On VS **18.8** (`18.8.12023.21` and later in that band), `devenv /updateconfiguration`
+never returns — it does the work but does not exit. VS 18.7 completes the same
+call in 27–99 s. `Reinstall-Vsix.ps1` therefore treats the timeout as an expected
+outcome on 18.8: it waits `-UpdateConfigurationTimeoutSec` (default 120), then
+terminates the whole `devenv` process tree, sweeps any `devenv` that appeared
+during its window, waits for the name to clear, and exits `3`.
+
+That sweep matters. `Process.Kill()` with no argument kills only the top process
+and returns without waiting, so the second `devenv` that `/updateconfiguration`
+spawns used to survive and make every later run of this script fail its
+"Visual Studio is running" guard (issue #1074). The logic lives in
+`VsProcessLib.ps1` and is covered by `tests/vs_reactor/ci/VsProcessLib.Tests.ps1`
+(run by the *VS extension script tests* workflow).
+
+If you see `Visual Studio is running (PIDs: ...)` on a machine where you have no
+IDE open, check the reported start times: a process seconds old is a leftover
+from a hung `/updateconfiguration`, and killing it is safe.
 
 ### `NoApplicableSKUsException` on VS 2026
 

--- a/src/vs-reactor/TESTING.md
+++ b/src/vs-reactor/TESTING.md
@@ -107,8 +107,9 @@ On VS **18.8** (`18.8.12023.21` and later in that band), `devenv /updateconfigur
 never returns — it does the work but does not exit. VS 18.7 completes the same
 call in 27–99 s. `Reinstall-Vsix.ps1` therefore treats the timeout as an expected
 outcome on 18.8: it waits `-UpdateConfigurationTimeoutSec` (default 120), then
-terminates the whole `devenv` process tree, sweeps any `devenv` that appeared
-during its window, waits for the name to clear, and exits `3`.
+terminates the whole `devenv` process tree, sweeps any leftover process it
+recorded as belonging to *that* tree, reports whether the name is clear, and
+exits `3`.
 
 That sweep matters. `Process.Kill()` with no argument kills only the top process
 and returns without waiting, so the second `devenv` that `/updateconfiguration`

--- a/src/vs-reactor/VsProcessLib.ps1
+++ b/src/vs-reactor/VsProcessLib.ps1
@@ -191,7 +191,9 @@ function Wait-ProcessNameCleared {
       ExitCode        [int?]  exit code, or $null if it could not be read
       DurationSeconds [double] wall-clock time, measured with a Stopwatch
       KilledPids      [int[]] ids reaped by the post-timeout sweep
-      Drained         [bool]  no $ProcessName process is left on the machine
+      Drained         [bool]  no $ProcessName process is left on the machine.
+                              Computed on every path — polled while draining
+                              after a timeout, point-checked otherwise.
 
 .NOTES
     DurationSeconds is deliberately measured with a Stopwatch rather than
@@ -222,7 +224,6 @@ function Invoke-DevenvUpdateConfiguration {
     $exited = $proc.WaitForExit($TimeoutSeconds * 1000)
 
     $killed = @()
-    $drained = $true
     if (-not $exited) {
         # Record the tree BEFORE killing anything: `taskkill /T` resolves
         # descendants at kill time, so a child whose own parent dies during the
@@ -244,7 +245,15 @@ function Invoke-DevenvUpdateConfiguration {
 
         Stop-ProcessTreeSafely -Process $proc -WaitSeconds $DrainTimeoutSeconds | Out-Null
         $killed = @(Stop-ProcessIdsSafely -ProcessIds $tree -ExpectedName $ProcessName -NotStartedAfter $recordedAt -WaitSeconds $DrainTimeoutSeconds)
+        # We are actively draining here, so wait for it.
         $drained = Wait-ProcessNameCleared -Name $ProcessName -TimeoutSeconds $DrainTimeoutSeconds
+    }
+    else {
+        # Measured, not assumed: a clean exit does not prove nothing was left
+        # behind — /updateconfiguration spawns a second devenv, and hardcoding
+        # $true here would report the one thing this field exists to deny. No
+        # poll, because there is nothing to wait for on this path.
+        $drained = (@(Get-ProcessIdsByName -Name $ProcessName).Count -eq 0)
     }
     $sw.Stop()
 

--- a/src/vs-reactor/VsProcessLib.ps1
+++ b/src/vs-reactor/VsProcessLib.ps1
@@ -153,8 +153,14 @@ function Stop-ProcessIdsSafely {
         if (-not $p) { continue }
         if ($ExpectedName -and $p.Name -ne $ExpectedName) { continue }
         try { if ($p.StartTime -gt $NotStartedAfter) { continue } } catch { continue }
-        $killed.Add($processId) | Out-Null
-        Stop-ProcessTreeSafely -Process $p -WaitSeconds $WaitSeconds | Out-Null
+        # Record only what was *confirmed* reaped. Adding the pid before the
+        # kill would make the caller's "Reaped leftover devenv PIDs" line claim
+        # a process that is still running — a log that lies about the cleanup is
+        # the same class of broken instrument as #1074's -425-year duration.
+        # Anything that survives is still caught by the drain report.
+        if (Stop-ProcessTreeSafely -Process $p -WaitSeconds $WaitSeconds) {
+            $killed.Add($processId) | Out-Null
+        }
     }
     # Bare array, not `,$array` — see Get-ProcessIdsByName. Callers wrap with @().
     return $killed.ToArray()

--- a/src/vs-reactor/VsProcessLib.ps1
+++ b/src/vs-reactor/VsProcessLib.ps1
@@ -45,7 +45,9 @@ function Get-ProcessIdsByName {
 }
 
 # Every descendant pid of $RootPid, breadth-first, via the Win32_Process
-# parent links. Add -IncludeRoot to get the root back in the result.
+# parent links. Add -IncludeRoot to get the root back in the result — but only
+# when the root can actually be verified; see the two degraded branches below,
+# which claim nothing at all.
 #
 # Windows recycles pids, and a process keeps its ParentProcessId after that
 # parent exits — so a stale ppid can point at an unrelated recycled process.
@@ -59,9 +61,10 @@ function Get-ProcessDescendantIds {
 
     $all = @(Get-CimInstance -ClassName Win32_Process -Property ProcessId, ParentProcessId, CreationDate -ErrorAction SilentlyContinue)
     if ($all.Count -eq 0) {
-        # CIM unavailable. Report only what we know for certain rather than
-        # guessing by name; the caller's drain poll still tells the truth.
-        if ($IncludeRoot) { return @($RootPid) }
+        # CIM unavailable: nothing can be verified, including the root itself.
+        # Returning the root pid here would hand the caller a number to kill on
+        # no evidence. The caller holds a live Process handle for the root and
+        # kills it through that; the drain poll still reports the truth.
         return @()
     }
 
@@ -87,11 +90,11 @@ function Get-ProcessDescendantIds {
     # therefore eligible for reuse. Every edge pointing at it is unverifiable —
     # the stale-edge check below needs the parent's creation time, and there
     # isn't one — so a process that merely inherited the number would be
-    # attributed to us and swept. Claim nothing rather than guess.
-    if (-not $createdAt.ContainsKey($RootPid)) {
-        if ($IncludeRoot) { return @($RootPid) }
-        return @()
-    }
+    # attributed to us and swept. Claim nothing rather than guess, and that
+    # includes the root: -IncludeRoot must not hand back the recycled pid this
+    # branch exists to distrust. The caller kills the root through its live
+    # Process handle, not by number.
+    if (-not $createdAt.ContainsKey($RootPid)) { return @() }
 
     while ($queue.Count -gt 0) {
         $current = $queue.Dequeue()

--- a/src/vs-reactor/VsProcessLib.ps1
+++ b/src/vs-reactor/VsProcessLib.ps1
@@ -162,6 +162,14 @@ function Stop-ProcessTreeSafely {
 # time we sweep, a recorded pid may belong to something else entirely. A pid
 # that no longer carries the expected name, or that started after we recorded
 # it, is somebody else's and is left alone.
+#
+# Why the pair is close to airtight, and where it still isn't: every pid the
+# caller records was alive during the walk, so it started at or before the
+# timestamp taken immediately after it. A replacement that grabbed the same pid
+# would have to start later — and so fails the timestamp test — unless it landed
+# inside the microseconds between the walk ending and the timestamp being taken,
+# *and* happened to be named devenv. That residue is not zero, so this is a
+# narrowing, not a guarantee; the drain report is what covers the remainder.
 function Stop-ProcessIdsSafely {
     param(
         [int[]]$ProcessIds = @(),

--- a/src/vs-reactor/VsProcessLib.ps1
+++ b/src/vs-reactor/VsProcessLib.ps1
@@ -234,8 +234,13 @@ function Invoke-DevenvUpdateConfiguration {
         # nothing can attribute it to us, and killing it by name would mean
         # killing a developer's IDE. That case is *reported* instead, via
         # Drained, and Reinstall-Vsix.ps1 turns it into an actionable warning.
-        $recordedAt = [DateTime]::Now
         $tree = @(Get-ProcessDescendantIds -RootPid $proc.Id -IncludeRoot)
+        # Timestamp AFTER the walk, never before. Every pid in $tree was already
+        # running when the walk observed it, so it necessarily started at or
+        # before this instant — whereas a timestamp taken first would be earlier
+        # than a descendant spawned *during* the walk, and Stop-ProcessIdsSafely
+        # would then skip that pid as "too young" and leave the stray behind.
+        $recordedAt = [DateTime]::Now
 
         Stop-ProcessTreeSafely -Process $proc -WaitSeconds $DrainTimeoutSeconds | Out-Null
         $killed = @(Stop-ProcessIdsSafely -ProcessIds $tree -ExpectedName $ProcessName -NotStartedAfter $recordedAt -WaitSeconds $DrainTimeoutSeconds)

--- a/src/vs-reactor/VsProcessLib.ps1
+++ b/src/vs-reactor/VsProcessLib.ps1
@@ -108,7 +108,17 @@ function Stop-ProcessTreeSafely {
         [int]$WaitSeconds = 30
     )
 
-    try { if ($Process.HasExited) { return $true } } catch { return $true }
+    # Report only what is known. An exception in here means the state is
+    # *unknown*, which is not the same as good: HasExited can throw for a live
+    # process we lack rights to inspect, and answering $true there would let
+    # Stop-ProcessIdsSafely record a still-running pid as reaped — reporting a
+    # cleanup that never happened, which is the failure mode this module exists
+    # to remove. So unknown falls through to the kill attempt, and an unknown
+    # wait answers $false, leaving the verdict to the drain poll, which observes
+    # the machine instead of a handle.
+    $processId = 0
+    try { $processId = $Process.Id } catch { return $false }
+    try { if ($Process.HasExited) { return $true } } catch { }
 
     # `taskkill /T` walks the tree on every supported Windows and on both
     # PowerShell hosts. Process.Kill($true) would do the same but needs .NET 5+,
@@ -116,7 +126,7 @@ function Stop-ProcessTreeSafely {
     # Kill() is the exact call that caused #1074. One path, tested everywhere,
     # beats a host-dependent pair where only one half runs in CI.
     try {
-        & "$env:SystemRoot\System32\taskkill.exe" '/PID' $Process.Id '/T' '/F' 2>&1 | Out-Null
+        & "$env:SystemRoot\System32\taskkill.exe" '/PID' $processId '/T' '/F' 2>&1 | Out-Null
     } catch {
         # Raced with a natural exit, or access denied on a process owned by
         # another user. Fall through to the wait, which reports the truth.
@@ -126,7 +136,7 @@ function Stop-ProcessTreeSafely {
     # whichever script dot-sourced us — #1074's third defect, in miniature.
     $global:LASTEXITCODE = 0
 
-    try { return $Process.WaitForExit($WaitSeconds * 1000) } catch { return $true }
+    try { return $Process.WaitForExit($WaitSeconds * 1000) } catch { return $false }
 }
 
 # Kill the given pids (tree and all) and return the ones that were still alive.

--- a/src/vs-reactor/VsProcessLib.ps1
+++ b/src/vs-reactor/VsProcessLib.ps1
@@ -83,6 +83,16 @@ function Get-ProcessDescendantIds {
     $queue = New-Object System.Collections.Generic.Queue[int]
     $queue.Enqueue($RootPid)
 
+    # If the root is not in the snapshot it has already exited, and its pid is
+    # therefore eligible for reuse. Every edge pointing at it is unverifiable —
+    # the stale-edge check below needs the parent's creation time, and there
+    # isn't one — so a process that merely inherited the number would be
+    # attributed to us and swept. Claim nothing rather than guess.
+    if (-not $createdAt.ContainsKey($RootPid)) {
+        if ($IncludeRoot) { return @($RootPid) }
+        return @()
+    }
+
     while ($queue.Count -gt 0) {
         $current = $queue.Dequeue()
         if (-not $childrenOf.ContainsKey($current)) { continue }

--- a/src/vs-reactor/VsProcessLib.ps1
+++ b/src/vs-reactor/VsProcessLib.ps1
@@ -18,12 +18,21 @@
     that had not exited yet, which returns the 1601 epoch and printed a
     duration of roughly -425 years.
 
+    ATTRIBUTION, NOT NAME MATCHING: the post-timeout sweep acts only on pids
+    this module recorded as descendants of the process *it* started. An earlier
+    revision swept by process name with a pre-start snapshot as the exclude
+    list, which is unsafe: Reinstall-Vsix.ps1 refuses to start while any devenv
+    is alive, so that snapshot is always empty and the sweep degenerated to
+    "kill every devenv" — including an IDE a developer opened during the
+    two-minute window. Anything we cannot attribute is reported (see Drained),
+    never killed.
+
     COMPATIBILITY: these functions must stay Windows PowerShell 5.1 clean.
     bootstrap.ps1 re-launches Reinstall-Vsix.ps1 with `(Get-Process -Id
     $PID).Path`, and `mur upgrade` falls back to powershell.exe when pwsh is
-    absent. That rules out `Process.Kill([bool])` (.NET 5+) and
-    `ProcessStartInfo.ArgumentList` (.NET Core only) as unconditional calls —
-    see Stop-ProcessTreeSafely for the reflection probe + taskkill fallback.
+    absent. That rules out `Process.Kill([bool])` (.NET 5+),
+    `ProcessStartInfo.ArgumentList` (.NET Core only), and the `$IsWindows`
+    automatic variable (PowerShell 6+).
 #>
 
 # Ids of every running process with the given name. Callers wrap with @() —
@@ -33,6 +42,62 @@ function Get-ProcessIdsByName {
     param([Parameter(Mandatory)][string]$Name)
 
     return @(Get-Process -Name $Name -ErrorAction SilentlyContinue | ForEach-Object { $_.Id })
+}
+
+# Every descendant pid of $RootPid, breadth-first, via the Win32_Process
+# parent links. Add -IncludeRoot to get the root back in the result.
+#
+# Windows recycles pids, and a process keeps its ParentProcessId after that
+# parent exits — so a stale ppid can point at an unrelated recycled process.
+# A child that was created *before* its claimed parent cannot really be its
+# child, so those edges are dropped.
+function Get-ProcessDescendantIds {
+    param(
+        [Parameter(Mandatory)][int]$RootPid,
+        [switch]$IncludeRoot
+    )
+
+    $all = @(Get-CimInstance -ClassName Win32_Process -Property ProcessId, ParentProcessId, CreationDate -ErrorAction SilentlyContinue)
+    if ($all.Count -eq 0) {
+        # CIM unavailable. Report only what we know for certain rather than
+        # guessing by name; the caller's drain poll still tells the truth.
+        if ($IncludeRoot) { return @($RootPid) }
+        return @()
+    }
+
+    $childrenOf = @{}
+    $createdAt = @{}
+    foreach ($p in $all) {
+        $processId = [int]$p.ProcessId
+        $parentId = [int]$p.ParentProcessId
+        $createdAt[$processId] = $p.CreationDate
+        if (-not $childrenOf.ContainsKey($parentId)) {
+            $childrenOf[$parentId] = New-Object System.Collections.Generic.List[int]
+        }
+        $childrenOf[$parentId].Add($processId) | Out-Null
+    }
+
+    $seen = New-Object System.Collections.Generic.HashSet[int]
+    $seen.Add($RootPid) | Out-Null
+    $found = New-Object System.Collections.Generic.List[int]
+    $queue = New-Object System.Collections.Generic.Queue[int]
+    $queue.Enqueue($RootPid)
+
+    while ($queue.Count -gt 0) {
+        $current = $queue.Dequeue()
+        if (-not $childrenOf.ContainsKey($current)) { continue }
+        foreach ($child in $childrenOf[$current]) {
+            if (-not $seen.Add($child)) { continue }
+            $childBirth = $createdAt[$child]
+            $parentBirth = $createdAt[$current]
+            if ($null -ne $childBirth -and $null -ne $parentBirth -and $childBirth -lt $parentBirth) { continue }
+            $found.Add($child) | Out-Null
+            $queue.Enqueue($child)
+        }
+    }
+
+    if ($IncludeRoot) { return @(@($RootPid) + $found.ToArray()) }
+    return $found.ToArray()
 }
 
 # Terminate a process AND its descendants, then block until it is really gone.
@@ -45,71 +110,71 @@ function Stop-ProcessTreeSafely {
 
     try { if ($Process.HasExited) { return $true } } catch { return $true }
 
-    # .NET 5+ (pwsh) has Kill($entireProcessTree). Windows PowerShell 5.1 runs
-    # on .NET Framework, which only has the single-process Kill() — the exact
-    # overload that caused #1074. Probe by reflection and fall back to
-    # `taskkill /T /F`, which walks the tree on every supported Windows.
-    $killTree = $Process.GetType().GetMethod('Kill', [type[]]@([bool]))
+    # `taskkill /T` walks the tree on every supported Windows and on both
+    # PowerShell hosts. Process.Kill($true) would do the same but needs .NET 5+,
+    # which Windows PowerShell 5.1 does not have — and its no-argument sibling
+    # Kill() is the exact call that caused #1074. One path, tested everywhere,
+    # beats a host-dependent pair where only one half runs in CI.
     try {
-        if ($killTree) {
-            $killTree.Invoke($Process, @($true)) | Out-Null
-        } else {
-            & "$env:SystemRoot\System32\taskkill.exe" '/PID' $Process.Id '/T' '/F' 2>&1 | Out-Null
-            # taskkill returns non-zero when the process is already gone. That
-            # is not an error here, and letting it linger would leak into the
-            # exit code of whichever script dot-sourced us.
-            $global:LASTEXITCODE = 0
-        }
+        & "$env:SystemRoot\System32\taskkill.exe" '/PID' $Process.Id '/T' '/F' 2>&1 | Out-Null
     } catch {
         # Raced with a natural exit, or access denied on a process owned by
         # another user. Fall through to the wait, which reports the truth.
     }
+    # taskkill returns non-zero when the process is already gone. That is not an
+    # error here, and letting it linger would leak into the exit code of
+    # whichever script dot-sourced us — #1074's third defect, in miniature.
+    $global:LASTEXITCODE = 0
 
     try { return $Process.WaitForExit($WaitSeconds * 1000) } catch { return $true }
 }
 
-# Kill every process named $Name whose id is not in $ExcludePids, tree and all.
-# Returns the ids it killed.
+# Kill the given pids (tree and all) and return the ones that were still alive.
 #
-# This is the belt to Stop-ProcessTreeSafely's braces: Kill($true) enumerates
-# descendants at kill time, so a grandchild that has already re-parented can be
-# missed. $ExcludePids carries the pre-start snapshot, so processes that were
-# running before we started are never touched.
-function Stop-NewProcessesByName {
+# This is the belt to Stop-ProcessTreeSafely's braces: `taskkill /T` enumerates
+# descendants at kill time, so a grandchild that has already re-parented is
+# missed. The caller records the tree *before* killing and passes it here.
+#
+# $ExpectedName and $NotStartedAfter exist because Windows recycles pids: by the
+# time we sweep, a recorded pid may belong to something else entirely. A pid
+# that no longer carries the expected name, or that started after we recorded
+# it, is somebody else's and is left alone.
+function Stop-ProcessIdsSafely {
     param(
-        [Parameter(Mandatory)][string]$Name,
-        [int[]]$ExcludePids = @(),
+        [int[]]$ProcessIds = @(),
+        [string]$ExpectedName = '',
+        [datetime]$NotStartedAfter = [datetime]::MaxValue,
         [int]$WaitSeconds = 30
     )
 
     $killed = New-Object System.Collections.Generic.List[int]
-    foreach ($p in @(Get-Process -Name $Name -ErrorAction SilentlyContinue)) {
-        if ($ExcludePids -contains $p.Id) { continue }
-        $killed.Add($p.Id) | Out-Null
+    foreach ($processId in @($ProcessIds)) {
+        $p = Get-Process -Id $processId -ErrorAction SilentlyContinue
+        if (-not $p) { continue }
+        if ($ExpectedName -and $p.Name -ne $ExpectedName) { continue }
+        try { if ($p.StartTime -gt $NotStartedAfter) { continue } } catch { continue }
+        $killed.Add($processId) | Out-Null
         Stop-ProcessTreeSafely -Process $p -WaitSeconds $WaitSeconds | Out-Null
     }
     # Bare array, not `,$array` — see Get-ProcessIdsByName. Callers wrap with @().
     return $killed.ToArray()
 }
 
-# Poll until no process named $Name (excluding $ExcludePids) is left, or the
-# timeout elapses. Returns $true when the name is clear.
+# Poll until no process named $Name is left, or the timeout elapses.
+# Returns $true when the name is clear. Observes only — never kills.
 #
-# This poll is the actual guarantee the caller needs: it is what makes it
-# impossible for the *next* Reinstall-Vsix.ps1 invocation to trip the
-# "Visual Studio is running" guard on a process this one started.
+# This answers the question the caller actually has: will the *next*
+# Reinstall-Vsix.ps1 invocation trip its "Visual Studio is running" guard? That
+# guard matches by name with no exclusions, so this must too.
 function Wait-ProcessNameCleared {
     param(
         [Parameter(Mandatory)][string]$Name,
-        [int[]]$ExcludePids = @(),
         [int]$TimeoutSeconds = 30
     )
 
     $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
     while ($true) {
-        $remaining = @(Get-Process -Name $Name -ErrorAction SilentlyContinue |
-            Where-Object { $ExcludePids -notcontains $_.Id })
-        if ($remaining.Count -eq 0) { return $true }
+        if (@(Get-ProcessIdsByName -Name $Name).Count -eq 0) { return $true }
         if ([DateTime]::UtcNow -ge $deadline) { return $false }
         Start-Sleep -Milliseconds 250
     }
@@ -118,7 +183,7 @@ function Wait-ProcessNameCleared {
 <#
 .SYNOPSIS
     Run `devenv /updateconfiguration` with a hard timeout that leaves nothing
-    running behind it.
+    of its own running behind it.
 
 .OUTPUTS
     [pscustomobject] with:
@@ -126,12 +191,16 @@ function Wait-ProcessNameCleared {
       ExitCode        [int?]  exit code, or $null if it could not be read
       DurationSeconds [double] wall-clock time, measured with a Stopwatch
       KilledPids      [int[]] ids reaped by the post-timeout sweep
-      Drained         [bool]  no $ProcessName process was left behind
+      Drained         [bool]  no $ProcessName process is left on the machine
 
 .NOTES
     DurationSeconds is deliberately measured with a Stopwatch rather than
     ($proc.ExitTime - $proc.StartTime): ExitTime on a process that has not
     exited returns the 1601 epoch, which is how #1074 came to log "-13430263500.8s".
+
+    Drained is deliberately unfiltered — it reports the machine state the next
+    run's guard will see, which may legitimately be $false because a developer
+    has Visual Studio open. It is a report, not a kill list.
 #>
 function Invoke-DevenvUpdateConfiguration {
     param(
@@ -141,11 +210,6 @@ function Invoke-DevenvUpdateConfiguration {
         [string]$ProcessName = 'devenv',
         [int]$DrainTimeoutSeconds = 30
     )
-
-    # Snapshot first. Reinstall-Vsix.ps1 refuses to run while any devenv is
-    # alive, so in practice this is empty — but if a developer launches VS
-    # mid-run we must not kill their IDE.
-    $preexisting = @(Get-ProcessIdsByName -Name $ProcessName)
 
     $psi = New-Object System.Diagnostics.ProcessStartInfo
     $psi.FileName = $DevenvPath
@@ -160,14 +224,28 @@ function Invoke-DevenvUpdateConfiguration {
     $killed = @()
     $drained = $true
     if (-not $exited) {
+        # Record the tree BEFORE killing anything: `taskkill /T` resolves
+        # descendants at kill time, so a child whose own parent dies during the
+        # kill drops out of the walk mid-flight. Capturing first closes that
+        # window.
+        #
+        # Scope, stated plainly: this does NOT recover a process that was
+        # already re-parented before the capture — once its parent is gone
+        # nothing can attribute it to us, and killing it by name would mean
+        # killing a developer's IDE. That case is *reported* instead, via
+        # Drained, and Reinstall-Vsix.ps1 turns it into an actionable warning.
+        $recordedAt = [DateTime]::Now
+        $tree = @(Get-ProcessDescendantIds -RootPid $proc.Id -IncludeRoot)
+
         Stop-ProcessTreeSafely -Process $proc -WaitSeconds $DrainTimeoutSeconds | Out-Null
-        $killed = @(Stop-NewProcessesByName -Name $ProcessName -ExcludePids $preexisting -WaitSeconds $DrainTimeoutSeconds)
-        $drained = Wait-ProcessNameCleared -Name $ProcessName -ExcludePids $preexisting -TimeoutSeconds $DrainTimeoutSeconds
+        $killed = @(Stop-ProcessIdsSafely -ProcessIds $tree -ExpectedName $ProcessName -NotStartedAfter $recordedAt -WaitSeconds $DrainTimeoutSeconds)
+        $drained = Wait-ProcessNameCleared -Name $ProcessName -TimeoutSeconds $DrainTimeoutSeconds
     }
     $sw.Stop()
 
     $exitCode = $null
     try { if ($proc.HasExited) { $exitCode = $proc.ExitCode } } catch { $exitCode = $null }
+    $proc.Dispose()
 
     return [pscustomobject]@{
         TimedOut        = (-not $exited)

--- a/src/vs-reactor/VsProcessLib.ps1
+++ b/src/vs-reactor/VsProcessLib.ps1
@@ -1,0 +1,179 @@
+<#
+.SYNOPSIS
+    Process-tree helpers for the Reactor VSIX install scripts.
+
+.DESCRIPTION
+    Dot-sourced by Reinstall-Vsix.ps1. Exists as a separate file so the
+    timeout / kill / drain logic can be unit-tested headlessly against fake
+    processes without running a real VSIX install
+    (tests/vs_reactor/ci/VsProcessLib.Tests.ps1).
+
+    Why this exists (issue #1074): on Visual Studio 18.8,
+    `devenv /updateconfiguration` never returns. The original code hit its
+    2-minute timeout and called `$proc.Kill()` — which terminates *only* the
+    top process, not its children, and returns without waiting. The second
+    `devenv` that /updateconfiguration spawns survived, and every later
+    Reinstall-Vsix.ps1 run on that machine tripped the "Visual Studio is
+    running" guard and exited 1. It also read `$proc.ExitTime` on a process
+    that had not exited yet, which returns the 1601 epoch and printed a
+    duration of roughly -425 years.
+
+    COMPATIBILITY: these functions must stay Windows PowerShell 5.1 clean.
+    bootstrap.ps1 re-launches Reinstall-Vsix.ps1 with `(Get-Process -Id
+    $PID).Path`, and `mur upgrade` falls back to powershell.exe when pwsh is
+    absent. That rules out `Process.Kill([bool])` (.NET 5+) and
+    `ProcessStartInfo.ArgumentList` (.NET Core only) as unconditional calls —
+    see Stop-ProcessTreeSafely for the reflection probe + taskkill fallback.
+#>
+
+# Ids of every running process with the given name. Callers wrap with @() —
+# returning a bare array (rather than the `,$array` idiom) keeps the shape
+# predictable for 0, 1 and N matches.
+function Get-ProcessIdsByName {
+    param([Parameter(Mandatory)][string]$Name)
+
+    return @(Get-Process -Name $Name -ErrorAction SilentlyContinue | ForEach-Object { $_.Id })
+}
+
+# Terminate a process AND its descendants, then block until it is really gone.
+# Returns $true when the process exited within $WaitSeconds.
+function Stop-ProcessTreeSafely {
+    param(
+        [Parameter(Mandatory)][System.Diagnostics.Process]$Process,
+        [int]$WaitSeconds = 30
+    )
+
+    try { if ($Process.HasExited) { return $true } } catch { return $true }
+
+    # .NET 5+ (pwsh) has Kill($entireProcessTree). Windows PowerShell 5.1 runs
+    # on .NET Framework, which only has the single-process Kill() — the exact
+    # overload that caused #1074. Probe by reflection and fall back to
+    # `taskkill /T /F`, which walks the tree on every supported Windows.
+    $killTree = $Process.GetType().GetMethod('Kill', [type[]]@([bool]))
+    try {
+        if ($killTree) {
+            $killTree.Invoke($Process, @($true)) | Out-Null
+        } else {
+            & "$env:SystemRoot\System32\taskkill.exe" '/PID' $Process.Id '/T' '/F' 2>&1 | Out-Null
+            # taskkill returns non-zero when the process is already gone. That
+            # is not an error here, and letting it linger would leak into the
+            # exit code of whichever script dot-sourced us.
+            $global:LASTEXITCODE = 0
+        }
+    } catch {
+        # Raced with a natural exit, or access denied on a process owned by
+        # another user. Fall through to the wait, which reports the truth.
+    }
+
+    try { return $Process.WaitForExit($WaitSeconds * 1000) } catch { return $true }
+}
+
+# Kill every process named $Name whose id is not in $ExcludePids, tree and all.
+# Returns the ids it killed.
+#
+# This is the belt to Stop-ProcessTreeSafely's braces: Kill($true) enumerates
+# descendants at kill time, so a grandchild that has already re-parented can be
+# missed. $ExcludePids carries the pre-start snapshot, so processes that were
+# running before we started are never touched.
+function Stop-NewProcessesByName {
+    param(
+        [Parameter(Mandatory)][string]$Name,
+        [int[]]$ExcludePids = @(),
+        [int]$WaitSeconds = 30
+    )
+
+    $killed = New-Object System.Collections.Generic.List[int]
+    foreach ($p in @(Get-Process -Name $Name -ErrorAction SilentlyContinue)) {
+        if ($ExcludePids -contains $p.Id) { continue }
+        $killed.Add($p.Id) | Out-Null
+        Stop-ProcessTreeSafely -Process $p -WaitSeconds $WaitSeconds | Out-Null
+    }
+    # Bare array, not `,$array` — see Get-ProcessIdsByName. Callers wrap with @().
+    return $killed.ToArray()
+}
+
+# Poll until no process named $Name (excluding $ExcludePids) is left, or the
+# timeout elapses. Returns $true when the name is clear.
+#
+# This poll is the actual guarantee the caller needs: it is what makes it
+# impossible for the *next* Reinstall-Vsix.ps1 invocation to trip the
+# "Visual Studio is running" guard on a process this one started.
+function Wait-ProcessNameCleared {
+    param(
+        [Parameter(Mandatory)][string]$Name,
+        [int[]]$ExcludePids = @(),
+        [int]$TimeoutSeconds = 30
+    )
+
+    $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
+    while ($true) {
+        $remaining = @(Get-Process -Name $Name -ErrorAction SilentlyContinue |
+            Where-Object { $ExcludePids -notcontains $_.Id })
+        if ($remaining.Count -eq 0) { return $true }
+        if ([DateTime]::UtcNow -ge $deadline) { return $false }
+        Start-Sleep -Milliseconds 250
+    }
+}
+
+<#
+.SYNOPSIS
+    Run `devenv /updateconfiguration` with a hard timeout that leaves nothing
+    running behind it.
+
+.OUTPUTS
+    [pscustomobject] with:
+      TimedOut        [bool]  the process did not exit within $TimeoutSeconds
+      ExitCode        [int?]  exit code, or $null if it could not be read
+      DurationSeconds [double] wall-clock time, measured with a Stopwatch
+      KilledPids      [int[]] ids reaped by the post-timeout sweep
+      Drained         [bool]  no $ProcessName process was left behind
+
+.NOTES
+    DurationSeconds is deliberately measured with a Stopwatch rather than
+    ($proc.ExitTime - $proc.StartTime): ExitTime on a process that has not
+    exited returns the 1601 epoch, which is how #1074 came to log "-13430263500.8s".
+#>
+function Invoke-DevenvUpdateConfiguration {
+    param(
+        [Parameter(Mandatory)][string]$DevenvPath,
+        [string]$Arguments = '/updateconfiguration',
+        [int]$TimeoutSeconds = 120,
+        [string]$ProcessName = 'devenv',
+        [int]$DrainTimeoutSeconds = 30
+    )
+
+    # Snapshot first. Reinstall-Vsix.ps1 refuses to run while any devenv is
+    # alive, so in practice this is empty — but if a developer launches VS
+    # mid-run we must not kill their IDE.
+    $preexisting = @(Get-ProcessIdsByName -Name $ProcessName)
+
+    $psi = New-Object System.Diagnostics.ProcessStartInfo
+    $psi.FileName = $DevenvPath
+    # .Arguments (not .ArgumentList) — see the compatibility note in the file header.
+    $psi.Arguments = $Arguments
+    $psi.UseShellExecute = $false
+
+    $sw = [System.Diagnostics.Stopwatch]::StartNew()
+    $proc = [System.Diagnostics.Process]::Start($psi)
+    $exited = $proc.WaitForExit($TimeoutSeconds * 1000)
+
+    $killed = @()
+    $drained = $true
+    if (-not $exited) {
+        Stop-ProcessTreeSafely -Process $proc -WaitSeconds $DrainTimeoutSeconds | Out-Null
+        $killed = @(Stop-NewProcessesByName -Name $ProcessName -ExcludePids $preexisting -WaitSeconds $DrainTimeoutSeconds)
+        $drained = Wait-ProcessNameCleared -Name $ProcessName -ExcludePids $preexisting -TimeoutSeconds $DrainTimeoutSeconds
+    }
+    $sw.Stop()
+
+    $exitCode = $null
+    try { if ($proc.HasExited) { $exitCode = $proc.ExitCode } } catch { $exitCode = $null }
+
+    return [pscustomobject]@{
+        TimedOut        = (-not $exited)
+        ExitCode        = $exitCode
+        DurationSeconds = [Math]::Round($sw.Elapsed.TotalSeconds, 1)
+        KilledPids      = @($killed)
+        Drained         = $drained
+    }
+}

--- a/tests/vs_reactor/ci/BootstrapExitCode.Tests.ps1
+++ b/tests/vs_reactor/ci/BootstrapExitCode.Tests.ps1
@@ -5,34 +5,44 @@
 
 .DESCRIPTION
     Headless: no build, no dotnet, no Visual Studio. Wired into
-    .github/workflows/vs-reactor-lib-tests.yml. Exits non-zero on any failed
-    assertion.
+    .github/workflows/vs-reactor-lib-tests.yml, which runs this file under BOTH
+    pwsh and Windows PowerShell 5.1 — so nothing here may use PowerShell 6+
+    syntax. Exits non-zero on any failed assertion.
 
-    Two kinds of check live here.
+    Three kinds of check live here.
 
     (a) Behavioural. `Write-Host` does not clear $LASTEXITCODE, and bootstrap.yml
         runs `./bootstrap.ps1` *in-process* before checking $LASTEXITCODE on the
         next line. $LASTEXITCODE is a global, so a non-zero code from the VSIX
         child survived to the workflow's `if ($LASTEXITCODE -ne 0) { throw }` —
-        the actual CI failure in #1074. Cases 2/3 reproduce that mechanism with
-        throwaway scripts and prove which parts of the fix stop it. The `leaky`
+        the actual CI failure in #1074. Case 2 reproduces that mechanism with
+        throwaway scripts and proves which parts of the fix stop it. The `leaky`
         variant is the positive control: if it ever reads 0, the other two
         assertions are measuring nothing.
 
-    (b) Structural. Whether bootstrap.ps1 *itself* applies that pattern cannot be
-        observed without running a full bootstrap (dotnet builds, winget, VS), so
-        cases 4-6 assert it over the parsed AST instead. These are deliberately
-        shape assertions — here the shape *is* the fix — and each one reddens if
-        the corresponding line is deleted.
+    (b) Structural. Whether bootstrap.ps1 and Reinstall-Vsix.ps1 *themselves*
+        apply that pattern cannot be observed without running a full bootstrap
+        (dotnet builds, winget, VS), so cases 3-5 assert it over the parsed AST
+        instead. These are deliberately shape assertions — here the shape *is*
+        the fix — and each reddens if the corresponding line is deleted. Note
+        they bind an exit code to the variable that guards it, not merely to its
+        presence: `if ($false) { exit 3 }` must fail, and does.
+
+    (c) Doc/code agreement. Case 6 derives the exit codes from the AST and from
+        the two places they are documented, and requires the three sets to be
+        equal. A contract nobody can trust is worse than no contract, and the
+        cheapest way for this one to rot is for a new exit path to skip the
+        table.
 
     Run locally:  pwsh tests/vs_reactor/ci/BootstrapExitCode.Tests.ps1
+                  powershell -File tests/vs_reactor/ci/BootstrapExitCode.Tests.ps1
 #>
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
 $script:Pass = 0
 $script:Fail = 0
-$script:Failures = [System.Collections.Generic.List[string]]::new()
+$script:Failures = New-Object System.Collections.Generic.List[string]
 
 function Assert-Equal {
     param($Expected, $Actual, [string]$Message)
@@ -45,15 +55,24 @@ function Assert-True {
     else { $script:Fail++; $script:Failures.Add($Message) }
 }
 
-$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..' '..')).Path
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..\..')).Path
 $bootstrap = Join-Path $repoRoot 'bootstrap.ps1'
 $reinstall = Join-Path $repoRoot 'src\vs-reactor\Reinstall-Vsix.ps1'
+$testingDoc = Join-Path $repoRoot 'src\vs-reactor\TESTING.md'
+
+# These files are BOM-less UTF-8. Windows PowerShell 5.1 decodes such files as
+# ANSI, which corrupts every non-ASCII comment character and yields spurious
+# parse errors, so read them with an explicit encoding rather than -Raw.
+function Get-Utf8Text {
+    param([string]$Path)
+    return [System.IO.File]::ReadAllText($Path, [System.Text.Encoding]::UTF8)
+}
 
 function Get-Ast {
     param([string]$Path)
     $parseErrors = $null
     $ast = [System.Management.Automation.Language.Parser]::ParseInput(
-        (Get-Content -LiteralPath $Path -Raw), [ref]$null, [ref]$parseErrors)
+        (Get-Utf8Text $Path), [ref]$null, [ref]$parseErrors)
     if ($parseErrors -and $parseErrors.Count -gt 0) {
         Write-Host "$(Split-Path $Path -Leaf) has $($parseErrors.Count) parse error(s):" -ForegroundColor Red
         $parseErrors | ForEach-Object { Write-Host "  line $($_.Extent.StartLineNumber): $($_.Message)" -ForegroundColor Red }
@@ -62,28 +81,59 @@ function Get-Ast {
     return $ast
 }
 
+# True when the script contains `if (<Condition>) { ... exit <Code> ... }`.
+# Binding the code to its guard is what stops `if ($false) { exit 3 }` from
+# satisfying the contract.
+function Test-GuardedExit {
+    param($Ast, [string]$Condition, [string]$Code)
+    foreach ($if in @($Ast.FindAll({
+                    param($n) $n -is [System.Management.Automation.Language.IfStatementAst]
+                }, $true))) {
+        foreach ($clause in $if.Clauses) {
+            if ($clause.Item1.Extent.Text.Trim() -ne $Condition) { continue }
+            foreach ($e in @($clause.Item2.FindAll({
+                            param($n) $n -is [System.Management.Automation.Language.ExitStatementAst]
+                        }, $true))) {
+                if ($null -ne $e.Pipeline -and $e.Pipeline.Extent.Text.Trim() -eq $Code) { return $true }
+            }
+        }
+    }
+    return $false
+}
+
+# Number of `<Name> = $true` assignments in the script.
+function Get-TrueAssignmentCount {
+    param($Ast, [string]$Name)
+    return @($Ast.FindAll({
+                param($n)
+                $n -is [System.Management.Automation.Language.AssignmentStatementAst]
+            }, $true) | Where-Object {
+            $_.Left.Extent.Text -eq $Name -and $_.Right.Extent.Text -eq '$true'
+        }).Count
+}
+
 $tmp = Join-Path ([System.IO.Path]::GetTempPath()) ("bootstrap-exit-" + [Guid]::NewGuid().ToString('N'))
 New-Item -ItemType Directory -Path $tmp | Out-Null
-$noBom = [System.Text.UTF8Encoding]::new($false)
+$noBom = New-Object System.Text.UTF8Encoding($false)
 
 try {
     # -- 1. Both scripts parse. --
     $bootstrapAst = Get-Ast $bootstrap
-    Get-Ast $reinstall | Out-Null
+    $reinstallAst = Get-Ast $reinstall
     $script:Pass += 2
 
-    # -- 2/3. Positive control + fix, modelled on how bootstrap.yml calls us. --
+    # -- 2. Positive control + fix, modelled on how bootstrap.yml calls us. --
     # The workflow runs `./bootstrap.ps1` *in-process* and then checks
     # $LASTEXITCODE on the next line. $LASTEXITCODE is a global, so a non-zero
     # code set by a child inside bootstrap.ps1 is still there when the step
     # inspects it — that is the #1074 mechanism, and it is why `pwsh -File`
     # (which returns 0 on fall-through) does not reproduce it.
-    $pwshPath = (Get-Process -Id $PID).Path
+    $hostPath = (Get-Process -Id $PID).Path
     $child = Join-Path $tmp 'child.ps1'
     [System.IO.File]::WriteAllText($child, "exit 7`n", $noBom)
 
-    $callChild = "& '$pwshPath' -NoLogo -NoProfile -File '$child'`n" +
-                 "Write-Host ('    [warn] child failed ({0}); continuing anyway.' -f `$LASTEXITCODE)`n"
+    $callChild = "& '$hostPath' -NoLogo -NoProfile -File '$child'`n" +
+    "Write-Host ('    [warn] child failed ({0}); continuing anyway.' -f `$LASTEXITCODE)`n"
 
     $variants = @{
         # Pre-fix shape: warn via Write-Host, fall off the end.
@@ -104,7 +154,7 @@ try {
     [System.IO.File]::WriteAllText($driver, ($driverLines -join "`n") + "`n", $noBom)
 
     $observed = @{}
-    foreach ($line in @(& $pwshPath -NoLogo -NoProfile -File $driver)) {
+    foreach ($line in @(& $hostPath -NoLogo -NoProfile -File $driver)) {
         if ($line -match '^(\w+)=(\d+)$') { $observed[$Matches[1]] = [int]$Matches[2] }
     }
 
@@ -114,25 +164,26 @@ try {
     Assert-Equal 0 $observed['reset'] 'fix: $global:LASTEXITCODE = 0 clears the leaked code'
     Assert-Equal 0 $observed['fixed'] 'fix: reset + trailing exit 0 yields a clean exit'
 
-    # -- 4. bootstrap.ps1 ends with an explicit `exit 0`. --
+    # -- 3. bootstrap.ps1 ends with an explicit `exit 0`. --
     $endBlock = $bootstrapAst.EndBlock
     $lastStatement = $endBlock.Statements[$endBlock.Statements.Count - 1]
     Assert-True ($lastStatement -is [System.Management.Automation.Language.ExitStatementAst]) `
         "bootstrap.ps1: final statement is an exit statement (found: $($lastStatement.GetType().Name))"
     if ($lastStatement -is [System.Management.Automation.Language.ExitStatementAst]) {
         Assert-Equal '0' $lastStatement.Pipeline.Extent.Text 'bootstrap.ps1: final statement is `exit 0`'
-    } else {
+    }
+    else {
         $script:Fail++; $script:Failures.Add('bootstrap.ps1: final statement is `exit 0`')
     }
 
-    # -- 5. The VS-extension branch resets $LASTEXITCODE. --
+    # -- 4. The VS-extension branch resets $LASTEXITCODE and branches on 3. --
     # Scope the search to the VSIX call site so an unrelated reset elsewhere in
     # the script cannot satisfy this.
     $reinstallCall = $bootstrapAst.FindAll({
-        param($n)
-        $n -is [System.Management.Automation.Language.CommandAst] -and
-        $n.Extent.Text -match '-File \$reinstall'
-    }, $true)
+            param($n)
+            $n -is [System.Management.Automation.Language.CommandAst] -and
+            $n.Extent.Text -match '-File \$reinstall'
+        }, $true)
     Assert-Equal 1 @($reinstallCall).Count 'bootstrap.ps1: found the Reinstall-Vsix.ps1 call site'
 
     if (@($reinstallCall).Count -eq 1) {
@@ -140,11 +191,11 @@ try {
         # The handling block sits immediately after the call; 40 lines is ample
         # and keeps a distant reset from counting.
         $resets = $bootstrapAst.FindAll({
-            param($n)
-            $n -is [System.Management.Automation.Language.AssignmentStatementAst] -and
-            $n.Left.Extent.Text -eq '$global:LASTEXITCODE' -and
-            $n.Right.Extent.Text -eq '0'
-        }, $true) | Where-Object {
+                param($n)
+                $n -is [System.Management.Automation.Language.AssignmentStatementAst] -and
+                $n.Left.Extent.Text -eq '$global:LASTEXITCODE' -and
+                $n.Right.Extent.Text -eq '0'
+            }, $true) | Where-Object {
             $_.Extent.StartLineNumber -gt $callLine -and
             $_.Extent.StartLineNumber -le ($callLine + 40)
         }
@@ -152,21 +203,55 @@ try {
             "bootstrap.ps1: the VS-extension branch resets `$global:LASTEXITCODE (searched lines $($callLine + 1)-$($callLine + 40))"
     }
 
-    # -- 6. Reinstall-Vsix.ps1 exposes the documented exit codes. --
-    $reinstallAst = Get-Ast $reinstall
-    $exitCodes = @($reinstallAst.FindAll({
-        param($n) $n -is [System.Management.Automation.Language.ExitStatementAst]
-    }, $true) | ForEach-Object {
-        if ($null -ne $_.Pipeline) { $_.Pipeline.Extent.Text } else { '' }
-    })
-    Assert-True ($exitCodes -contains '3') 'Reinstall-Vsix.ps1: signals the /updateconfiguration timeout with `exit 3`'
-    Assert-True ($exitCodes -contains '0') 'Reinstall-Vsix.ps1: signals full success with an explicit `exit 0`'
-
     # bootstrap.ps1 must actually branch on 3 rather than lumping it into the
     # generic failure warning — otherwise it prints `[ok] VS extension installed`
     # for a run whose pkgdef merge never happened.
-    $bootstrapText = Get-Content -LiteralPath $bootstrap -Raw
-    Assert-True ($bootstrapText -match '\$vsixExit -eq 3') 'bootstrap.ps1: special-cases Reinstall-Vsix.ps1 exit code 3'
+    Assert-True ((Get-Utf8Text $bootstrap) -match '\$vsixExit -eq 3') 'bootstrap.ps1: special-cases Reinstall-Vsix.ps1 exit code 3'
+
+    # -- 5. Reinstall-Vsix.ps1's exit codes are bound to their guards. --
+    # Presence alone would be satisfied by dead code; these fail if the guard is
+    # neutered (verified by mutating each condition to `$false`).
+    Assert-True (Test-GuardedExit $reinstallAst '$updateConfigTimedOut' '3') `
+        'Reinstall-Vsix.ps1: `exit 3` is guarded by $updateConfigTimedOut'
+    Assert-True (Test-GuardedExit $reinstallAst '$installIncomplete' '1') `
+        'Reinstall-Vsix.ps1: `exit 1` is guarded by $installIncomplete'
+
+    # ...and the guards are actually raised. A guard nothing sets is the same as
+    # no exit path at all. $updateConfigTimedOut has two producers — the timeout
+    # itself and the missing-devenv branch — and both mean "installed, not merged".
+    Assert-True ((Get-TrueAssignmentCount $reinstallAst '$updateConfigTimedOut') -ge 2) `
+        'Reinstall-Vsix.ps1: both /updateconfiguration skip paths set $updateConfigTimedOut'
+    Assert-True ((Get-TrueAssignmentCount $reinstallAst '$installIncomplete') -ge 1) `
+        'Reinstall-Vsix.ps1: the duplicate-install branch sets $installIncomplete'
+
+    $tail = $reinstallAst.EndBlock.Statements[$reinstallAst.EndBlock.Statements.Count - 1]
+    Assert-True ($tail -is [System.Management.Automation.Language.ExitStatementAst]) `
+        "Reinstall-Vsix.ps1: falls through to an explicit exit (found: $($tail.GetType().Name))"
+
+    # -- 6. The code and both documented tables agree on the exit codes. --
+    # Literal exits only: `exit $LASTEXITCODE` forwards a child's code and is
+    # unreachable anyway (Write-Error throws first under $ErrorActionPreference
+    # = 'Stop'), so it is not part of the contract.
+    $actual = @($reinstallAst.FindAll({
+                param($n) $n -is [System.Management.Automation.Language.ExitStatementAst]
+            }, $true) | ForEach-Object {
+            if ($null -ne $_.Pipeline) { $_.Pipeline.Extent.Text.Trim() } else { '0' }
+        } | Where-Object { $_ -match '^\d+$' } | Sort-Object -Unique)
+    Assert-True ($actual.Count -ge 2) "contract: Reinstall-Vsix.ps1 has literal exit codes to check (found: $($actual -join ', '))"
+
+    # The .OUTPUTS help block lists them as "  <code>  <description>".
+    $helpBlock = ''
+    if ((Get-Utf8Text $reinstall) -match '(?s)\.OUTPUTS(.*?)#>') { $helpBlock = $Matches[1] }
+    $documented = @([regex]::Matches($helpBlock, '(?m)^\s{4,}(\d+)\s{2,}\S') |
+        ForEach-Object { $_.Groups[1].Value } | Sort-Object -Unique)
+    Assert-Equal ($actual -join ',') ($documented -join ',') `
+        'contract: Reinstall-Vsix.ps1 .OUTPUTS documents exactly the exit codes the script can return'
+
+    # TESTING.md carries the same table for humans who never open the script.
+    $docTable = @([regex]::Matches((Get-Utf8Text $testingDoc), '(?m)^\|\s*`(\d+)`\s*\|') |
+        ForEach-Object { $_.Groups[1].Value } | Sort-Object -Unique)
+    Assert-Equal ($actual -join ',') ($docTable -join ',') `
+        'contract: src/vs-reactor/TESTING.md documents exactly the exit codes the script can return'
 }
 finally {
     Remove-Item $tmp -Recurse -Force -ErrorAction SilentlyContinue

--- a/tests/vs_reactor/ci/BootstrapExitCode.Tests.ps1
+++ b/tests/vs_reactor/ci/BootstrapExitCode.Tests.ps1
@@ -212,16 +212,16 @@ try {
     # -- 5. Reinstall-Vsix.ps1's exit codes are bound to their guards. --
     # Presence alone would be satisfied by dead code; these fail if the guard is
     # neutered (verified by mutating each condition to `$false`).
-    Assert-True (Test-GuardedExit $reinstallAst '$updateConfigTimedOut' '3') `
-        'Reinstall-Vsix.ps1: `exit 3` is guarded by $updateConfigTimedOut'
+    Assert-True (Test-GuardedExit $reinstallAst '$updateConfigIncomplete' '3') `
+        'Reinstall-Vsix.ps1: `exit 3` is guarded by $updateConfigIncomplete'
     Assert-True (Test-GuardedExit $reinstallAst '$installIncomplete' '1') `
         'Reinstall-Vsix.ps1: `exit 1` is guarded by $installIncomplete'
 
     # ...and the guards are actually raised. A guard nothing sets is the same as
-    # no exit path at all. $updateConfigTimedOut has two producers — the timeout
+    # no exit path at all. $updateConfigIncomplete has two producers — the timeout
     # itself and the missing-devenv branch — and both mean "installed, not merged".
-    Assert-True ((Get-TrueAssignmentCount $reinstallAst '$updateConfigTimedOut') -ge 2) `
-        'Reinstall-Vsix.ps1: both /updateconfiguration skip paths set $updateConfigTimedOut'
+    Assert-True ((Get-TrueAssignmentCount $reinstallAst '$updateConfigIncomplete') -ge 2) `
+        'Reinstall-Vsix.ps1: both /updateconfiguration skip paths set $updateConfigIncomplete'
     Assert-True ((Get-TrueAssignmentCount $reinstallAst '$installIncomplete') -ge 1) `
         'Reinstall-Vsix.ps1: the duplicate-install branch sets $installIncomplete'
 

--- a/tests/vs_reactor/ci/BootstrapExitCode.Tests.ps1
+++ b/tests/vs_reactor/ci/BootstrapExitCode.Tests.ps1
@@ -58,6 +58,7 @@ function Assert-True {
 $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..\..')).Path
 $bootstrap = Join-Path $repoRoot 'bootstrap.ps1'
 $reinstall = Join-Path $repoRoot 'src\vs-reactor\Reinstall-Vsix.ps1'
+$vsProcessLib = Join-Path $repoRoot 'src\vs-reactor\VsProcessLib.ps1'
 $testingDoc = Join-Path $repoRoot 'src\vs-reactor\TESTING.md'
 
 # These files are BOM-less UTF-8. Windows PowerShell 5.1 decodes such files as
@@ -252,6 +253,22 @@ try {
         ForEach-Object { $_.Groups[1].Value } | Sort-Object -Unique)
     Assert-Equal ($actual -join ',') ($docTable -join ',') `
         'contract: src/vs-reactor/TESTING.md documents exactly the exit codes the script can return'
+
+    # -- 7. No carriage return outside a CRLF pair. --
+    # These files are CRLF. An edit that inserts a bare LF leaves a mid-line CR,
+    # which merges the following statement onto the brace line — still valid
+    # PowerShell, so it survives a parse check and every behavioural assertion
+    # above, and is near-invisible in a diff. It happened once in this PR's own
+    # history; four lines of guard is cheaper than the next reviewer finding it.
+    foreach ($f in @($bootstrap, $reinstall, $vsProcessLib)) {
+        $bytes = [System.IO.File]::ReadAllBytes($f)
+        $loneCr = 0
+        for ($i = 0; $i -lt $bytes.Length; $i++) {
+            if ($bytes[$i] -ne 13) { continue }
+            if (($i + 1) -ge $bytes.Length -or $bytes[$i + 1] -ne 10) { $loneCr++ }
+        }
+        Assert-Equal 0 $loneCr "$(Split-Path $f -Leaf): no carriage return outside a CRLF pair"
+    }
 }
 finally {
     Remove-Item $tmp -Recurse -Force -ErrorAction SilentlyContinue

--- a/tests/vs_reactor/ci/BootstrapExitCode.Tests.ps1
+++ b/tests/vs_reactor/ci/BootstrapExitCode.Tests.ps1
@@ -1,0 +1,183 @@
+<#
+.SYNOPSIS
+    Contract tests for the bootstrap.ps1 / Reinstall-Vsix.ps1 exit-code
+    handshake (issue #1074).
+
+.DESCRIPTION
+    Headless: no build, no dotnet, no Visual Studio. Wired into
+    .github/workflows/vs-reactor-lib-tests.yml. Exits non-zero on any failed
+    assertion.
+
+    Two kinds of check live here.
+
+    (a) Behavioural. `Write-Host` does not clear $LASTEXITCODE, and bootstrap.yml
+        runs `./bootstrap.ps1` *in-process* before checking $LASTEXITCODE on the
+        next line. $LASTEXITCODE is a global, so a non-zero code from the VSIX
+        child survived to the workflow's `if ($LASTEXITCODE -ne 0) { throw }` —
+        the actual CI failure in #1074. Cases 2/3 reproduce that mechanism with
+        throwaway scripts and prove which parts of the fix stop it. The `leaky`
+        variant is the positive control: if it ever reads 0, the other two
+        assertions are measuring nothing.
+
+    (b) Structural. Whether bootstrap.ps1 *itself* applies that pattern cannot be
+        observed without running a full bootstrap (dotnet builds, winget, VS), so
+        cases 4-6 assert it over the parsed AST instead. These are deliberately
+        shape assertions — here the shape *is* the fix — and each one reddens if
+        the corresponding line is deleted.
+
+    Run locally:  pwsh tests/vs_reactor/ci/BootstrapExitCode.Tests.ps1
+#>
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$script:Pass = 0
+$script:Fail = 0
+$script:Failures = [System.Collections.Generic.List[string]]::new()
+
+function Assert-Equal {
+    param($Expected, $Actual, [string]$Message)
+    if ($Expected -eq $Actual) { $script:Pass++ }
+    else { $script:Fail++; $script:Failures.Add("$Message`n    expected: [$Expected]`n    actual:   [$Actual]") }
+}
+function Assert-True {
+    param([bool]$Condition, [string]$Message)
+    if ($Condition) { $script:Pass++ }
+    else { $script:Fail++; $script:Failures.Add($Message) }
+}
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..' '..')).Path
+$bootstrap = Join-Path $repoRoot 'bootstrap.ps1'
+$reinstall = Join-Path $repoRoot 'src\vs-reactor\Reinstall-Vsix.ps1'
+
+function Get-Ast {
+    param([string]$Path)
+    $parseErrors = $null
+    $ast = [System.Management.Automation.Language.Parser]::ParseInput(
+        (Get-Content -LiteralPath $Path -Raw), [ref]$null, [ref]$parseErrors)
+    if ($parseErrors -and $parseErrors.Count -gt 0) {
+        Write-Host "$(Split-Path $Path -Leaf) has $($parseErrors.Count) parse error(s):" -ForegroundColor Red
+        $parseErrors | ForEach-Object { Write-Host "  line $($_.Extent.StartLineNumber): $($_.Message)" -ForegroundColor Red }
+        exit 1
+    }
+    return $ast
+}
+
+$tmp = Join-Path ([System.IO.Path]::GetTempPath()) ("bootstrap-exit-" + [Guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Path $tmp | Out-Null
+$noBom = [System.Text.UTF8Encoding]::new($false)
+
+try {
+    # -- 1. Both scripts parse. --
+    $bootstrapAst = Get-Ast $bootstrap
+    Get-Ast $reinstall | Out-Null
+    $script:Pass += 2
+
+    # -- 2/3. Positive control + fix, modelled on how bootstrap.yml calls us. --
+    # The workflow runs `./bootstrap.ps1` *in-process* and then checks
+    # $LASTEXITCODE on the next line. $LASTEXITCODE is a global, so a non-zero
+    # code set by a child inside bootstrap.ps1 is still there when the step
+    # inspects it — that is the #1074 mechanism, and it is why `pwsh -File`
+    # (which returns 0 on fall-through) does not reproduce it.
+    $pwshPath = (Get-Process -Id $PID).Path
+    $child = Join-Path $tmp 'child.ps1'
+    [System.IO.File]::WriteAllText($child, "exit 7`n", $noBom)
+
+    $callChild = "& '$pwshPath' -NoLogo -NoProfile -File '$child'`n" +
+                 "Write-Host ('    [warn] child failed ({0}); continuing anyway.' -f `$LASTEXITCODE)`n"
+
+    $variants = @{
+        # Pre-fix shape: warn via Write-Host, fall off the end.
+        'leaky' = $callChild + "Write-Host 'Bootstrap complete.'`n"
+        # Half the fix: reset the global, fall off the end.
+        'reset' = $callChild + "`$global:LASTEXITCODE = 0`nWrite-Host 'Bootstrap complete.'`n"
+        # Full fix as shipped: reset the global *and* exit 0 explicitly.
+        'fixed' = $callChild + "`$global:LASTEXITCODE = 0`nWrite-Host 'Bootstrap complete.'`nexit 0`n"
+    }
+    $driverLines = New-Object System.Collections.Generic.List[string]
+    foreach ($name in @('leaky', 'reset', 'fixed')) {
+        $path = Join-Path $tmp "$name.ps1"
+        [System.IO.File]::WriteAllText($path, $variants[$name], $noBom)
+        $driverLines.Add("& '$path' | Out-Null") | Out-Null
+        $driverLines.Add("Write-Output ('$name=' + `$LASTEXITCODE)") | Out-Null
+    }
+    $driver = Join-Path $tmp 'driver.ps1'
+    [System.IO.File]::WriteAllText($driver, ($driverLines -join "`n") + "`n", $noBom)
+
+    $observed = @{}
+    foreach ($line in @(& $pwshPath -NoLogo -NoProfile -File $driver)) {
+        if ($line -match '^(\w+)=(\d+)$') { $observed[$Matches[1]] = [int]$Matches[2] }
+    }
+
+    # Positive control: without the fix the code really does leak. If this ever
+    # reads 0, the two assertions below are measuring nothing.
+    Assert-Equal 7 $observed['leaky'] 'positive control: Write-Host alone does NOT clear a leaked child exit code'
+    Assert-Equal 0 $observed['reset'] 'fix: $global:LASTEXITCODE = 0 clears the leaked code'
+    Assert-Equal 0 $observed['fixed'] 'fix: reset + trailing exit 0 yields a clean exit'
+
+    # -- 4. bootstrap.ps1 ends with an explicit `exit 0`. --
+    $endBlock = $bootstrapAst.EndBlock
+    $lastStatement = $endBlock.Statements[$endBlock.Statements.Count - 1]
+    Assert-True ($lastStatement -is [System.Management.Automation.Language.ExitStatementAst]) `
+        "bootstrap.ps1: final statement is an exit statement (found: $($lastStatement.GetType().Name))"
+    if ($lastStatement -is [System.Management.Automation.Language.ExitStatementAst]) {
+        Assert-Equal '0' $lastStatement.Pipeline.Extent.Text 'bootstrap.ps1: final statement is `exit 0`'
+    } else {
+        $script:Fail++; $script:Failures.Add('bootstrap.ps1: final statement is `exit 0`')
+    }
+
+    # -- 5. The VS-extension branch resets $LASTEXITCODE. --
+    # Scope the search to the VSIX call site so an unrelated reset elsewhere in
+    # the script cannot satisfy this.
+    $reinstallCall = $bootstrapAst.FindAll({
+        param($n)
+        $n -is [System.Management.Automation.Language.CommandAst] -and
+        $n.Extent.Text -match '-File \$reinstall'
+    }, $true)
+    Assert-Equal 1 @($reinstallCall).Count 'bootstrap.ps1: found the Reinstall-Vsix.ps1 call site'
+
+    if (@($reinstallCall).Count -eq 1) {
+        $callLine = $reinstallCall[0].Extent.StartLineNumber
+        # The handling block sits immediately after the call; 40 lines is ample
+        # and keeps a distant reset from counting.
+        $resets = $bootstrapAst.FindAll({
+            param($n)
+            $n -is [System.Management.Automation.Language.AssignmentStatementAst] -and
+            $n.Left.Extent.Text -eq '$global:LASTEXITCODE' -and
+            $n.Right.Extent.Text -eq '0'
+        }, $true) | Where-Object {
+            $_.Extent.StartLineNumber -gt $callLine -and
+            $_.Extent.StartLineNumber -le ($callLine + 40)
+        }
+        Assert-True (@($resets).Count -ge 1) `
+            "bootstrap.ps1: the VS-extension branch resets `$global:LASTEXITCODE (searched lines $($callLine + 1)-$($callLine + 40))"
+    }
+
+    # -- 6. Reinstall-Vsix.ps1 exposes the documented exit codes. --
+    $reinstallAst = Get-Ast $reinstall
+    $exitCodes = @($reinstallAst.FindAll({
+        param($n) $n -is [System.Management.Automation.Language.ExitStatementAst]
+    }, $true) | ForEach-Object {
+        if ($null -ne $_.Pipeline) { $_.Pipeline.Extent.Text } else { '' }
+    })
+    Assert-True ($exitCodes -contains '3') 'Reinstall-Vsix.ps1: signals the /updateconfiguration timeout with `exit 3`'
+    Assert-True ($exitCodes -contains '0') 'Reinstall-Vsix.ps1: signals full success with an explicit `exit 0`'
+
+    # bootstrap.ps1 must actually branch on 3 rather than lumping it into the
+    # generic failure warning — otherwise it prints `[ok] VS extension installed`
+    # for a run whose pkgdef merge never happened.
+    $bootstrapText = Get-Content -LiteralPath $bootstrap -Raw
+    Assert-True ($bootstrapText -match '\$vsixExit -eq 3') 'bootstrap.ps1: special-cases Reinstall-Vsix.ps1 exit code 3'
+}
+finally {
+    Remove-Item $tmp -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+# -- Report --
+Write-Host ""
+Write-Host "Bootstrap exit-code tests: $script:Pass passed, $script:Fail failed"
+if ($script:Fail -gt 0) {
+    Write-Host ""
+    $script:Failures | ForEach-Object { Write-Host "FAIL: $_" -ForegroundColor Red }
+    exit 1
+}
+exit 0

--- a/tests/vs_reactor/ci/README.md
+++ b/tests/vs_reactor/ci/README.md
@@ -35,6 +35,13 @@ red.
 | drop the trailing `exit 0` from `bootstrap.ps1` | 2 fail |
 | drop the `$global:LASTEXITCODE = 0` reset | 1 fail |
 | drift the `TESTING.md` exit table (`3` → `4`) | 1 fail |
+| re-inject a mid-line `CR` into `Reinstall-Vsix.ps1` | 1 fail |
+
+That last row earns its place: a bare `LF` inserted into a `CRLF` file leaves a
+mid-line carriage return that merges the next statement onto the brace line. It
+is still valid PowerShell, so it survived the parse check *and* all fifty
+behavioural assertions, and is near-invisible in a diff. It reached `main`'s
+review queue once; now it cannot.
 
 Two known limits, recorded rather than papered over:
 
@@ -75,6 +82,13 @@ on `windows-latest`, triggered by changes to `bootstrap.ps1`, the two
 third consumer of the exit-code contract), or anything under this directory.
 
 The tests spawn real processes and kill them by pid. They are safe to run on a
-developer machine: the fake is named `reactor-fake-devenv`, nothing is ever
-matched by the name `devenv` or `pwsh`, and the suite tears its own processes
-down in a `finally` block.
+developer machine, and safe to run concurrently with each other: the fake is
+named `reactor-fake-devenv-<pid>`, so each run only ever sees its own
+processes, nothing is matched by the name `devenv` or `pwsh`, and the suite
+tears its own processes down in a `finally` block.
+
+The pid namespacing is not cosmetic. `Get-Process -Name` is machine-wide, so a
+shared fake name lets two overlapping runs kill each other's fixtures — which
+reproduces as "the process died early" failures that look like product bugs and
+are not. That is the same attribution mistake the product fix above corrects, so
+the harness is held to it too.

--- a/tests/vs_reactor/ci/README.md
+++ b/tests/vs_reactor/ci/README.md
@@ -37,6 +37,20 @@ red.
 | drift the `TESTING.md` exit table (`3` → `4`) | 1 fail |
 | re-inject a mid-line `CR` into `Reinstall-Vsix.ps1` | 1 fail |
 
+The AST mutations were re-run under **Windows PowerShell 5.1** as well, not just
+`pwsh`, because a 5.1 leg that cannot fail is worse than no 5.1 leg: it reports
+coverage it does not have. Dropping the trailing `exit 0` reddens 2 there and
+neutering the `exit 3` guard reddens 1, both exiting non-zero — so the second
+half of the CI matrix is load-bearing.
+
+That leg only works because both suites read source files with
+`[System.IO.File]::ReadAllText($path, [Text.Encoding]::UTF8)`. These files are
+BOM-less UTF-8 containing em dashes, and 5.1 decodes such files as the system
+ANSI codepage: measured on `bootstrap.ps1`, `ParseFile` and
+`ParseInput(Get-Content -Raw)` both yield **6 parse errors** under 5.1 and 0
+under `pwsh`, while the explicit-UTF8 read yields 0 on both. An AST assertion
+built on that corrupted tree can pass vacuously. Do not "simplify" those reads.
+
 That last row earns its place: a bare `LF` inserted into a `CRLF` file leaves a
 mid-line carriage return that merges the next statement onto the brace line. It
 is still valid PowerShell, so it survived the parse check *and* all fifty

--- a/tests/vs_reactor/ci/README.md
+++ b/tests/vs_reactor/ci/README.md
@@ -1,0 +1,80 @@
+# VS extension install-script tests
+
+Headless tests for the PowerShell that installs the Reactor Preview VSIX. No
+build, no `dotnet`, no Visual Studio: the `devenv` under test is a renamed copy
+of `cmd.exe`, so the whole suite runs in seconds on a bare runner.
+
+These exist because of [#1074](https://github.com/microsoft/microsoft-ui-reactor/issues/1074).
+On Visual Studio **18.8**, `devenv /updateconfiguration` never returns. That is
+upstream behaviour we cannot fix — but three defects in *our* scripts turned it
+into a red `bootstrap.ps1 (windows-latest)` job, and those are what this suite
+pins down.
+
+## Files
+
+| File | Role |
+|---|---|
+| `VsProcessLib.Tests.ps1` | Behavioural tests for `src/vs-reactor/VsProcessLib.ps1` against a real, genuinely-hanging, two-level process tree: tree kill, attributed sweep, drain poll, pid-reuse guards, `$LASTEXITCODE` hygiene. |
+| `BootstrapExitCode.Tests.ps1` | Contract tests for the `bootstrap.ps1` ↔ `Reinstall-Vsix.ps1` exit-code handshake: the `$LASTEXITCODE` leak, the guarded `exit 1` / `exit 3` paths, and agreement between the code and both documented exit tables. |
+
+The library under test lives in `src/vs-reactor/`, not here, because
+`Reinstall-Vsix.ps1` dot-sources it at runtime — it ships with the script rather
+than with the tests.
+
+## What the assertions are worth
+
+Every load-bearing oracle in this suite has been mutation-checked. A green run
+means nothing on its own; what follows is the evidence that these tests can go
+red.
+
+| Mutation | Result |
+|---|---|
+| `taskkill /T` → bare `$Process.Kill()` (the original defect) | 2 fail — the inner fake survives |
+| attributed sweep → name-based sweep (kills any same-named process) | 2 fail — the unrelated tree is killed, `Drained` lies |
+| `if ($updateConfigTimedOut) { exit 3 }` → `if ($false) { ... }` | 1 fail — the code is bound to its guard, not merely present |
+| drop the trailing `exit 0` from `bootstrap.ps1` | 2 fail |
+| drop the `$global:LASTEXITCODE = 0` reset | 1 fail |
+| drift the `TESTING.md` exit table (`3` → `4`) | 1 fail |
+
+Two known limits, recorded rather than papered over:
+
+- **The duration assertion does not discriminate.** The issue's `-13430263500.8s`
+  comes from reading `Process.ExitTime` before the OS reaps a *heavy* process. A
+  `cmd.exe` fake dies sub-millisecond, so swapping the `Stopwatch` back for
+  `ExitTime - StartTime` does **not** redden the suite. The `Stopwatch` is kept
+  because it cannot be wrong; the assertion is a bounds check on the symptom.
+- **The `$LASTEXITCODE` reset in `Stop-ProcessTreeSafely` is not independently
+  provable.** Forcing `taskkill`'s already-gone status means racing the
+  `HasExited` check. The test asserts the boundary contract instead.
+
+## Running locally
+
+```pwsh
+pwsh       -File tests/vs_reactor/ci/VsProcessLib.Tests.ps1
+pwsh       -File tests/vs_reactor/ci/BootstrapExitCode.Tests.ps1
+
+# ...and the host `mur upgrade` falls back to:
+powershell -File tests/vs_reactor/ci/VsProcessLib.Tests.ps1
+powershell -File tests/vs_reactor/ci/BootstrapExitCode.Tests.ps1
+```
+
+Each script prints `<n> passed, <n> failed` and exits non-zero on any failure.
+
+**Windows PowerShell 5.1 is not optional.** `bootstrap.ps1` re-launches
+`Reinstall-Vsix.ps1` with the *current* host, and `mur upgrade` falls back to
+`powershell.exe` when `pwsh` is absent — so 5.1 is a shipped code path. It has
+no `Process.Kill(bool)` and no `$IsWindows`, and it decodes BOM-less UTF-8 as
+ANSI. Both suites therefore avoid PowerShell 6+ syntax and read source files
+with an explicit UTF-8 encoding.
+
+## Workflow
+
+`.github/workflows/vs-reactor-lib-tests.yml` runs both suites under both hosts
+on `windows-latest`, triggered by changes to `bootstrap.ps1`, the two
+`src/vs-reactor/` scripts, `src/Reactor.Cli/Upgrade/UpgradeCommand.cs` (the
+third consumer of the exit-code contract), or anything under this directory.
+
+The tests spawn real processes and kill them by pid. They are safe to run on a
+developer machine: the fake is named `reactor-fake-devenv`, nothing is ever
+matched by the name `devenv` or `pwsh`, and the suite tears its own processes
+down in a `finally` block.

--- a/tests/vs_reactor/ci/README.md
+++ b/tests/vs_reactor/ci/README.md
@@ -53,6 +53,13 @@ Two known limits, recorded rather than papered over:
 - **The `$LASTEXITCODE` reset in `Stop-ProcessTreeSafely` is not independently
   provable.** Forcing `taskkill`'s already-gone status means racing the
   `HasExited` check. The test asserts the boundary contract instead.
+- **`KilledPids` recording only confirmed kills is not covered either.** The
+  branch it protects needs a kill that *fails*, and every kill in these tests
+  succeeds; reverting to record-before-kill leaves the suite green. Forcing a
+  failed kill means either a protected process or a zero-length wait race, and a
+  flaky assertion is worse than an acknowledged gap. It is kept because a log
+  claiming it reaped a pid that is still running is the same broken-instrument
+  class as the `-425 years` duration.
 
 ## Running locally
 

--- a/tests/vs_reactor/ci/VsProcessLib.Tests.ps1
+++ b/tests/vs_reactor/ci/VsProcessLib.Tests.ps1
@@ -265,6 +265,22 @@ try {
     Assert-True ($kidsAgain -notcontains $unrelated.Id) "descendants: an unrelated same-named process is not claimed as a descendant (pid $($unrelated.Id))"
     Remove-AllFakes
 
+    # -- 7b. A root that has left the process table claims nothing. --
+    # Kill only the root and its child survives still naming that pid as its
+    # parent. Windows reuses pids, so once the root is gone those edges prove
+    # nothing — and with no creation time for the parent the stale-edge check
+    # cannot run either. Attributing them would sweep a process on the strength
+    # of a recycled number.
+    $orphanRoot = Start-Fake -Arguments $hangArgs
+    Wait-ForFakeCount -AtLeast 2 | Out-Null
+    $orphanRootPid = $orphanRoot.Id
+    $orphanRoot.Kill()
+    $orphanRoot.WaitForExit(10000) | Out-Null
+    Start-Sleep -Milliseconds 500
+    $claimed = @(Get-ProcessDescendantIds -RootPid $orphanRootPid)
+    Assert-Equal 0 $claimed.Count "descendants: a root absent from the process table claims nothing (got: $($claimed -join ', '))"
+    Remove-AllFakes
+
     # -- 8. Wait-ProcessNameCleared reports failure rather than lying. --
     # Without a truthful negative, a false "drained" would let the next run trip
     # the guard with no explanation.

--- a/tests/vs_reactor/ci/VsProcessLib.Tests.ps1
+++ b/tests/vs_reactor/ci/VsProcessLib.Tests.ps1
@@ -1,0 +1,224 @@
+<#
+.SYNOPSIS
+    Dependency-free tests for src/vs-reactor/VsProcessLib.ps1 — the process-tree
+    timeout/kill/drain helpers behind `devenv /updateconfiguration`.
+
+.DESCRIPTION
+    Windows-only and headless: no build, no dotnet, no Visual Studio. Wired into
+    .github/workflows/vs-reactor-lib-tests.yml. Exits non-zero on any failed
+    assertion.
+
+    The fake "devenv" is a copy of cmd.exe renamed to reactor-fake-devenv.exe,
+    launched as `/c "<fake>" /c ping -n 600 127.0.0.1`. That produces a real
+    two-level, same-named, genuinely-hanging process tree, which is what makes
+    these assertions non-vacuous: mutation-checked against the shipped pre-fix
+    implementation (`$proc.Kill()`, no argument, no wait) the inner
+    reactor-fake-devenv.exe survives and the tree assertions redden.
+
+    Known limit, stated rather than papered over: the "-425 years" duration in
+    the issue is a race on reading Process.ExitTime before the OS reaps a heavy
+    process. A cmd.exe fake dies too fast to reproduce it, so the duration
+    assertion here is a bounds check on the symptom, not a discriminator
+    between a Stopwatch and a correctly-sequenced ExitTime read. See case 4.
+
+    A distinctly-named fake also keeps the sweep tests safe — Stop-NewProcessesByName
+    is never pointed at `pwsh`, so an exclude-list regression cannot take out the
+    test host.
+
+    Run locally:  pwsh tests/vs_reactor/ci/VsProcessLib.Tests.ps1
+#>
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+if (-not $IsWindows) {
+    Write-Host "VsProcessLib tests: skipped (Windows-only process semantics)."
+    exit 0
+}
+
+$script:Pass = 0
+$script:Fail = 0
+$script:Failures = [System.Collections.Generic.List[string]]::new()
+
+function Assert-Equal {
+    param($Expected, $Actual, [string]$Message)
+    if ($Expected -eq $Actual) { $script:Pass++ }
+    else { $script:Fail++; $script:Failures.Add("$Message`n    expected: [$Expected]`n    actual:   [$Actual]") }
+}
+function Assert-True {
+    param([bool]$Condition, [string]$Message)
+    if ($Condition) { $script:Pass++ }
+    else { $script:Fail++; $script:Failures.Add($Message) }
+}
+function Assert-InRange {
+    param([double]$Value, [double]$Min, [double]$Max, [string]$Message)
+    if ($Value -ge $Min -and $Value -le $Max) { $script:Pass++ }
+    else { $script:Fail++; $script:Failures.Add("$Message`n    expected: [$Min..$Max]`n    actual:   [$Value]") }
+}
+
+$vsReactor = (Resolve-Path (Join-Path $PSScriptRoot '..' '..' '..' 'src' 'vs-reactor')).Path
+$libPath = Join-Path $vsReactor 'VsProcessLib.ps1'
+
+# -- 1. Parse-check the lib and the script that dot-sources it. --
+foreach ($p in @($libPath, (Join-Path $vsReactor 'Reinstall-Vsix.ps1'))) {
+    $parseErrors = $null
+    [System.Management.Automation.Language.Parser]::ParseInput(
+        (Get-Content $p -Raw), [ref]$null, [ref]$parseErrors) | Out-Null
+    if ($parseErrors -and $parseErrors.Count -gt 0) {
+        Write-Host "$(Split-Path $p -Leaf) has $($parseErrors.Count) parse error(s):" -ForegroundColor Red
+        $parseErrors | ForEach-Object { Write-Host "  line $($_.Extent.StartLineNumber): $($_.Message)" -ForegroundColor Red }
+        exit 1
+    }
+}
+
+. $libPath
+
+# -- Fake-process harness. --
+$fakeName = 'reactor-fake-devenv'
+$tmp = Join-Path ([System.IO.Path]::GetTempPath()) ("vsprocesslib-" + [Guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Path $tmp | Out-Null
+$fakeExe = Join-Path $tmp "$fakeName.exe"
+# cmd.exe has no sidecar dependencies, so a renamed copy runs standalone and
+# gives us a process with a name we fully control.
+Copy-Item "$env:SystemRoot\System32\cmd.exe" $fakeExe
+
+# Outer fake spawns an inner fake, which spawns ping. `>nul` on the outer
+# command line suppresses the whole tree's output.
+$hangArgs  = '/c "' + $fakeExe + '" /c ping -n 600 127.0.0.1 >nul'
+$quickArgs = '/c exit 0'
+
+function Get-FakeCount {
+    @(Get-Process -Name $fakeName -ErrorAction SilentlyContinue).Count
+}
+
+function Start-Fake {
+    param([string]$Arguments)
+    $psi = New-Object System.Diagnostics.ProcessStartInfo
+    $psi.FileName = $fakeExe
+    $psi.Arguments = $Arguments
+    $psi.UseShellExecute = $false
+    [System.Diagnostics.Process]::Start($psi)
+}
+
+function Wait-ForFakeCount {
+    param([int]$AtLeast, [int]$TimeoutSeconds = 15)
+    $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
+    while ((Get-FakeCount) -lt $AtLeast -and [DateTime]::UtcNow -lt $deadline) {
+        Start-Sleep -Milliseconds 200
+    }
+    Get-FakeCount
+}
+
+function Remove-AllFakes {
+    foreach ($p in @(Get-Process -Name $fakeName -ErrorAction SilentlyContinue)) {
+        try { $p.Kill() } catch { }
+    }
+}
+
+try {
+    # -- 2. The harness itself really does build a multi-process tree. --
+    # Positive control: if this were 1, every "tree" assertion below would be
+    # satisfiable by a single-process kill and would prove nothing.
+    $p = Start-Fake -Arguments $hangArgs
+    $count = Wait-ForFakeCount -AtLeast 2
+    Assert-True ($count -ge 2) "harness: fake devenv spawns a real tree (saw $count '$fakeName' processes, expected >= 2)"
+    try { $p.Kill() } catch { }
+    Remove-AllFakes
+    Assert-True (Wait-ProcessNameCleared -Name $fakeName -TimeoutSeconds 15) 'harness: fakes are cleaned up between cases'
+
+    # -- 3. Stop-ProcessTreeSafely reaps descendants, not just the root. --
+    # This is the #1074 fix. Against `$proc.Kill()` the inner fake survives.
+    $p = Start-Fake -Arguments $hangArgs
+    Wait-ForFakeCount -AtLeast 2 | Out-Null
+    $exited = Stop-ProcessTreeSafely -Process $p -WaitSeconds 20
+    Assert-True $exited 'Stop-ProcessTreeSafely: root process exited within the wait'
+    Assert-True (Wait-ProcessNameCleared -Name $fakeName -TimeoutSeconds 20) 'Stop-ProcessTreeSafely: no descendant is left running'
+    Assert-Equal 0 (Get-FakeCount) 'Stop-ProcessTreeSafely: process name is fully clear'
+    # Explicit teardown so a failure here is attributed to this case rather than
+    # cascading into the next one's counts.
+    Remove-AllFakes
+    Wait-ProcessNameCleared -Name $fakeName -TimeoutSeconds 20 | Out-Null
+
+    # -- 4. Timeout path: nothing survives, duration is a real measurement. --
+    $timeout = 4
+    $r = Invoke-DevenvUpdateConfiguration -DevenvPath $fakeExe -Arguments $hangArgs `
+        -TimeoutSeconds $timeout -ProcessName $fakeName -DrainTimeoutSeconds 20
+    Assert-True $r.TimedOut 'timeout: TimedOut is reported'
+    Assert-True $r.Drained  'timeout: Drained is reported true (name cleared)'
+    Assert-Equal 0 (Get-FakeCount) 'timeout: no fake devenv survives the call'
+    # The pre-fix instrument read ExitTime on a process that had not been reaped
+    # yet, which returns the 1601 epoch and printed "-13430263500.8s". This
+    # bounds check catches that class of nonsense. It does NOT distinguish a
+    # Stopwatch from a *correctly sequenced* ExitTime-StartTime read, because
+    # once we wait for the kill to complete the two agree — verified by
+    # mutation: swapping the Stopwatch back for ExitTime-StartTime does not
+    # redden this suite, whereas removing the tree kill reddens it immediately.
+    # The Stopwatch is kept because it cannot be wrong; the assertion below is
+    # honest about guarding the symptom, not the implementation choice.
+    Assert-InRange $r.DurationSeconds $timeout ($timeout + 30) 'timeout: DurationSeconds is a plausible wall-clock measurement'
+    # ExitCode must be readable, i.e. we waited for the kill to complete rather
+    # than racing it.
+    Assert-True ($null -ne $r.ExitCode) 'timeout: ExitCode is defined after the tree kill'
+
+    # -- 5. Happy path is untouched (guards the VS 18.7 flow). --
+    $r = Invoke-DevenvUpdateConfiguration -DevenvPath $fakeExe -Arguments $quickArgs `
+        -TimeoutSeconds 30 -ProcessName $fakeName -DrainTimeoutSeconds 10
+    Assert-Equal $false $r.TimedOut 'happy path: TimedOut is false when the process exits on its own'
+    Assert-Equal 0 $r.ExitCode 'happy path: real exit code is surfaced'
+    Assert-Equal 0 $r.KilledPids.Count 'happy path: nothing is killed'
+    Assert-InRange $r.DurationSeconds 0 30 'happy path: DurationSeconds is non-negative and bounded'
+
+    # -- 6. The sweep spares pre-existing processes. --
+    # A developer who opens VS mid-run must not have their IDE killed; the
+    # pre-start snapshot is what protects them.
+    $pre = Start-Fake -Arguments $hangArgs
+    # Wait for the *whole* pre-existing tree before snapshotting: if the inner
+    # process were missed by the snapshot the sweep would kill it, the outer
+    # would exit with it, and "excluded process is still alive" would flake.
+    Wait-ForFakeCount -AtLeast 2 | Out-Null
+    $preIds = @(Get-Process -Name $fakeName -ErrorAction SilentlyContinue | ForEach-Object { $_.Id })
+    $new = Start-Fake -Arguments $hangArgs
+    Wait-ForFakeCount -AtLeast ($preIds.Count + 1) | Out-Null
+
+    $killed = @(Stop-NewProcessesByName -Name $fakeName -ExcludePids $preIds -WaitSeconds 20)
+    Assert-True ($killed -contains $new.Id) "sweep: kills the process started after the snapshot (pid $($new.Id))"
+    Assert-True ($killed -notcontains $pre.Id) "sweep: does not kill the excluded pre-existing process (pid $($pre.Id))"
+    $pre.Refresh()
+    Assert-Equal $false $pre.HasExited 'sweep: the excluded process is still alive'
+    Assert-True $new.HasExited 'sweep: the swept process is gone'
+
+    Remove-AllFakes
+    Assert-True (Wait-ProcessNameCleared -Name $fakeName -TimeoutSeconds 20) 'sweep: teardown clears the name'
+
+    # -- 7. Wait-ProcessNameCleared reports failure rather than lying. --
+    # Without a truthful negative, a false "drained" would let the next run trip
+    # the guard with no explanation.
+    $stubborn = Start-Fake -Arguments $hangArgs
+    Wait-ForFakeCount -AtLeast 1 | Out-Null
+    Assert-Equal $false (Wait-ProcessNameCleared -Name $fakeName -TimeoutSeconds 2) 'Wait-ProcessNameCleared: returns false while a process is still running'
+    Remove-AllFakes
+    Assert-True (Wait-ProcessNameCleared -Name $fakeName -TimeoutSeconds 20) 'Wait-ProcessNameCleared: returns true once the name is clear'
+
+    # -- 8. Stop-ProcessTreeSafely does not leak $LASTEXITCODE. --
+    # The 5.1 path shells out to taskkill, whose non-zero "not found" status
+    # would otherwise ride out to the caller's exit code (the #1074 defect class).
+    $done = Start-Fake -Arguments $quickArgs
+    $done.WaitForExit(10000) | Out-Null
+    $global:LASTEXITCODE = 0
+    Stop-ProcessTreeSafely -Process $done -WaitSeconds 5 | Out-Null
+    Assert-Equal 0 $LASTEXITCODE 'Stop-ProcessTreeSafely: leaves $LASTEXITCODE at 0'
+}
+finally {
+    Remove-AllFakes
+    Wait-ProcessNameCleared -Name $fakeName -TimeoutSeconds 20 | Out-Null
+    Remove-Item $tmp -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+# -- Report --
+Write-Host ""
+Write-Host "VsProcessLib tests: $script:Pass passed, $script:Fail failed"
+if ($script:Fail -gt 0) {
+    Write-Host ""
+    $script:Failures | ForEach-Object { Write-Host "FAIL: $_" -ForegroundColor Red }
+    exit 1
+}
+exit 0

--- a/tests/vs_reactor/ci/VsProcessLib.Tests.ps1
+++ b/tests/vs_reactor/ci/VsProcessLib.Tests.ps1
@@ -5,15 +5,26 @@
 
 .DESCRIPTION
     Windows-only and headless: no build, no dotnet, no Visual Studio. Wired into
-    .github/workflows/vs-reactor-lib-tests.yml. Exits non-zero on any failed
-    assertion.
+    .github/workflows/vs-reactor-lib-tests.yml, which runs this file under BOTH
+    pwsh and Windows PowerShell 5.1 — 5.1 is a real entry point (bootstrap.ps1
+    re-launches with the current host, `mur upgrade` falls back to
+    powershell.exe), so nothing here may use PowerShell 6+ syntax such as the
+    $IsWindows automatic variable. Exits non-zero on any failed assertion.
 
     The fake "devenv" is a copy of cmd.exe renamed to reactor-fake-devenv.exe,
     launched as `/c "<fake>" /c ping -n 600 127.0.0.1`. That produces a real
-    two-level, same-named, genuinely-hanging process tree, which is what makes
-    these assertions non-vacuous: mutation-checked against the shipped pre-fix
-    implementation (`$proc.Kill()`, no argument, no wait) the inner
-    reactor-fake-devenv.exe survives and the tree assertions redden.
+    two-level, same-named, genuinely-hanging process tree — which is what makes
+    the orphan assertions non-vacuous: mutation-checked against the shipped
+    pre-fix implementation (`$proc.Kill()`, no argument, no wait) the inner
+    reactor-fake-devenv.exe survives and case 3 and case 6 redden.
+
+    Case 6 is the attribution oracle and it cuts both ways: it runs a real
+    timeout against one tree while an unrelated same-named tree is running, and
+    requires that the unrelated one survives untouched. An earlier revision of
+    the lib swept by process name against a pre-start snapshot, which would kill
+    a developer's IDE (Reinstall-Vsix.ps1 refuses to start while any devenv
+    lives, so that snapshot is always empty). That revision passes case 3 and
+    fails case 6.
 
     Known limit, stated rather than papered over: the "-425 years" duration in
     the issue is a race on reading Process.ExitTime before the OS reaps a heavy
@@ -21,23 +32,26 @@
     assertion here is a bounds check on the symptom, not a discriminator
     between a Stopwatch and a correctly-sequenced ExitTime read. See case 4.
 
-    A distinctly-named fake also keeps the sweep tests safe — Stop-NewProcessesByName
-    is never pointed at `pwsh`, so an exclude-list regression cannot take out the
+    A distinctly-named fake also keeps the sweep tests safe — nothing here is
+    ever pointed at `pwsh`, so an attribution regression cannot take out the
     test host.
 
     Run locally:  pwsh tests/vs_reactor/ci/VsProcessLib.Tests.ps1
+                  powershell -File tests/vs_reactor/ci/VsProcessLib.Tests.ps1
 #>
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-if (-not $IsWindows) {
+# $IsWindows does not exist before PowerShell 6, and this file must run on 5.1.
+$onWindows = if ($PSVersionTable.ContainsKey('Platform')) { $PSVersionTable.Platform -eq 'Win32NT' } else { $true }
+if (-not $onWindows) {
     Write-Host "VsProcessLib tests: skipped (Windows-only process semantics)."
     exit 0
 }
 
 $script:Pass = 0
 $script:Fail = 0
-$script:Failures = [System.Collections.Generic.List[string]]::new()
+$script:Failures = New-Object System.Collections.Generic.List[string]
 
 function Assert-Equal {
     param($Expected, $Actual, [string]$Message)
@@ -55,14 +69,17 @@ function Assert-InRange {
     else { $script:Fail++; $script:Failures.Add("$Message`n    expected: [$Min..$Max]`n    actual:   [$Value]") }
 }
 
-$vsReactor = (Resolve-Path (Join-Path $PSScriptRoot '..' '..' '..' 'src' 'vs-reactor')).Path
+$vsReactor = (Resolve-Path (Join-Path $PSScriptRoot '..\..\..\src\vs-reactor')).Path
 $libPath = Join-Path $vsReactor 'VsProcessLib.ps1'
 
 # -- 1. Parse-check the lib and the script that dot-sources it. --
+# ParseInput over UTF8-decoded text, not ParseFile: these files are BOM-less
+# UTF-8, and Windows PowerShell 5.1's ParseFile decodes them as ANSI, which
+# turns any non-ASCII comment character into a spurious syntax error.
 foreach ($p in @($libPath, (Join-Path $vsReactor 'Reinstall-Vsix.ps1'))) {
     $parseErrors = $null
-    [System.Management.Automation.Language.Parser]::ParseInput(
-        (Get-Content $p -Raw), [ref]$null, [ref]$parseErrors) | Out-Null
+    $text = [System.IO.File]::ReadAllText($p, [System.Text.Encoding]::UTF8)
+    [System.Management.Automation.Language.Parser]::ParseInput($text, [ref]$null, [ref]$parseErrors) | Out-Null
     if ($parseErrors -and $parseErrors.Count -gt 0) {
         Write-Host "$(Split-Path $p -Leaf) has $($parseErrors.Count) parse error(s):" -ForegroundColor Red
         $parseErrors | ForEach-Object { Write-Host "  line $($_.Extent.StartLineNumber): $($_.Message)" -ForegroundColor Red }
@@ -83,7 +100,7 @@ Copy-Item "$env:SystemRoot\System32\cmd.exe" $fakeExe
 
 # Outer fake spawns an inner fake, which spawns ping. `>nul` on the outer
 # command line suppresses the whole tree's output.
-$hangArgs  = '/c "' + $fakeExe + '" /c ping -n 600 127.0.0.1 >nul'
+$hangArgs = '/c "' + $fakeExe + '" /c ping -n 600 127.0.0.1 >nul'
 $quickArgs = '/c exit 0'
 
 function Get-FakeCount {
@@ -112,6 +129,7 @@ function Remove-AllFakes {
     foreach ($p in @(Get-Process -Name $fakeName -ErrorAction SilentlyContinue)) {
         try { $p.Kill() } catch { }
     }
+    Wait-ProcessNameCleared -Name $fakeName -TimeoutSeconds 20 | Out-Null
 }
 
 try {
@@ -121,9 +139,8 @@ try {
     $p = Start-Fake -Arguments $hangArgs
     $count = Wait-ForFakeCount -AtLeast 2
     Assert-True ($count -ge 2) "harness: fake devenv spawns a real tree (saw $count '$fakeName' processes, expected >= 2)"
-    try { $p.Kill() } catch { }
     Remove-AllFakes
-    Assert-True (Wait-ProcessNameCleared -Name $fakeName -TimeoutSeconds 15) 'harness: fakes are cleaned up between cases'
+    Assert-Equal 0 (Get-FakeCount) 'harness: fakes are cleaned up between cases'
 
     # -- 3. Stop-ProcessTreeSafely reaps descendants, not just the root. --
     # This is the #1074 fix. Against `$proc.Kill()` the inner fake survives.
@@ -136,7 +153,6 @@ try {
     # Explicit teardown so a failure here is attributed to this case rather than
     # cascading into the next one's counts.
     Remove-AllFakes
-    Wait-ProcessNameCleared -Name $fakeName -TimeoutSeconds 20 | Out-Null
 
     # -- 4. Timeout path: nothing survives, duration is a real measurement. --
     $timeout = 4
@@ -158,6 +174,7 @@ try {
     # ExitCode must be readable, i.e. we waited for the kill to complete rather
     # than racing it.
     Assert-True ($null -ne $r.ExitCode) 'timeout: ExitCode is defined after the tree kill'
+    Remove-AllFakes
 
     # -- 5. Happy path is untouched (guards the VS 18.7 flow). --
     $r = Invoke-DevenvUpdateConfiguration -DevenvPath $fakeExe -Arguments $quickArgs `
@@ -166,50 +183,101 @@ try {
     Assert-Equal 0 $r.ExitCode 'happy path: real exit code is surfaced'
     Assert-Equal 0 $r.KilledPids.Count 'happy path: nothing is killed'
     Assert-InRange $r.DurationSeconds 0 30 'happy path: DurationSeconds is non-negative and bounded'
-
-    # -- 6. The sweep spares pre-existing processes. --
-    # A developer who opens VS mid-run must not have their IDE killed; the
-    # pre-start snapshot is what protects them.
-    $pre = Start-Fake -Arguments $hangArgs
-    # Wait for the *whole* pre-existing tree before snapshotting: if the inner
-    # process were missed by the snapshot the sweep would kill it, the outer
-    # would exit with it, and "excluded process is still alive" would flake.
-    Wait-ForFakeCount -AtLeast 2 | Out-Null
-    $preIds = @(Get-Process -Name $fakeName -ErrorAction SilentlyContinue | ForEach-Object { $_.Id })
-    $new = Start-Fake -Arguments $hangArgs
-    Wait-ForFakeCount -AtLeast ($preIds.Count + 1) | Out-Null
-
-    $killed = @(Stop-NewProcessesByName -Name $fakeName -ExcludePids $preIds -WaitSeconds 20)
-    Assert-True ($killed -contains $new.Id) "sweep: kills the process started after the snapshot (pid $($new.Id))"
-    Assert-True ($killed -notcontains $pre.Id) "sweep: does not kill the excluded pre-existing process (pid $($pre.Id))"
-    $pre.Refresh()
-    Assert-Equal $false $pre.HasExited 'sweep: the excluded process is still alive'
-    Assert-True $new.HasExited 'sweep: the swept process is gone'
-
     Remove-AllFakes
-    Assert-True (Wait-ProcessNameCleared -Name $fakeName -TimeoutSeconds 20) 'sweep: teardown clears the name'
 
-    # -- 7. Wait-ProcessNameCleared reports failure rather than lying. --
+    # -- 6. The timeout sweep is attributed, not name-matched. --
+    # The scenario: a developer opens Visual Studio during the two-minute
+    # window. Their IDE shares the process name but is not ours, and must
+    # survive. Meanwhile every process from *our* tree must be gone — killing
+    # only the root is what #1074 was.
+    $victim = Start-Fake -Arguments $hangArgs
+    Wait-ForFakeCount -AtLeast 2 | Out-Null
+    $victimIds = @(Get-ProcessIdsByName -Name $fakeName)
+
+    $r = Invoke-DevenvUpdateConfiguration -DevenvPath $fakeExe -Arguments $hangArgs `
+        -TimeoutSeconds 4 -ProcessName $fakeName -DrainTimeoutSeconds 4
+
+    $victim.Refresh()
+    Assert-Equal $false $victim.HasExited "attribution: an unrelated same-named process survives the sweep (pid $($victim.Id))"
+    $strays = @(@(Get-ProcessIdsByName -Name $fakeName) | Where-Object { $victimIds -notcontains $_ })
+    Assert-Equal 0 $strays.Count "attribution: no process from the invoked tree survives (strays: $($strays -join ', '))"
+    # Drained is a report on the machine, not on our tree: an unrelated process
+    # legitimately holds the name, and saying otherwise would tell the caller
+    # the next run's guard will pass when it will not.
+    Assert-Equal $false $r.Drained 'attribution: Drained is false while an unrelated process still holds the name'
+    Remove-AllFakes
+
+    # -- 7. Get-ProcessDescendantIds resolves the tree by parentage. --
+    # This is what makes case 6 possible: without it the sweep has nothing to
+    # distinguish our processes from anyone else's.
+    $root = Start-Fake -Arguments $hangArgs
+    Wait-ForFakeCount -AtLeast 2 | Out-Null
+    $kids = @(Get-ProcessDescendantIds -RootPid $root.Id)
+    Assert-True ($kids.Count -ge 1) "descendants: the child of the fake tree is found (got $($kids.Count))"
+    Assert-True ($kids -notcontains $root.Id) 'descendants: the root is excluded by default'
+    $withRoot = @(Get-ProcessDescendantIds -RootPid $root.Id -IncludeRoot)
+    Assert-True ($withRoot -contains $root.Id) 'descendants: -IncludeRoot returns the root'
+    Assert-Equal ($kids.Count + 1) $withRoot.Count 'descendants: -IncludeRoot adds exactly the root'
+
+    $unrelated = Start-Fake -Arguments $hangArgs
+    Wait-ForFakeCount -AtLeast 4 | Out-Null
+    $kidsAgain = @(Get-ProcessDescendantIds -RootPid $root.Id)
+    Assert-True ($kidsAgain -notcontains $unrelated.Id) "descendants: an unrelated same-named process is not claimed as a descendant (pid $($unrelated.Id))"
+    Remove-AllFakes
+
+    # -- 8. Wait-ProcessNameCleared reports failure rather than lying. --
     # Without a truthful negative, a false "drained" would let the next run trip
     # the guard with no explanation.
     $stubborn = Start-Fake -Arguments $hangArgs
     Wait-ForFakeCount -AtLeast 1 | Out-Null
     Assert-Equal $false (Wait-ProcessNameCleared -Name $fakeName -TimeoutSeconds 2) 'Wait-ProcessNameCleared: returns false while a process is still running'
+    Assert-True ($stubborn.Id -gt 0) 'Wait-ProcessNameCleared: observes only — the process it reported on is untouched'
+    $stubborn.Refresh()
+    Assert-Equal $false $stubborn.HasExited 'Wait-ProcessNameCleared: does not kill what it polls'
     Remove-AllFakes
     Assert-True (Wait-ProcessNameCleared -Name $fakeName -TimeoutSeconds 20) 'Wait-ProcessNameCleared: returns true once the name is clear'
 
-    # -- 8. Stop-ProcessTreeSafely does not leak $LASTEXITCODE. --
-    # The 5.1 path shells out to taskkill, whose non-zero "not found" status
-    # would otherwise ride out to the caller's exit code (the #1074 defect class).
-    $done = Start-Fake -Arguments $quickArgs
-    $done.WaitForExit(10000) | Out-Null
-    $global:LASTEXITCODE = 0
-    Stop-ProcessTreeSafely -Process $done -WaitSeconds 5 | Out-Null
-    Assert-Equal 0 $LASTEXITCODE 'Stop-ProcessTreeSafely: leaves $LASTEXITCODE at 0'
+    # -- 9. Stop-ProcessIdsSafely will not act on a pid it cannot attribute. --
+    # Windows recycles pids, so by sweep time a recorded pid may belong to
+    # something else. Both guards are checked against a live process.
+    $bystander = Start-Fake -Arguments $hangArgs
+    Wait-ForFakeCount -AtLeast 1 | Out-Null
+    $killed = @(Stop-ProcessIdsSafely -ProcessIds @($bystander.Id) -ExpectedName 'some-other-name' -WaitSeconds 5)
+    Assert-Equal 0 $killed.Count 'pid reuse: a pid whose name no longer matches is left alone'
+    $bystander.Refresh()
+    Assert-Equal $false $bystander.HasExited 'pid reuse: the name-mismatched process is still running'
+
+    $killed = @(Stop-ProcessIdsSafely -ProcessIds @($bystander.Id) -ExpectedName $fakeName `
+            -NotStartedAfter ([DateTime]::Now.AddHours(-1)) -WaitSeconds 5)
+    Assert-Equal 0 $killed.Count 'pid reuse: a pid that started after we recorded it is left alone'
+    $bystander.Refresh()
+    Assert-Equal $false $bystander.HasExited 'pid reuse: the too-young process is still running'
+
+    # Positive control for the two assertions above: with both guards satisfied
+    # the same call really does kill. Without this, "0 killed" would be
+    # indistinguishable from a Stop-ProcessIdsSafely that never kills anything.
+    $killed = @(Stop-ProcessIdsSafely -ProcessIds @($bystander.Id) -ExpectedName $fakeName -WaitSeconds 20)
+    Assert-Equal 1 $killed.Count 'pid reuse: an attributable pid IS killed (positive control)'
+    Remove-AllFakes
+
+    # -- 10. Stop-ProcessTreeSafely does not leak $LASTEXITCODE. --
+    # It shells out to taskkill on every host now, and taskkill reports non-zero
+    # when its target is already gone — #1074's third defect is exactly that
+    # class of leak riding out to the caller's exit code.
+    #
+    # Honest scope: this asserts the boundary contract (the lib hands back 0
+    # after shelling out). It cannot force taskkill's already-gone status
+    # without racing the HasExited check, so deleting the reset line alone will
+    # not redden it. The line is kept because it costs one statement and the
+    # failure mode is a red CI job with no local repro.
+    $global:LASTEXITCODE = 42
+    $live = Start-Fake -Arguments $hangArgs
+    Wait-ForFakeCount -AtLeast 1 | Out-Null
+    Stop-ProcessTreeSafely -Process $live -WaitSeconds 20 | Out-Null
+    Assert-Equal 0 $LASTEXITCODE 'Stop-ProcessTreeSafely: leaves $LASTEXITCODE at 0 after shelling out to taskkill'
 }
 finally {
     Remove-AllFakes
-    Wait-ProcessNameCleared -Name $fakeName -TimeoutSeconds 20 | Out-Null
     Remove-Item $tmp -Recurse -Force -ErrorAction SilentlyContinue
 }
 

--- a/tests/vs_reactor/ci/VsProcessLib.Tests.ps1
+++ b/tests/vs_reactor/ci/VsProcessLib.Tests.ps1
@@ -279,6 +279,11 @@ try {
     Start-Sleep -Milliseconds 500
     $claimed = @(Get-ProcessDescendantIds -RootPid $orphanRootPid)
     Assert-Equal 0 $claimed.Count "descendants: a root absent from the process table claims nothing (got: $($claimed -join ', '))"
+    # ...and -IncludeRoot must not smuggle the recycled pid back in. The caller
+    # feeds this straight to the sweep, so returning the number here would kill
+    # whatever inherited it.
+    $claimedWithRoot = @(Get-ProcessDescendantIds -RootPid $orphanRootPid -IncludeRoot)
+    Assert-Equal 0 $claimedWithRoot.Count "descendants: -IncludeRoot returns nothing for an absent root (got: $($claimedWithRoot -join ', '))"
     Remove-AllFakes
 
     # -- 8. Wait-ProcessNameCleared reports failure rather than lying. --

--- a/tests/vs_reactor/ci/VsProcessLib.Tests.ps1
+++ b/tests/vs_reactor/ci/VsProcessLib.Tests.ps1
@@ -11,9 +11,11 @@
     powershell.exe), so nothing here may use PowerShell 6+ syntax such as the
     $IsWindows automatic variable. Exits non-zero on any failed assertion.
 
-    The fake "devenv" is a copy of cmd.exe renamed to reactor-fake-devenv.exe,
-    launched as `/c "<fake>" /c ping -n 600 127.0.0.1`. That produces a real
-    two-level, same-named, genuinely-hanging process tree — which is what makes
+    The fake "devenv" is a copy of cmd.exe renamed to
+    reactor-fake-devenv-<pid>.exe (see the harness comment for why the pid is
+    part of the name), launched as `/c "<fake>" /c ping -n 600 127.0.0.1`. That
+    produces a real two-level, same-named, genuinely-hanging process tree —
+    which is what makes
     the orphan assertions non-vacuous: mutation-checked against the shipped
     pre-fix implementation (`$proc.Kill()`, no argument, no wait) the inner
     reactor-fake-devenv.exe survives and case 3 and case 6 redden.

--- a/tests/vs_reactor/ci/VsProcessLib.Tests.ps1
+++ b/tests/vs_reactor/ci/VsProcessLib.Tests.ps1
@@ -205,6 +205,22 @@ try {
     Assert-Equal 0 $r.ExitCode 'happy path: real exit code is surfaced'
     Assert-Equal 0 $r.KilledPids.Count 'happy path: nothing is killed'
     Assert-InRange $r.DurationSeconds 0 30 'happy path: DurationSeconds is non-negative and bounded'
+    Assert-True $r.Drained 'happy path: Drained is true when the name really is clear'
+    Remove-AllFakes
+
+    # -- 5b. Drained is measured on the happy path, not assumed. --
+    # A clean exit does not prove nothing was left behind: /updateconfiguration
+    # spawns a second devenv, so "it exited, therefore the machine is clear" is
+    # exactly the inference that must not be hardcoded. With a same-named
+    # process running, a truthful Drained is false.
+    $bystander = Start-Fake -Arguments $hangArgs
+    Wait-ForFakeCount -AtLeast 1 | Out-Null
+    $r = Invoke-DevenvUpdateConfiguration -DevenvPath $fakeExe -Arguments $quickArgs `
+        -TimeoutSeconds 30 -ProcessName $fakeName -DrainTimeoutSeconds 10
+    Assert-Equal $false $r.TimedOut 'happy path: still a non-timeout run with a bystander present'
+    Assert-Equal $false $r.Drained 'happy path: Drained is false while another same-named process runs'
+    $bystander.Refresh()
+    Assert-Equal $false $bystander.HasExited 'happy path: the bystander is reported on, not killed'
     Remove-AllFakes
 
     # -- 6. The timeout sweep is attributed, not name-matched. --

--- a/tests/vs_reactor/ci/VsProcessLib.Tests.ps1
+++ b/tests/vs_reactor/ci/VsProcessLib.Tests.ps1
@@ -34,7 +34,8 @@
 
     A distinctly-named fake also keeps the sweep tests safe — nothing here is
     ever pointed at `pwsh`, so an attribution regression cannot take out the
-    test host.
+    test host. The name is further namespaced with the host pid so two
+    concurrent runs cannot kill each other's fixtures; see the harness comment.
 
     Run locally:  pwsh tests/vs_reactor/ci/VsProcessLib.Tests.ps1
                   powershell -File tests/vs_reactor/ci/VsProcessLib.Tests.ps1
@@ -90,7 +91,14 @@ foreach ($p in @($libPath, (Join-Path $vsReactor 'Reinstall-Vsix.ps1'))) {
 . $libPath
 
 # -- Fake-process harness. --
-$fakeName = 'reactor-fake-devenv'
+# The name is namespaced per run. Every helper below finds and kills fakes by
+# process *name*, and Get-Process is machine-wide — so a shared name means two
+# concurrent runs of this file (or a leftover from an aborted one) silently
+# destroy each other's fixtures. Verified: two overlapping runs under a shared
+# name produce spurious "process died early" failures and an Access-denied on
+# Process.Start. That is the same attribution mistake this suite exists to catch
+# in the product, so the harness does not get to make it either.
+$fakeName = "reactor-fake-devenv-$PID"
 $tmp = Join-Path ([System.IO.Path]::GetTempPath()) ("vsprocesslib-" + [Guid]::NewGuid().ToString('N'))
 New-Item -ItemType Directory -Path $tmp | Out-Null
 $fakeExe = Join-Path $tmp "$fakeName.exe"

--- a/tests/vs_reactor/ci/VsProcessLib.Tests.ps1
+++ b/tests/vs_reactor/ci/VsProcessLib.Tests.ps1
@@ -134,10 +134,24 @@ function Wait-ForFakeCount {
 }
 
 function Remove-AllFakes {
+    # Kill the *tree*, not just the roots. The fake spawns ping.exe, and
+    # Process.Kill() orphans it for the full 600-second ping — which is #1074's
+    # defect committed in the harness of the suite that exists to catch it.
+    #
+    # taskkill is invoked directly rather than through Stop-ProcessTreeSafely,
+    # and the drain below polls locally rather than through
+    # Wait-ProcessNameCleared, so teardown stays independent of the code under
+    # test: a broken lib must redden an assertion, not silently poison the next
+    # case's fixture.
     foreach ($p in @(Get-Process -Name $fakeName -ErrorAction SilentlyContinue)) {
-        try { $p.Kill() } catch { }
+        try { & "$env:SystemRoot\System32\taskkill.exe" '/PID' $p.Id '/T' '/F' 2>&1 | Out-Null } catch { }
     }
-    Wait-ProcessNameCleared -Name $fakeName -TimeoutSeconds 20 | Out-Null
+    # taskkill reports non-zero for a pid already reaped by an earlier /T.
+    $global:LASTEXITCODE = 0
+    $deadline = [DateTime]::UtcNow.AddSeconds(20)
+    while ((Get-FakeCount) -gt 0 -and [DateTime]::UtcNow -lt $deadline) {
+        Start-Sleep -Milliseconds 200
+    }
 }
 
 try {


### PR DESCRIPTION
Fixes #1074.

On VS **18.8**, `devenv /updateconfiguration` never returns. That is upstream behaviour we can't fix. But three defects in *our own* scripts turned that hang into a consistently red `bootstrap.ps1 (windows-latest)` job, and those are what this PR fixes.

## The three defects

**1. `Process.Kill()` orphaned the devenv tree.** No argument means "kill only this process", and it returns without waiting. The second `devenv` that `/updateconfiguration` spawns survived and tripped the next run's "Visual Studio is running" guard.

**2. The duration was read from `ExitTime` on a live process**, printing `-13430263500.8s` — a broken instrument sitting next to the bug it was announcing. Now a `Stopwatch`.

**3. `$LASTEXITCODE` leaked past `Bootstrap complete.`** The issue correctly names `Write-Host` as the culprit, but *how* `bootstrap.ps1` is invoked turned out to be load-bearing: `bootstrap.yml` runs it **in-process**, and `$LASTEXITCODE` is a global, so the child's `1` survives into the workflow's `if ($LASTEXITCODE -ne 0) { throw }`.

That last point cost a false start worth recording. My first regression test used `pwsh -File` as the positive control — and it **failed to reproduce the leak at all**, because that form returns 0 on fall-through. Shipped as-is it would have been green against both broken and fixed code.

| invocation | leaky | + `$global:LASTEXITCODE = 0` | + trailing `exit 0` |
|---|---|---|---|
| in-process (what CI does) | **7** | 0 | 0 |
| `pwsh -File` | 0 | 0 | 0 |

## What changed

| File | Change |
|---|---|
| `src/vs-reactor/VsProcessLib.ps1` | **New.** Timeout → record the tree by parentage → kill and wait → attributed sweep → drain report. |
| `src/vs-reactor/Reinstall-Vsix.ps1` | Documented exit-code contract; `-UpdateConfigurationTimeoutSec` (range-validated); guard message reports process start times. |
| `bootstrap.ps1` | Branches on exit 3; resets `$global:LASTEXITCODE`; ends with an explicit `exit 0`. |
| `src/Reactor.Cli/Upgrade/UpgradeCommand.cs` | Treats exit 3 as partial success; pins the install to the VS instance it probed. |
| `tests/vs_reactor/ci/*` | Two dependency-free suites (38 + 21 assertions) + README. |
| `.github/workflows/vs-reactor-lib-tests.yml` | **New.** Both suites under **both** PowerShell hosts. |

### Exit-code contract

| Code | Meaning |
|---|---|
| `0` | Installed **and** `/updateconfiguration` completed. |
| `1` | Needs developer action — build/`vswhere`/`VSIXInstaller` failure, VS running, or duplicate installs. |
| `3` | Installed, but the merge didn't complete (timed out, or `devenv.exe` missing). Launch VS once. |

`[ok] VS extension installed` is no longer printed for a partly-failed operation. A test fails if the code, the `.OUTPUTS` block, and the `TESTING.md` table ever disagree.

## Review

I ran the repo's `pr-review` skill (8 dimensions incl. a cross-model check), then iterated with the GitHub Copilot reviewer until it returned clean. **13 commits, 13 review rounds.** The findings were genuinely good, so they're worth summarising rather than hiding.

The pre-push review found three highs:

- **The sweep could have killed a developer's Visual Studio.** It killed every same-named process not in a pre-start snapshot — but `Reinstall-Vsix.ps1` refuses to start while any devenv is alive, so that snapshot is *always empty* and the sweep degenerated to "kill every devenv". My own test asserted the collateral kill as correct. Now attributed via `Win32_Process` parentage.
- **`exit 0` on paths where the merge never ran**, contradicting the table I'd just written.
- **The tests couldn't run under Windows PowerShell 5.1 at all** (`$IsWindows` is PS 6+), while CI ran only `pwsh` — so the 5.1 path, the one `mur upgrade` actually takes, was never executed.

The Copilot rounds then found a consistent theme: **claiming things that were never measured.**

- `Drained` was hardcoded `$true` on the happy path.
- `KilledPids` recorded a pid *before* attempting the kill, so the "Reaped leftover devenv PIDs" log could name a running process.
- `Stop-ProcessTreeSafely` returned `$true` from two `catch` blocks, reporting *unknown* as *success*.
- `Get-ProcessDescendantIds` walked from a root that might have left the process table, attributing processes on the strength of a recycled pid — **2 processes** falsely claimed, demonstrated by mutation.
- A mid-line `CR` that merged two statements onto one line, valid PowerShell, invisible to a parse check and all 50 assertions.

Every one is the same shape as the original `-425 years` duration: a value reported without being measured. One finding was **disputed and dropped** with evidence (`exit $LASTEXITCODE` is unreachable — `Write-Error` throws first under `$ErrorActionPreference = 'Stop'`), and one was **declined** with measurements showing the claim didn't hold in any invocation shape.

Chasing one of these turned up a flake in my own harness: it matched fixtures by process **name**, globally, so two overlapping runs destroyed each other's processes. Established rather than assumed — 31/31 isolated probes couldn't reproduce it, so I ran two suites concurrently: before, one passed 32/32 while the other died at `Process.Start`; after namespacing by pid, 32/32 and 32/32. That is the PR's own lesson applied to my own code.

## Evidence

A green suite proves nothing by itself, so every load-bearing oracle was mutation-checked (each reverted after):

| Mutation | Result |
|---|---|
| tree kill → bare `Kill()` (the original defect) | **2 fail** |
| attributed sweep → name-based sweep | **2 fail** |
| `if ($updateConfigIncomplete)` → `if ($false)` | **1 fail** |
| drop trailing `exit 0` from `bootstrap.ps1` | **2 fail** |
| drop the `$global:LASTEXITCODE` reset | **1 fail** |
| drift the `TESTING.md` exit table (`3`→`4`) | **1 fail** |
| re-inject a mid-line `CR` | **1 fail** |
| hardcode `Drained = $true` | **1 fail** |
| remove the absent-root guard | **1 fail** (claims 2 processes) |
| let `-IncludeRoot` return an unverifiable pid | **1 fail** |

Three limits are documented rather than papered over — the **duration** assertion doesn't discriminate (a `cmd.exe` fake is reaped too fast to open the `ExitTime` race), and the `$LASTEXITCODE` reset and the confirmed-kill recording both need a failure that can't be forced without a race. All three are stated in the test headers and the README. I'd rather ship an acknowledged gap than an assertion that only looks like a guard.

Also verified: 38 + 21 assertions green on **both** hosts locally and on the CI runner; `dotnet build src/Reactor.Cli -c Release` clean; no leaked processes, temp dirs, or stray carriage returns.

## Deliberately not changed

- **The 120 s timeout** — healthy 18.7 runs take 27–99 s; shortening it would start killing successful merges.
- **Skipping `/updateconfiguration` in CI** — that hides the path this workflow exists to exercise.
- **A `-Force` kill in the VS-running guard** — it would kill a developer's IDE. With the orphan reaped deterministically the guard no longer misfires.
- The `no Reactor.VsExtension folder appeared within 30s` warning — confirmed out of scope in the issue.

## Incidental, pre-existing, not fixed

`bootstrap.ps1` declares `#requires -Version 5.1` but won't *parse* under 5.1 — it's BOM-less UTF-8 containing em dashes, which 5.1 decodes as ANSI. Confirmed identical at `main` and confirmed decode-only (`ParseInput` on correctly-decoded text yields 0 errors). Harmless today because CI runs it under `shell: pwsh` and it re-launches itself via `(Get-Process -Id $PID).Path`. Noting it so it isn't rediscovered as a mystery; the new test scripts sidestep it by reading with an explicit encoding.
