### PR TITLE
Release prep: 0.1.0-preview.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,20 @@ Conventions for contributors:
 
 ### Added
 
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+## [0.1.0-preview.13] — 2026-08-04
+
+### Added
+
 - **`TabView.FillContentArea` — opt-in full-height tab body (issue #914).**
   WinUI's `DefaultTabViewStyle` sets `VerticalAlignment="Top"` on the `TabView`
   control itself, so the `*` content row in its template never receives leftover
@@ -118,6 +132,28 @@ Conventions for contributors:
   fire for callback-bearing elements of a type and silently not for callback-free
   ones.
 
+- **`IsHitTestVisible(bool)` common element modifier (issue #809).** Fills the
+  last gap among the sibling boolean visual-state modifiers (`IsEnabled`,
+  `IsTabStop`, `IsVisible`, `Opacity`). Opting an element out of pointer
+  hit-testing — an overlay that should not swallow input, a decorative adorner —
+  no longer needs the imperative `.Set(c => c.IsHitTestVisible = false)` escape
+  hatch, so the write participates in the property diff and is unwound on
+  removal.
+
+- **`ReactorBinding.ShouldSuppressEcho(UIElement)` — public read-side echo
+  primitive (spec 062, issue #163).** The read-side counterpart of the existing
+  `WriteSuppressed` write primitive. External wrapper authors — and the
+  `[WrapControlled]` source generator, which now emits this instead of the
+  internal `ChangeEchoSuppressor.ShouldSuppress` — can ask whether a change
+  notification is Reactor's own echo and skip it, closing the one place the
+  generator emitted an internal Reactor symbol into externally generated code.
+
+- **`REACTOR_ITEMS_002` — `ItemsView` viewBuilder must return an `ItemContainer`
+  root (spec 060).** A `viewBuilder` that returns a bare `Border(...)` (or any
+  non-`ItemContainer` root) trips a framework guard at runtime and renders an
+  error banner instead of the list. The analyzer now catches that shape at build
+  time and points at `ItemContainer(...)`.
+
 ### Changed
 
 - **`WithNavigation` gained an optional `settingsRoute` argument (binary-breaking,
@@ -131,6 +167,38 @@ Conventions for contributors:
   was added: the project is pre-1.0 and explicitly reserves the right to change
   the public surface between releases, and a permanent duplicate overload is a
   worse public shape than one optional argument.
+
+- **Charting, docking, markdown and the data grid moved into
+  `Microsoft.UI.Reactor.Advanced` (breaking; spec 062 §7, issue #163).** Four
+  heavy subsystems — charting (and its D3 layer), docking, markdown, and
+  `DataGrid<T>` — no longer ship in the core `Microsoft.UI.Reactor` package. The
+  dependency direction is one-way (`Reactor.Advanced → Reactor`, enforced by a
+  new architecture test), and core `Reactor.dll` drops **~0.9 MB (≈28%)** — ~3.2
+  MB to ~2.3 MB in Release — so apps that don't use these subsystems ship a
+  smaller core. **Apps that do use them must reference
+  `Microsoft.UI.Reactor.Advanced`**, which is versioned in lock-step with the
+  framework and already referenced by the scaffolded template. Namespaces are
+  preserved (`Microsoft.UI.Reactor.Charting[.D3]`, `.Docking`, `.Controls`,
+  `.Markdown`) and the relocated event fluents stayed in their element's own
+  namespace, so type references and `using`s are unchanged. The factory entry
+  points `DataGrid`, `Column`, `AutoColumns` and `Markdown` now live in
+  `Microsoft.UI.Reactor.Advanced.Factories`.
+
+- **The OS now picks the default window size.** `WindowSpec.Width` / `Height` and
+  the `ReactorApp.Run(width, height)` parameters defaulted to a hardcoded
+  1024x768 inherited from the pre-spec-036 `Run` signature — never a design
+  decision (spec 036 only ever discussed the units, never the value). Every app
+  that did not care about window size was still overriding the size Windows
+  would have picked. Those defaults are now unset, so the OS chooses; passing an
+  explicit width/height behaves exactly as before.
+
+- **Icon fonts now fall back through `Segoe Fluent Icons, Segoe MDL2 Assets`.**
+  The legacy Windows 10-era `"Segoe MDL2 Assets"` font is no longer used on its
+  own, and the `FontIcon` / `FontIconSource` fallbacks — which previously
+  hardcoded a bare `"Segoe Fluent Icons"` with no Windows 10 tail — now share one
+  `IconResolver.SymbolFontFallback` stack with the rest of the framework. Font
+  allocations on that path also route through `WinRTCache` instead of crossing
+  the managed/WinRT boundary on every render.
 
 ### Deprecated
 
@@ -410,6 +478,50 @@ Conventions for contributors:
   body qualified — exact rather than conservative, since the fix is already
   all-or-nothing over the whole body. Predates the attached-property work above,
   where the same shape would have emitted a call that does not compile.
+
+- **A `Frame` navigating to a code-only `Page` no longer kills the process.**
+  Navigating to a page with no XAML backing terminated the
+  process instantly with an access violation (`0xC0000005`). Because it is a
+  native WinUI AV rather than a managed exception,
+  `Application.UnhandledException` never fired — the process simply vanished with
+  no error, no dialog and no log. `Frame.Navigate` resolves a custom navigation
+  target through the XAML application object, which is a path a code-only page
+  cannot satisfy; Reactor now resolves those targets itself instead of handing
+  them to the framework.
+
+- **`CommandBarFlyout(...)` now opens from its target.** The flyout was installed
+  as attached-flyout *metadata* only (`FlyoutBase.SetAttachedFlyout`), which
+  associates it with the element but never shows it — so a
+  `CommandBarFlyout(Button("Show Commands"), primaryCommands: …)` rendered a
+  button that did nothing at all. It is now wired to actually open from its
+  target, which also brings it under the default-placement guard described above.
+
+- **Keyed `ListView` / `GridView` rows no longer announce Reactor's internal row
+  identity (issue #951).** Items of a keyed or data-driven list announced the
+  internal row identity — `Row[0]=<key>`, degenerating to a raw GUID when the key
+  selector produced one — instead of their content, so screen-reader users heard
+  bookkeeping rather than the item. The keyed path no longer projects that
+  identity onto the container's automation name.
+
+- **Expanding a `DataGrid<T>` row no longer throws `InvalidCastException` (issue
+  #919).** The row's root element record type flipped on expand — collapsed,
+  `RenderRow` returned a bare `GridElement`; expanded, it wrapped the row in
+  `FlexColumn(row, detail)`, a `FlexElement` — so the reconciler tried to reuse
+  the realized `Grid` as a `FlexPanel` and threw
+  `Unable to cast 'Microsoft.UI.Xaml.Controls.Grid' to
+  'Microsoft.UI.Reactor.Layout.FlexPanel'`. The row root is now a stable type
+  across both states.
+
+- **Docking's accessibility focus hand-off actually moves focus.**
+  The hand-off ran but left real keyboard focus where it was, so the announced
+  target and the focused element disagreed after a dock operation.
+
+- **Unpackaged launches no longer raise a first-chance WinRT exception.** Every
+  unpackaged app start probed for package identity in a way that threw
+  `InvalidOperationException` (`HRESULT 0x80073D54 — The process has no package
+  identity`) before anything useful happened — harmless but noisy under a
+  debugger and a false lead when diagnosing real startup failures. Identity is
+  now detected without throwing.
 
 ### Security
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -44,7 +44,7 @@
       a floating range like 0.1.* matches nothing and fails restore (NU1103) —
       pin a real version here and substitute it, never float.
     -->
-    <ReactorPublicVersion>0.1.0-preview.12</ReactorPublicVersion>
+    <ReactorPublicVersion>0.1.0-preview.13</ReactorPublicVersion>
   </PropertyGroup>
 
   <!--

--- a/docs/guide/architecture-overview.md
+++ b/docs/guide/architecture-overview.md
@@ -157,37 +157,51 @@ public UIElement GetElement(ElementFactoryGetArgs args)
     var element = BuildOrCache(key, item, index, keyed);
 
     UIElement? control;
-    if (_recyclePool.Count > 0)
+    if (TryTakeCompatibleFromPool(element, out var reused, out var oldElement, out var parkedVisibility))
     {
         // Reuse a previously-recycled container. The framework still has
         // it parented to the ItemsRepeater, so the ViewManager.cpp:866
         // Append-skip kicks in and the visual tree stays stable.
-        var reused = _recyclePool.Pop();
-        if (_lastElementByControl.TryGetValue(reused, out var oldElement))
+        //
+        // Undo the parking collapse from RecycleElement BEFORE reconciling.
+        // Restore the exact pre-park value source rather than forcing
+        // Visible: an in-place diff whose Visibility modifier is unchanged
+        // writes nothing, so forcing Visible would silently un-collapse a
+        // row the author asked to hide.
+        RestoreParkedVisibility(reused, parkedVisibility);
+        var replacement = _reconciler.Reconcile(oldElement, element, reused, _requestRerender);
+        if (replacement is not null && !ReferenceEquals(replacement, reused))
         {
-            var replacement = _reconciler.Reconcile(oldElement, element, reused, _requestRerender);
-            if (replacement is not null && !ReferenceEquals(replacement, reused))
+            // Pass-2 reuse: the row's key changed, so Reconcile unmounted the old
+            // component (effect cleanups ran) and built a fresh wrapper. Move that
+            // subtree back into the container we already have — returning the
+            // replacement instead would strand `reused`, which cannot be un-parented
+            // from an ItemsRepeater (see DetachFromParent). (Issues #326, #919.)
+            //
+            // A pass-1 selection can land here too: CanUpdate was true, but a
+            // decorator-style handler substituted a different instance. Re-check
+            // CanSafelyAdopt so only wrappers whose entire state lives in the
+            // component subtree are adopted; everything else takes the fresh
+            // replacement and parks the container.
+            if (CanSafelyAdopt(reused, oldElement, element)
+                && _reconciler.TryAdoptRealizedReplacement(reused, replacement))
             {
-                // Heterogeneous-row case: Reconcile decided the root
-                // element type changed and built a fresh control.
-                // `reused` is now unmounted but still parented to the
-                // ItemsRepeater — detach so it doesn't sit there as
-                // an orphan (the original leak shape we're fixing).
-                // (PR #324 review)
-                DetachFromParent(reused);
-                _lastElementByControl.Remove(reused);
-                control = replacement;
+                control = reused;
             }
             else
             {
-                control = reused;
+                // Nothing can install `replacement` into `reused`. Retire `reused`
+                // — park it collapsed with its Reactor state detached — rather than
+                // leaving a live ghost row painted over the list. Do NOT return it to
+                // the pool: it was unmounted inside Reconcile, so its tracked Element
+                // no longer describes it.
+                RetireAlreadyUnmounted(reused);
+                control = replacement;
             }
         }
         else
         {
-            // Defensive: pool entry without a tracked oldElement should
-            // not happen — fall back to re-mounting on top of it.
-            control = _reconciler.Mount(element, _requestRerender);
+            control = reused;
         }
     }
     else
@@ -200,6 +214,7 @@ public UIElement GetElement(ElementFactoryGetArgs args)
     {
         _keyByControl[control] = key;
         _lastElementByControl[control] = element;
+        if (_keyByControl.Count > _maxRealized) _maxRealized = _keyByControl.Count;
 
         // Issue #383: arm the multi-select checkmark flicker guard on the
         // realized container. Idempotent per container instance.

--- a/docs/guide/control-reconciler-protocol.md
+++ b/docs/guide/control-reconciler-protocol.md
@@ -299,6 +299,15 @@ public TControl Mount(MountContext ctx, TElement el)
 {
     var ctrl = ctx.RentControl(_descriptor.PoolPolicy, _descriptor.Factory);
 
+    // A descriptor that declares teardown must actually receive it. The engine's unmount
+    // dispatch is tag-gated (Reconciler.UnmountRecursive only reaches the V1 handler when
+    // GetElementTag returns an element), and SetElementTagIfNeeded allocates ReactorState
+    // only for elements that carry callbacks, a key, extensions, or reference modifiers.
+    // Without this, OnUnmount would fire for some elements of a type and silently not for
+    // others — the callback-free ones — which is not a contract an author can reason about.
+    if (_descriptor.OnUnmount is not null)
+        Reconciler.GetOrCreateReactorState(ctrl);
+
     // §14 Phase 3-final: when the descriptor declares an ItemsHost,
     // populate the items collection BEFORE the prop loop. Initial writes
     // for selection-tracking props (SelectedIndex/SelectedItem) need the

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -19,7 +19,7 @@ the rest of the docset elaborates.
 <!-- /ai:lock -->
 
 > **Public preview package available.** Reactor ships `Microsoft.UI.Reactor`
-> `0.1.0-preview.12` on NuGet.org. The project template package is still
+> `0.1.0-preview.13` on NuGet.org. The project template package is still
 > installed from source for now; `bootstrap.ps1` installs `mur`, packs/registers
 > the local `reactorapp` template, and stamps generated apps to reference the
 > public preview package by default. Broader signed distribution is tracked in
@@ -43,7 +43,7 @@ install (so it's on PATH cross-shell with no manual `$env:Path` edits), runs
 matching `ProjectTemplates` nupkg, registers the `dotnet new reactorapp`
 template, and drops the Reactor agent plugin under `~/.claude/plugins/reactor`
 (symlink when allowed, copy otherwise). Apps created from that template reference
-`Microsoft.UI.Reactor` version `0.1.0-preview.12` from NuGet.org by default.
+`Microsoft.UI.Reactor` version `0.1.0-preview.13` from NuGet.org by default.
 
 When it finishes you can immediately run:
 
@@ -81,7 +81,7 @@ with a one-line remediation for anything broken.
 > **What this gets you.** A globally-resolvable `mur` (via `~/.dotnet/tools`),
 > a locally installed `reactorapp` template that references
 > `<PackageReference Include="Microsoft.UI.Reactor"
-> Version="0.1.0-preview.12" />`, a local NuGet feed at `<repo>/local-nupkgs/`
+> Version="0.1.0-preview.13" />`, a local NuGet feed at `<repo>/local-nupkgs/`
 > for source-built smoke tests, and an agent plugin so AI assistants generate
 > against the real factories (`mur --skill` / `mur --api` print the same
 > content). Run `mur upgrade` whenever you pull new template, CLI, plugin, or
@@ -171,7 +171,7 @@ New PowerShell windows pick up the user-PATH change on their own.
 **5. Pack local framework snapshots and project templates.** This produces the
 source-built `0.0.0-local` framework nupkgs for smoke tests plus the local
 `ProjectTemplates` nupkg that installs `dotnet new reactorapp`. The template's
-normal default references the public `Microsoft.UI.Reactor` `0.1.0-preview.12`
+normal default references the public `Microsoft.UI.Reactor` `0.1.0-preview.13`
 package.
 
 ```powershell
@@ -268,7 +268,7 @@ Reactor component. No `App.xaml`, no `MainWindow.xaml.cs` — just one C#
 file.
 
 By default that package reference is
-`<PackageReference Include="Microsoft.UI.Reactor" Version="0.1.0-preview.12" />`.
+`<PackageReference Include="Microsoft.UI.Reactor" Version="0.1.0-preview.13" />`.
 For local framework smoke tests, generate with
 `dotnet new reactorapp -n MyLocalApp --MSUIReactorVersion 0.0.0-local` and run
 from inside the source checkout or another folder that has the local feed

--- a/docs/guide/packaging.md
+++ b/docs/guide/packaging.md
@@ -237,7 +237,7 @@ a folder inside `Reactor.dll`.
 
 **`Reactor.dll` is in your publish output as a managed assembly,
 not a tucked-away framework package.** Reactor ships as the public preview
-NuGet package `Microsoft.UI.Reactor` version `0.1.0-preview.12`; local
+NuGet package `Microsoft.UI.Reactor` version `0.1.0-preview.13`; local
 source-built smoke packages still use `0.0.0-local` via `mur pack-local`.
 Trim-friendly deployments don't get any framework-side magic; the same trimmer
 configuration that works for any WinUI 3 app works here.


### PR DESCRIPTION
Bumps `<ReactorPublicVersion>` to **0.1.0-preview.13**, recompiles the version-stamped docs, and cuts the `0.1.0-preview.13` CHANGELOG section.

Follows `docs/contributing/release-runbook.md`. Tag + publish stay human-gated (two-person rule) and are **not** part of this PR.

## What's here

| File | Change |
|---|---|
| `Directory.Build.props` | `<ReactorPublicVersion>` `0.1.0-preview.12` → `0.1.0-preview.13` |
| `CHANGELOG.md` | `## [Unreleased]` → `## [0.1.0-preview.13] — 2026-08-04`, fresh empty Unreleased block, plus a completeness pass |
| `docs/guide/getting-started.md`, `docs/guide/packaging.md` | `{{reactorVersion}}` token now renders `0.1.0-preview.13` |
| `docs/guide/architecture-overview.md`, `docs/guide/control-reconciler-protocol.md` | Embedded source snippets refreshed (were stale on main after the #919 row-root and #949 `OnUnmount` changes) |

## CHANGELOG completeness pass

Audited all **83 PRs** merged since `v0.1.0-preview.12` against the accumulated `Unreleased` block and added 12 significant user-facing changes that incremental logging had missed:

**Added** — `IsHitTestVisible(bool)` (#809), `ReactorBinding.ShouldSuppressEcho` (spec 062 / #163), `REACTOR_ITEMS_002`.

**Changed** — **charting / docking / markdown / `DataGrid<T>` moved into `Microsoft.UI.Reactor.Advanced`** (breaking, spec 062 §7 / #163; core drops ~0.9 MB ≈28%), OS-chosen default window size, `Segoe Fluent Icons, Segoe MDL2 Assets` icon-font fallback.

**Fixed** — process-killing AV on `Frame` → code-only `Page`, `CommandBarFlyout` never opening, keyed list rows announcing internal row identity (#951), `DataGrid<T>` row-expand `InvalidCastException` (#919), docking a11y focus hand-off, unpackaged-launch first-chance WinRT exception.

Deliberately excluded as internal: dependabot/CI bumps, AOT-honesty work on test/tooling projects, gallery-sample and test-infra fixes, docs-only PRs.

## Validation

- `VersionSingleSourceTests` + `TemplateMetadataTests` + `VersionSubstitutionTests` → **13 passed**, Release build clean (`-c Release -p:Platform=x64`).
- `dotnet pack` of the ProjectTemplates package confirms `template.json` stamps `"defaultValue": "0.1.0-preview.13"`.
- Docs recompiled with `mur docs compile --no-screenshots --skip-diagrams`, satisfying the CI docs-freshness gate.