### PR TITLE
Fix bootstrap CI failure on VS 18.8 runners (#1074)

### DIFF
--- a/.github/workflows/vs-reactor-lib-tests.yml
+++ b/.github/workflows/vs-reactor-lib-tests.yml
@@ -1,0 +1,49 @@
+# Fast, headless tests for the PowerShell that installs the Reactor VS extension:
+#   - src/vs-reactor/VsProcessLib.ps1  (devenv /updateconfiguration timeout + tree kill)
+#   - src/vs-reactor/Reinstall-Vsix.ps1 + bootstrap.ps1 (the exit-code handshake)
+# No build, no dotnet, no Visual Studio — the "devenv" under test is a renamed
+# copy of cmd.exe. Runs on windows-latest because the process semantics being
+# tested (tree kill, taskkill fallback, Get-Process by name) are Windows-specific.
+#
+# Guards issue #1074: on VS 18.8 `devenv /updateconfiguration` never returns, and
+# a bare Process.Kill() orphaned its child, poisoning every later VSIX install on
+# the machine. Each test script exits non-zero on any failed assertion.
+name: VS extension script tests
+
+on:
+  push:
+    paths:
+      - 'bootstrap.ps1'
+      - 'src/vs-reactor/VsProcessLib.ps1'
+      - 'src/vs-reactor/Reinstall-Vsix.ps1'
+      - 'tests/vs_reactor/ci/**'
+      - '.github/workflows/vs-reactor-lib-tests.yml'
+  pull_request:
+    paths:
+      - 'bootstrap.ps1'
+      - 'src/vs-reactor/VsProcessLib.ps1'
+      - 'src/vs-reactor/Reinstall-Vsix.ps1'
+      - 'tests/vs_reactor/ci/**'
+      - '.github/workflows/vs-reactor-lib-tests.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  vs-reactor-scripts:
+    name: VsProcessLib + bootstrap exit-code tests
+    runs-on: windows-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Run VsProcessLib tests
+        shell: pwsh
+        run: ./tests/vs_reactor/ci/VsProcessLib.Tests.ps1
+
+      - name: Run bootstrap exit-code tests
+        shell: pwsh
+        run: ./tests/vs_reactor/ci/BootstrapExitCode.Tests.ps1

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -557,11 +557,12 @@ if ($SkipVsExtension) {
                     $vsixExit = $LASTEXITCODE
                     # Reinstall-Vsix.ps1's exit-code contract (see its .OUTPUTS):
                     # 3 == VSIX installed but `devenv /updateconfiguration`
-                    # timed out. Don't claim [ok] for that, and don't fail
-                    # either — the extension is installed and usable.
+                    # did not complete (timed out, or skipped). Don't claim [ok]
+                    # for that, and don't fail either — the extension is
+                    # installed and usable.
                     if ($vsixExit -eq 3) {
                         Write-Host ''
-                        Write-Host "    [warn] VS extension installed into $($target.displayName), but 'devenv /updateconfiguration' timed out and was terminated. Launch VS once to finish the menu merge; if View -> Other Windows -> Reactor Preview is missing, re-run src\vs-reactor\Reinstall-Vsix.ps1." -ForegroundColor Yellow
+                        Write-Host "    [warn] VS extension installed into $($target.displayName), but 'devenv /updateconfiguration' did not complete (see the warnings above). Launch VS once to finish the menu merge; if View -> Other Windows -> Reactor Preview is missing, re-run src\vs-reactor\Reinstall-Vsix.ps1." -ForegroundColor Yellow
                     } elseif ($vsixExit -ne 0) {
                         # Don't fail the whole bootstrap — the rest of the install is
                         # usable without the VS extension. Surface the failure clearly

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -554,15 +554,28 @@ if ($SkipVsExtension) {
                     # the next launch. -VsInstanceId pins to the same instance we probed.
                     $powerShellExe = (Get-Process -Id $PID).Path
                     & $powerShellExe -NoLogo -NoProfile -ExecutionPolicy Bypass -File $reinstall -Configuration $Configuration -VsInstanceId $target.instanceId
-                    if ($LASTEXITCODE -ne 0) {
+                    $vsixExit = $LASTEXITCODE
+                    # Reinstall-Vsix.ps1's exit-code contract (see its .OUTPUTS):
+                    # 3 == VSIX installed but `devenv /updateconfiguration`
+                    # timed out. Don't claim [ok] for that, and don't fail
+                    # either — the extension is installed and usable.
+                    if ($vsixExit -eq 3) {
+                        Write-Host ''
+                        Write-Host "    [warn] VS extension installed into $($target.displayName), but 'devenv /updateconfiguration' timed out and was terminated. Launch VS once to finish the menu merge; if View -> Other Windows -> Reactor Preview is missing, re-run src\vs-reactor\Reinstall-Vsix.ps1." -ForegroundColor Yellow
+                    } elseif ($vsixExit -ne 0) {
                         # Don't fail the whole bootstrap — the rest of the install is
                         # usable without the VS extension. Surface the failure clearly
                         # so users debugging install issues see it.
                         Write-Host ''
-                        Write-Host "    [warn] VS extension install reported a non-zero exit code ($LASTEXITCODE). The rest of the bootstrap completed; re-run src\vs-reactor\Reinstall-Vsix.ps1 directly to retry." -ForegroundColor Yellow
+                        Write-Host "    [warn] VS extension install reported a non-zero exit code ($vsixExit). The rest of the bootstrap completed; re-run src\vs-reactor\Reinstall-Vsix.ps1 directly to retry." -ForegroundColor Yellow
                     } else {
                         Write-Ok "VS extension installed into $($target.displayName) — launch VS, then View -> Other Windows -> Reactor Preview."
                     }
+                    # Write-Host does NOT clear $LASTEXITCODE, so without this
+                    # the child's non-zero code survives to the end of the
+                    # script and fails callers that check it (issue #1074:
+                    # bootstrap.yml's `if ($LASTEXITCODE -ne 0) { throw }`).
+                    $global:LASTEXITCODE = 0
                 }
             }
         }
@@ -589,3 +602,9 @@ Write-Host 'Run the E2E UI tests (needs the winapp CLI installed above):'
 Write-Host "    dotnet test tests/Reactor.AppTests -c Debug -p:Platform=$hostArch"
 Write-Host ''
 Write-Host 'Visual Studio preview (if VS installed): View -> Other Windows -> Reactor Preview'
+
+# Every hard failure above exits via Fail (exit 1), so reaching here means
+# success. Say so explicitly: any best-effort step that shelled out to a native
+# command leaves its code in $LASTEXITCODE, and PowerShell propagates that to
+# the caller when a -File script falls off the end (issue #1074).
+exit 0

--- a/src/Reactor.Cli/Upgrade/UpgradeCommand.cs
+++ b/src/Reactor.Cli/Upgrade/UpgradeCommand.cs
@@ -225,7 +225,16 @@ public static class UpgradeCommand
                 return;
             }
             proc.WaitForExit();
-            if (proc.ExitCode != 0)
+            // Reinstall-Vsix.ps1's exit-code contract (see its .OUTPUTS): 3 means
+            // the VSIX installed but `devenv /updateconfiguration` timed out and
+            // was terminated. That's a partial success, not a failure — report it
+            // on stdout so it doesn't read as a broken upgrade.
+            if (proc.ExitCode == 3)
+            {
+                Console.WriteLine("  VS extension installed, but `devenv /updateconfiguration` timed out and was terminated.");
+                Console.WriteLine("  Launch Visual Studio once to finish the menu merge.");
+            }
+            else if (proc.ExitCode != 0)
             {
                 Console.Error.WriteLine($"  VS extension reinstall exited with code {proc.ExitCode}; the rest of the upgrade completed.");
             }

--- a/src/Reactor.Cli/Upgrade/UpgradeCommand.cs
+++ b/src/Reactor.Cli/Upgrade/UpgradeCommand.cs
@@ -226,12 +226,12 @@ public static class UpgradeCommand
             }
             proc.WaitForExit();
             // Reinstall-Vsix.ps1's exit-code contract (see its .OUTPUTS): 3 means
-            // the VSIX installed but `devenv /updateconfiguration` timed out and
-            // was terminated. That's a partial success, not a failure — report it
-            // on stdout so it doesn't read as a broken upgrade.
+            // the VSIX installed but `devenv /updateconfiguration` did not complete
+            // — it timed out, or was skipped. That's a partial success, not a
+            // failure — report it on stdout so it doesn't read as a broken upgrade.
             if (proc.ExitCode == 3)
             {
-                Console.WriteLine("  VS extension installed, but `devenv /updateconfiguration` timed out and was terminated.");
+                Console.WriteLine("  VS extension installed, but `devenv /updateconfiguration` did not complete (see the warnings above).");
                 Console.WriteLine("  Launch Visual Studio once to finish the menu merge.");
             }
             else if (proc.ExitCode != 0)

--- a/src/vs-reactor/Reinstall-Vsix.ps1
+++ b/src/vs-reactor/Reinstall-Vsix.ps1
@@ -1,13 +1,35 @@
+<#
+.SYNOPSIS
+    Clean rebuild + reinstall of the Reactor Preview VSIX into a local Visual
+    Studio instance.
+
+.PARAMETER UpdateConfigurationTimeoutSec
+    How long to wait for `devenv /updateconfiguration` before terminating it
+    and its children. Healthy runs take 27-99s; the default leaves headroom.
+    Visual Studio 18.8 never returns from this call (issue #1074), so the
+    timeout is the normal path there, not an error.
+
+.OUTPUTS
+    Exit codes:
+      0  VSIX installed and `devenv /updateconfiguration` completed.
+      1  Install failed (build, vswhere, VSIXInstaller, or VS already running).
+      3  VSIX installed, but `devenv /updateconfiguration` did not complete —
+         it timed out and was terminated. The extension is usable; the menu
+         merge may need one manual VS launch.
+#>
 [CmdletBinding()]
 param(
     [switch]$SkipBuild,
     [switch]$NoRestore,
     [ValidateSet('Debug', 'Release')]
     [string]$Configuration = 'Debug',
-    [string]$VsInstanceId
+    [string]$VsInstanceId,
+    [int]$UpdateConfigurationTimeoutSec = 120
 )
 
 $ErrorActionPreference = 'Stop'
+
+. (Join-Path $PSScriptRoot 'VsProcessLib.ps1')
 
 # 1. Build the VSIX unless caller asks us to skip it.
 if (-not $SkipBuild) {
@@ -64,9 +86,17 @@ Write-Host "Target VS: $($target.displayName) ($instanceHash, $instanceVersion)"
 Write-Host "Per-user extension root: $extRoot"
 
 # 3. Make sure VS is closed (a running devenv locks the extension DLL).
-$vsRunning = Get-Process devenv -ErrorAction SilentlyContinue
+$vsRunning = @(Get-Process devenv -ErrorAction SilentlyContinue)
 if ($vsRunning) {
-    Write-Error "Visual Studio is running (PIDs: $($vsRunning.Id -join ', ')). Close it and re-run."
+    # Report start times too: a devenv that started seconds ago is almost
+    # always a leftover from a previous /updateconfiguration on this machine
+    # (issue #1074), not a developer's open IDE. Knowing which it is turns a
+    # confusing CI failure into a one-line diagnosis.
+    $detail = ($vsRunning | ForEach-Object {
+        $started = try { $_.StartTime.ToString('u') } catch { 'unknown start time' }
+        "$($_.Id) (started $started)"
+    }) -join ', '
+    Write-Error "Visual Studio is running (PIDs: $detail). Close it and re-run."
     exit 1
 }
 
@@ -165,6 +195,7 @@ if ($installedFoldersArray.Count -eq 0) {
     Write-Host ("Installed v{0} at {1}" -f $m.PackageManifest.Metadata.Identity.Version, $folder.FullName)
 }
 
+$updateConfigTimedOut = $false
 if (-not $skipUpdateConfig) {
     Write-Host ""
     Write-Host "Running 'devenv /updateconfiguration' to force the menu/pkgdef merge synchronously."
@@ -172,13 +203,21 @@ if (-not $skipUpdateConfig) {
     Write-Host "and our menu entry never appears. This step blocks until the merge completes (~10-30s)."
     $devenv = Join-Path $installationPath 'Common7\IDE\devenv.exe'
     if (Test-Path -LiteralPath $devenv) {
-        $psi = New-Object System.Diagnostics.ProcessStartInfo
-        $psi.FileName = $devenv
-        $psi.Arguments = '/updateconfiguration'
-        $psi.UseShellExecute = $false
-        $proc = [System.Diagnostics.Process]::Start($psi)
-        if (-not $proc.WaitForExit(120000)) { $proc.Kill(); Write-Warning "/updateconfiguration timed out after 2 min." }
-        Write-Host ("  /updateconfiguration exit code: {0} ({1:0.0}s)" -f $proc.ExitCode, ($proc.ExitTime - $proc.StartTime).TotalSeconds)
+        $r = Invoke-DevenvUpdateConfiguration -DevenvPath $devenv -TimeoutSeconds $UpdateConfigurationTimeoutSec
+        if ($r.TimedOut) {
+            $updateConfigTimedOut = $true
+            Write-Warning ("/updateconfiguration timed out after {0}s and was terminated (tree kill). This is the known Visual Studio 18.8 hang - see issue #1074." -f $UpdateConfigurationTimeoutSec)
+            if ($r.KilledPids.Count -gt 0) {
+                Write-Warning ("  Reaped leftover devenv PIDs: {0}" -f ($r.KilledPids -join ', '))
+            }
+            if (-not $r.Drained) {
+                # The next invocation's "Visual Studio is running" guard will
+                # fail. Say so here rather than letting it look like a fresh bug.
+                Write-Warning "  A devenv process is still running after the sweep. Close it before re-running this script."
+            }
+        }
+        $exitText = if ($null -ne $r.ExitCode) { $r.ExitCode } else { 'unknown' }
+        Write-Host ("  /updateconfiguration exit code: {0} ({1:0.0}s)" -f $exitText, $r.DurationSeconds)
     } else {
         Write-Warning "devenv.exe not found at $devenv. Run /updateconfiguration manually before launching VS."
     }
@@ -187,3 +226,9 @@ if (-not $skipUpdateConfig) {
     Write-Host "  1. Launch Visual Studio (no special flags needed)."
     Write-Host "  2. View -> Other Windows -> Reactor Preview."
 }
+
+# See .OUTPUTS in the header for the exit-code contract. 3 means "the VSIX is
+# installed, but the pkgdef merge didn't finish" — callers warn instead of
+# claiming success, and instead of failing outright.
+if ($updateConfigTimedOut) { exit 3 }
+exit 0

--- a/src/vs-reactor/Reinstall-Vsix.ps1
+++ b/src/vs-reactor/Reinstall-Vsix.ps1
@@ -13,9 +13,10 @@
     Exit codes:
       0  VSIX installed and `devenv /updateconfiguration` completed.
       1  Install failed (build, vswhere, VSIXInstaller, or VS already running).
-      3  VSIX installed, but `devenv /updateconfiguration` did not complete —
-         it timed out and was terminated. The extension is usable; the menu
-         merge may need one manual VS launch.
+      3  VSIX installed, but `devenv /updateconfiguration` did not complete.
+         It timed out and was terminated, or it was skipped (duplicate
+         installs detected, or devenv.exe missing). The extension is usable;
+         the menu merge may need one manual VS launch.
 #>
 [CmdletBinding()]
 param(
@@ -24,7 +25,7 @@ param(
     [ValidateSet('Debug', 'Release')]
     [string]$Configuration = 'Debug',
     [string]$VsInstanceId,
-    [int]$UpdateConfigurationTimeoutSec = 120
+    [ValidateRange(1, 86400)][int]$UpdateConfigurationTimeoutSec = 120
 )
 
 $ErrorActionPreference = 'Stop'
@@ -195,7 +196,9 @@ if ($installedFoldersArray.Count -eq 0) {
     Write-Host ("Installed v{0} at {1}" -f $m.PackageManifest.Metadata.Identity.Version, $folder.FullName)
 }
 
-$updateConfigTimedOut = $false
+# Tracks whether the pkgdef merge actually ran to completion. Every path that
+# leaves it unfinished must set this, or the exit-code contract below lies.
+$updateConfigIncomplete = $skipUpdateConfig
 if (-not $skipUpdateConfig) {
     Write-Host ""
     Write-Host "Running 'devenv /updateconfiguration' to force the menu/pkgdef merge synchronously."
@@ -205,7 +208,7 @@ if (-not $skipUpdateConfig) {
     if (Test-Path -LiteralPath $devenv) {
         $r = Invoke-DevenvUpdateConfiguration -DevenvPath $devenv -TimeoutSeconds $UpdateConfigurationTimeoutSec
         if ($r.TimedOut) {
-            $updateConfigTimedOut = $true
+            $updateConfigIncomplete = $true
             Write-Warning ("/updateconfiguration timed out after {0}s and was terminated (tree kill). This is the known Visual Studio 18.8 hang - see issue #1074." -f $UpdateConfigurationTimeoutSec)
             if ($r.KilledPids.Count -gt 0) {
                 Write-Warning ("  Reaped leftover devenv PIDs: {0}" -f ($r.KilledPids -join ', '))
@@ -213,12 +216,18 @@ if (-not $skipUpdateConfig) {
             if (-not $r.Drained) {
                 # The next invocation's "Visual Studio is running" guard will
                 # fail. Say so here rather than letting it look like a fresh bug.
-                Write-Warning "  A devenv process is still running after the sweep. Close it before re-running this script."
+                Write-Warning "  A devenv we started is STILL running after the kill. Close it before re-running this script."
+            }
+            if ($r.ForeignPids.Count -gt 0) {
+                # Deliberately left alone - we only ever kill what we started,
+                # so this is almost certainly the developer's own IDE.
+                Write-Warning ("  Left running (not started by us): devenv PIDs {0}." -f ($r.ForeignPids -join ', '))
             }
         }
         $exitText = if ($null -ne $r.ExitCode) { $r.ExitCode } else { 'unknown' }
         Write-Host ("  /updateconfiguration exit code: {0} ({1:0.0}s)" -f $exitText, $r.DurationSeconds)
     } else {
+        $updateConfigIncomplete = $true
         Write-Warning "devenv.exe not found at $devenv. Run /updateconfiguration manually before launching VS."
     }
     Write-Host ""
@@ -229,6 +238,6 @@ if (-not $skipUpdateConfig) {
 
 # See .OUTPUTS in the header for the exit-code contract. 3 means "the VSIX is
 # installed, but the pkgdef merge didn't finish" — callers warn instead of
-# claiming success, and instead of failing outright.
-if ($updateConfigTimedOut) { exit 3 }
-exit 0
+# claiming success, and instead of failing outright. The mapping lives in
+# VsProcessLib.ps1 because bootstrap.ps1 and `mur upgrade` both branch on it.
+exit (Get-VsixReinstallExitCode -UpdateConfigIncomplete $updateConfigIncomplete)

--- a/src/vs-reactor/TESTING.md
+++ b/src/vs-reactor/TESTING.md
@@ -90,7 +90,7 @@ It exits with:
 | --- | --- |
 | `0` | VSIX installed and `devenv /updateconfiguration` completed. |
 | `1` | Install failed (build, `vswhere`, `VSIXInstaller`, or VS already running). |
-| `3` | VSIX installed, but `devenv /updateconfiguration` timed out and was terminated. The extension is usable; the menu merge may need one manual VS launch. |
+| `3` | VSIX installed, but `devenv /updateconfiguration` did not complete — it timed out and was terminated, or it was skipped (duplicate installs detected, or `devenv.exe` missing). The extension is usable; the menu merge may need one manual VS launch. |
 
 `bootstrap.ps1` and `mur upgrade` both treat `3` as a warning and carry on.
 
@@ -104,14 +104,21 @@ On VS **18.8** (`18.8.12023.21` and later in that band), `devenv /updateconfigur
 never returns — it does the work but does not exit. VS 18.7 completes the same
 call in 27–99 s. `Reinstall-Vsix.ps1` therefore treats the timeout as an expected
 outcome on 18.8: it waits `-UpdateConfigurationTimeoutSec` (default 120), then
-terminates the whole `devenv` process tree, sweeps any `devenv` that appeared
-during its window, waits for the name to clear, and exits `3`.
+terminates the `devenv` it launched **and that process's descendants**, waits for
+them to exit, and exits `3`.
 
-That sweep matters. `Process.Kill()` with no argument kills only the top process
-and returns without waiting, so the second `devenv` that `/updateconfiguration`
-spawns used to survive and make every later run of this script fail its
-"Visual Studio is running" guard (issue #1074). The logic lives in
-`VsProcessLib.ps1` and is covered by `tests/vs_reactor/ci/VsProcessLib.Tests.ps1`
+That descendant kill matters. `Process.Kill()` with no argument kills only the
+top process and returns without waiting, so the second `devenv` that
+`/updateconfiguration` spawns used to survive and make every later run of this
+script fail its "Visual Studio is running" guard (issue #1074).
+
+Only processes the script can prove are its own are ever terminated. Ownership
+comes from the `Win32_Process` parent chain, captured while the tree is still
+alive — Windows does not re-parent orphans, so once the root is killed that
+ancestry is unrecoverable. Any *other* `devenv` (your open IDE) is reported as
+`Left running (not started by us)` and deliberately untouched; matching on the
+process name instead would `/F`-kill a developer's IDE mid-edit. The logic lives
+in `VsProcessLib.ps1` and is covered by `tests/vs_reactor/ci/VsProcessLib.Tests.ps1`
 (run by the *VS extension script tests* workflow).
 
 If you see `Visual Studio is running (PIDs: ...)` on a machine where you have no

--- a/src/vs-reactor/TESTING.md
+++ b/src/vs-reactor/TESTING.md
@@ -84,9 +84,39 @@ VSIX silently into the highest-version VS instance reported by `vswhere`. Pass
 `-VsInstanceId <id>` to target a specific install. Skip `-SkipBuild` if the
 VSIX is already current.
 
+It exits with:
+
+| Code | Meaning |
+| --- | --- |
+| `0` | VSIX installed and `devenv /updateconfiguration` completed. |
+| `1` | Install failed (build, `vswhere`, `VSIXInstaller`, or VS already running). |
+| `3` | VSIX installed, but `devenv /updateconfiguration` timed out and was terminated. The extension is usable; the menu merge may need one manual VS launch. |
+
+`bootstrap.ps1` and `mur upgrade` both treat `3` as a warning and carry on.
+
 After it completes, launch VS once with `devenv /updateconfiguration` if the
 menu still does not appear — that forces a synchronous pkgdef merge before the
 shell starts.
+
+### `devenv /updateconfiguration` hangs on Visual Studio 18.8
+
+On VS **18.8** (`18.8.12023.21` and later in that band), `devenv /updateconfiguration`
+never returns — it does the work but does not exit. VS 18.7 completes the same
+call in 27–99 s. `Reinstall-Vsix.ps1` therefore treats the timeout as an expected
+outcome on 18.8: it waits `-UpdateConfigurationTimeoutSec` (default 120), then
+terminates the whole `devenv` process tree, sweeps any `devenv` that appeared
+during its window, waits for the name to clear, and exits `3`.
+
+That sweep matters. `Process.Kill()` with no argument kills only the top process
+and returns without waiting, so the second `devenv` that `/updateconfiguration`
+spawns used to survive and make every later run of this script fail its
+"Visual Studio is running" guard (issue #1074). The logic lives in
+`VsProcessLib.ps1` and is covered by `tests/vs_reactor/ci/VsProcessLib.Tests.ps1`
+(run by the *VS extension script tests* workflow).
+
+If you see `Visual Studio is running (PIDs: ...)` on a machine where you have no
+IDE open, check the reported start times: a process seconds old is a leftover
+from a hung `/updateconfiguration`, and killing it is safe.
 
 ### `NoApplicableSKUsException` on VS 2026
 

--- a/src/vs-reactor/VsProcessLib.ps1
+++ b/src/vs-reactor/VsProcessLib.ps1
@@ -35,6 +35,20 @@ function Get-ProcessIdsByName {
     return @(Get-Process -Name $Name -ErrorAction SilentlyContinue | ForEach-Object { $_.Id })
 }
 
+# Kill a process tree with `taskkill /T /F`. Split out from Stop-ProcessTreeSafely
+# so the Windows PowerShell 5.1 path can be tested directly: under pwsh the
+# reflection probe below always finds Kill([bool]), so this branch would
+# otherwise never execute in CI.
+function Stop-ProcessTreeViaTaskkill {
+    param([Parameter(Mandatory)][int]$Id)
+
+    & "$env:SystemRoot\System32\taskkill.exe" '/PID' $Id '/T' '/F' 2>&1 | Out-Null
+    # taskkill returns non-zero when the process is already gone. That is not an
+    # error here, and letting it linger would leak into the exit code of
+    # whichever script dot-sourced us — which is defect 3 of #1074.
+    $global:LASTEXITCODE = 0
+}
+
 # Terminate a process AND its descendants, then block until it is really gone.
 # Returns $true when the process exited within $WaitSeconds.
 function Stop-ProcessTreeSafely {
@@ -54,11 +68,7 @@ function Stop-ProcessTreeSafely {
         if ($killTree) {
             $killTree.Invoke($Process, @($true)) | Out-Null
         } else {
-            & "$env:SystemRoot\System32\taskkill.exe" '/PID' $Process.Id '/T' '/F' 2>&1 | Out-Null
-            # taskkill returns non-zero when the process is already gone. That
-            # is not an error here, and letting it linger would leak into the
-            # exit code of whichever script dot-sourced us.
-            $global:LASTEXITCODE = 0
+            Stop-ProcessTreeViaTaskkill -Id $Process.Id
         }
     } catch {
         # Raced with a natural exit, or access denied on a process owned by
@@ -68,84 +78,141 @@ function Stop-ProcessTreeSafely {
     try { return $Process.WaitForExit($WaitSeconds * 1000) } catch { return $true }
 }
 
-# Kill every process named $Name whose id is not in $ExcludePids, tree and all.
-# Returns the ids it killed.
+# Every descendant of $ParentId, to any depth, via the Win32_Process parent link.
 #
-# This is the belt to Stop-ProcessTreeSafely's braces: Kill($true) enumerates
-# descendants at kill time, so a grandchild that has already re-parented can be
-# missed. $ExcludePids carries the pre-start snapshot, so processes that were
-# running before we started are never touched.
-function Stop-NewProcessesByName {
+# MUST be called while the tree is still alive. Windows never re-parents an
+# orphan — when a parent dies, its children keep pointing at the now-dead pid —
+# so once the root is killed the ancestry is unrecoverable.
+#
+# Returns $null (not @()) when CIM is unavailable, so a caller can tell
+# "no descendants" apart from "could not tell".
+function Get-DescendantProcessIds {
+    param([Parameter(Mandatory)][int]$ParentId)
+
+    try {
+        $all = @(Get-CimInstance -ClassName Win32_Process -ErrorAction Stop |
+            Select-Object -Property ProcessId, ParentProcessId)
+    } catch {
+        return $null
+    }
+
+    $found = New-Object System.Collections.Generic.List[int]
+    $frontier = New-Object System.Collections.Generic.List[int]
+    $frontier.Add($ParentId) | Out-Null
+    while ($frontier.Count -gt 0) {
+        $current = $frontier[0]
+        $frontier.RemoveAt(0)
+        foreach ($p in $all) {
+            if ($p.ParentProcessId -ne $current) { continue }
+            $childId = [int]$p.ProcessId
+            if ($childId -eq $current -or $found.Contains($childId)) { continue }
+            $found.Add($childId) | Out-Null
+            $frontier.Add($childId) | Out-Null
+        }
+    }
+    # Bare array, not `,$array` — see Get-ProcessIdsByName. Callers wrap with @().
+    return $found.ToArray()
+}
+
+# Kill the given pids, tree and all. Returns the ids it actually killed.
+#
+# $RequireName guards against pid reuse: between the ancestry snapshot and the
+# kill, a pid we recorded may have exited and been handed to something
+# unrelated. Killing by pid alone would then terminate an innocent process.
+function Stop-ProcessIds {
     param(
-        [Parameter(Mandatory)][string]$Name,
-        [int[]]$ExcludePids = @(),
+        [int[]]$Ids = @(),
+        [string]$RequireName,
         [int]$WaitSeconds = 30
     )
 
     $killed = New-Object System.Collections.Generic.List[int]
-    foreach ($p in @(Get-Process -Name $Name -ErrorAction SilentlyContinue)) {
-        if ($ExcludePids -contains $p.Id) { continue }
-        $killed.Add($p.Id) | Out-Null
+    foreach ($id in $Ids) {
+        $p = Get-Process -Id $id -ErrorAction SilentlyContinue
+        if (-not $p) { continue }
+        if ($RequireName -and $p.Name -ne $RequireName) { continue }
+        $killed.Add($id) | Out-Null
         Stop-ProcessTreeSafely -Process $p -WaitSeconds $WaitSeconds | Out-Null
     }
     # Bare array, not `,$array` — see Get-ProcessIdsByName. Callers wrap with @().
     return $killed.ToArray()
 }
 
-# Poll until no process named $Name (excluding $ExcludePids) is left, or the
-# timeout elapses. Returns $true when the name is clear.
+# Poll until none of $Ids is running any more, or the timeout elapses.
+# Returns $true when they are all gone.
 #
 # This poll is the actual guarantee the caller needs: it is what makes it
 # impossible for the *next* Reinstall-Vsix.ps1 invocation to trip the
 # "Visual Studio is running" guard on a process this one started.
-function Wait-ProcessNameCleared {
+function Wait-ProcessIdsCleared {
     param(
-        [Parameter(Mandatory)][string]$Name,
-        [int[]]$ExcludePids = @(),
+        [int[]]$Ids = @(),
         [int]$TimeoutSeconds = 30
     )
 
     $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
     while ($true) {
-        $remaining = @(Get-Process -Name $Name -ErrorAction SilentlyContinue |
-            Where-Object { $ExcludePids -notcontains $_.Id })
-        if ($remaining.Count -eq 0) { return $true }
+        $alive = @($Ids | Where-Object { Get-Process -Id $_ -ErrorAction SilentlyContinue })
+        if ($alive.Count -eq 0) { return $true }
         if ([DateTime]::UtcNow -ge $deadline) { return $false }
         Start-Sleep -Milliseconds 250
     }
 }
 
+# The Reinstall-Vsix.ps1 exit-code contract, in one place because three parties
+# depend on it: Reinstall-Vsix.ps1 emits it, and bootstrap.ps1 and `mur upgrade`
+# (UpgradeCommand.cs) both branch on it.
+#
+#   0  VSIX installed and `devenv /updateconfiguration` completed.
+#   3  VSIX installed, but /updateconfiguration did not complete — it timed out,
+#      or was skipped (duplicate installs detected, or devenv.exe missing).
+#
+# Install failures exit 1 at their failure site and never reach here.
+function Get-VsixReinstallExitCode {
+    param([bool]$UpdateConfigIncomplete)
+
+    if ($UpdateConfigIncomplete) { return 3 }
+    return 0
+}
+
 <#
 .SYNOPSIS
     Run `devenv /updateconfiguration` with a hard timeout that leaves nothing
-    running behind it.
+    of ours running behind it.
 
 .OUTPUTS
     [pscustomobject] with:
       TimedOut        [bool]  the process did not exit within $TimeoutSeconds
       ExitCode        [int?]  exit code, or $null if it could not be read
       DurationSeconds [double] wall-clock time, measured with a Stopwatch
-      KilledPids      [int[]] ids reaped by the post-timeout sweep
-      Drained         [bool]  no $ProcessName process was left behind
+      KilledPids      [int[]] ids reaped after the timeout (the launched process
+                              and its descendants)
+      Drained         [bool]  nothing we started is still running
+      ForeignPids     [int[]] processes named $ProcessName that we did NOT start
+                              and deliberately left alone
 
 .NOTES
     DurationSeconds is deliberately measured with a Stopwatch rather than
     ($proc.ExitTime - $proc.StartTime): ExitTime on a process that has not
     exited returns the 1601 epoch, which is how #1074 came to log "-13430263500.8s".
+
+    Only processes we can prove are ours — the launched process and its
+    descendants, captured from the live ancestry before the kill — are ever
+    terminated. An earlier revision swept every same-named process outside a
+    pre-start snapshot; because Reinstall-Vsix.ps1 refuses to run while any
+    devenv is alive, that snapshot is virtually always empty, which made the
+    sweep a "kill every devenv" with /F. A developer who opened Visual Studio
+    during the timeout window would have lost unsaved work. Anything we cannot
+    attribute to ourselves is now reported in ForeignPids instead of killed.
 #>
 function Invoke-DevenvUpdateConfiguration {
     param(
         [Parameter(Mandatory)][string]$DevenvPath,
         [string]$Arguments = '/updateconfiguration',
-        [int]$TimeoutSeconds = 120,
+        [ValidateRange(1, 86400)][int]$TimeoutSeconds = 120,
         [string]$ProcessName = 'devenv',
-        [int]$DrainTimeoutSeconds = 30
+        [ValidateRange(1, 86400)][int]$DrainTimeoutSeconds = 30
     )
-
-    # Snapshot first. Reinstall-Vsix.ps1 refuses to run while any devenv is
-    # alive, so in practice this is empty — but if a developer launches VS
-    # mid-run we must not kill their IDE.
-    $preexisting = @(Get-ProcessIdsByName -Name $ProcessName)
 
     $psi = New-Object System.Diagnostics.ProcessStartInfo
     $psi.FileName = $DevenvPath
@@ -158,16 +225,27 @@ function Invoke-DevenvUpdateConfiguration {
     $exited = $proc.WaitForExit($TimeoutSeconds * 1000)
 
     $killed = @()
+    $ours = @($proc.Id)
     $drained = $true
     if (-not $exited) {
+        # Capture ancestry BEFORE killing anything — see Get-DescendantProcessIds.
+        # $null means CIM could not answer; treat that as "no extra ids" rather
+        # than falling back to a name sweep that could hit someone's IDE.
+        $descendants = Get-DescendantProcessIds -ParentId $proc.Id
+        if ($null -ne $descendants) { $ours = @($ours) + @($descendants) }
+
         Stop-ProcessTreeSafely -Process $proc -WaitSeconds $DrainTimeoutSeconds | Out-Null
-        $killed = @(Stop-NewProcessesByName -Name $ProcessName -ExcludePids $preexisting -WaitSeconds $DrainTimeoutSeconds)
-        $drained = Wait-ProcessNameCleared -Name $ProcessName -ExcludePids $preexisting -TimeoutSeconds $DrainTimeoutSeconds
+        $killed = @(Stop-ProcessIds -Ids @($ours) -RequireName $ProcessName -WaitSeconds $DrainTimeoutSeconds)
+        $drained = Wait-ProcessIdsCleared -Ids @($ours) -TimeoutSeconds $DrainTimeoutSeconds
     }
     $sw.Stop()
 
     $exitCode = $null
     try { if ($proc.HasExited) { $exitCode = $proc.ExitCode } } catch { $exitCode = $null }
+
+    # Same-named processes that are not ours. Reported, never killed: on a
+    # developer's machine this is their IDE.
+    $foreign = @(Get-ProcessIdsByName -Name $ProcessName | Where-Object { @($ours) -notcontains $_ })
 
     return [pscustomobject]@{
         TimedOut        = (-not $exited)
@@ -175,5 +253,6 @@ function Invoke-DevenvUpdateConfiguration {
         DurationSeconds = [Math]::Round($sw.Elapsed.TotalSeconds, 1)
         KilledPids      = @($killed)
         Drained         = $drained
+        ForeignPids     = @($foreign)
     }
 }

--- a/src/vs-reactor/VsProcessLib.ps1
+++ b/src/vs-reactor/VsProcessLib.ps1
@@ -1,0 +1,179 @@
+<#
+.SYNOPSIS
+    Process-tree helpers for the Reactor VSIX install scripts.
+
+.DESCRIPTION
+    Dot-sourced by Reinstall-Vsix.ps1. Exists as a separate file so the
+    timeout / kill / drain logic can be unit-tested headlessly against fake
+    processes without running a real VSIX install
+    (tests/vs_reactor/ci/VsProcessLib.Tests.ps1).
+
+    Why this exists (issue #1074): on Visual Studio 18.8,
+    `devenv /updateconfiguration` never returns. The original code hit its
+    2-minute timeout and called `$proc.Kill()` — which terminates *only* the
+    top process, not its children, and returns without waiting. The second
+    `devenv` that /updateconfiguration spawns survived, and every later
+    Reinstall-Vsix.ps1 run on that machine tripped the "Visual Studio is
+    running" guard and exited 1. It also read `$proc.ExitTime` on a process
+    that had not exited yet, which returns the 1601 epoch and printed a
+    duration of roughly -425 years.
+
+    COMPATIBILITY: these functions must stay Windows PowerShell 5.1 clean.
+    bootstrap.ps1 re-launches Reinstall-Vsix.ps1 with `(Get-Process -Id
+    $PID).Path`, and `mur upgrade` falls back to powershell.exe when pwsh is
+    absent. That rules out `Process.Kill([bool])` (.NET 5+) and
+    `ProcessStartInfo.ArgumentList` (.NET Core only) as unconditional calls —
+    see Stop-ProcessTreeSafely for the reflection probe + taskkill fallback.
+#>
+
+# Ids of every running process with the given name. Callers wrap with @() —
+# returning a bare array (rather than the `,$array` idiom) keeps the shape
+# predictable for 0, 1 and N matches.
+function Get-ProcessIdsByName {
+    param([Parameter(Mandatory)][string]$Name)
+
+    return @(Get-Process -Name $Name -ErrorAction SilentlyContinue | ForEach-Object { $_.Id })
+}
+
+# Terminate a process AND its descendants, then block until it is really gone.
+# Returns $true when the process exited within $WaitSeconds.
+function Stop-ProcessTreeSafely {
+    param(
+        [Parameter(Mandatory)][System.Diagnostics.Process]$Process,
+        [int]$WaitSeconds = 30
+    )
+
+    try { if ($Process.HasExited) { return $true } } catch { return $true }
+
+    # .NET 5+ (pwsh) has Kill($entireProcessTree). Windows PowerShell 5.1 runs
+    # on .NET Framework, which only has the single-process Kill() — the exact
+    # overload that caused #1074. Probe by reflection and fall back to
+    # `taskkill /T /F`, which walks the tree on every supported Windows.
+    $killTree = $Process.GetType().GetMethod('Kill', [type[]]@([bool]))
+    try {
+        if ($killTree) {
+            $killTree.Invoke($Process, @($true)) | Out-Null
+        } else {
+            & "$env:SystemRoot\System32\taskkill.exe" '/PID' $Process.Id '/T' '/F' 2>&1 | Out-Null
+            # taskkill returns non-zero when the process is already gone. That
+            # is not an error here, and letting it linger would leak into the
+            # exit code of whichever script dot-sourced us.
+            $global:LASTEXITCODE = 0
+        }
+    } catch {
+        # Raced with a natural exit, or access denied on a process owned by
+        # another user. Fall through to the wait, which reports the truth.
+    }
+
+    try { return $Process.WaitForExit($WaitSeconds * 1000) } catch { return $true }
+}
+
+# Kill every process named $Name whose id is not in $ExcludePids, tree and all.
+# Returns the ids it killed.
+#
+# This is the belt to Stop-ProcessTreeSafely's braces: Kill($true) enumerates
+# descendants at kill time, so a grandchild that has already re-parented can be
+# missed. $ExcludePids carries the pre-start snapshot, so processes that were
+# running before we started are never touched.
+function Stop-NewProcessesByName {
+    param(
+        [Parameter(Mandatory)][string]$Name,
+        [int[]]$ExcludePids = @(),
+        [int]$WaitSeconds = 30
+    )
+
+    $killed = New-Object System.Collections.Generic.List[int]
+    foreach ($p in @(Get-Process -Name $Name -ErrorAction SilentlyContinue)) {
+        if ($ExcludePids -contains $p.Id) { continue }
+        $killed.Add($p.Id) | Out-Null
+        Stop-ProcessTreeSafely -Process $p -WaitSeconds $WaitSeconds | Out-Null
+    }
+    # Bare array, not `,$array` — see Get-ProcessIdsByName. Callers wrap with @().
+    return $killed.ToArray()
+}
+
+# Poll until no process named $Name (excluding $ExcludePids) is left, or the
+# timeout elapses. Returns $true when the name is clear.
+#
+# This poll is the actual guarantee the caller needs: it is what makes it
+# impossible for the *next* Reinstall-Vsix.ps1 invocation to trip the
+# "Visual Studio is running" guard on a process this one started.
+function Wait-ProcessNameCleared {
+    param(
+        [Parameter(Mandatory)][string]$Name,
+        [int[]]$ExcludePids = @(),
+        [int]$TimeoutSeconds = 30
+    )
+
+    $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
+    while ($true) {
+        $remaining = @(Get-Process -Name $Name -ErrorAction SilentlyContinue |
+            Where-Object { $ExcludePids -notcontains $_.Id })
+        if ($remaining.Count -eq 0) { return $true }
+        if ([DateTime]::UtcNow -ge $deadline) { return $false }
+        Start-Sleep -Milliseconds 250
+    }
+}
+
+<#
+.SYNOPSIS
+    Run `devenv /updateconfiguration` with a hard timeout that leaves nothing
+    running behind it.
+
+.OUTPUTS
+    [pscustomobject] with:
+      TimedOut        [bool]  the process did not exit within $TimeoutSeconds
+      ExitCode        [int?]  exit code, or $null if it could not be read
+      DurationSeconds [double] wall-clock time, measured with a Stopwatch
+      KilledPids      [int[]] ids reaped by the post-timeout sweep
+      Drained         [bool]  no $ProcessName process was left behind
+
+.NOTES
+    DurationSeconds is deliberately measured with a Stopwatch rather than
+    ($proc.ExitTime - $proc.StartTime): ExitTime on a process that has not
+    exited returns the 1601 epoch, which is how #1074 came to log "-13430263500.8s".
+#>
+function Invoke-DevenvUpdateConfiguration {
+    param(
+        [Parameter(Mandatory)][string]$DevenvPath,
+        [string]$Arguments = '/updateconfiguration',
+        [int]$TimeoutSeconds = 120,
+        [string]$ProcessName = 'devenv',
+        [int]$DrainTimeoutSeconds = 30
+    )
+
+    # Snapshot first. Reinstall-Vsix.ps1 refuses to run while any devenv is
+    # alive, so in practice this is empty — but if a developer launches VS
+    # mid-run we must not kill their IDE.
+    $preexisting = @(Get-ProcessIdsByName -Name $ProcessName)
+
+    $psi = New-Object System.Diagnostics.ProcessStartInfo
+    $psi.FileName = $DevenvPath
+    # .Arguments (not .ArgumentList) — see the compatibility note in the file header.
+    $psi.Arguments = $Arguments
+    $psi.UseShellExecute = $false
+
+    $sw = [System.Diagnostics.Stopwatch]::StartNew()
+    $proc = [System.Diagnostics.Process]::Start($psi)
+    $exited = $proc.WaitForExit($TimeoutSeconds * 1000)
+
+    $killed = @()
+    $drained = $true
+    if (-not $exited) {
+        Stop-ProcessTreeSafely -Process $proc -WaitSeconds $DrainTimeoutSeconds | Out-Null
+        $killed = @(Stop-NewProcessesByName -Name $ProcessName -ExcludePids $preexisting -WaitSeconds $DrainTimeoutSeconds)
+        $drained = Wait-ProcessNameCleared -Name $ProcessName -ExcludePids $preexisting -TimeoutSeconds $DrainTimeoutSeconds
+    }
+    $sw.Stop()
+
+    $exitCode = $null
+    try { if ($proc.HasExited) { $exitCode = $proc.ExitCode } } catch { $exitCode = $null }
+
+    return [pscustomobject]@{
+        TimedOut        = (-not $exited)
+        ExitCode        = $exitCode
+        DurationSeconds = [Math]::Round($sw.Elapsed.TotalSeconds, 1)
+        KilledPids      = @($killed)
+        Drained         = $drained
+    }
+}

--- a/tests/vs_reactor/ci/BootstrapExitCode.Tests.ps1
+++ b/tests/vs_reactor/ci/BootstrapExitCode.Tests.ps1
@@ -153,14 +153,32 @@ try {
     }
 
     # -- 6. Reinstall-Vsix.ps1 exposes the documented exit codes. --
+    # The literal codes now live in Get-VsixReinstallExitCode (VsProcessLib.ps1)
+    # so bootstrap.ps1 and `mur upgrade` can't drift from the emitter; the 0/3
+    # mapping itself is asserted behaviourally in VsProcessLib.Tests.ps1 case 13.
+    # What must hold *here* is that the script's exit is actually driven by that
+    # helper rather than by an unconditional literal — a hard-coded `exit 0`
+    # would report success for a run whose pkgdef merge never happened.
     $reinstallAst = Get-Ast $reinstall
-    $exitCodes = @($reinstallAst.FindAll({
+    $exits = @($reinstallAst.FindAll({
         param($n) $n -is [System.Management.Automation.Language.ExitStatementAst]
     }, $true) | ForEach-Object {
         if ($null -ne $_.Pipeline) { $_.Pipeline.Extent.Text } else { '' }
     })
-    Assert-True ($exitCodes -contains '3') 'Reinstall-Vsix.ps1: signals the /updateconfiguration timeout with `exit 3`'
-    Assert-True ($exitCodes -contains '0') 'Reinstall-Vsix.ps1: signals full success with an explicit `exit 0`'
+    $contractExits = @($exits | Where-Object { $_ -match 'Get-VsixReinstallExitCode' })
+    Assert-True (@($contractExits).Count -ge 1) 'Reinstall-Vsix.ps1: its exit code is produced by Get-VsixReinstallExitCode'
+
+    # Every path that leaves the pkgdef merge unfinished must feed that helper.
+    # Regression guard for the two paths that used to fall through to a bare
+    # `exit 0` while the .OUTPUTS table claimed /updateconfiguration had run:
+    # duplicate installs, and a missing devenv.exe.
+    $reinstallText = Get-Content -LiteralPath $reinstall -Raw
+    $incompleteWrites = @([regex]::Matches($reinstallText, '\$updateConfigIncomplete\s*=')).Count
+    Assert-True ($incompleteWrites -ge 3) `
+        "Reinstall-Vsix.ps1: all three incomplete-merge paths set `$updateConfigIncomplete (found $incompleteWrites, expected >= 3)"
+
+    # The install-failure code is still a plain literal and must stay reachable.
+    Assert-True ($exits -contains '1') 'Reinstall-Vsix.ps1: install failures still exit 1'
 
     # bootstrap.ps1 must actually branch on 3 rather than lumping it into the
     # generic failure warning — otherwise it prints `[ok] VS extension installed`

--- a/tests/vs_reactor/ci/BootstrapExitCode.Tests.ps1
+++ b/tests/vs_reactor/ci/BootstrapExitCode.Tests.ps1
@@ -1,0 +1,183 @@
+<#
+.SYNOPSIS
+    Contract tests for the bootstrap.ps1 / Reinstall-Vsix.ps1 exit-code
+    handshake (issue #1074).
+
+.DESCRIPTION
+    Headless: no build, no dotnet, no Visual Studio. Wired into
+    .github/workflows/vs-reactor-lib-tests.yml. Exits non-zero on any failed
+    assertion.
+
+    Two kinds of check live here.
+
+    (a) Behavioural. `Write-Host` does not clear $LASTEXITCODE, and bootstrap.yml
+        runs `./bootstrap.ps1` *in-process* before checking $LASTEXITCODE on the
+        next line. $LASTEXITCODE is a global, so a non-zero code from the VSIX
+        child survived to the workflow's `if ($LASTEXITCODE -ne 0) { throw }` —
+        the actual CI failure in #1074. Cases 2/3 reproduce that mechanism with
+        throwaway scripts and prove which parts of the fix stop it. The `leaky`
+        variant is the positive control: if it ever reads 0, the other two
+        assertions are measuring nothing.
+
+    (b) Structural. Whether bootstrap.ps1 *itself* applies that pattern cannot be
+        observed without running a full bootstrap (dotnet builds, winget, VS), so
+        cases 4-6 assert it over the parsed AST instead. These are deliberately
+        shape assertions — here the shape *is* the fix — and each one reddens if
+        the corresponding line is deleted.
+
+    Run locally:  pwsh tests/vs_reactor/ci/BootstrapExitCode.Tests.ps1
+#>
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$script:Pass = 0
+$script:Fail = 0
+$script:Failures = [System.Collections.Generic.List[string]]::new()
+
+function Assert-Equal {
+    param($Expected, $Actual, [string]$Message)
+    if ($Expected -eq $Actual) { $script:Pass++ }
+    else { $script:Fail++; $script:Failures.Add("$Message`n    expected: [$Expected]`n    actual:   [$Actual]") }
+}
+function Assert-True {
+    param([bool]$Condition, [string]$Message)
+    if ($Condition) { $script:Pass++ }
+    else { $script:Fail++; $script:Failures.Add($Message) }
+}
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..' '..')).Path
+$bootstrap = Join-Path $repoRoot 'bootstrap.ps1'
+$reinstall = Join-Path $repoRoot 'src\vs-reactor\Reinstall-Vsix.ps1'
+
+function Get-Ast {
+    param([string]$Path)
+    $parseErrors = $null
+    $ast = [System.Management.Automation.Language.Parser]::ParseInput(
+        (Get-Content -LiteralPath $Path -Raw), [ref]$null, [ref]$parseErrors)
+    if ($parseErrors -and $parseErrors.Count -gt 0) {
+        Write-Host "$(Split-Path $Path -Leaf) has $($parseErrors.Count) parse error(s):" -ForegroundColor Red
+        $parseErrors | ForEach-Object { Write-Host "  line $($_.Extent.StartLineNumber): $($_.Message)" -ForegroundColor Red }
+        exit 1
+    }
+    return $ast
+}
+
+$tmp = Join-Path ([System.IO.Path]::GetTempPath()) ("bootstrap-exit-" + [Guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Path $tmp | Out-Null
+$noBom = [System.Text.UTF8Encoding]::new($false)
+
+try {
+    # -- 1. Both scripts parse. --
+    $bootstrapAst = Get-Ast $bootstrap
+    Get-Ast $reinstall | Out-Null
+    $script:Pass += 2
+
+    # -- 2/3. Positive control + fix, modelled on how bootstrap.yml calls us. --
+    # The workflow runs `./bootstrap.ps1` *in-process* and then checks
+    # $LASTEXITCODE on the next line. $LASTEXITCODE is a global, so a non-zero
+    # code set by a child inside bootstrap.ps1 is still there when the step
+    # inspects it — that is the #1074 mechanism, and it is why `pwsh -File`
+    # (which returns 0 on fall-through) does not reproduce it.
+    $pwshPath = (Get-Process -Id $PID).Path
+    $child = Join-Path $tmp 'child.ps1'
+    [System.IO.File]::WriteAllText($child, "exit 7`n", $noBom)
+
+    $callChild = "& '$pwshPath' -NoLogo -NoProfile -File '$child'`n" +
+                 "Write-Host ('    [warn] child failed ({0}); continuing anyway.' -f `$LASTEXITCODE)`n"
+
+    $variants = @{
+        # Pre-fix shape: warn via Write-Host, fall off the end.
+        'leaky' = $callChild + "Write-Host 'Bootstrap complete.'`n"
+        # Half the fix: reset the global, fall off the end.
+        'reset' = $callChild + "`$global:LASTEXITCODE = 0`nWrite-Host 'Bootstrap complete.'`n"
+        # Full fix as shipped: reset the global *and* exit 0 explicitly.
+        'fixed' = $callChild + "`$global:LASTEXITCODE = 0`nWrite-Host 'Bootstrap complete.'`nexit 0`n"
+    }
+    $driverLines = New-Object System.Collections.Generic.List[string]
+    foreach ($name in @('leaky', 'reset', 'fixed')) {
+        $path = Join-Path $tmp "$name.ps1"
+        [System.IO.File]::WriteAllText($path, $variants[$name], $noBom)
+        $driverLines.Add("& '$path' | Out-Null") | Out-Null
+        $driverLines.Add("Write-Output ('$name=' + `$LASTEXITCODE)") | Out-Null
+    }
+    $driver = Join-Path $tmp 'driver.ps1'
+    [System.IO.File]::WriteAllText($driver, ($driverLines -join "`n") + "`n", $noBom)
+
+    $observed = @{}
+    foreach ($line in @(& $pwshPath -NoLogo -NoProfile -File $driver)) {
+        if ($line -match '^(\w+)=(\d+)$') { $observed[$Matches[1]] = [int]$Matches[2] }
+    }
+
+    # Positive control: without the fix the code really does leak. If this ever
+    # reads 0, the two assertions below are measuring nothing.
+    Assert-Equal 7 $observed['leaky'] 'positive control: Write-Host alone does NOT clear a leaked child exit code'
+    Assert-Equal 0 $observed['reset'] 'fix: $global:LASTEXITCODE = 0 clears the leaked code'
+    Assert-Equal 0 $observed['fixed'] 'fix: reset + trailing exit 0 yields a clean exit'
+
+    # -- 4. bootstrap.ps1 ends with an explicit `exit 0`. --
+    $endBlock = $bootstrapAst.EndBlock
+    $lastStatement = $endBlock.Statements[$endBlock.Statements.Count - 1]
+    Assert-True ($lastStatement -is [System.Management.Automation.Language.ExitStatementAst]) `
+        "bootstrap.ps1: final statement is an exit statement (found: $($lastStatement.GetType().Name))"
+    if ($lastStatement -is [System.Management.Automation.Language.ExitStatementAst]) {
+        Assert-Equal '0' $lastStatement.Pipeline.Extent.Text 'bootstrap.ps1: final statement is `exit 0`'
+    } else {
+        $script:Fail++; $script:Failures.Add('bootstrap.ps1: final statement is `exit 0`')
+    }
+
+    # -- 5. The VS-extension branch resets $LASTEXITCODE. --
+    # Scope the search to the VSIX call site so an unrelated reset elsewhere in
+    # the script cannot satisfy this.
+    $reinstallCall = $bootstrapAst.FindAll({
+        param($n)
+        $n -is [System.Management.Automation.Language.CommandAst] -and
+        $n.Extent.Text -match '-File \$reinstall'
+    }, $true)
+    Assert-Equal 1 @($reinstallCall).Count 'bootstrap.ps1: found the Reinstall-Vsix.ps1 call site'
+
+    if (@($reinstallCall).Count -eq 1) {
+        $callLine = $reinstallCall[0].Extent.StartLineNumber
+        # The handling block sits immediately after the call; 40 lines is ample
+        # and keeps a distant reset from counting.
+        $resets = $bootstrapAst.FindAll({
+            param($n)
+            $n -is [System.Management.Automation.Language.AssignmentStatementAst] -and
+            $n.Left.Extent.Text -eq '$global:LASTEXITCODE' -and
+            $n.Right.Extent.Text -eq '0'
+        }, $true) | Where-Object {
+            $_.Extent.StartLineNumber -gt $callLine -and
+            $_.Extent.StartLineNumber -le ($callLine + 40)
+        }
+        Assert-True (@($resets).Count -ge 1) `
+            "bootstrap.ps1: the VS-extension branch resets `$global:LASTEXITCODE (searched lines $($callLine + 1)-$($callLine + 40))"
+    }
+
+    # -- 6. Reinstall-Vsix.ps1 exposes the documented exit codes. --
+    $reinstallAst = Get-Ast $reinstall
+    $exitCodes = @($reinstallAst.FindAll({
+        param($n) $n -is [System.Management.Automation.Language.ExitStatementAst]
+    }, $true) | ForEach-Object {
+        if ($null -ne $_.Pipeline) { $_.Pipeline.Extent.Text } else { '' }
+    })
+    Assert-True ($exitCodes -contains '3') 'Reinstall-Vsix.ps1: signals the /updateconfiguration timeout with `exit 3`'
+    Assert-True ($exitCodes -contains '0') 'Reinstall-Vsix.ps1: signals full success with an explicit `exit 0`'
+
+    # bootstrap.ps1 must actually branch on 3 rather than lumping it into the
+    # generic failure warning — otherwise it prints `[ok] VS extension installed`
+    # for a run whose pkgdef merge never happened.
+    $bootstrapText = Get-Content -LiteralPath $bootstrap -Raw
+    Assert-True ($bootstrapText -match '\$vsixExit -eq 3') 'bootstrap.ps1: special-cases Reinstall-Vsix.ps1 exit code 3'
+}
+finally {
+    Remove-Item $tmp -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+# -- Report --
+Write-Host ""
+Write-Host "Bootstrap exit-code tests: $script:Pass passed, $script:Fail failed"
+if ($script:Fail -gt 0) {
+    Write-Host ""
+    $script:Failures | ForEach-Object { Write-Host "FAIL: $_" -ForegroundColor Red }
+    exit 1
+}
+exit 0

--- a/tests/vs_reactor/ci/README.md
+++ b/tests/vs_reactor/ci/README.md
@@ -1,0 +1,84 @@
+# VS extension script tests
+
+Headless, dependency-free PowerShell tests for the scripts that install the
+Reactor Preview VSIX. No build, no `dotnet`, no Visual Studio — the "devenv"
+under test is a renamed copy of `cmd.exe`.
+
+These guard [issue #1074](https://github.com/microsoft/microsoft-ui-reactor/issues/1074):
+on Visual Studio 18.8 `devenv /updateconfiguration` never returns, and three
+defects in our own scripts turned that upstream hang into a red
+`bootstrap.ps1` CI job.
+
+| Defect | Symptom | Guarded by |
+|---|---|---|
+| `Process.Kill()` (no argument) killed only the top `devenv` and returned without waiting | An orphaned `devenv` tripped the next run's "Visual Studio is running" guard | `VsProcessLib.Tests.ps1` cases 3, 5 |
+| Duration read from `ExitTime` on a live process | Logged `-13430263500.8s` (≈ −425 years) | `VsProcessLib.Tests.ps1` case 5 (bounds check — see the limit below) |
+| `Write-Host` doesn't clear `$LASTEXITCODE` | The VSIX child's `1` leaked into `bootstrap.yml`'s `if ($LASTEXITCODE -ne 0) { throw }` | `BootstrapExitCode.Tests.ps1` cases 2–3 |
+
+## Files
+
+| File | Role |
+|---|---|
+| `VsProcessLib.Tests.ps1` | Behavioural tests for `src/vs-reactor/VsProcessLib.ps1` — timeout, process-tree kill, ownership attribution, drain, and the exit-code mapping. Spawns real hanging process trees. |
+| `BootstrapExitCode.Tests.ps1` | Reproduces the `$LASTEXITCODE` leak in-process, then asserts the structural contract between `bootstrap.ps1`, `Reinstall-Vsix.ps1`, and `mur upgrade`. |
+
+Both scripts exit non-zero on any failed assertion and skip cleanly on
+non-Windows.
+
+## Running locally
+
+```powershell
+pwsh tests/vs_reactor/ci/VsProcessLib.Tests.ps1
+pwsh tests/vs_reactor/ci/BootstrapExitCode.Tests.ps1
+```
+
+Each takes well under a minute. They spawn processes named
+`reactor-fake-devenv` and clean them up in a `finally` block; a deliberately
+distinct name keeps them from ever targeting `pwsh` or a real `devenv`.
+
+## Workflow
+
+| Workflow | Trigger | Runner |
+|---|---|---|
+| `.github/workflows/vs-reactor-lib-tests.yml` | `push` / `pull_request` touching `bootstrap.ps1`, `src/vs-reactor/{VsProcessLib,Reinstall-Vsix}.ps1`, `tests/vs_reactor/ci/**`, or the workflow itself | `windows-latest` |
+
+`windows-latest` rather than the cheaper `ubuntu-latest` used by the sibling
+`*-lib-tests` workflows, because every behaviour under test — process-tree
+kill, `taskkill`, `Win32_Process` ancestry, `Get-Process` by name — is
+Windows-specific.
+
+## Why the tests spawn real processes
+
+A mock can't reproduce the defect. `Kill()` vs `Kill($true)` differ only in
+what happens to a *real* child process, so the fake is a copy of `cmd.exe`
+renamed `reactor-fake-devenv.exe`, launched as
+`/c "<fake>" /c ping -n 600 127.0.0.1`. That builds a genuine two-level,
+same-named, hanging tree. Case 2 is the positive control: it asserts the
+harness really produced ≥ 2 processes, because if it only ever made one, every
+"tree" assertion below it would be satisfiable by a single-process kill and
+would prove nothing.
+
+## Ownership attribution
+
+The riskiest thing these scripts do is kill a process called `devenv` — which
+is also the name of the developer's IDE. Ownership is therefore established
+from the `Win32_Process` parent chain, captured **while the tree is still
+alive** (Windows does not re-parent orphans, so after the root dies the
+ancestry is unrecoverable). Anything not attributable to us is reported in
+`ForeignPids` and left alone.
+
+Case 8 asserts this end-to-end through `Invoke-DevenvUpdateConfiguration`, not
+just against the helpers. That distinction is load-bearing: an earlier revision
+of these tests exercised the helpers directly, and swapping the ancestry lookup
+for a name match left the whole suite green while the product would have
+`/F`-killed an open IDE.
+
+## Known limit, stated rather than papered over
+
+The `-425 years` duration is a race on reading `Process.ExitTime` before the OS
+reaps a *heavy* process. A `cmd.exe` fake dies sub-millisecond, so the race
+never opens and swapping the `Stopwatch` back for `ExitTime - StartTime` does
+**not** redden this suite. The Stopwatch is kept because it cannot be wrong,
+but the duration assertion in case 5 is a bounds check on the symptom, not a
+discriminator between the two implementations. The orphan, attribution, and
+exit-code assertions **are** mutation-verified.

--- a/tests/vs_reactor/ci/VsProcessLib.Tests.ps1
+++ b/tests/vs_reactor/ci/VsProcessLib.Tests.ps1
@@ -1,0 +1,224 @@
+<#
+.SYNOPSIS
+    Dependency-free tests for src/vs-reactor/VsProcessLib.ps1 — the process-tree
+    timeout/kill/drain helpers behind `devenv /updateconfiguration`.
+
+.DESCRIPTION
+    Windows-only and headless: no build, no dotnet, no Visual Studio. Wired into
+    .github/workflows/vs-reactor-lib-tests.yml. Exits non-zero on any failed
+    assertion.
+
+    The fake "devenv" is a copy of cmd.exe renamed to reactor-fake-devenv.exe,
+    launched as `/c "<fake>" /c ping -n 600 127.0.0.1`. That produces a real
+    two-level, same-named, genuinely-hanging process tree, which is what makes
+    these assertions non-vacuous: mutation-checked against the shipped pre-fix
+    implementation (`$proc.Kill()`, no argument, no wait) the inner
+    reactor-fake-devenv.exe survives and the tree assertions redden.
+
+    Known limit, stated rather than papered over: the "-425 years" duration in
+    the issue is a race on reading Process.ExitTime before the OS reaps a heavy
+    process. A cmd.exe fake dies too fast to reproduce it, so the duration
+    assertion here is a bounds check on the symptom, not a discriminator
+    between a Stopwatch and a correctly-sequenced ExitTime read. See case 4.
+
+    A distinctly-named fake also keeps the sweep tests safe — Stop-NewProcessesByName
+    is never pointed at `pwsh`, so an exclude-list regression cannot take out the
+    test host.
+
+    Run locally:  pwsh tests/vs_reactor/ci/VsProcessLib.Tests.ps1
+#>
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+if (-not $IsWindows) {
+    Write-Host "VsProcessLib tests: skipped (Windows-only process semantics)."
+    exit 0
+}
+
+$script:Pass = 0
+$script:Fail = 0
+$script:Failures = [System.Collections.Generic.List[string]]::new()
+
+function Assert-Equal {
+    param($Expected, $Actual, [string]$Message)
+    if ($Expected -eq $Actual) { $script:Pass++ }
+    else { $script:Fail++; $script:Failures.Add("$Message`n    expected: [$Expected]`n    actual:   [$Actual]") }
+}
+function Assert-True {
+    param([bool]$Condition, [string]$Message)
+    if ($Condition) { $script:Pass++ }
+    else { $script:Fail++; $script:Failures.Add($Message) }
+}
+function Assert-InRange {
+    param([double]$Value, [double]$Min, [double]$Max, [string]$Message)
+    if ($Value -ge $Min -and $Value -le $Max) { $script:Pass++ }
+    else { $script:Fail++; $script:Failures.Add("$Message`n    expected: [$Min..$Max]`n    actual:   [$Value]") }
+}
+
+$vsReactor = (Resolve-Path (Join-Path $PSScriptRoot '..' '..' '..' 'src' 'vs-reactor')).Path
+$libPath = Join-Path $vsReactor 'VsProcessLib.ps1'
+
+# -- 1. Parse-check the lib and the script that dot-sources it. --
+foreach ($p in @($libPath, (Join-Path $vsReactor 'Reinstall-Vsix.ps1'))) {
+    $parseErrors = $null
+    [System.Management.Automation.Language.Parser]::ParseInput(
+        (Get-Content $p -Raw), [ref]$null, [ref]$parseErrors) | Out-Null
+    if ($parseErrors -and $parseErrors.Count -gt 0) {
+        Write-Host "$(Split-Path $p -Leaf) has $($parseErrors.Count) parse error(s):" -ForegroundColor Red
+        $parseErrors | ForEach-Object { Write-Host "  line $($_.Extent.StartLineNumber): $($_.Message)" -ForegroundColor Red }
+        exit 1
+    }
+}
+
+. $libPath
+
+# -- Fake-process harness. --
+$fakeName = 'reactor-fake-devenv'
+$tmp = Join-Path ([System.IO.Path]::GetTempPath()) ("vsprocesslib-" + [Guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Path $tmp | Out-Null
+$fakeExe = Join-Path $tmp "$fakeName.exe"
+# cmd.exe has no sidecar dependencies, so a renamed copy runs standalone and
+# gives us a process with a name we fully control.
+Copy-Item "$env:SystemRoot\System32\cmd.exe" $fakeExe
+
+# Outer fake spawns an inner fake, which spawns ping. `>nul` on the outer
+# command line suppresses the whole tree's output.
+$hangArgs  = '/c "' + $fakeExe + '" /c ping -n 600 127.0.0.1 >nul'
+$quickArgs = '/c exit 0'
+
+function Get-FakeCount {
+    @(Get-Process -Name $fakeName -ErrorAction SilentlyContinue).Count
+}
+
+function Start-Fake {
+    param([string]$Arguments)
+    $psi = New-Object System.Diagnostics.ProcessStartInfo
+    $psi.FileName = $fakeExe
+    $psi.Arguments = $Arguments
+    $psi.UseShellExecute = $false
+    [System.Diagnostics.Process]::Start($psi)
+}
+
+function Wait-ForFakeCount {
+    param([int]$AtLeast, [int]$TimeoutSeconds = 15)
+    $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
+    while ((Get-FakeCount) -lt $AtLeast -and [DateTime]::UtcNow -lt $deadline) {
+        Start-Sleep -Milliseconds 200
+    }
+    Get-FakeCount
+}
+
+function Remove-AllFakes {
+    foreach ($p in @(Get-Process -Name $fakeName -ErrorAction SilentlyContinue)) {
+        try { $p.Kill() } catch { }
+    }
+}
+
+try {
+    # -- 2. The harness itself really does build a multi-process tree. --
+    # Positive control: if this were 1, every "tree" assertion below would be
+    # satisfiable by a single-process kill and would prove nothing.
+    $p = Start-Fake -Arguments $hangArgs
+    $count = Wait-ForFakeCount -AtLeast 2
+    Assert-True ($count -ge 2) "harness: fake devenv spawns a real tree (saw $count '$fakeName' processes, expected >= 2)"
+    try { $p.Kill() } catch { }
+    Remove-AllFakes
+    Assert-True (Wait-ProcessNameCleared -Name $fakeName -TimeoutSeconds 15) 'harness: fakes are cleaned up between cases'
+
+    # -- 3. Stop-ProcessTreeSafely reaps descendants, not just the root. --
+    # This is the #1074 fix. Against `$proc.Kill()` the inner fake survives.
+    $p = Start-Fake -Arguments $hangArgs
+    Wait-ForFakeCount -AtLeast 2 | Out-Null
+    $exited = Stop-ProcessTreeSafely -Process $p -WaitSeconds 20
+    Assert-True $exited 'Stop-ProcessTreeSafely: root process exited within the wait'
+    Assert-True (Wait-ProcessNameCleared -Name $fakeName -TimeoutSeconds 20) 'Stop-ProcessTreeSafely: no descendant is left running'
+    Assert-Equal 0 (Get-FakeCount) 'Stop-ProcessTreeSafely: process name is fully clear'
+    # Explicit teardown so a failure here is attributed to this case rather than
+    # cascading into the next one's counts.
+    Remove-AllFakes
+    Wait-ProcessNameCleared -Name $fakeName -TimeoutSeconds 20 | Out-Null
+
+    # -- 4. Timeout path: nothing survives, duration is a real measurement. --
+    $timeout = 4
+    $r = Invoke-DevenvUpdateConfiguration -DevenvPath $fakeExe -Arguments $hangArgs `
+        -TimeoutSeconds $timeout -ProcessName $fakeName -DrainTimeoutSeconds 20
+    Assert-True $r.TimedOut 'timeout: TimedOut is reported'
+    Assert-True $r.Drained  'timeout: Drained is reported true (name cleared)'
+    Assert-Equal 0 (Get-FakeCount) 'timeout: no fake devenv survives the call'
+    # The pre-fix instrument read ExitTime on a process that had not been reaped
+    # yet, which returns the 1601 epoch and printed "-13430263500.8s". This
+    # bounds check catches that class of nonsense. It does NOT distinguish a
+    # Stopwatch from a *correctly sequenced* ExitTime-StartTime read, because
+    # once we wait for the kill to complete the two agree — verified by
+    # mutation: swapping the Stopwatch back for ExitTime-StartTime does not
+    # redden this suite, whereas removing the tree kill reddens it immediately.
+    # The Stopwatch is kept because it cannot be wrong; the assertion below is
+    # honest about guarding the symptom, not the implementation choice.
+    Assert-InRange $r.DurationSeconds $timeout ($timeout + 30) 'timeout: DurationSeconds is a plausible wall-clock measurement'
+    # ExitCode must be readable, i.e. we waited for the kill to complete rather
+    # than racing it.
+    Assert-True ($null -ne $r.ExitCode) 'timeout: ExitCode is defined after the tree kill'
+
+    # -- 5. Happy path is untouched (guards the VS 18.7 flow). --
+    $r = Invoke-DevenvUpdateConfiguration -DevenvPath $fakeExe -Arguments $quickArgs `
+        -TimeoutSeconds 30 -ProcessName $fakeName -DrainTimeoutSeconds 10
+    Assert-Equal $false $r.TimedOut 'happy path: TimedOut is false when the process exits on its own'
+    Assert-Equal 0 $r.ExitCode 'happy path: real exit code is surfaced'
+    Assert-Equal 0 $r.KilledPids.Count 'happy path: nothing is killed'
+    Assert-InRange $r.DurationSeconds 0 30 'happy path: DurationSeconds is non-negative and bounded'
+
+    # -- 6. The sweep spares pre-existing processes. --
+    # A developer who opens VS mid-run must not have their IDE killed; the
+    # pre-start snapshot is what protects them.
+    $pre = Start-Fake -Arguments $hangArgs
+    # Wait for the *whole* pre-existing tree before snapshotting: if the inner
+    # process were missed by the snapshot the sweep would kill it, the outer
+    # would exit with it, and "excluded process is still alive" would flake.
+    Wait-ForFakeCount -AtLeast 2 | Out-Null
+    $preIds = @(Get-Process -Name $fakeName -ErrorAction SilentlyContinue | ForEach-Object { $_.Id })
+    $new = Start-Fake -Arguments $hangArgs
+    Wait-ForFakeCount -AtLeast ($preIds.Count + 1) | Out-Null
+
+    $killed = @(Stop-NewProcessesByName -Name $fakeName -ExcludePids $preIds -WaitSeconds 20)
+    Assert-True ($killed -contains $new.Id) "sweep: kills the process started after the snapshot (pid $($new.Id))"
+    Assert-True ($killed -notcontains $pre.Id) "sweep: does not kill the excluded pre-existing process (pid $($pre.Id))"
+    $pre.Refresh()
+    Assert-Equal $false $pre.HasExited 'sweep: the excluded process is still alive'
+    Assert-True $new.HasExited 'sweep: the swept process is gone'
+
+    Remove-AllFakes
+    Assert-True (Wait-ProcessNameCleared -Name $fakeName -TimeoutSeconds 20) 'sweep: teardown clears the name'
+
+    # -- 7. Wait-ProcessNameCleared reports failure rather than lying. --
+    # Without a truthful negative, a false "drained" would let the next run trip
+    # the guard with no explanation.
+    $stubborn = Start-Fake -Arguments $hangArgs
+    Wait-ForFakeCount -AtLeast 1 | Out-Null
+    Assert-Equal $false (Wait-ProcessNameCleared -Name $fakeName -TimeoutSeconds 2) 'Wait-ProcessNameCleared: returns false while a process is still running'
+    Remove-AllFakes
+    Assert-True (Wait-ProcessNameCleared -Name $fakeName -TimeoutSeconds 20) 'Wait-ProcessNameCleared: returns true once the name is clear'
+
+    # -- 8. Stop-ProcessTreeSafely does not leak $LASTEXITCODE. --
+    # The 5.1 path shells out to taskkill, whose non-zero "not found" status
+    # would otherwise ride out to the caller's exit code (the #1074 defect class).
+    $done = Start-Fake -Arguments $quickArgs
+    $done.WaitForExit(10000) | Out-Null
+    $global:LASTEXITCODE = 0
+    Stop-ProcessTreeSafely -Process $done -WaitSeconds 5 | Out-Null
+    Assert-Equal 0 $LASTEXITCODE 'Stop-ProcessTreeSafely: leaves $LASTEXITCODE at 0'
+}
+finally {
+    Remove-AllFakes
+    Wait-ProcessNameCleared -Name $fakeName -TimeoutSeconds 20 | Out-Null
+    Remove-Item $tmp -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+# -- Report --
+Write-Host ""
+Write-Host "VsProcessLib tests: $script:Pass passed, $script:Fail failed"
+if ($script:Fail -gt 0) {
+    Write-Host ""
+    $script:Failures | ForEach-Object { Write-Host "FAIL: $_" -ForegroundColor Red }
+    exit 1
+}
+exit 0

--- a/tests/vs_reactor/ci/VsProcessLib.Tests.ps1
+++ b/tests/vs_reactor/ci/VsProcessLib.Tests.ps1
@@ -19,11 +19,10 @@
     the issue is a race on reading Process.ExitTime before the OS reaps a heavy
     process. A cmd.exe fake dies too fast to reproduce it, so the duration
     assertion here is a bounds check on the symptom, not a discriminator
-    between a Stopwatch and a correctly-sequenced ExitTime read. See case 4.
+    between a Stopwatch and a correctly-sequenced ExitTime read. See case 5.
 
-    A distinctly-named fake also keeps the sweep tests safe — Stop-NewProcessesByName
-    is never pointed at `pwsh`, so an exclude-list regression cannot take out the
-    test host.
+    A distinctly-named fake also keeps these tests safe: nothing here is ever
+    pointed at `pwsh`, so an attribution regression cannot take out the test host.
 
     Run locally:  pwsh tests/vs_reactor/ci/VsProcessLib.Tests.ps1
 #>
@@ -86,8 +85,18 @@ Copy-Item "$env:SystemRoot\System32\cmd.exe" $fakeExe
 $hangArgs  = '/c "' + $fakeExe + '" /c ping -n 600 127.0.0.1 >nul'
 $quickArgs = '/c exit 0'
 
+# Pings that already existed before this run. Teardown asserts we add no
+# permanent ones — an earlier revision killed only $fakeName and leaked the
+# grandchild ping on every case.
+$script:PreExistingPings = @(Get-Process -Name 'PING' -ErrorAction SilentlyContinue | ForEach-Object { $_.Id })
+
 function Get-FakeCount {
     @(Get-Process -Name $fakeName -ErrorAction SilentlyContinue).Count
+}
+
+function Get-LeakedPingCount {
+    @(Get-Process -Name 'PING' -ErrorAction SilentlyContinue |
+        Where-Object { $script:PreExistingPings -notcontains $_.Id }).Count
 }
 
 function Start-Fake {
@@ -108,9 +117,25 @@ function Wait-ForFakeCount {
     Get-FakeCount
 }
 
+# Teardown must take the whole tree, not just the $fakeName layer: the grandchild
+# is `ping`, and killing its parent does not kill it.
 function Remove-AllFakes {
     foreach ($p in @(Get-Process -Name $fakeName -ErrorAction SilentlyContinue)) {
+        try { Stop-ProcessTreeViaTaskkill -Id $p.Id } catch { }
+    }
+    foreach ($p in @(Get-Process -Name 'PING' -ErrorAction SilentlyContinue |
+                     Where-Object { $script:PreExistingPings -notcontains $_.Id })) {
         try { $p.Kill() } catch { }
+    }
+}
+
+function Wait-FakeNameCleared {
+    param([int]$TimeoutSeconds = 20)
+    $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
+    while ($true) {
+        if ((Get-FakeCount) -eq 0) { return $true }
+        if ([DateTime]::UtcNow -ge $deadline) { return $false }
+        Start-Sleep -Milliseconds 250
     }
 }
 
@@ -121,9 +146,8 @@ try {
     $p = Start-Fake -Arguments $hangArgs
     $count = Wait-ForFakeCount -AtLeast 2
     Assert-True ($count -ge 2) "harness: fake devenv spawns a real tree (saw $count '$fakeName' processes, expected >= 2)"
-    try { $p.Kill() } catch { }
     Remove-AllFakes
-    Assert-True (Wait-ProcessNameCleared -Name $fakeName -TimeoutSeconds 15) 'harness: fakes are cleaned up between cases'
+    Assert-True (Wait-FakeNameCleared) 'harness: fakes are cleaned up between cases'
 
     # -- 3. Stop-ProcessTreeSafely reaps descendants, not just the root. --
     # This is the #1074 fix. Against `$proc.Kill()` the inner fake survives.
@@ -131,19 +155,31 @@ try {
     Wait-ForFakeCount -AtLeast 2 | Out-Null
     $exited = Stop-ProcessTreeSafely -Process $p -WaitSeconds 20
     Assert-True $exited 'Stop-ProcessTreeSafely: root process exited within the wait'
-    Assert-True (Wait-ProcessNameCleared -Name $fakeName -TimeoutSeconds 20) 'Stop-ProcessTreeSafely: no descendant is left running'
+    Assert-True (Wait-FakeNameCleared) 'Stop-ProcessTreeSafely: no descendant is left running'
     Assert-Equal 0 (Get-FakeCount) 'Stop-ProcessTreeSafely: process name is fully clear'
-    # Explicit teardown so a failure here is attributed to this case rather than
-    # cascading into the next one's counts.
     Remove-AllFakes
-    Wait-ProcessNameCleared -Name $fakeName -TimeoutSeconds 20 | Out-Null
+    Wait-FakeNameCleared | Out-Null
 
-    # -- 4. Timeout path: nothing survives, duration is a real measurement. --
+    # -- 4. The taskkill fallback works on its own. --
+    # Under pwsh the reflection probe in Stop-ProcessTreeSafely always finds
+    # Kill([bool]), so the Windows PowerShell 5.1 branch never runs in CI.
+    # Calling it directly is what stops that branch from rotting: pointing
+    # taskkill.exe at a bogus path reddens these two assertions.
+    $p = Start-Fake -Arguments $hangArgs
+    Wait-ForFakeCount -AtLeast 2 | Out-Null
+    $global:LASTEXITCODE = 0
+    Stop-ProcessTreeViaTaskkill -Id $p.Id
+    Assert-True (Wait-FakeNameCleared) 'Stop-ProcessTreeViaTaskkill: kills the whole tree'
+    Assert-Equal 0 $LASTEXITCODE 'Stop-ProcessTreeViaTaskkill: leaves $LASTEXITCODE at 0'
+    Remove-AllFakes
+    Wait-FakeNameCleared | Out-Null
+
+    # -- 5. Timeout path: nothing of ours survives, duration is a real measurement. --
     $timeout = 4
     $r = Invoke-DevenvUpdateConfiguration -DevenvPath $fakeExe -Arguments $hangArgs `
         -TimeoutSeconds $timeout -ProcessName $fakeName -DrainTimeoutSeconds 20
     Assert-True $r.TimedOut 'timeout: TimedOut is reported'
-    Assert-True $r.Drained  'timeout: Drained is reported true (name cleared)'
+    Assert-True $r.Drained  'timeout: Drained is reported true'
     Assert-Equal 0 (Get-FakeCount) 'timeout: no fake devenv survives the call'
     # The pre-fix instrument read ExitTime on a process that had not been reaped
     # yet, which returns the 1601 epoch and printed "-13430263500.8s". This
@@ -158,8 +194,10 @@ try {
     # ExitCode must be readable, i.e. we waited for the kill to complete rather
     # than racing it.
     Assert-True ($null -ne $r.ExitCode) 'timeout: ExitCode is defined after the tree kill'
+    Remove-AllFakes
+    Wait-FakeNameCleared | Out-Null
 
-    # -- 5. Happy path is untouched (guards the VS 18.7 flow). --
+    # -- 6. Happy path is untouched (guards the VS 18.7 flow). --
     $r = Invoke-DevenvUpdateConfiguration -DevenvPath $fakeExe -Arguments $quickArgs `
         -TimeoutSeconds 30 -ProcessName $fakeName -DrainTimeoutSeconds 10
     Assert-Equal $false $r.TimedOut 'happy path: TimedOut is false when the process exits on its own'
@@ -167,38 +205,81 @@ try {
     Assert-Equal 0 $r.KilledPids.Count 'happy path: nothing is killed'
     Assert-InRange $r.DurationSeconds 0 30 'happy path: DurationSeconds is non-negative and bounded'
 
-    # -- 6. The sweep spares pre-existing processes. --
-    # A developer who opens VS mid-run must not have their IDE killed; the
-    # pre-start snapshot is what protects them.
-    $pre = Start-Fake -Arguments $hangArgs
-    # Wait for the *whole* pre-existing tree before snapshotting: if the inner
-    # process were missed by the snapshot the sweep would kill it, the outer
-    # would exit with it, and "excluded process is still alive" would flake.
+    # -- 7. Ancestry: we kill our own tree and nobody else's. --
+    # THE safety property. `devenv` is a shared process name, so identifying
+    # victims by name would take out a developer's IDE. Attribution is by
+    # Win32_Process ancestry captured while the tree is still alive.
+    $mine = Start-Fake -Arguments $hangArgs
     Wait-ForFakeCount -AtLeast 2 | Out-Null
-    $preIds = @(Get-Process -Name $fakeName -ErrorAction SilentlyContinue | ForEach-Object { $_.Id })
-    $new = Start-Fake -Arguments $hangArgs
-    Wait-ForFakeCount -AtLeast ($preIds.Count + 1) | Out-Null
+    $theirs = Start-Fake -Arguments $hangArgs   # stands in for the developer's IDE
+    Wait-ForFakeCount -AtLeast 4 | Out-Null
 
-    $killed = @(Stop-NewProcessesByName -Name $fakeName -ExcludePids $preIds -WaitSeconds 20)
-    Assert-True ($killed -contains $new.Id) "sweep: kills the process started after the snapshot (pid $($new.Id))"
-    Assert-True ($killed -notcontains $pre.Id) "sweep: does not kill the excluded pre-existing process (pid $($pre.Id))"
-    $pre.Refresh()
-    Assert-Equal $false $pre.HasExited 'sweep: the excluded process is still alive'
-    Assert-True $new.HasExited 'sweep: the swept process is gone'
+    $descendants = @(Get-DescendantProcessIds -ParentId $mine.Id)
+    Assert-True ($descendants.Count -ge 1) "ancestry: finds the descendant of pid $($mine.Id) (saw $($descendants.Count))"
+    Assert-True ($descendants -notcontains $theirs.Id) 'ancestry: an unrelated same-named process is not a descendant'
 
+    $ours = @($mine.Id) + $descendants
+    $killed = @(Stop-ProcessIds -Ids $ours -RequireName $fakeName -WaitSeconds 20)
+    Assert-True ($killed -contains $mine.Id) 'attribution: our own root is killed'
+    $theirs.Refresh()
+    Assert-Equal $false $theirs.HasExited "attribution: the unrelated process (pid $($theirs.Id)) is left running"
+    Assert-True ($killed -notcontains $theirs.Id) 'attribution: the unrelated process is never targeted'
     Remove-AllFakes
-    Assert-True (Wait-ProcessNameCleared -Name $fakeName -TimeoutSeconds 20) 'sweep: teardown clears the name'
+    Assert-True (Wait-FakeNameCleared) 'attribution: teardown clears the name'
 
-    # -- 7. Wait-ProcessNameCleared reports failure rather than lying. --
+    # -- 8. END-TO-END: a foreign same-named process survives a timeout. --
+    # The safety property that matters, asserted through the real entry point.
+    # Case 7 exercises the helpers directly, so it does NOT catch a regression
+    # in how Invoke-DevenvUpdateConfiguration decides what is "ours" — verified
+    # by mutation: swapping the ancestry call for a name lookup leaves case 7
+    # green and reddens only the assertions below.
+    $theirs = Start-Fake -Arguments $hangArgs   # the developer's open IDE
+    Wait-ForFakeCount -AtLeast 2 | Out-Null
+    $theirsId = $theirs.Id
+
+    $r = Invoke-DevenvUpdateConfiguration -DevenvPath $fakeExe -Arguments $hangArgs `
+        -TimeoutSeconds 3 -ProcessName $fakeName -DrainTimeoutSeconds 15
+    Assert-True $r.TimedOut 'e2e attribution: the run timed out (precondition for the sweep path)'
+    $theirs.Refresh()
+    Assert-Equal $false $theirs.HasExited "e2e attribution: the developer's IDE (pid $theirsId) is still running"
+    Assert-True ($r.KilledPids -notcontains $theirsId) 'e2e attribution: the foreign pid is never killed'
+    Assert-True ($r.ForeignPids -contains $theirsId) 'e2e attribution: the foreign pid is reported, not silently ignored'
+    Remove-AllFakes
+    Wait-FakeNameCleared | Out-Null
+
+    # -- 9. Stop-ProcessIds refuses a pid whose name no longer matches. --
+    # Guards pid reuse between the ancestry snapshot and the kill.
+    $survivor = Start-Fake -Arguments $hangArgs
+    Wait-ForFakeCount -AtLeast 1 | Out-Null
+    $killed = @(Stop-ProcessIds -Ids @($survivor.Id) -RequireName 'some-other-name' -WaitSeconds 5)
+    Assert-Equal 0 $killed.Count 'pid reuse: a pid whose name does not match RequireName is skipped'
+    $survivor.Refresh()
+    Assert-Equal $false $survivor.HasExited 'pid reuse: the mismatched process is left alone'
+    Remove-AllFakes
+    Wait-FakeNameCleared | Out-Null
+
+    # -- 10. Wait-ProcessIdsCleared reports failure rather than lying. --
     # Without a truthful negative, a false "drained" would let the next run trip
     # the guard with no explanation.
     $stubborn = Start-Fake -Arguments $hangArgs
     Wait-ForFakeCount -AtLeast 1 | Out-Null
-    Assert-Equal $false (Wait-ProcessNameCleared -Name $fakeName -TimeoutSeconds 2) 'Wait-ProcessNameCleared: returns false while a process is still running'
+    Assert-Equal $false (Wait-ProcessIdsCleared -Ids @($stubborn.Id) -TimeoutSeconds 2) 'Wait-ProcessIdsCleared: false while the pid is still running'
     Remove-AllFakes
-    Assert-True (Wait-ProcessNameCleared -Name $fakeName -TimeoutSeconds 20) 'Wait-ProcessNameCleared: returns true once the name is clear'
+    Wait-FakeNameCleared | Out-Null
+    Assert-True (Wait-ProcessIdsCleared -Ids @($stubborn.Id) -TimeoutSeconds 20) 'Wait-ProcessIdsCleared: true once the pid is gone'
 
-    # -- 8. Stop-ProcessTreeSafely does not leak $LASTEXITCODE. --
+    # -- 11. Drained=false actually propagates to the caller. --
+    # Shadow the drain helper so the failure is deterministic; without this the
+    # Drained field could be hard-coded $true and the suite would not notice.
+    function Wait-ProcessIdsCleared { param([int[]]$Ids = @(), [int]$TimeoutSeconds = 30) return $false }
+    $r = Invoke-DevenvUpdateConfiguration -DevenvPath $fakeExe -Arguments $hangArgs `
+        -TimeoutSeconds 2 -ProcessName $fakeName -DrainTimeoutSeconds 3
+    Assert-Equal $false $r.Drained 'Drained: a failed drain is reported, not swallowed'
+    . $libPath   # restore the real implementation
+    Remove-AllFakes
+    Wait-FakeNameCleared | Out-Null
+
+    # -- 12. Stop-ProcessTreeSafely does not leak $LASTEXITCODE. --
     # The 5.1 path shells out to taskkill, whose non-zero "not found" status
     # would otherwise ride out to the caller's exit code (the #1074 defect class).
     $done = Start-Fake -Arguments $quickArgs
@@ -206,12 +287,23 @@ try {
     $global:LASTEXITCODE = 0
     Stop-ProcessTreeSafely -Process $done -WaitSeconds 5 | Out-Null
     Assert-Equal 0 $LASTEXITCODE 'Stop-ProcessTreeSafely: leaves $LASTEXITCODE at 0'
+
+    # -- 13. The exit-code contract three scripts depend on. --
+    # Reinstall-Vsix.ps1 exits with this; bootstrap.ps1 and `mur upgrade` branch
+    # on it. Mutating the mapping reddens here instead of silently changing what
+    # CI does with a partly-failed install.
+    Assert-Equal 3 (Get-VsixReinstallExitCode -UpdateConfigIncomplete $true)  'exit contract: incomplete /updateconfiguration maps to 3'
+    Assert-Equal 0 (Get-VsixReinstallExitCode -UpdateConfigIncomplete $false) 'exit contract: a completed run maps to 0'
 }
 finally {
     Remove-AllFakes
-    Wait-ProcessNameCleared -Name $fakeName -TimeoutSeconds 20 | Out-Null
+    Wait-FakeNameCleared | Out-Null
     Remove-Item $tmp -Recurse -Force -ErrorAction SilentlyContinue
 }
+
+# The harness spawns `ping` grandchildren; leaking them would slowly fill a CI
+# runner's process table across repeated runs.
+Assert-Equal 0 (Get-LeakedPingCount) 'teardown: the harness leaks no ping processes'
 
 # -- Report --
 Write-Host ""


### PR DESCRIPTION
Fixes #1074.

## The failure

`bootstrap.ps1 (windows-latest)` started failing when the runner image's Visual Studio rolled 18.7 → 18.8. On 18.8 `devenv /updateconfiguration` never returns. Three defects in our own scripts turned that upstream hang into a red job:

1. **`Process.Kill()` orphaned the devenv tree.** No argument means "kill this process only", and it returns without waiting. The second `devenv` that `/updateconfiguration` spawns survived and tripped the next run's "Visual Studio is running" guard.
2. **The duration was read from `ExitTime` on a live process**, printing `-13430263500.8s` (≈ −425 years) — a broken instrument sitting next to the bug it was announcing.
3. **The warn-and-continue path leaked `$LASTEXITCODE`** past `Bootstrap complete.` into the workflow's `if ($LASTEXITCODE -ne 0) { throw }`.

## One correction to the issue's diagnosis

The issue attributes defect 3 to `Write-Host` not clearing `$LASTEXITCODE`. That's true but insufficient — *how* `bootstrap.ps1` is invoked is load-bearing. `bootstrap.yml` runs it **in-process**, and `$LASTEXITCODE` is a global, which is why the child's code survives the script boundary.

This mattered concretely: my first regression test used `pwsh -File` as the positive control and **failed to reproduce the leak at all** (that form returns 0 on fall-through). Shipped as-is, it would have been green against both broken and fixed code.

| invocation | leaky | + `$global:LASTEXITCODE = 0` | + trailing `exit 0` |
|---|---|---|---|
| in-process (what CI does) | **7** | 0 | 0 |
| `pwsh -File` | 0 | 0 | 0 |

## The fix

New `src/vs-reactor/VsProcessLib.ps1` (following the repo's existing `CoverageLib.ps1` / `PerfLib.ps1` convention so it's testable headlessly): on timeout, kill the launched process **and its descendants**, wait for them, then poll until they're gone. Duration comes from a `Stopwatch`. `bootstrap.ps1` resets `$LASTEXITCODE` and ends with an explicit `exit 0`.

### Ownership attribution — the part worth reviewing closely

The riskiest thing this code does is kill a process named `devenv`, which is also the name of the developer's IDE.

My first implementation swept every same-named process outside a pre-launch snapshot. A review pass caught that this was unsafe: because `Reinstall-Vsix.ps1` refuses to run while any devenv is alive, **the snapshot is virtually always empty**, making the sweep an unconditional "kill every devenv" with `/F`. Open Visual Studio during the 120-second window and you'd lose unsaved work. The code comment claimed the snapshot protected exactly that case — it did not.

Ownership now comes from the `Win32_Process` parent chain, captured **while the tree is still alive** (Windows doesn't re-parent orphans, so once the root dies the ancestry is unrecoverable). Anything unattributable is reported in `ForeignPids` and left running. `Stop-ProcessIds` re-checks the process name to survive pid reuse between snapshot and kill.

### Exit-code contract

`.OUTPUTS` claimed `0` meant "`/updateconfiguration` completed", but duplicate installs and a missing `devenv.exe` both fell through to a bare `exit 0`. Now:

| Code | Meaning |
|---|---|
| `0` | VSIX installed and `/updateconfiguration` completed |
| `1` | Install failed |
| `3` | VSIX installed, but `/updateconfiguration` did not complete (timed out, or skipped) |

The mapping lives in one function because three scripts depend on it: `Reinstall-Vsix.ps1` emits it, `bootstrap.ps1` and `mur upgrade` branch on it. `[ok] VS extension installed` is no longer printed for a partly-failed operation.

## What the tests actually prove

Real process trees, not mocks — `Kill()` vs `Kill($true)` differ only in what happens to a real child. The fake "devenv" is a renamed copy of `cmd.exe`.

| mutation | result |
|---|---|
| `Kill($true)` → `Kill()` | 3 assertions redden |
| ancestry → name matching (the unsafe version) | 2 redden |
| `taskkill.exe` → bogus path | suite fails |
| `Drained` hard-coded `$true` | 1 reddens |
| exit mapping always `0` | 1 reddens |
| exit routed back to a literal | 1 reddens |
| drop one incomplete-flag write | 1 reddens |
| remove trailing `exit 0` / the `$LASTEXITCODE` reset | 2 / 1 redden |
| **`Stopwatch` → `ExitTime - StartTime`** | **all pass** |

**Two things I want to flag rather than bury.**

The end-to-end attribution test earned its place. My first version exercised the helpers directly, and reverting the product to name-matching left all 31 assertions green — a vacuous test for the exact safety property it was named after. Driving the real entry point with a foreign same-named process running is what makes it bite.

The duration assertion **does not discriminate**. The −425-year symptom is a race on reading `ExitTime` before a *heavy* process is reaped; a `cmd.exe` fake dies sub-millisecond, so the race never opens. The `Stopwatch` is kept because it cannot be wrong, but that assertion is a bounds check on the symptom, documented as such in the test header and README rather than left to look like a guarantee.

## Also

- New `.github/workflows/vs-reactor-lib-tests.yml` (`windows-latest` — every behaviour under test is Windows-specific).
- `tests/vs_reactor/ci/README.md`, matching the sibling suites.
- The "Visual Studio is running" guard now reports process start times, so a leftover is distinguishable from a real IDE in one line.

**Deliberately unchanged:** the 120 s timeout (healthy 18.7 runs take 27–99 s), skipping `/updateconfiguration` in CI (it would hide the path this workflow exists to exercise), and force-killing from the guard (it would kill a developer's IDE). The `no Reactor.VsExtension folder appeared within 30s` warning is confirmed unrelated per the issue.

## Verification

35 + 13 assertions pass. `dotnet build src/Reactor.Cli -c Release` clean (0 warnings). Verified under **Windows PowerShell 5.1**, where `Process.Kill(bool)` is *absent* — so the `taskkill /T /F` fallback is the only path there, not a rare edge case — draining to zero survivors with no `$LASTEXITCODE` leak.

<sub>One pre-existing, unrelated thing noticed and left alone: `bootstrap.ps1` declares `#requires -Version 5.1` but won't *parse* under 5.1 — it's BOM-less UTF-8 with em dashes, which 5.1 decodes as ANSI. Confirmed identical at `main` and confirmed decode-only (`ParseInput` on correctly-decoded text gives 0 errors). Harmless today because CI runs it under `shell: pwsh`.</sub>