### PR TITLE
Add Uno Platform support: run Reactor on desktop, WebAssembly, Android and iOS

### DIFF
--- a/.github/workflows/ci-uno.yml
+++ b/.github/workflows/ci-uno.yml
@@ -23,6 +23,8 @@ on:
       # Reactor.Advanced (spec 062 Track B moved them out of core), so changes
       # there can break the Uno build exactly like changes to src/Reactor.
       - 'src/Reactor.Advanced/**'
+      # The Uno gallery source-shares ~10k lines from the Windows gallery.
+      - 'samples/ReactorGallery/**'
       - 'Reactor.Uno.slnx'
       - 'global.json'
       - '.github/workflows/ci-uno.yml'
@@ -36,6 +38,8 @@ on:
       # Reactor.Advanced (spec 062 Track B moved them out of core), so changes
       # there can break the Uno build exactly like changes to src/Reactor.
       - 'src/Reactor.Advanced/**'
+      # The Uno gallery source-shares ~10k lines from the Windows gallery.
+      - 'samples/ReactorGallery/**'
       - 'Reactor.Uno.slnx'
       - 'global.json'
       - '.github/workflows/ci-uno.yml'

--- a/.github/workflows/ci-uno.yml
+++ b/.github/workflows/ci-uno.yml
@@ -1,0 +1,98 @@
+name: CI (Uno)
+
+# Build gate for the Uno Platform port (src/Reactor.Uno + samples/Uno).
+#
+# Kept separate from ci.yml on purpose: the main CI drives the Windows / Windows
+# App SDK build against Reactor.slnx and must never restore Uno.Sdk. This leg
+# restores Uno.Sdk (from nuget.org, incl. the current 6.7.0-dev.* build the port
+# pins) and builds Reactor.Uno.slnx for desktop and WebAssembly, plus Android and
+# iOS in a second job. It is path-gated so it only runs when the Uno port or the
+# shared source it source-shares (src/Reactor, src/Reactor.Advanced) changes.
+#
+# Both samples are Uno single-projects targeting all four heads, so the whole
+# solution builds per-TFM for desktop / wasm / android / ios. Android and iOS run
+# in a second job because they need extra workloads. See issue #2033.
+
+on:
+  pull_request:
+    paths:
+      - 'src/Reactor.Uno/**'
+      - 'samples/Uno/**'
+      - 'src/Reactor/**'
+      # The port also source-shares Charting/, Markdown/ and the DataGrid from
+      # Reactor.Advanced (spec 062 Track B moved them out of core), so changes
+      # there can break the Uno build exactly like changes to src/Reactor.
+      - 'src/Reactor.Advanced/**'
+      - 'Reactor.Uno.slnx'
+      - 'global.json'
+      - '.github/workflows/ci-uno.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'src/Reactor.Uno/**'
+      - 'samples/Uno/**'
+      - 'src/Reactor/**'
+      # The port also source-shares Charting/, Markdown/ and the DataGrid from
+      # Reactor.Advanced (spec 062 Track B moved them out of core), so changes
+      # there can break the Uno build exactly like changes to src/Reactor.
+      - 'src/Reactor.Advanced/**'
+      - 'Reactor.Uno.slnx'
+      - 'global.json'
+      - '.github/workflows/ci-uno.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: ci-uno-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build-uno:
+    name: Build Reactor.Uno (desktop + wasm)
+    runs-on: windows-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
+        with:
+          dotnet-version: 10.0.x
+
+      # Required for the net10.0-browserwasm target.
+      - name: Install wasm-tools workload
+        run: dotnet workload install wasm-tools
+
+      # Per-TFM builds (not a bare slnx build) so the library's net10.0-android
+      # TFM is skipped — desktop and wasm are the sample-backed, validated targets.
+      - name: Build desktop
+        run: dotnet build Reactor.Uno.slnx -f net10.0-desktop -c Debug
+
+      - name: Build WebAssembly
+        run: dotnet build Reactor.Uno.slnx -f net10.0-browserwasm -c Debug
+
+  build-mobile:
+    name: Build Reactor.Uno (android + ios)
+    runs-on: windows-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Install mobile workloads
+        run: dotnet workload install android ios
+
+      # Produces a signed APK for both samples, so the Android head cannot rot.
+      - name: Build Android
+        run: dotnet build Reactor.Uno.slnx -f net10.0-android -c Debug
+
+      # Managed compile only -- a device build/deploy needs a Mac, but this keeps
+      # the iOS head honest.
+      - name: Build iOS
+        run: dotnet build Reactor.Uno.slnx -f net10.0-ios -c Debug

--- a/Reactor.Uno.slnx
+++ b/Reactor.Uno.slnx
@@ -23,5 +23,6 @@
   <Folder Name="/samples/">
     <Project Path="samples/Uno/ReactorUnoCounter/ReactorUnoCounter.csproj" />
     <Project Path="samples/Uno/ReactorUnoShowcase/ReactorUnoShowcase.csproj" />
+    <Project Path="samples/Uno/ReactorGalleryUno/ReactorGalleryUno.csproj" />
   </Folder>
 </Solution>

--- a/Reactor.Uno.slnx
+++ b/Reactor.Uno.slnx
@@ -1,0 +1,27 @@
+<Solution>
+  <!--
+    Dedicated solution for the Uno Platform port. Kept SEPARATE from
+    Reactor.slnx on purpose: the main solution drives the Windows / Windows
+    App SDK build (and CI restores/builds it), so pulling the Uno.Sdk projects
+    into it would force Uno.Sdk + Skia/WASM/Android package restore onto every
+    Windows build. Each project here resolves the Uno.Sdk from its own nearby
+    global.json (src/Reactor.Uno, samples/Uno) and builds in isolation.
+
+    Build everything:  dotnet build Reactor.Uno.slnx
+    The file-based single-file app (samples/Uno/file-based/Counter.cs) is not a
+    project; run it with `dotnet run Counter.cs` from its folder.
+
+    samples/Uno/ReactorUnoDroid (the Android head) is deliberately NOT listed
+    here either: it targets only net10.0-android, and this solution is built
+    per-TFM (`-f net10.0-desktop` / `-f net10.0-browserwasm`), which would fail
+    that project with NETSDK1005. Build it directly instead:
+      cd samples/Uno/ReactorUnoDroid && dotnet build
+  -->
+  <Folder Name="/src/">
+    <Project Path="src/Reactor.Uno/Reactor.Uno.csproj" />
+  </Folder>
+  <Folder Name="/samples/">
+    <Project Path="samples/Uno/ReactorUnoCounter/ReactorUnoCounter.csproj" />
+    <Project Path="samples/Uno/ReactorUnoShowcase/ReactorUnoShowcase.csproj" />
+  </Folder>
+</Solution>

--- a/global.json
+++ b/global.json
@@ -2,5 +2,8 @@
   "sdk": {
     "version": "10.0.100",
     "rollForward": "latestFeature"
+  },
+  "msbuild-sdks": {
+    "Uno.Sdk": "6.7.0-dev.117"
   }
 }

--- a/samples/Uno/Directory.Build.props
+++ b/samples/Uno/Directory.Build.props
@@ -1,0 +1,16 @@
+<Project>
+  <!--
+    Isolation boundary for the Uno samples. Like src/Reactor.Uno, these are
+    Uno.Sdk single-project apps that must NOT inherit the Windows build
+    infrastructure: the repo-root samples/Directory.Build.props chains up to
+    the WinAppSDK-tuned root Directory.Build.props (which imports
+    Reactor.targets). MSBuild stops walking up at the first match, so this
+    file stops that inheritance — the samples build against the Uno.Sdk pinned
+    in this folder's global.json, with Central Package Management OFF
+    (Directory.Packages.props) and the isolated nuget.config alongside.
+    Intentionally does NOT chain to the parent.
+  -->
+  <PropertyGroup>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+</Project>

--- a/samples/Uno/Directory.Packages.props
+++ b/samples/Uno/Directory.Packages.props
@@ -1,0 +1,11 @@
+<Project>
+  <!--
+    Nearest Directory.Packages.props wins, so this shadows the repo-root one and
+    keeps Central Package Management OFF for the Uno port. Uno.Sdk supplies the
+    versions of its implicit (UnoFeatures) packages from the SDK version pinned
+    in global.json; the few extra packages we add carry inline versions.
+  -->
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+</Project>

--- a/samples/Uno/README.md
+++ b/samples/Uno/README.md
@@ -1,0 +1,127 @@
+# Reactor on Uno Platform — samples
+
+Samples that run **Microsoft.UI.Reactor** on Uno Platform Skia targets
+(desktop, WebAssembly, Android), backed by the
+[`Reactor.Uno`](../../src/Reactor.Uno) port library.
+
+| Sample | What it shows | Targets |
+| --- | --- | --- |
+| [`ReactorUnoCounter`](ReactorUnoCounter) | Minimal counter — the smallest Reactor-on-Uno app | desktop, wasm, android, ios |
+| [`ReactorUnoShowcase`](ReactorUnoShowcase) | ToggleSwitch, Slider, ProgressBar, CheckBox, ComboBox, pickers, multi-window | desktop, wasm, android, ios |
+| [`file-based/Counter.cs`](file-based/Counter.cs) | A whole WinUI-style Reactor app in **one `.cs` file** (`dotnet run Counter.cs`) | desktop |
+
+Both app samples are **single Uno projects targeting all four heads** — the
+`Component` source is identical everywhere; only the entry point differs.
+
+## Prerequisites
+
+- **.NET 10 SDK** (`10.0.100`+ — see [`global.json`](global.json))
+- The **`wasm-tools`** workload for the WebAssembly target: `dotnet workload install wasm-tools`
+- The **`android`** / **`ios`** workloads for the mobile heads: `dotnet workload install android ios`
+  (iOS compiles on Windows; deploying to a device still needs a Mac)
+
+The Uno projects resolve `Uno.Sdk` from the nearby `global.json` and restore from
+`nuget.org` only (see [`nuget.config`](nuget.config)); they do **not** inherit the
+repo-root Windows/WinAppSDK build infrastructure.
+
+## Run
+
+### ReactorUnoCounter / ReactorUnoShowcase
+
+```bash
+# Desktop (X11 / Win32 / macOS / FrameBuffer — picked at runtime)
+cd samples/Uno/ReactorUnoCounter
+dotnet run -f net10.0-desktop
+
+# WebAssembly (opens a localhost URL in your browser)
+dotnet run -f net10.0-browserwasm
+```
+
+Swap `ReactorUnoCounter` for `ReactorUnoShowcase` to run the control showcase.
+
+### Android / iOS
+
+The same projects, different heads. Only the entry point is platform-specific:
+desktop and **iOS** both use `ReactorApp.Run<T>()` (Uno gives the Apple heads the
+same host-builder shape as desktop); **Android** is the one target with no console
+entry point, so `Platforms/Android/Main.Android.cs` starts from an `Activity` and
+asks Reactor for the `Application`:
+
+```csharp
+public class Application : Microsoft.UI.Xaml.NativeApplication
+{
+    public Application(IntPtr javaReference, JniHandleOwnership transfer)
+        : base(() => ReactorApp.CreateApplication<CounterApp>("Reactor Counter (Uno)"),
+               javaReference, transfer) { }
+}
+```
+
+```bash
+cd samples/Uno/ReactorUnoCounter
+
+# Deploy + launch on a connected device or emulator (check `adb devices` first)
+dotnet build -f net10.0-android -t:Run
+
+# iOS — compiles on Windows; deploying to a device needs a Mac
+dotnet build -f net10.0-ios
+```
+
+> **Don't sideload the Debug APK.** A Debug Android build uses .NET's *Fast
+> Deployment*: the managed assemblies are **not inside the APK** — the deploy
+> tooling pushes them separately to `files/.__override__/`. Installing the APK by
+> hand therefore produces an app that aborts at startup with
+> `No assemblies found in '…/.__override__/arm64-v8a'` (SIGABRT), which the phone
+> reports only as a generic failure. Use `-t:Run`, or build a self-contained APK
+> with `-p:EmbedAssembliesIntoApk=true` (or `-c Release`) if you really need to
+> sideload one.
+
+> Reactor apps contain **no XAML**, so there is no `ApplicationDefinition` for
+> Uno's iOS Hot Restart helper generator to read and it fails with `Uno0005`. The
+> samples set `<UnoDisableHotRestartHelperGeneration>true</...>`, which disables
+> only VS's iOS *Hot Restart* deploy helper — not Hot Reload.
+
+### file-based/Counter.cs
+
+A single-file app — no project, no `.csproj`. Reactor owns the Uno `Application`,
+so the file's root component must **not** be named `App` (Uno.Sdk generates its own
+`App`).
+
+```bash
+cd samples/Uno/file-based
+dotnet run Counter.cs
+```
+
+## Build the whole Uno set
+
+From the repo root:
+
+```bash
+dotnet build Reactor.Uno.slnx
+```
+
+The solution builds per-TFM across all four heads:
+
+```bash
+dotnet build Reactor.Uno.slnx -f net10.0-desktop
+dotnet build Reactor.Uno.slnx -f net10.0-browserwasm
+dotnet build Reactor.Uno.slnx -f net10.0-android
+dotnet build Reactor.Uno.slnx -f net10.0-ios
+```
+
+> The file-based `Counter.cs` is not a project and is not in the solution — run it
+> directly with `dotnet run Counter.cs`.
+
+## Hot Reload
+
+`dotnet watch` (desktop) and the Uno Dev Server (wasm / Android / iOS) both
+re-render edits to a `Component.Render()` body live, preserving `UseState`.
+
+No opt-in is required: there is **no `HotReload` UnoFeature**, the dev-server
+client is referenced automatically in Debug builds, and the Dev Server itself is
+started by the IDE. (`.UseStudio()` is not needed either — that enables **Hot
+Design**, Uno's runtime *XAML* designer, which doesn't apply to a XAML-free
+framework.)
+
+One caveat: from the CLI, `dotnet watch -f <tfm>` only works against a
+**single-targeted** head — see
+[the Hot Reload section in the port README](../../src/Reactor.Uno/README.md#hot-reload).

--- a/samples/Uno/ReactorGalleryUno/GlobalUsings.cs
+++ b/samples/Uno/ReactorGalleryUno/GlobalUsings.cs
@@ -1,0 +1,11 @@
+// Name disambiguation for the source-shared gallery pages.
+//
+// Every gallery page carries `using Microsoft.UI.Xaml.Controls;` alongside
+// `using static Microsoft.UI.Reactor.Factories;`. On Uno that pulls Uno's own
+// SelectionMode into scope next to Reactor's, and the shared source refers to
+// the bare name — so pin it here rather than forking the pages.
+//
+// Reactor's Reactor.Uno library does exactly the same thing for the same reason
+// (see src/Reactor.Uno/GlobalUsings.cs).
+
+global using SelectionMode = Microsoft.UI.Reactor.Controls.SelectionMode;

--- a/samples/Uno/ReactorGalleryUno/Platforms/Android/AndroidManifest.xml
+++ b/samples/Uno/ReactorGalleryUno/Platforms/Android/AndroidManifest.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+  <application android:allowBackup="true" android:supportsRtl="true"></application>
+</manifest>

--- a/samples/Uno/ReactorGalleryUno/Platforms/Android/Main.Android.cs
+++ b/samples/Uno/ReactorGalleryUno/Platforms/Android/Main.Android.cs
@@ -1,0 +1,23 @@
+using System;
+using Android.Runtime;
+using Microsoft.UI.Reactor;
+using WinUIGalleryReactor;
+
+namespace ReactorGalleryUno.Droid;
+
+[global::Android.App.ApplicationAttribute(
+    Label = "@string/ApplicationName",
+    LargeHeap = true,
+    HardwareAccelerated = true,
+    Theme = "@style/AppTheme"
+)]
+public class Application : Microsoft.UI.Xaml.NativeApplication
+{
+    public Application(IntPtr javaReference, JniHandleOwnership transfer)
+        : base(
+            () => ReactorApp.CreateApplication<GalleryShell>("Reactor Gallery (Uno)"),
+            javaReference,
+            transfer)
+    {
+    }
+}

--- a/samples/Uno/ReactorGalleryUno/Platforms/Android/MainActivity.Android.cs
+++ b/samples/Uno/ReactorGalleryUno/Platforms/Android/MainActivity.Android.cs
@@ -1,0 +1,13 @@
+using Android.App;
+using Android.Views;
+
+namespace ReactorGalleryUno.Droid;
+
+[Activity(
+    MainLauncher = true,
+    ConfigurationChanges = global::Uno.UI.ActivityHelper.AllConfigChanges,
+    WindowSoftInputMode = SoftInput.AdjustNothing | SoftInput.StateHidden
+)]
+public class MainActivity : Microsoft.UI.Xaml.ApplicationActivity
+{
+}

--- a/samples/Uno/ReactorGalleryUno/Platforms/Android/Resources/values/Strings.xml
+++ b/samples/Uno/ReactorGalleryUno/Platforms/Android/Resources/values/Strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+	<string name="ApplicationName">Reactor Gallery</string>
+</resources>

--- a/samples/Uno/ReactorGalleryUno/Platforms/Android/Resources/values/Styles.xml
+++ b/samples/Uno/ReactorGalleryUno/Platforms/Android/Resources/values/Styles.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<resources>
+	<!-- Deliberately minimal: no Theme.SplashScreen entry, so this head does not
+	     depend on the Uno.Resizetizer-generated splash colour/drawable. -->
+	<style name="AppTheme" parent="Theme.MaterialComponents.Light">
+		<item name="windowActionBar">false</item>
+		<item name="android:windowActionBar">false</item>
+		<item name="windowNoTitle">true</item>
+		<item name="android:windowNoTitle">true</item>
+	</style>
+</resources>

--- a/samples/Uno/ReactorGalleryUno/Platforms/Android/environment.conf
+++ b/samples/Uno/ReactorGalleryUno/Platforms/Android/environment.conf
@@ -1,0 +1,2 @@
+# See http://developer.xamarin.com/guides/android/advanced_topics/garbage_collection/
+MONO_GC_PARAMS=bridge-implementation=new,nursery-size=32m,soft-heap-limit=256m

--- a/samples/Uno/ReactorGalleryUno/Platforms/iOS/Entitlements.plist
+++ b/samples/Uno/ReactorGalleryUno/Platforms/iOS/Entitlements.plist
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<dict>
+	</dict>
+</plist>

--- a/samples/Uno/ReactorGalleryUno/Platforms/iOS/Info.plist
+++ b/samples/Uno/ReactorGalleryUno/Platforms/iOS/Info.plist
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<dict>
+		<key>LSRequiresIPhoneOS</key>
+		<true/>
+		<key>UIDeviceFamily</key>
+		<array>
+			<integer>1</integer>
+			<integer>2</integer>
+		</array>
+		<key>UIRequiredDeviceCapabilities</key>
+		<array>
+			<string>armv7</string>
+			<string>arm64</string>
+		</array>
+		<key>UISupportedInterfaceOrientations</key>
+		<array>
+			<string>UIInterfaceOrientationPortrait</string>
+			<string>UIInterfaceOrientationLandscapeLeft</string>
+			<string>UIInterfaceOrientationLandscapeRight</string>
+		</array>
+		<key>UISupportedInterfaceOrientations~ipad</key>
+		<array>
+			<string>UIInterfaceOrientationPortrait</string>
+			<string>UIInterfaceOrientationPortraitUpsideDown</string>
+			<string>UIInterfaceOrientationLandscapeLeft</string>
+			<string>UIInterfaceOrientationLandscapeRight</string>
+		</array>
+		<key>UIViewControllerBasedStatusBarAppearance</key>
+		<false/>
+		<key>XSAppIconAssets</key>
+		<string>Assets.xcassets/icon.appiconset</string>
+		<key>UIApplicationSupportsIndirectInputEvents</key>
+		<true/>
+
+		<!--
+		Adjust this to your application's encryption usage.
+		<key>ITSAppUsesNonExemptEncryption</key>
+		<false/>
+		-->
+	</dict>
+</plist>

--- a/samples/Uno/ReactorGalleryUno/Platforms/iOS/Media.xcassets/LaunchImages.launchimage/Contents.json
+++ b/samples/Uno/ReactorGalleryUno/Platforms/iOS/Media.xcassets/LaunchImages.launchimage/Contents.json
@@ -1,0 +1,58 @@
+{
+  "images": [
+    {
+      "orientation": "portrait",
+      "extent": "full-screen",
+      "minimum-system-version": "7.0",
+      "scale": "2x",
+      "size": "640x960",
+      "idiom": "iphone"
+    },
+    {
+      "orientation": "portrait",
+      "extent": "full-screen",
+      "minimum-system-version": "7.0",
+      "subtype": "retina4",
+      "scale": "2x",
+      "size": "640x1136",
+      "idiom": "iphone"
+    },
+    {
+      "orientation": "portrait",
+      "extent": "full-screen",
+      "minimum-system-version": "7.0",
+      "scale": "1x",
+      "size": "768x1024",
+      "idiom": "ipad"
+    },
+    {
+      "orientation": "landscape",
+      "extent": "full-screen",
+      "minimum-system-version": "7.0",
+      "scale": "1x",
+      "size": "1024x768",
+      "idiom": "ipad"
+    },
+    {
+      "orientation": "portrait",
+      "extent": "full-screen",
+      "minimum-system-version": "7.0",
+      "scale": "2x",
+      "size": "1536x2048",
+      "idiom": "ipad"
+    },
+    {
+      "orientation": "landscape",
+      "extent": "full-screen",
+      "minimum-system-version": "7.0",
+      "scale": "2x",
+      "size": "2048x1536",
+      "idiom": "ipad"
+    }
+  ],
+  "properties": {},
+  "info": {
+    "version": 1,
+    "author": ""
+  }
+}

--- a/samples/Uno/ReactorGalleryUno/Platforms/iOS/PrivacyInfo.xcprivacy
+++ b/samples/Uno/ReactorGalleryUno/Platforms/iOS/PrivacyInfo.xcprivacy
@@ -1,0 +1,41 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<!-- see https://aka.platform/uno/apple-privacy-manifest for more information -->
+	
+	<!-- .NET Runtime/BCL -->
+	<dict>
+		<key>NSPrivacyAccessedAPIType</key>
+		<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+		<key>NSPrivacyAccessedAPITypeReasons</key>
+		<array>
+			<string>C617.1</string>
+		</array>
+	</dict>
+	<dict>
+		<key>NSPrivacyAccessedAPIType</key>
+		<string>NSPrivacyAccessedAPICategorySystemBootTime</string>
+		<key>NSPrivacyAccessedAPITypeReasons</key>
+		<array>
+			<string>35F9.1</string>
+		</array>
+	</dict>
+	<dict>
+		<key>NSPrivacyAccessedAPIType</key>
+		<string>NSPrivacyAccessedAPICategoryDiskSpace</string>
+		<key>NSPrivacyAccessedAPITypeReasons</key>
+		<array>
+			<string>E174.1</string>
+		</array>
+	</dict>
+
+	<!-- NSUserDefaults -->
+	<dict>
+		<key>NSPrivacyAccessedAPIType</key>
+		<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+		<key>NSPrivacyAccessedAPITypeReasons</key>
+		<array>
+			<string>CA92.1</string>
+		</array>
+	</dict>
+</plist>

--- a/samples/Uno/ReactorGalleryUno/Program.cs
+++ b/samples/Uno/ReactorGalleryUno/Program.cs
@@ -1,0 +1,24 @@
+using Microsoft.UI.Reactor;
+using Microsoft.UI.Reactor.Hosting;
+using WinUIGalleryReactor;
+
+// The Uno gallery head.
+//
+// Mirrors samples/ReactorGallery/Program.cs minus the two Windows-only steps:
+// there is no `reactor-gallery://` single-instance redirection or HKCU protocol
+// registration (see Shims/GalleryDeepLinkShims.cs), and no docking interop to
+// register because that subsystem is not part of the Uno port.
+//
+// As on Windows, no explicit width/height: the gallery is content-heavy and
+// benefits from the OS-chosen default window size.
+#if __ANDROID__
+// intentionally empty — Android starts from the Activity in Platforms/Android/
+#elif __WASM__
+await ReactorApp.RunAsync<GalleryShell>(
+    "Reactor Gallery (Uno)",
+    configure: static host => XamlInterop.Register(host.Reconciler));
+#else
+ReactorApp.Run<GalleryShell>(
+    "Reactor Gallery (Uno)",
+    configure: static host => XamlInterop.Register(host.Reconciler));
+#endif

--- a/samples/Uno/ReactorGalleryUno/ReactorGalleryUno.csproj
+++ b/samples/Uno/ReactorGalleryUno/ReactorGalleryUno.csproj
@@ -1,0 +1,90 @@
+<Project Sdk="Uno.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net10.0-desktop;net10.0-browserwasm;net10.0-android;net10.0-ios</TargetFrameworks>
+
+    <OutputType>Exe</OutputType>
+    <UnoSingleProject>true</UnoSingleProject>
+
+    <ApplicationTitle>Reactor Gallery (Uno)</ApplicationTitle>
+    <ApplicationId>dev.reactor.gallery</ApplicationId>
+    <ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
+    <ApplicationVersion>1</ApplicationVersion>
+
+    <!-- The gallery source is written against the Windows gallery's root namespace. -->
+    <RootNamespace>WinUIGalleryReactor</RootNamespace>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <!-- Reactor apps have no XAML, so there is no ApplicationDefinition for Uno's
+         iOS Hot Restart helper generator to read (Uno0005). Opt out; this only
+         disables VS's iOS *Hot Restart* deploy helper, not Hot Reload. -->
+    <UnoDisableHotRestartHelperGeneration>true</UnoDisableHotRestartHelperGeneration>
+
+    <UnoFeatures>
+      SkiaRenderer;
+    </UnoFeatures>
+  </PropertyGroup>
+
+  <!-- ── Shared gallery source ──────────────────────────────────────────────
+       The gallery is ~10k lines of pure Reactor C# and is source-shared verbatim
+       from samples/ReactorGallery rather than forked, so the two galleries can
+       never drift. Only the handful of files that reach for Windows App SDK or
+       Win32 are excluded, and each has an Uno-side counterpart in Shims/ that
+       keeps the shared source compiling untouched. -->
+  <ItemGroup>
+    <Compile Include="..\..\ReactorGallery\ControlPages\**\*.cs" />
+    <Compile Include="..\..\ReactorGallery\Pages\**\*.cs" />
+    <Compile Include="..\..\ReactorGallery\UserControls\**\*.cs" />
+    <Compile Include="..\..\ReactorGallery\ControlRegistry.cs" />
+    <Compile Include="..\..\ReactorGallery\GalleryShell.cs" />
+    <Compile Include="..\..\ReactorGallery\PageRouter.cs" />
+    <Compile Include="..\..\ReactorGallery\SamplePageHost.cs" />
+
+    <!-- Portable halves of the deep-link subsystem: pure routing/tag helpers. -->
+    <Compile Include="..\..\ReactorGallery\DeepLink\GalleryRoutes.cs" />
+    <Compile Include="..\..\ReactorGallery\DeepLink\GalleryActivationRouting.cs" />
+  </ItemGroup>
+
+  <!-- Excludes (must follow the Include globs above to take effect). -->
+  <ItemGroup>
+    <!-- Docking is Win32 tear-off / floating windows and is excluded from the
+         Reactor.Uno port entirely. PageRouter still routes "docking", so Shims/
+         supplies a DockingPage that explains the gap instead. -->
+    <Compile Remove="..\..\ReactorGallery\ControlPages\Layout\DockingPage.cs" />
+
+    <!-- On Uno, `WebView2` resolves to a NAMESPACE that shadows Reactor's
+         WebView2(...) element factory, so the shared page cannot compile here
+         (CS0118) and no alias can fix a namespace-vs-method-group shadow.
+         Shims/ supplies a stand-in page. -->
+    <Compile Remove="..\..\ReactorGallery\ControlPages\Media\WebView2Page.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Reactor.Uno\Reactor.Uno.csproj" />
+  </ItemGroup>
+
+  <!-- Gallery assets, linked so they land in the output with their folder layout. -->
+  <ItemGroup>
+    <Content Include="..\..\ReactorGallery\Assets\ControlImages\**"
+             Link="Assets\ControlImages\%(RecursiveDir)%(Filename)%(Extension)"
+             CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="..\..\ReactorGallery\Assets\SampleImages\**"
+             Link="Assets\SampleImages\%(RecursiveDir)%(Filename)%(Extension)"
+             CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+  <!-- Source-share drift guard: a <Compile Include> glob matching zero files is
+       silent in MSBuild, so assert the gallery roots still exist. -->
+  <Target Name="VerifyGallerySourceRoots" BeforeTargets="CoreCompile">
+    <ItemGroup>
+      <GallerySourceRoot Include="..\..\ReactorGallery\ControlPages" />
+      <GallerySourceRoot Include="..\..\ReactorGallery\Pages" />
+      <GallerySourceRoot Include="..\..\ReactorGallery\UserControls" />
+      <GallerySourceRoot Include="..\..\ReactorGallery\DeepLink" />
+    </ItemGroup>
+    <Error Condition="!Exists('%(GallerySourceRoot.Identity)')"
+           Text="Gallery source root '%(GallerySourceRoot.Identity)' no longer exists — the Windows gallery moved or renamed it, so this Uno head is silently missing pages. Re-point the Compile globs." />
+  </Target>
+
+</Project>

--- a/samples/Uno/ReactorGalleryUno/Shims/DockingPage.cs
+++ b/samples/Uno/ReactorGalleryUno/Shims/DockingPage.cs
@@ -1,0 +1,27 @@
+// Uno stand-in for the gallery's docking page.
+//
+// The docking subsystem (dock manager, tab tear-off, floating windows) is built
+// on Win32 native windowing and is excluded from the Reactor.Uno port entirely,
+// so ControlPages/Layout/DockingPage.cs cannot compile here. PageRouter is shared
+// source and still routes the "docking" tag, so this page takes its place and
+// says so plainly rather than 404-ing or silently rendering nothing.
+
+using Microsoft.UI.Reactor;
+using Microsoft.UI.Reactor.Core;
+using static Microsoft.UI.Reactor.Factories;
+
+namespace WinUIGalleryReactor.ControlPages.Layout;
+
+class DockingPage : Component
+{
+    public override Element Render() =>
+        VStack(12,
+            Heading("Docking"),
+            Body("Not available on Uno Platform."),
+            Body(
+                "The dock manager, tab tear-off and floating windows are implemented "
+                + "against Win32 native windowing, so the docking subsystem is excluded "
+                + "from the Uno port. Every other page in this gallery is the exact same "
+                + "source as the Windows gallery.")
+        ).Padding(24);
+}

--- a/samples/Uno/ReactorGalleryUno/Shims/GalleryDeepLinkShims.cs
+++ b/samples/Uno/ReactorGalleryUno/Shims/GalleryDeepLinkShims.cs
@@ -1,0 +1,80 @@
+// Uno-side counterparts for the gallery's Windows-only deep-link plumbing.
+//
+// samples/ReactorGallery/DeepLink splits cleanly in two:
+//   * GalleryRoutes.cs / GalleryActivationRouting.cs are pure routing logic and
+//     are source-shared verbatim by this project;
+//   * GalleryActivation.cs / GalleryProtocol.cs / GalleryPackageIdentity.cs are
+//     Windows App SDK (Microsoft.Windows.AppLifecycle.AppInstance) and Win32
+//     (LibraryImport + HKCU registry), which have no Uno equivalent.
+//
+// Rather than fork GalleryShell.cs and SettingsPage.cs to remove their calls,
+// this file re-declares the same types with the same surface so ALL gallery
+// source compiles unchanged. The semantics are honest, not fake: on Uno the app
+// is never launched by a `reactor-gallery://` link, so there is no initial route,
+// no activation event ever fires, and protocol registration reports "not
+// registered" and refuses to register.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace WinUIGalleryReactor;
+
+/// <summary>
+/// Uno stand-in for the WinAppSDK single-instance activation handler.
+/// Deep-link activation needs <c>AppInstance.FindOrRegisterForKey</c> /
+/// <c>GetActivatedEventArgs</c>, which are Windows App SDK APIs; nothing
+/// equivalent exists across the Uno heads, so this reports "no activation".
+/// </summary>
+public static class GalleryActivation
+{
+    /// <summary>Always <c>null</c> on Uno: the app is never protocol-activated.</summary>
+    public static GalleryRoute? InitialRoute => null;
+
+    /// <summary>
+    /// Never raised on Uno. Declared so <c>GalleryShell</c>'s subscribe/unsubscribe
+    /// effect compiles and runs unchanged.
+    /// </summary>
+#pragma warning disable CS0067 // part of the shared API surface; intentionally never raised here
+    public static event Action<GalleryRoute>? RouteActivated;
+#pragma warning restore CS0067
+
+    /// <summary>Always <c>false</c> — there is never a pending warm-start route.</summary>
+    public static bool TryTakePendingRoute([NotNullWhen(true)] out GalleryRoute? route)
+    {
+        route = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Always <c>false</c> — no single-instance redirection, so startup continues
+    /// normally and opens this instance's window.
+    /// </summary>
+    public static bool TryRedirectToRunningInstance() => false;
+}
+
+/// <summary>
+/// Uno stand-in for the <c>reactor-gallery://</c> protocol registration.
+/// The Windows build either declares the scheme in its MSIX manifest or writes
+/// an HKCU registration via Win32; neither is available (or meaningful) here, so
+/// registration is reported as unsupported rather than pretended.
+/// </summary>
+public static class GalleryProtocol
+{
+    /// <summary>Uno heads have no MSIX package identity.</summary>
+    public static bool IsPackaged => false;
+
+    /// <summary>Nothing manages the scheme on Uno, so the Settings page shows the toggle as off and inert.</summary>
+    public static bool IsManagedByPackage => false;
+
+    /// <summary>Always <c>false</c>: the scheme is never registered on Uno.</summary>
+    public static bool IsRegistered => false;
+
+    /// <summary>No-op; returns <c>false</c> to report "not registered".</summary>
+    public static bool EnsureRegistered() => false;
+
+    /// <summary>Unsupported on Uno; returns <c>false</c>.</summary>
+    public static bool Register() => false;
+
+    /// <summary>Unsupported on Uno; returns <c>false</c>.</summary>
+    public static bool Unregister() => false;
+}

--- a/samples/Uno/ReactorGalleryUno/Shims/WebView2Page.cs
+++ b/samples/Uno/ReactorGalleryUno/Shims/WebView2Page.cs
@@ -1,0 +1,31 @@
+// Uno stand-in for the gallery's WebView2 page.
+//
+// This is a *compilation* limitation, not a capability one. On Uno the name
+// `WebView2` resolves to a namespace, which shadows Reactor's `WebView2(...)`
+// element factory that the shared page calls — and a namespace shadowing a
+// method group is not something a `global using` alias can disambiguate. The
+// page is therefore excluded and replaced here, rather than forking it.
+//
+// Uno does implement a WebView2 control, so a fully-qualified variant of the
+// shared page would work; that is worth revisiting upstream so both galleries
+// can keep using one file.
+
+using Microsoft.UI.Reactor;
+using Microsoft.UI.Reactor.Core;
+using static Microsoft.UI.Reactor.Factories;
+
+namespace WinUIGalleryReactor.ControlPages.Media;
+
+class WebView2Page : Component
+{
+    public override Element Render() =>
+        VStack(12,
+            Heading("WebView2"),
+            Body("Not shown in the Uno gallery."),
+            Body(
+                "Reactor's WebView2(...) factory is shadowed by a namespace of the "
+                + "same name on Uno, so the shared gallery page does not compile here. "
+                + "Uno itself does implement WebView2 — this is a naming collision in "
+                + "the sample, not a missing platform feature.")
+        ).Padding(24);
+}

--- a/samples/Uno/ReactorUnoCounter/Platforms/Android/AndroidManifest.xml
+++ b/samples/Uno/ReactorUnoCounter/Platforms/Android/AndroidManifest.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+  <application android:allowBackup="true" android:supportsRtl="true"></application>
+</manifest>

--- a/samples/Uno/ReactorUnoCounter/Platforms/Android/Main.Android.cs
+++ b/samples/Uno/ReactorUnoCounter/Platforms/Android/Main.Android.cs
@@ -1,0 +1,22 @@
+using System;
+using Android.Runtime;
+using Microsoft.UI.Reactor;
+
+namespace ReactorUnoCounter.Droid;
+
+[global::Android.App.ApplicationAttribute(
+    Label = "@string/ApplicationName",
+    LargeHeap = true,
+    HardwareAccelerated = true,
+    Theme = "@style/AppTheme"
+)]
+public class Application : Microsoft.UI.Xaml.NativeApplication
+{
+    public Application(IntPtr javaReference, JniHandleOwnership transfer)
+        : base(
+            () => ReactorApp.CreateApplication<CounterApp>("Reactor Counter (Uno)"),
+            javaReference,
+            transfer)
+    {
+    }
+}

--- a/samples/Uno/ReactorUnoCounter/Platforms/Android/MainActivity.Android.cs
+++ b/samples/Uno/ReactorUnoCounter/Platforms/Android/MainActivity.Android.cs
@@ -1,0 +1,13 @@
+using Android.App;
+using Android.Views;
+
+namespace ReactorUnoCounter.Droid;
+
+[Activity(
+    MainLauncher = true,
+    ConfigurationChanges = global::Uno.UI.ActivityHelper.AllConfigChanges,
+    WindowSoftInputMode = SoftInput.AdjustNothing | SoftInput.StateHidden
+)]
+public class MainActivity : Microsoft.UI.Xaml.ApplicationActivity
+{
+}

--- a/samples/Uno/ReactorUnoCounter/Platforms/Android/Resources/values/Strings.xml
+++ b/samples/Uno/ReactorUnoCounter/Platforms/Android/Resources/values/Strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+	<string name="ApplicationName">Reactor Counter</string>
+</resources>

--- a/samples/Uno/ReactorUnoCounter/Platforms/Android/Resources/values/Styles.xml
+++ b/samples/Uno/ReactorUnoCounter/Platforms/Android/Resources/values/Styles.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<resources>
+	<!-- Deliberately minimal: no Theme.SplashScreen entry, so this head does not
+	     depend on the Uno.Resizetizer-generated splash colour/drawable. -->
+	<style name="AppTheme" parent="Theme.MaterialComponents.Light">
+		<item name="windowActionBar">false</item>
+		<item name="android:windowActionBar">false</item>
+		<item name="windowNoTitle">true</item>
+		<item name="android:windowNoTitle">true</item>
+	</style>
+</resources>

--- a/samples/Uno/ReactorUnoCounter/Platforms/Android/environment.conf
+++ b/samples/Uno/ReactorUnoCounter/Platforms/Android/environment.conf
@@ -1,0 +1,2 @@
+# See http://developer.xamarin.com/guides/android/advanced_topics/garbage_collection/
+MONO_GC_PARAMS=bridge-implementation=new,nursery-size=32m,soft-heap-limit=256m

--- a/samples/Uno/ReactorUnoCounter/Platforms/iOS/Entitlements.plist
+++ b/samples/Uno/ReactorUnoCounter/Platforms/iOS/Entitlements.plist
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<dict>
+	</dict>
+</plist>

--- a/samples/Uno/ReactorUnoCounter/Platforms/iOS/Info.plist
+++ b/samples/Uno/ReactorUnoCounter/Platforms/iOS/Info.plist
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<dict>
+		<key>LSRequiresIPhoneOS</key>
+		<true/>
+		<key>UIDeviceFamily</key>
+		<array>
+			<integer>1</integer>
+			<integer>2</integer>
+		</array>
+		<key>UIRequiredDeviceCapabilities</key>
+		<array>
+			<string>armv7</string>
+			<string>arm64</string>
+		</array>
+		<key>UISupportedInterfaceOrientations</key>
+		<array>
+			<string>UIInterfaceOrientationPortrait</string>
+			<string>UIInterfaceOrientationLandscapeLeft</string>
+			<string>UIInterfaceOrientationLandscapeRight</string>
+		</array>
+		<key>UISupportedInterfaceOrientations~ipad</key>
+		<array>
+			<string>UIInterfaceOrientationPortrait</string>
+			<string>UIInterfaceOrientationPortraitUpsideDown</string>
+			<string>UIInterfaceOrientationLandscapeLeft</string>
+			<string>UIInterfaceOrientationLandscapeRight</string>
+		</array>
+		<key>UIViewControllerBasedStatusBarAppearance</key>
+		<false/>
+		<key>XSAppIconAssets</key>
+		<string>Assets.xcassets/icon.appiconset</string>
+		<key>UIApplicationSupportsIndirectInputEvents</key>
+		<true/>
+
+		<!--
+		Adjust this to your application's encryption usage.
+		<key>ITSAppUsesNonExemptEncryption</key>
+		<false/>
+		-->
+	</dict>
+</plist>

--- a/samples/Uno/ReactorUnoCounter/Platforms/iOS/Media.xcassets/LaunchImages.launchimage/Contents.json
+++ b/samples/Uno/ReactorUnoCounter/Platforms/iOS/Media.xcassets/LaunchImages.launchimage/Contents.json
@@ -1,0 +1,58 @@
+{
+  "images": [
+    {
+      "orientation": "portrait",
+      "extent": "full-screen",
+      "minimum-system-version": "7.0",
+      "scale": "2x",
+      "size": "640x960",
+      "idiom": "iphone"
+    },
+    {
+      "orientation": "portrait",
+      "extent": "full-screen",
+      "minimum-system-version": "7.0",
+      "subtype": "retina4",
+      "scale": "2x",
+      "size": "640x1136",
+      "idiom": "iphone"
+    },
+    {
+      "orientation": "portrait",
+      "extent": "full-screen",
+      "minimum-system-version": "7.0",
+      "scale": "1x",
+      "size": "768x1024",
+      "idiom": "ipad"
+    },
+    {
+      "orientation": "landscape",
+      "extent": "full-screen",
+      "minimum-system-version": "7.0",
+      "scale": "1x",
+      "size": "1024x768",
+      "idiom": "ipad"
+    },
+    {
+      "orientation": "portrait",
+      "extent": "full-screen",
+      "minimum-system-version": "7.0",
+      "scale": "2x",
+      "size": "1536x2048",
+      "idiom": "ipad"
+    },
+    {
+      "orientation": "landscape",
+      "extent": "full-screen",
+      "minimum-system-version": "7.0",
+      "scale": "2x",
+      "size": "2048x1536",
+      "idiom": "ipad"
+    }
+  ],
+  "properties": {},
+  "info": {
+    "version": 1,
+    "author": ""
+  }
+}

--- a/samples/Uno/ReactorUnoCounter/Platforms/iOS/PrivacyInfo.xcprivacy
+++ b/samples/Uno/ReactorUnoCounter/Platforms/iOS/PrivacyInfo.xcprivacy
@@ -1,0 +1,41 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<!-- see https://aka.platform/uno/apple-privacy-manifest for more information -->
+	
+	<!-- .NET Runtime/BCL -->
+	<dict>
+		<key>NSPrivacyAccessedAPIType</key>
+		<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+		<key>NSPrivacyAccessedAPITypeReasons</key>
+		<array>
+			<string>C617.1</string>
+		</array>
+	</dict>
+	<dict>
+		<key>NSPrivacyAccessedAPIType</key>
+		<string>NSPrivacyAccessedAPICategorySystemBootTime</string>
+		<key>NSPrivacyAccessedAPITypeReasons</key>
+		<array>
+			<string>35F9.1</string>
+		</array>
+	</dict>
+	<dict>
+		<key>NSPrivacyAccessedAPIType</key>
+		<string>NSPrivacyAccessedAPICategoryDiskSpace</string>
+		<key>NSPrivacyAccessedAPITypeReasons</key>
+		<array>
+			<string>E174.1</string>
+		</array>
+	</dict>
+
+	<!-- NSUserDefaults -->
+	<dict>
+		<key>NSPrivacyAccessedAPIType</key>
+		<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+		<key>NSPrivacyAccessedAPITypeReasons</key>
+		<array>
+			<string>CA92.1</string>
+		</array>
+	</dict>
+</plist>

--- a/samples/Uno/ReactorUnoCounter/Program.cs
+++ b/samples/Uno/ReactorUnoCounter/Program.cs
@@ -1,0 +1,36 @@
+using Microsoft.UI.Reactor;
+using Microsoft.UI.Reactor.Core;
+using static Microsoft.UI.Reactor.Factories;
+
+// Reactor owns the Uno Application + window + render loop. This single call is
+// the whole entry point — the same shape as the Windows/WinUI ReactorApp.Run,
+// and it is what desktop AND iOS use (Uno gives the Apple heads the same
+// host-builder shape as desktop).
+//
+// Two targets differ:
+//  - WebAssembly can't block the browser thread, so it uses the async entry.
+//  - Android has no console entry point at all — the OS starts the Activity in
+//    Platforms/Android/, which calls ReactorApp.CreateApplication<CounterApp>().
+#if __ANDROID__
+// intentionally empty — see Platforms/Android/
+#elif __WASM__
+await ReactorApp.RunAsync<CounterApp>("Reactor Counter (Uno)", width: 480, height: 360);
+#else
+ReactorApp.Run<CounterApp>("Reactor Counter (Uno)", width: 480, height: 360);
+#endif
+
+class CounterApp : Component
+{
+    public override Element Render()
+    {
+        var (count, setCount) = UseState(0);
+
+        return VStack(12,
+            Heading($"Count: {count}"),
+            HStack(8,
+                Button("-", () => setCount(count - 1)),
+                Button("+", () => setCount(count + 1))
+            )
+        ).Padding(24);
+    }
+}

--- a/samples/Uno/ReactorUnoCounter/ReactorUnoCounter.csproj
+++ b/samples/Uno/ReactorUnoCounter/ReactorUnoCounter.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Uno.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net10.0-desktop;net10.0-browserwasm;net10.0-android;net10.0-ios</TargetFrameworks>
+    <OutputType>Exe</OutputType>
+    <UnoSingleProject>true</UnoSingleProject>
+
+    <ApplicationTitle>Reactor Counter (Uno)</ApplicationTitle>
+    <ApplicationId>dev.reactor.unocounter</ApplicationId>
+    <ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
+    <ApplicationVersion>1</ApplicationVersion>
+
+    <Nullable>enable</Nullable>
+
+    <!-- Reactor apps have NO XAML at all — Reactor owns the Application in code —
+         so there is no ApplicationDefinition (App.xaml) for Uno's iOS Hot Restart
+         helper generator to read, and it fails the build with Uno0005. Opt out;
+         this only disables VS's iOS *Hot Restart* deploy helper, not Hot Reload. -->
+    <UnoDisableHotRestartHelperGeneration>true</UnoDisableHotRestartHelperGeneration>
+
+    <!-- NOTE: there is no "HotReload" UnoFeature. The Uno dev-server client
+         (Uno.WinUI.DevServer / Uno.UI.RemoteControl) is referenced automatically
+         for Debug builds, and the Dev Server itself is started by the IDE. -->
+    <UnoFeatures>
+      SkiaRenderer;
+    </UnoFeatures>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Reactor.Uno\Reactor.Uno.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/Uno/ReactorUnoShowcase/Platforms/Android/AndroidManifest.xml
+++ b/samples/Uno/ReactorUnoShowcase/Platforms/Android/AndroidManifest.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+  <application android:allowBackup="true" android:supportsRtl="true"></application>
+</manifest>

--- a/samples/Uno/ReactorUnoShowcase/Platforms/Android/Main.Android.cs
+++ b/samples/Uno/ReactorUnoShowcase/Platforms/Android/Main.Android.cs
@@ -1,0 +1,22 @@
+using System;
+using Android.Runtime;
+using Microsoft.UI.Reactor;
+
+namespace ReactorUnoShowcase.Droid;
+
+[global::Android.App.ApplicationAttribute(
+    Label = "@string/ApplicationName",
+    LargeHeap = true,
+    HardwareAccelerated = true,
+    Theme = "@style/AppTheme"
+)]
+public class Application : Microsoft.UI.Xaml.NativeApplication
+{
+    public Application(IntPtr javaReference, JniHandleOwnership transfer)
+        : base(
+            () => ReactorApp.CreateApplication<Showcase>("Reactor Showcase (Uno)"),
+            javaReference,
+            transfer)
+    {
+    }
+}

--- a/samples/Uno/ReactorUnoShowcase/Platforms/Android/MainActivity.Android.cs
+++ b/samples/Uno/ReactorUnoShowcase/Platforms/Android/MainActivity.Android.cs
@@ -1,0 +1,13 @@
+using Android.App;
+using Android.Views;
+
+namespace ReactorUnoShowcase.Droid;
+
+[Activity(
+    MainLauncher = true,
+    ConfigurationChanges = global::Uno.UI.ActivityHelper.AllConfigChanges,
+    WindowSoftInputMode = SoftInput.AdjustNothing | SoftInput.StateHidden
+)]
+public class MainActivity : Microsoft.UI.Xaml.ApplicationActivity
+{
+}

--- a/samples/Uno/ReactorUnoShowcase/Platforms/Android/Resources/values/Strings.xml
+++ b/samples/Uno/ReactorUnoShowcase/Platforms/Android/Resources/values/Strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+	<string name="ApplicationName">Reactor Showcase</string>
+</resources>

--- a/samples/Uno/ReactorUnoShowcase/Platforms/Android/Resources/values/Styles.xml
+++ b/samples/Uno/ReactorUnoShowcase/Platforms/Android/Resources/values/Styles.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<resources>
+	<!-- Deliberately minimal: no Theme.SplashScreen entry, so this head does not
+	     depend on the Uno.Resizetizer-generated splash colour/drawable. -->
+	<style name="AppTheme" parent="Theme.MaterialComponents.Light">
+		<item name="windowActionBar">false</item>
+		<item name="android:windowActionBar">false</item>
+		<item name="windowNoTitle">true</item>
+		<item name="android:windowNoTitle">true</item>
+	</style>
+</resources>

--- a/samples/Uno/ReactorUnoShowcase/Platforms/Android/environment.conf
+++ b/samples/Uno/ReactorUnoShowcase/Platforms/Android/environment.conf
@@ -1,0 +1,2 @@
+# See http://developer.xamarin.com/guides/android/advanced_topics/garbage_collection/
+MONO_GC_PARAMS=bridge-implementation=new,nursery-size=32m,soft-heap-limit=256m

--- a/samples/Uno/ReactorUnoShowcase/Platforms/iOS/Entitlements.plist
+++ b/samples/Uno/ReactorUnoShowcase/Platforms/iOS/Entitlements.plist
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<dict>
+	</dict>
+</plist>

--- a/samples/Uno/ReactorUnoShowcase/Platforms/iOS/Info.plist
+++ b/samples/Uno/ReactorUnoShowcase/Platforms/iOS/Info.plist
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<dict>
+		<key>LSRequiresIPhoneOS</key>
+		<true/>
+		<key>UIDeviceFamily</key>
+		<array>
+			<integer>1</integer>
+			<integer>2</integer>
+		</array>
+		<key>UIRequiredDeviceCapabilities</key>
+		<array>
+			<string>armv7</string>
+			<string>arm64</string>
+		</array>
+		<key>UISupportedInterfaceOrientations</key>
+		<array>
+			<string>UIInterfaceOrientationPortrait</string>
+			<string>UIInterfaceOrientationLandscapeLeft</string>
+			<string>UIInterfaceOrientationLandscapeRight</string>
+		</array>
+		<key>UISupportedInterfaceOrientations~ipad</key>
+		<array>
+			<string>UIInterfaceOrientationPortrait</string>
+			<string>UIInterfaceOrientationPortraitUpsideDown</string>
+			<string>UIInterfaceOrientationLandscapeLeft</string>
+			<string>UIInterfaceOrientationLandscapeRight</string>
+		</array>
+		<key>UIViewControllerBasedStatusBarAppearance</key>
+		<false/>
+		<key>XSAppIconAssets</key>
+		<string>Assets.xcassets/icon.appiconset</string>
+		<key>UIApplicationSupportsIndirectInputEvents</key>
+		<true/>
+
+		<!--
+		Adjust this to your application's encryption usage.
+		<key>ITSAppUsesNonExemptEncryption</key>
+		<false/>
+		-->
+	</dict>
+</plist>

--- a/samples/Uno/ReactorUnoShowcase/Platforms/iOS/Media.xcassets/LaunchImages.launchimage/Contents.json
+++ b/samples/Uno/ReactorUnoShowcase/Platforms/iOS/Media.xcassets/LaunchImages.launchimage/Contents.json
@@ -1,0 +1,58 @@
+{
+  "images": [
+    {
+      "orientation": "portrait",
+      "extent": "full-screen",
+      "minimum-system-version": "7.0",
+      "scale": "2x",
+      "size": "640x960",
+      "idiom": "iphone"
+    },
+    {
+      "orientation": "portrait",
+      "extent": "full-screen",
+      "minimum-system-version": "7.0",
+      "subtype": "retina4",
+      "scale": "2x",
+      "size": "640x1136",
+      "idiom": "iphone"
+    },
+    {
+      "orientation": "portrait",
+      "extent": "full-screen",
+      "minimum-system-version": "7.0",
+      "scale": "1x",
+      "size": "768x1024",
+      "idiom": "ipad"
+    },
+    {
+      "orientation": "landscape",
+      "extent": "full-screen",
+      "minimum-system-version": "7.0",
+      "scale": "1x",
+      "size": "1024x768",
+      "idiom": "ipad"
+    },
+    {
+      "orientation": "portrait",
+      "extent": "full-screen",
+      "minimum-system-version": "7.0",
+      "scale": "2x",
+      "size": "1536x2048",
+      "idiom": "ipad"
+    },
+    {
+      "orientation": "landscape",
+      "extent": "full-screen",
+      "minimum-system-version": "7.0",
+      "scale": "2x",
+      "size": "2048x1536",
+      "idiom": "ipad"
+    }
+  ],
+  "properties": {},
+  "info": {
+    "version": 1,
+    "author": ""
+  }
+}

--- a/samples/Uno/ReactorUnoShowcase/Platforms/iOS/PrivacyInfo.xcprivacy
+++ b/samples/Uno/ReactorUnoShowcase/Platforms/iOS/PrivacyInfo.xcprivacy
@@ -1,0 +1,41 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<!-- see https://aka.platform/uno/apple-privacy-manifest for more information -->
+	
+	<!-- .NET Runtime/BCL -->
+	<dict>
+		<key>NSPrivacyAccessedAPIType</key>
+		<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+		<key>NSPrivacyAccessedAPITypeReasons</key>
+		<array>
+			<string>C617.1</string>
+		</array>
+	</dict>
+	<dict>
+		<key>NSPrivacyAccessedAPIType</key>
+		<string>NSPrivacyAccessedAPICategorySystemBootTime</string>
+		<key>NSPrivacyAccessedAPITypeReasons</key>
+		<array>
+			<string>35F9.1</string>
+		</array>
+	</dict>
+	<dict>
+		<key>NSPrivacyAccessedAPIType</key>
+		<string>NSPrivacyAccessedAPICategoryDiskSpace</string>
+		<key>NSPrivacyAccessedAPITypeReasons</key>
+		<array>
+			<string>E174.1</string>
+		</array>
+	</dict>
+
+	<!-- NSUserDefaults -->
+	<dict>
+		<key>NSPrivacyAccessedAPIType</key>
+		<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+		<key>NSPrivacyAccessedAPITypeReasons</key>
+		<array>
+			<string>CA92.1</string>
+		</array>
+	</dict>
+</plist>

--- a/samples/Uno/ReactorUnoShowcase/Program.cs
+++ b/samples/Uno/ReactorUnoShowcase/Program.cs
@@ -1,0 +1,117 @@
+// Secondary windows are real on every Uno *desktop* head (X11 / Win32 / macOS /
+// FrameBuffer) but throw InvalidOperationException on Android and iOS, and there
+// are no OS windows in the browser at all. So the multi-window demo is gated on
+// "desktop", not merely "not wasm".
+#if !__WASM__ && !__ANDROID__ && !__IOS__ && !__MACCATALYST__
+#define REACTOR_DESKTOP
+#endif
+
+using Microsoft.UI.Reactor;
+using Microsoft.UI.Reactor.Core;
+using static Microsoft.UI.Reactor.Factories;
+
+// Desktop and iOS share ReactorApp.Run; wasm needs the async entry (the browser
+// thread can't block); Android has no console entry point and starts from the
+// Activity in Platforms/Android/.
+#if __ANDROID__
+// intentionally empty — see Platforms/Android/
+#elif __WASM__
+await ReactorApp.RunAsync<Showcase>("Reactor Showcase (Uno)", width: 560, height: 620);
+#else
+ReactorApp.Run<Showcase>("Reactor Showcase (Uno)", width: 560, height: 620);
+#endif
+
+class Showcase : Component
+{
+    static readonly string[] Fruits = { "Donuts", "Apples", "Bananas" };
+
+    public override Element Render()
+    {
+        var (on, setOn) = UseState(true);
+        var (slider, setSlider) = UseState(40.0);
+        var (chk, setChk) = UseState<bool?>(true);
+        var (combo, setCombo) = UseState(0);
+        var (count, setCount) = UseState(0);
+        var (picked, setPicked) = UseState("(none)");
+
+        return ScrollView(
+            VStack(14,
+                Heading("Reactor on Uno — Control Showcase"),
+
+                TextBlock($"Counter: {count}"),
+                HStack(8,
+                    Button("-", () => setCount(count - 1)),
+                    Button("+", () => setCount(count + 1))),
+
+                ToggleSwitch(on, setOn, header: "Feature toggle"),
+                TextBlock(on ? "Feature is ON" : "Feature is OFF"),
+
+                TextBlock($"Slider value: {slider:0}"),
+                Slider(slider, 0, 100, setSlider),
+                Progress(slider),
+
+                CheckBox(chk, b => setChk(b), label: "I agree"),
+                TextBlock(chk == true ? "Checked" : "Unchecked"),
+
+                TextBlock($"Favourite: {Fruits[combo]}"),
+                ComboBox(Fruits, combo, setCombo),
+
+                // Uno implements the WinRT pickers, including the
+                // WindowNative.GetWindowHandle + InitializeWithWindow association
+                // the shared hook performs — the very pattern Uno's own docs
+                // prescribe. Nothing Windows-only here.
+                Heading("File picker"),
+                TextBlock($"Picked: {picked}"),
+                Button("Pick a file…", async () =>
+                {
+                    var file = await UseFilePickerAsync(new FilePickerOptions());
+                    setPicked(file?.Name ?? "(cancelled)");
+                })
+#if REACTOR_DESKTOP
+                ,
+                Heading("Multi-window"),
+                TextBlock("Each window gets its own Reactor host, render loop, and state."),
+                Button("Open a second window", OpenSecondWindow)
+#endif
+            ).Padding(24)
+        );
+    }
+
+#if REACTOR_DESKTOP
+    // Secondary windows are real on every Uno desktop head (X11 / Win32 / macOS /
+    // FrameBuffer). Android and iOS throw InvalidOperationException instead.
+    static void OpenSecondWindow() =>
+        ReactorApp.OpenWindow(
+            new WindowSpec { Title = "Second Window", Width = 380, Height = 260 },
+            static () => new SecondWindow());
+#endif
+}
+
+#if REACTOR_DESKTOP
+class SecondWindow : Component
+{
+    public override Element Render()
+    {
+        var (count, setCount) = UseState(0);
+        var (locked, setLocked) = UseState<bool?>(false);
+
+        // A real closing guard, backed by Uno's AppWindow.Closing on the desktop
+        // heads: tick the box and the window refuses to close.
+        UseClosingGuard(() => locked != true);
+
+        return VStack(12,
+            Heading("Second window 🎉"),
+            TextBlock("Independent of the main window:"),
+            TextBlock($"Count: {count}"),
+            HStack(8,
+                Button("-", () => setCount(count - 1)),
+                Button("+", () => setCount(count + 1))
+            ),
+            CheckBox(locked, b => setLocked(b), label: "Prevent closing"),
+            TextBlock(locked == true
+                ? "Close is blocked — untick to close."
+                : "Close is allowed.")
+        ).Padding(24);
+    }
+}
+#endif

--- a/samples/Uno/ReactorUnoShowcase/ReactorUnoShowcase.csproj
+++ b/samples/Uno/ReactorUnoShowcase/ReactorUnoShowcase.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Uno.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net10.0-desktop;net10.0-browserwasm;net10.0-android;net10.0-ios</TargetFrameworks>
+    <OutputType>Exe</OutputType>
+    <UnoSingleProject>true</UnoSingleProject>
+
+    <ApplicationTitle>Reactor Showcase (Uno)</ApplicationTitle>
+    <ApplicationId>dev.reactor.unoshowcase</ApplicationId>
+    <ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
+    <ApplicationVersion>1</ApplicationVersion>
+    <Nullable>enable</Nullable>
+
+    <!-- Reactor apps have no XAML, so there is no ApplicationDefinition for Uno's
+         iOS Hot Restart helper generator to read (Uno0005). Opt out; this only
+         disables VS's iOS *Hot Restart* deploy helper, not Hot Reload. -->
+    <UnoDisableHotRestartHelperGeneration>true</UnoDisableHotRestartHelperGeneration>
+
+    <!-- NOTE: there is no "HotReload" UnoFeature. The Uno dev-server client
+         (Uno.WinUI.DevServer / Uno.UI.RemoteControl) is referenced automatically
+         for Debug builds, and the Dev Server itself is started by the IDE. -->
+    <UnoFeatures>
+      SkiaRenderer;
+    </UnoFeatures>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Reactor.Uno\Reactor.Uno.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/Uno/file-based/Counter.cs
+++ b/samples/Uno/file-based/Counter.cs
@@ -1,0 +1,35 @@
+#:sdk Uno.Sdk@6.7.0-dev.117
+#:project ../../../src/Reactor.Uno/Reactor.Uno.csproj
+#:property TargetFramework=net10.0-desktop
+#:property OutputType=Exe
+#:property UnoSingleProject=true
+#:property UnoFeatures=SkiaRenderer
+#:property PublishAot=false
+#:property PackAsTool=false
+
+using Microsoft.UI.Reactor;
+using Microsoft.UI.Reactor.Core;
+using static Microsoft.UI.Reactor.Factories;
+
+// A whole WinUI-style Reactor app — in one .cs file — running on Uno Platform.
+// Run it with:  dotnet run Counter.cs
+ReactorApp.Run<CounterApp>("Single-File Reactor on Uno", width: 520, height: 400);
+
+class CounterApp : Component
+{
+    public override Element Render()
+    {
+        var (name, setName) = UseState("Uno");
+        var (count, setCount) = UseState(0);
+
+        return VStack(12,
+            Heading($"Hello, {name}!"),
+            TextBox(name, setName, placeholderText: "Your name"),
+            Heading($"Count: {count}"),
+            HStack(8,
+                Button("-", () => setCount(count - 1)),
+                Button("+", () => setCount(count + 1))
+            )
+        ).Padding(24);
+    }
+}

--- a/samples/Uno/global.json
+++ b/samples/Uno/global.json
@@ -1,0 +1,10 @@
+{
+  "msbuild-sdks": {
+    "Uno.Sdk": "6.7.0-dev.117"
+  },
+  "sdk": {
+    "version": "10.0.100",
+    "rollForward": "latestFeature",
+    "allowPrerelease": false
+  }
+}

--- a/samples/Uno/nuget.config
+++ b/samples/Uno/nuget.config
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <!-- Isolated NuGet sources for the Uno port. nuget.org carries Uno.Sdk
+       (incl. the 6.7.0-dev.* builds) and the .NET runtime packages. We clear
+       first so inherited/authenticated enterprise feeds don't slow restore. -->
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+  </packageSources>
+  <disabledPackageSources>
+    <clear />
+  </disabledPackageSources>
+</configuration>

--- a/src/Reactor.Uno/Directory.Build.props
+++ b/src/Reactor.Uno/Directory.Build.props
@@ -1,0 +1,16 @@
+<Project>
+  <!--
+    Isolation boundary for the Uno port. This file STOPS MSBuild from walking up
+    into the repo-root Directory.Build.props (which is tuned for the Windows /
+    Windows App SDK build and imports Reactor.targets). The Uno port is a
+    self-contained subtree that only *shares source* with src/Reactor via
+    explicit <Compile Include> globs — it must not inherit the Windows build
+    infrastructure. Intentionally does NOT chain to the parent.
+  -->
+  <PropertyGroup>
+    <LangVersion>latest</LangVersion>
+    <!-- Quiet down doc-comment cref warnings: shared source has <see cref>
+         pointers to Windows-only types that don't exist in the Uno build. -->
+    <NoWarn>$(NoWarn);CS1591;CS1574;CS1580;CS1735</NoWarn>
+  </PropertyGroup>
+</Project>

--- a/src/Reactor.Uno/Directory.Packages.props
+++ b/src/Reactor.Uno/Directory.Packages.props
@@ -1,0 +1,11 @@
+<Project>
+  <!--
+    Nearest Directory.Packages.props wins, so this shadows the repo-root one and
+    keeps Central Package Management OFF for the Uno port. Uno.Sdk supplies the
+    versions of its implicit (UnoFeatures) packages from the SDK version pinned
+    in global.json; the few extra packages we add carry inline versions.
+  -->
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+</Project>

--- a/src/Reactor.Uno/GlobalUsings.cs
+++ b/src/Reactor.Uno/GlobalUsings.cs
@@ -1,0 +1,16 @@
+// Disambiguation aliases for the Uno port.
+//
+// Uno defines ElementFactoryGetArgs / ElementFactoryRecycleArgs in BOTH
+// Microsoft.UI.Xaml and Microsoft.UI.Xaml.Controls, which makes the unqualified
+// name in Core/ElementFactory.cs (it imports both namespaces) ambiguous. On the
+// Windows build the type only exists in Microsoft.UI.Xaml, so pin the alias to
+// that namespace — matching IElementFactory's member signature.
+global using ElementFactoryGetArgs = Microsoft.UI.Xaml.ElementFactoryGetArgs;
+global using ElementFactoryRecycleArgs = Microsoft.UI.Xaml.ElementFactoryRecycleArgs;
+
+// Uno's implicit `Microsoft.UI.Xaml.Controls` global using cannot be removed via
+// <Using Remove> (Uno injects it from the SDK targets). The only bare-`SelectionMode`
+// *type* reference in shared source is DataGridFactories.cs, which wants Reactor's
+// enum; the WinUI list controls use control-specific enums (ListViewSelectionMode,
+// …), so pinning the bare name to Reactor's type is safe project-wide.
+global using SelectionMode = Microsoft.UI.Reactor.Controls.SelectionMode;

--- a/src/Reactor.Uno/Hosting/ReactorApp.cs
+++ b/src/Reactor.Uno/Hosting/ReactorApp.cs
@@ -1,0 +1,387 @@
+// Uno hosting entry point for Reactor.
+//
+// Replaces the Windows framework's src/Reactor/Hosting/ReactorApp.cs (which is
+// built on Application.Start + Win32/DWM/shell P/Invoke). Here, startup goes
+// through Uno's UnoPlatformHostBuilder (Uno 6 unified Skia hosting) and a
+// code-only Application subclass. Only the static surface the shared core reads
+// (ActiveHostInternal, UIDispatcher, …) plus the public Run/OpenWindow entry points
+// are provided. Multi-window is real on the desktop heads (every window gets its own
+// ReactorHost); tray icons and window persistence remain stubs.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.UI.Dispatching;
+using Microsoft.UI.Reactor.Core;
+using Microsoft.UI.Reactor.Hosting;
+using Microsoft.UI.Windowing;
+
+namespace Microsoft.UI.Reactor;
+
+/// <summary>Startup configuration captured before the Uno host bootstraps.</summary>
+internal sealed record ReactorAppOptions(
+    Func<Component>? RootFactory = null,
+    Func<RenderContext, Element>? RootRenderFunc = null,
+    Action<ReactorHost>? Configure = null,
+    string WindowTitle = "Reactor App",
+    double? WindowWidth = null,
+    double? WindowHeight = null,
+    bool FullScreen = false);
+
+/// <summary>
+/// Application entry point for Reactor apps running on Uno Platform Skia targets
+/// (desktop + WebAssembly, and theoretically mobile).
+/// </summary>
+public static partial class ReactorApp
+{
+    private static ReactorAppOptions _options = new();
+    internal static ReactorAppOptions Options
+    {
+        get => Volatile.Read(ref _options);
+        set => Volatile.Write(ref _options, value);
+    }
+
+    private static ReactorHost? _activeHost;
+
+    /// <summary>The host of the active Reactor window (single-window model).</summary>
+    public static ReactorHost? ActiveHost => Volatile.Read(ref _activeHost);
+
+    internal static ReactorHost? ActiveHostInternal
+    {
+        get => Volatile.Read(ref _activeHost);
+        set => Volatile.Write(ref _activeHost, value);
+    }
+
+    private static DispatcherQueue? _uiDispatcher;
+
+    /// <summary>The UI dispatcher captured at launch (null before the window exists).</summary>
+    public static DispatcherQueue? UIDispatcher
+    {
+        get => Volatile.Read(ref _uiDispatcher);
+        internal set => Volatile.Write(ref _uiDispatcher, value);
+    }
+
+    /// <summary>Optional process-wide logger snapshotted by each host at construction.</summary>
+    public static ILogger? AppLogger { get; set; }
+
+    /// <summary>
+    /// Optional process-wide unhandled-exception hook. Return true to mark the
+    /// exception handled; return false (or leave null) to let it crash. Mirrors
+    /// the Windows framework's <c>ReactorApp.OnUnhandledException</c>.
+    /// </summary>
+    public static Func<Exception, bool>? OnUnhandledException { get; set; }
+
+    /// <summary>Devtools are not available in the Uno port.</summary>
+    public static bool DevtoolsEnabled => false;
+
+    // ── window topology (tray icons remain a Windows-shell stub) ──
+    private static readonly List<ReactorWindow> _windows = new();
+    private static readonly List<ReactorTrayIcon> _trayIcons = new();
+
+    /// <summary>Snapshot of open Reactor windows.</summary>
+    public static IReadOnlyList<ReactorWindow> Windows
+    {
+        get { lock (_windows) { return _windows.ToArray(); } }
+    }
+
+    /// <summary>The primary (first) window, or null before launch.</summary>
+    public static ReactorWindow? PrimaryWindow { get; internal set; }
+
+    internal static void RegisterWindow(ReactorWindow w)
+    {
+        lock (_windows) { if (!_windows.Contains(w)) _windows.Add(w); }
+        PrimaryWindow ??= w;
+    }
+
+    internal static void UnregisterWindow(ReactorWindow w)
+    {
+        lock (_windows)
+        {
+            _windows.Remove(w);
+            if (ReferenceEquals(PrimaryWindow, w))
+                PrimaryWindow = _windows.Count > 0 ? _windows[0] : null;
+        }
+    }
+
+    /// <summary>Finds an open window by its <see cref="WindowSpec.Key"/>.</summary>
+    public static ReactorWindow? FindWindow(WindowKey key)
+    {
+        lock (_windows)
+        {
+            foreach (var w in _windows)
+                if (w.Spec.Key == key) return w;
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Opens a window hosting its own Reactor tree. Signature-compatible with the
+    /// Windows framework's <c>ReactorApp.OpenWindow</c>.
+    /// </summary>
+    /// <remarks>
+    /// <para>Real secondary windows work on every Uno <b>desktop</b> head
+    /// (X11 / Win32 / macOS / FrameBuffer). Android and iOS do not support secondary
+    /// windows: Uno throws <see cref="InvalidOperationException"/> from the
+    /// <c>Window</c> constructor, which <c>UseOpenWindow</c> catches and degrades to
+    /// a null handle rather than failing the render.</para>
+    /// <para>Must be called on the UI thread.</para>
+    /// </remarks>
+    public static ReactorWindow OpenWindow(
+        WindowSpec spec,
+        Func<Component> root,
+        Action<ReactorHost>? configure = null)
+    {
+        ArgumentNullException.ThrowIfNull(spec);
+        ArgumentNullException.ThrowIfNull(root);
+        return OpenWindowCore(spec, root, renderFunc: null, configure);
+    }
+
+    /// <summary>
+    /// Opens a window with a render-function root. See the <see cref="Component"/>
+    /// overload for platform support and <paramref name="configure"/> semantics.
+    /// </summary>
+    public static ReactorWindow OpenWindow(
+        WindowSpec spec,
+        Func<RenderContext, Element> render,
+        Action<ReactorHost>? configure = null)
+    {
+        ArgumentNullException.ThrowIfNull(spec);
+        ArgumentNullException.ThrowIfNull(render);
+        return OpenWindowCore(spec, rootFactory: null, render, configure);
+    }
+
+    // Single construction path for every Reactor window — the primary one that
+    // UnoBootstrap opens at launch and every secondary window opened later.
+    internal static ReactorWindow OpenWindowCore(
+        WindowSpec spec,
+        Func<Component>? rootFactory,
+        Func<RenderContext, Element>? renderFunc,
+        Action<ReactorHost>? configure)
+    {
+        // On Android/iOS this throws InvalidOperationException for anything after
+        // the first window. Deliberately not caught here: UseOpenWindow handles it.
+        var native = new Microsoft.UI.Xaml.Window();
+        var window = new ReactorWindow(native, spec);
+        var host = new ReactorHost(native) { OwningWindow = window };
+        window.Host = host;
+
+        configure?.Invoke(host);
+        RegisterWindow(window);
+        native.Closed += (_, _) => UnregisterWindow(window);
+
+        try
+        {
+            if (rootFactory is not null)
+                host.Mount(rootFactory());
+            else if (renderFunc is not null)
+                host.Mount(renderFunc);
+
+            ApplyChrome(native, spec);
+            native.Activate();
+            // DIP->physical sizing needs a live RasterizationScale, so it can
+            // only run once the window has a XamlRoot. Attempt it here and let
+            // ReactorWindow.OnContentAttached retry if that hasn't happened yet.
+            window.ApplyInitialSize();
+        }
+        catch
+        {
+            UnregisterWindow(window);
+            try { host.Dispose(); } catch { /* best effort */ }
+            throw;
+        }
+
+        return window;
+    }
+
+    // Title + caption height. AppWindow is only partially supported across Skia
+    // heads, so every step is best-effort.
+    private static void ApplyChrome(Microsoft.UI.Xaml.Window native, WindowSpec spec)
+    {
+        try { native.Title = spec.Title; } catch { /* best effort */ }
+
+        if (spec.TitleBarHeight is { } height)
+        {
+            try
+            {
+                var titleBar = native.AppWindow?.TitleBar;
+                if (titleBar is not null)
+                {
+                    titleBar.PreferredHeightOption = height switch
+                    {
+                        WindowTitleBarHeight.Tall => TitleBarHeightOption.Tall,
+                        WindowTitleBarHeight.Collapsed => TitleBarHeightOption.Collapsed,
+                        _ => TitleBarHeightOption.Standard,
+                    };
+                }
+            }
+            catch { /* caption sizing unsupported on this head */ }
+        }
+    }
+
+    /// <summary>Tray icons are a Windows shell feature; returns a stub handle.</summary>
+    public static ReactorTrayIcon OpenTrayIcon(TrayIconSpec spec)
+    {
+        var icon = new ReactorTrayIcon(spec);
+        lock (_trayIcons) { _trayIcons.Add(icon); }
+        return icon;
+    }
+
+    /// <summary>Finds a registered tray-icon stub by key.</summary>
+    public static ReactorTrayIcon? FindTrayIcon(WindowKey key)
+    {
+        lock (_trayIcons)
+        {
+            foreach (var t in _trayIcons)
+                if (t.Spec.Key == key) return t;
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Bulk-registers the built-in control catalog. Factory methods already
+    /// self-register on first use, so this is only needed for the direct
+    /// element-record idiom. The Uno port relies on factory self-registration,
+    /// so this is currently a no-op kept for API parity.
+    /// </summary>
+    public static void RegisterAllBuiltIns() { /* factories self-register */ }
+
+    // ── public Run entry points ───────────────────────────────────────────
+
+    /// <summary>
+    /// Launches a Reactor app whose root is a <see cref="Component"/> subclass.
+    /// Blocks until the window closes (desktop). For WebAssembly use
+    /// <see cref="RunAsync{TRoot}"/>.
+    /// </summary>
+    public static void Run<TRoot>(
+        string title = "Reactor App",
+        double? width = null,
+        double? height = null,
+        bool fullScreen = false,
+        Action<ReactorHost>? configure = null)
+        where TRoot : Component, new()
+    {
+        Options = new ReactorAppOptions(
+            RootFactory: static () => new TRoot(),
+            Configure: configure,
+            WindowTitle: title,
+            WindowWidth: width,
+            WindowHeight: height,
+            FullScreen: fullScreen);
+        UnoBootstrap.Run();
+    }
+
+    /// <summary>
+    /// Launches a Reactor app from a render function (no Component subclass).
+    /// Blocks until the window closes (desktop).
+    /// </summary>
+    public static void Run(
+        string title,
+        Func<RenderContext, Element> rootRender,
+        double? width = null,
+        double? height = null,
+        bool fullScreen = false,
+        Action<ReactorHost>? configure = null)
+    {
+        Options = new ReactorAppOptions(
+            RootRenderFunc: rootRender,
+            Configure: configure,
+            WindowTitle: title,
+            WindowWidth: width,
+            WindowHeight: height,
+            FullScreen: fullScreen);
+        UnoBootstrap.Run();
+    }
+
+    /// <summary>
+    /// Async launch for WebAssembly (the browser thread cannot block). Mirror of
+    /// <see cref="Run{TRoot}"/>; await it from a file-based app's top-level statements.
+    /// </summary>
+    public static Task RunAsync<TRoot>(
+        string title = "Reactor App",
+        double? width = null,
+        double? height = null,
+        bool fullScreen = false,
+        Action<ReactorHost>? configure = null)
+        where TRoot : Component, new()
+    {
+        Options = new ReactorAppOptions(
+            RootFactory: static () => new TRoot(),
+            Configure: configure,
+            WindowTitle: title,
+            WindowWidth: width,
+            WindowHeight: height,
+            FullScreen: fullScreen);
+        return UnoBootstrap.RunAsync();
+    }
+
+    /// <summary>Async launch (render function) for WebAssembly.</summary>
+    public static Task RunAsync(
+        string title,
+        Func<RenderContext, Element> rootRender,
+        double? width = null,
+        double? height = null,
+        bool fullScreen = false,
+        Action<ReactorHost>? configure = null)
+    {
+        Options = new ReactorAppOptions(
+            RootRenderFunc: rootRender,
+            Configure: configure,
+            WindowTitle: title,
+            WindowWidth: width,
+            WindowHeight: height,
+            FullScreen: fullScreen);
+        return UnoBootstrap.RunAsync();
+    }
+
+    // ── mobile / native-head entry point ──────────────────────────────────
+
+    /// <summary>
+    /// Builds the Uno <see cref="Microsoft.UI.Xaml.Application"/> that hosts
+    /// <typeparamref name="TRoot"/>, without starting a host builder.
+    /// </summary>
+    /// <remarks>
+    /// <para>Android and iOS do not start from a console <c>Main</c> — the OS
+    /// owns the entry point (an <c>Activity</c> / <c>AppDelegate</c>) and the
+    /// native head hands Uno an application factory. <see cref="Run{TRoot}"/>
+    /// therefore cannot be used there; call this from the head instead:</para>
+    /// <code>
+    /// public class Application : Microsoft.UI.Xaml.NativeApplication
+    /// {
+    ///     public Application(IntPtr javaReference, JniHandleOwnership transfer)
+    ///         : base(() => ReactorApp.CreateApplication&lt;CounterApp&gt;("My App"),
+    ///                javaReference, transfer) { }
+    /// }
+    /// </code>
+    /// <para>Everything above the hosting layer — components, hooks, the
+    /// reconciler — is identical to desktop and WebAssembly.</para>
+    /// </remarks>
+    public static Microsoft.UI.Xaml.Application CreateApplication<TRoot>(
+        string title = "Reactor App",
+        Action<ReactorHost>? configure = null)
+        where TRoot : Component, new()
+    {
+        Options = new ReactorAppOptions(
+            RootFactory: static () => new TRoot(),
+            Configure: configure,
+            WindowTitle: title);
+        return new ReactorApplication();
+    }
+
+    /// <summary>
+    /// Render-function overload of <see cref="CreateApplication{TRoot}"/> for
+    /// native heads.
+    /// </summary>
+    public static Microsoft.UI.Xaml.Application CreateApplication(
+        string title,
+        Func<RenderContext, Element> rootRender,
+        Action<ReactorHost>? configure = null)
+    {
+        Options = new ReactorAppOptions(
+            RootRenderFunc: rootRender,
+            Configure: configure,
+            WindowTitle: title);
+        return new ReactorApplication();
+    }
+}

--- a/src/Reactor.Uno/Hosting/ReactorHost.cs
+++ b/src/Reactor.Uno/Hosting/ReactorHost.cs
@@ -1,0 +1,535 @@
+// Slim Reactor render host for Uno Skia targets.
+//
+// Adapted from src/Reactor/Hosting/ReactorHost.cs, keeping the coalescing render
+// loop, the reconcile→Window.Content install, effects flush, perf stats, and the
+// charting-activation seam. Dropped (vs. the Windows host): system backdrop,
+// dev-overlay wiring, hot-reload state migration, focus-revalidation, and the
+// in-render accessibility push — none are needed for the Skia port's core path.
+
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.UI.Dispatching;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Reactor.Animation;
+using Microsoft.UI.Reactor.Core;
+
+namespace Microsoft.UI.Reactor.Hosting;
+
+/// <summary>
+/// Hosts a Reactor component tree inside an Uno <see cref="Window"/>. Drives the
+/// render loop: on state change, re-renders the component and reconciles the
+/// virtual tree against the real control tree.
+/// </summary>
+public sealed class ReactorHost : IDisposable
+{
+    private readonly Window _window;
+    private readonly Reconciler _reconciler;
+    private readonly DispatcherQueue _dispatcherQueue;
+    private readonly ILogger? _logger;
+
+    private Component? _rootComponent;
+    private Func<RenderContext, Element>? _rootRenderFunc;
+    private RenderContext? _funcContext;
+
+    private Element? _currentTree;
+    private UIElement? _currentControl;
+    private int _renderPending;
+    private volatile bool _isRendering;
+    private volatile bool _needsRerender;
+    private FrameworkElement? _themeListenerElement;
+    private volatile bool _disposed;
+
+    private Curve? _pendingAnimationCurve;
+    private Microsoft.UI.Reactor.Core.Internal.AmbientAnimation? _pendingAmbientAnimation;
+
+    // ── charting accessibility seam (issue #498) ──
+    private global::Windows.UI.ViewManagement.AccessibilitySettings? _accessibilitySettings;
+    private global::Windows.UI.ViewManagement.UISettings? _uiSettings;
+    private volatile bool _isForcedColors;
+    private volatile bool _isReducedMotion;
+    private object? _forcedColorsTheme;
+    private int _chartingActiveFlag;
+    private static IChartingHostBridge? s_chartingBridge;
+
+    private readonly Stopwatch _phaseSw = new();
+    private double _lastRenderMs;
+    private RenderStats _stats;
+
+    /// <summary>Live render performance snapshot, updated about once per second.</summary>
+    public ref readonly RenderStats Stats => ref _stats;
+
+    /// <summary>The underlying reconciler (for RegisterType calls).</summary>
+    public Reconciler Reconciler => _reconciler;
+
+    /// <summary>Optional per-render timing callback: (treeBuildMs, reconcileMs, effectsMs).</summary>
+    public Action<double, double, double>? OnRenderComplete { get; set; }
+
+    /// <summary>The Uno window hosting this Reactor tree.</summary>
+    public Window Window => _window;
+
+    /// <summary>The Reactor window wrapper that owns this host.</summary>
+    public ReactorWindow? OwningWindow { get; internal set; }
+
+    /// <summary>When set, Reactor renders into this Border instead of Window.Content.</summary>
+    public Microsoft.UI.Xaml.Controls.Border? ContentTarget { get; set; }
+
+    internal Component? RootComponent => _rootComponent;
+    internal UIElement? CurrentControl => _currentControl;
+
+    public ReactorHost(Window window, ILogger? logger = null)
+    {
+        _logger = logger ?? ReactorApp.AppLogger;
+        _reconciler = new Reconciler(_logger);
+        _window = window;
+        _dispatcherQueue = DispatcherQueue.GetForCurrentThread();
+
+        if (ReactorApp.UIDispatcher is null)
+            ReactorApp.UIDispatcher = _dispatcherQueue;
+        ReactorApp.ActiveHostInternal = this;
+
+        try
+        {
+            _window.Closed += (_, _) => Dispose();
+        }
+        catch { /* headless / windowless */ }
+    }
+
+    // ── charting activation seam ──
+
+    internal static void RegisterChartingBridge(IChartingHostBridge bridge)
+        => s_chartingBridge = bridge;
+
+    internal void EnsureChartingActive()
+    {
+        if (Interlocked.CompareExchange(ref _chartingActiveFlag, 1, 0) != 0)
+            return;
+
+        if (_dispatcherQueue.HasThreadAccess)
+            InitChartingState();
+        else
+            _dispatcherQueue.TryEnqueue(InitChartingState);
+    }
+
+    private void InitChartingState()
+    {
+        try
+        {
+            _accessibilitySettings = new global::Windows.UI.ViewManagement.AccessibilitySettings();
+            _isForcedColors = _accessibilitySettings.HighContrast;
+            if (_isForcedColors)
+                _forcedColorsTheme = s_chartingBridge?.CaptureForcedColorsTheme();
+        }
+        catch { /* settings unavailable on this head */ }
+
+        try
+        {
+            _uiSettings = new global::Windows.UI.ViewManagement.UISettings();
+            _isReducedMotion = !_uiSettings.AnimationsEnabled;
+        }
+        catch { /* settings unavailable */ }
+
+        PushChartingState();
+    }
+
+    private void PushChartingState()
+        => s_chartingBridge?.PushAccessibilityState(_isForcedColors, _isReducedMotion, _forcedColorsTheme);
+
+    // ── mount + render loop ──
+
+    public void Mount(Component component)
+    {
+        _rootComponent = component;
+        RequestRender();
+    }
+
+    public void Mount(Func<RenderContext, Element> renderFunc)
+    {
+        _rootRenderFunc = renderFunc;
+        _funcContext = new RenderContext();
+        RequestRender();
+    }
+
+    internal void RequestRender(bool force = false)
+    {
+        if (_disposed) return;
+
+        if (force)
+            _reconciler.ForceFullRenderPending = true;
+
+        if (AnimationScope.HasScope)
+            _pendingAnimationCurve = AnimationScope.Current;
+
+        var captured = Microsoft.UI.Reactor.Core.Internal.AnimationAmbient.Current;
+        if (captured is not null)
+            _pendingAmbientAnimation = captured;
+
+        if (_isRendering)
+        {
+            _needsRerender = true;
+            return;
+        }
+
+        if (Interlocked.CompareExchange(ref _renderPending, 1, 0) != 0)
+        {
+            _needsRerender = true;
+            return;
+        }
+
+        // First render is synchronous on the UI thread so content attaches
+        // before window.Activate() returns.
+        if (_currentControl is null && _dispatcherQueue.HasThreadAccess)
+        {
+            RenderLoop();
+            return;
+        }
+
+        _dispatcherQueue.TryEnqueue(
+            RenderPriorityPolicy.PickPriority(Volatile.Read(ref _lastRenderMs)),
+            RenderLoop);
+    }
+
+    private void RenderLoop()
+    {
+        if (_disposed) return;
+
+        _needsRerender = false;
+        Render();
+
+        Interlocked.Exchange(ref _renderPending, 0);
+
+        if (_needsRerender)
+        {
+            if (Interlocked.CompareExchange(ref _renderPending, 1, 0) == 0)
+                _dispatcherQueue.TryEnqueue(DispatcherQueuePriority.Low, RenderLoop);
+        }
+    }
+
+    /// <summary>
+    /// Hot Reload state migration entry point (spec 049 §6). Runs once at the
+    /// start of a hot-reload render pass, before any component re-renders, and
+    /// asks every live <see cref="RenderContext"/> to value-swap hook cells
+    /// whose stored type was edited. The root component/function context is not
+    /// registered with the reconciler, so it is migrated explicitly. Never
+    /// throws out — a migration failure must not abort the reload render.
+    /// </summary>
+    private void MigrateHotReloadState()
+    {
+        if (!HotReloadService.IsHotReloadLive) return;
+
+        var updatedTypes = HotReloadService.UpdatedTypes;
+        if (updatedTypes is null || updatedTypes.Count == 0) return;
+
+        try
+        {
+            _rootComponent?.Context.MigrateHooksForHotReload(updatedTypes);
+            _funcContext?.MigrateHooksForHotReload(updatedTypes);
+            _reconciler.ForEachLiveContext(ctx => ctx.MigrateHooksForHotReload(updatedTypes));
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogWarning(ex, "Hot reload: state migration pass failed; continuing with re-render");
+        }
+    }
+
+    private void Render()
+    {
+        _isRendering = true;
+
+        // Hot Reload (spec 049). HotReloadService is source-shared from the
+        // Windows framework and its [assembly: MetadataUpdateHandler] is active
+        // in this assembly too, so `dotnet watch` edits land here identically:
+        // atomic capture-and-clear gives at-most-once recovery per
+        // UpdateApplication call.
+        bool hotReloadRender = HotReloadService.ConsumeUpdatePending();
+
+        // Open a tree-wide pass so the reconciler can recover hook-order changes
+        // in non-root children (Reconciler.UpdateComponent reads WithinUpdatePass).
+        using IDisposable? hotReloadPass = hotReloadRender
+            ? HotReloadService.BeginUpdatePass()
+            : null;
+
+        // Value-swap hook cells whose stored type was edited, so adding or
+        // removing a field on a record held in UseState/UseReducer preserves the
+        // surviving values instead of resetting to the initializer.
+        if (hotReloadRender)
+            MigrateHotReloadState();
+
+        var prevActiveHost = ReactorApp.ActiveHostInternal;
+        ReactorApp.ActiveHostInternal = this;
+
+        void RecoverFromHookOrder(HookOrderException ex, RenderContext ctx, string mode)
+        {
+            _logger?.LogWarning(ex,
+                "Hot reload: hook order/type changed — resetting {Mode} state and re-rendering",
+                mode);
+            ctx.ResetForHotReload();
+            RequestRender();
+        }
+
+        try
+        {
+            Element? newTree = null;
+            _phaseSw.Restart();
+
+            Action rerender = () => RequestRender();
+
+            if (_rootComponent is not null)
+            {
+                _rootComponent.Context.BeginRender(rerender);
+                try { newTree = _rootComponent.Render(); }
+                catch (HookOrderException ex) when (hotReloadRender)
+                {
+                    // An edit that adds/removes/reorders hooks changes the hook
+                    // shape the context was built with. Under hot reload that is
+                    // an expected consequence of the edit, not a user bug: drop
+                    // the hook state and re-mount rather than falling through to
+                    // the error overlay.
+                    RecoverFromHookOrder(ex, _rootComponent.Context, "component");
+                    return;
+                }
+                catch (Exception ex)
+                {
+                    _logger?.LogError(ex, "Component Render() threw");
+                    ShowErrorFallback(ex);
+                    return;
+                }
+            }
+            else if (_rootRenderFunc is not null && _funcContext is not null)
+            {
+                _funcContext.BeginRender(rerender);
+                try { newTree = _rootRenderFunc(_funcContext); }
+                catch (HookOrderException ex) when (hotReloadRender)
+                {
+                    RecoverFromHookOrder(ex, _funcContext, "function-component");
+                    return;
+                }
+                catch (Exception ex)
+                {
+                    _logger?.LogError(ex, "Function component threw");
+                    ShowErrorFallback(ex);
+                    return;
+                }
+            }
+
+            double treeBuildMs = _phaseSw.Elapsed.TotalMilliseconds;
+            if (newTree is null) return;
+
+            _phaseSw.Restart();
+
+            var capturedCurve = Interlocked.Exchange(ref _pendingAnimationCurve, null);
+            if (capturedCurve is not null)
+                AnimationScope.PushScope(capturedCurve);
+
+            var capturedAmbient = Interlocked.Exchange(ref _pendingAmbientAnimation, null);
+            using var ambientRestore = capturedAmbient is not null
+                ? new Microsoft.UI.Reactor.Core.Internal.AnimationAmbient.Scope(capturedAmbient)
+                : default;
+
+            UIElement? newControl;
+            try
+            {
+                newControl = _reconciler.Reconcile(_currentTree, newTree, _currentControl, rerender);
+            }
+            finally
+            {
+                if (capturedCurve is not null)
+                    AnimationScope.PopScope();
+            }
+
+            if (newControl != _currentControl)
+            {
+                if (ContentTarget is not null)
+                {
+                    ContentTarget.Child = newControl;
+                    AttachThemeListener(newControl);
+                    OwningWindow?.OnContentAttached(newControl);
+                }
+                else
+                {
+                    // Mount through a themed root rather than assigning the tree
+                    // to Window.Content directly. A Skia window paints nothing of
+                    // its own, so anything the app leaves transparent — a
+                    // NavigationView pane, the gutters around a smaller root —
+                    // shows through as black. WinUI gets a system-painted window
+                    // background for free; this is the Uno equivalent, and it
+                    // follows the light/dark theme because the brush is resolved
+                    // from the theme dictionary.
+                    var root = EnsureWindowRoot();
+                    root.Child = newControl;
+                    AttachThemeListener(newControl);
+                    // The XamlRoot (and hence RasterizationScale) only exists once
+                    // content is attached — let the window (re)bind its DPI
+                    // listener against the element that is actually in the tree.
+                    OwningWindow?.OnContentAttached(root);
+                }
+            }
+
+            _currentControl = newControl;
+            _currentTree = newTree;
+
+            _reconciler.FlushConnectedAnimations();
+
+            double reconcileMs = _phaseSw.Elapsed.TotalMilliseconds;
+            _phaseSw.Restart();
+
+            if (_rootComponent is not null)
+                _rootComponent.Context.FlushEffects();
+            else
+                _funcContext?.FlushEffects();
+
+            double effectsMs = _phaseSw.Elapsed.TotalMilliseconds;
+
+            Interlocked.Exchange(ref _lastRenderMs, treeBuildMs + reconcileMs + effectsMs);
+            OnRenderComplete?.Invoke(treeBuildMs, reconcileMs, effectsMs);
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "Render FAILED");
+            ShowErrorFallback(ex);
+        }
+        finally
+        {
+            _isRendering = false;
+            ReactorApp.ActiveHostInternal = prevActiveHost;
+        }
+    }
+
+    private void AttachThemeListener(UIElement? control)
+    {
+        if (_themeListenerElement is not null)
+            _themeListenerElement.ActualThemeChanged -= OnActualThemeChanged;
+
+        if (control is not FrameworkElement fe)
+        {
+            _themeListenerElement = null;
+            return;
+        }
+
+        _themeListenerElement = fe;
+        fe.ActualThemeChanged += OnActualThemeChanged;
+    }
+
+    private void OnActualThemeChanged(FrameworkElement sender, object args)
+    {
+        // The window root's brush was resolved from the theme dictionary at the
+        // time it was applied, so re-resolve it for the new theme before the
+        // re-render (a plain Background assignment is not a live ThemeResource).
+        ApplyWindowRootBackground();
+        RequestRender();
+    }
+
+    // Root container for the window-hosted case. A Skia window paints nothing of
+    // its own, so without this every region the app leaves transparent renders
+    // black. WinUI apps get this for free: a Page carries
+    // ApplicationPageBackgroundThemeBrush from its template, and the stock Uno
+    // template sets exactly that on its MainPage. Reactor hands the reconciled
+    // tree straight to Window.Content, so the host has to supply it.
+    private Microsoft.UI.Xaml.Controls.Border? _windowRoot;
+
+    private Microsoft.UI.Xaml.Controls.Border EnsureWindowRoot()
+    {
+        if (_windowRoot is not null) return _windowRoot;
+
+        // Built from markup rather than `new Border()` so Background is a real
+        // {ThemeResource} binding. Resolving the brush in code (reading
+        // Application.Current.Resources) is NOT theme-aware — it returns whichever
+        // variant the app dictionary happens to hold, which produced a dark
+        // background under a light theme.
+        try
+        {
+            _windowRoot = (Microsoft.UI.Xaml.Controls.Border)Microsoft.UI.Xaml.Markup.XamlReader.Load(
+                """
+                <Border xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                        Background="{ThemeResource ApplicationPageBackgroundThemeBrush}" />
+                """);
+        }
+        catch
+        {
+            // XamlReader unavailable on this head — fall back to an unpainted root
+            // rather than failing the render.
+            _windowRoot = new Microsoft.UI.Xaml.Controls.Border();
+        }
+
+        _window.Content = _windowRoot;
+        return _windowRoot;
+    }
+
+    // The {ThemeResource} binding above re-resolves itself on theme change, so
+    // nothing to re-apply here; kept as a seam for heads where the markup path
+    // fell back to a plain Border.
+    private void ApplyWindowRootBackground() { }
+
+    /// <summary>True when no render is pending, in-flight, or queued.</summary>
+    public bool IsIdle =>
+        _disposed ||
+        (Volatile.Read(ref _renderPending) == 0 && !_isRendering && !_needsRerender);
+
+    /// <summary>Awaits until the render loop is idle. Used by test harnesses.</summary>
+    public Task WaitForIdleAsync(int maxYields = 50)
+    {
+        if (_disposed) return Task.CompletedTask;
+        if (_renderPending == 0 && !_isRendering && !_needsRerender)
+            return Task.CompletedTask;
+
+        var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        int yields = 0;
+        void CheckIdle()
+        {
+            if (_disposed || (_renderPending == 0 && !_isRendering && !_needsRerender))
+            {
+                tcs.TrySetResult();
+                return;
+            }
+            if (++yields > maxYields)
+            {
+                tcs.TrySetResult();
+                return;
+            }
+            if (!_dispatcherQueue.TryEnqueue(DispatcherQueuePriority.Low, CheckIdle))
+                tcs.TrySetResult();
+        }
+        if (!_dispatcherQueue.TryEnqueue(DispatcherQueuePriority.Low, CheckIdle))
+            tcs.TrySetResult();
+        return tcs.Task;
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+
+        _dispatcherQueue.TryEnqueue(() =>
+        {
+            if (_themeListenerElement is not null)
+                _themeListenerElement.ActualThemeChanged -= OnActualThemeChanged;
+            _themeListenerElement = null;
+        });
+
+        _rootComponent?.Context.RunCleanups();
+        _funcContext?.RunCleanups();
+
+        _reconciler.Dispose();
+        _rootComponent = null;
+        _rootRenderFunc = null;
+        _funcContext = null;
+        _currentTree = null;
+        _currentControl = null;
+
+        if (ReferenceEquals(ReactorApp.ActiveHostInternal, this))
+            ReactorApp.ActiveHostInternal = null;
+    }
+
+    private void ShowErrorFallback(Exception ex)
+    {
+        var errorPanel = Microsoft.UI.Reactor.Core.ErrorFallback.BuildPanel(ex);
+        if (ContentTarget is not null)
+            ContentTarget.Child = errorPanel;
+        else
+            EnsureWindowRoot().Child = errorPanel;
+        _currentControl = errorPanel;
+        _currentTree = null;
+    }
+}

--- a/src/Reactor.Uno/Hosting/UnoBootstrap.cs
+++ b/src/Reactor.Uno/Hosting/UnoBootstrap.cs
@@ -1,0 +1,105 @@
+// Uno host-builder bootstrap + code-only Application subclass.
+//
+// Uno 6 unifies hosting behind UnoPlatformHostBuilder (Uno.UI.Hosting). The
+// platform providers are compiled per-TFM: __WASM__ gets UseWebAssembly(); the
+// desktop TFM gets the X11/Framebuffer/macOS/Win32 providers (the builder picks
+// the one available at runtime).
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.UI.Dispatching;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Reactor.Hosting;
+using Uno.UI.Hosting;
+
+namespace Microsoft.UI.Reactor;
+
+internal static class UnoBootstrap
+{
+    public static void Run() => BuildHost().Run();
+
+    public static Task RunAsync() => BuildHost().RunAsync();
+
+    private static UnoPlatformHost BuildHost()
+    {
+        var builder = UnoPlatformHostBuilder.Create()
+            .App(() => new ReactorApplication());
+
+#if __WASM__
+        builder = builder.UseWebAssembly();
+#elif __IOS__ || __MACCATALYST__ || __TVOS__
+        // Apple heads DO start from a real Main, and Uno gives them the same
+        // host-builder shape as desktop — so ReactorApp.Run works there
+        // unchanged, with UIKit as the platform provider.
+        builder = builder.UseAppleUIKit();
+#elif __ANDROID__
+        // Android is the one target with no console entry point: the OS starts
+        // an Activity, so the head calls ReactorApp.CreateApplication<TRoot>()
+        // and this builder path is never reached.
+#else
+        builder = builder
+            .UseX11()
+            .UseLinuxFrameBuffer()
+            .UseMacOS()
+            .UseWin32();
+#endif
+
+        return builder.Build();
+    }
+}
+
+/// <summary>
+/// The Uno <see cref="Application"/> that hosts a Reactor tree. Created by
+/// <see cref="UnoBootstrap"/>; reads startup config from <see cref="ReactorApp.Options"/>.
+/// </summary>
+internal sealed class ReactorApplication : Application
+{
+    private ReactorWindow? _primary;
+
+    protected override void OnLaunched(LaunchActivatedEventArgs args)
+    {
+        // Process-wide unhandled-exception routing. Mirrors the Windows host:
+        // log, then let an app-supplied hook decide whether to swallow. Unknown
+        // exceptions are left unhandled so the app crashes with a useful error
+        // rather than limping along corrupt.
+        UnhandledException += (_, e) =>
+        {
+            ReactorApp.AppLogger?.LogError(
+                e.Exception,
+                "UnhandledException: {ExceptionType}: {ExceptionMessage}",
+                e.Exception.GetType().Name, e.Exception.Message);
+            if (ReactorApp.OnUnhandledException is not null)
+                e.Handled = ReactorApp.OnUnhandledException(e.Exception);
+        };
+
+        // Marshal cross-thread setState callbacks back onto the UI thread.
+        var dq = DispatcherQueue.GetForCurrentThread();
+        if (dq is not null)
+        {
+            SynchronizationContext.SetSynchronizationContext(
+                new DispatcherQueueSynchronizationContext(dq));
+        }
+
+        // WinUI control templates/styles.
+        try { Resources.MergedDictionaries.Add(new XamlControlsResources()); }
+        catch { /* resources already present / headless */ }
+
+        var opts = ReactorApp.Options;
+
+        var spec = new WindowSpec
+        {
+            Title = opts.WindowTitle,
+            Width = opts.WindowWidth,
+            Height = opts.WindowHeight,
+            FullScreen = opts.FullScreen,
+        };
+
+        // The primary window goes through the same construction path as every
+        // secondary window opened later via ReactorApp.OpenWindow / UseOpenWindow.
+        _primary = ReactorApp.OpenWindowCore(
+            spec, opts.RootFactory, opts.RootRenderFunc, opts.Configure);
+    }
+}

--- a/src/Reactor.Uno/Hosting/Windowing.cs
+++ b/src/Reactor.Uno/Hosting/Windowing.cs
@@ -1,0 +1,592 @@
+// Minimal windowing layer for the Uno port.
+//
+// The Windows framework's windowing stack (src/Reactor/Hosting/ReactorWindow.cs,
+// ReactorDisplay.cs, WindowSpec.cs, …) is heavily Win32/AppWindow/DWM coupled and
+// is excluded from the Uno build. The shared core (Core/RenderContext.cs windowing
+// hooks, Core/Element.cs title-bar wiring) still references these *types*, so this
+// file provides Uno-friendly equivalents with the exact member surface the shared
+// source touches. Windows are real: ReactorApp.OpenWindow builds one of these per
+// Microsoft.UI.Xaml.Window, each with its own ReactorHost. The chrome members Skia
+// can't honour (tray, drag-move, aspect-ratio lock, display enumeration) are no-op
+// stubs so the shared core still compiles and degrades gracefully.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using Microsoft.UI.Reactor.Core;
+using Microsoft.UI.Windowing;
+using WinUIWindow = Microsoft.UI.Xaml.Window;
+
+namespace Microsoft.UI.Reactor;
+
+/// <summary>Window display state. Mirrors the Windows framework's enum.</summary>
+public enum WindowState
+{
+    Normal,
+    Minimized,
+    Maximized,
+}
+
+/// <summary>Stable identity key for <c>UseOpenWindow</c> de-duplication.</summary>
+public readonly record struct WindowKey(string Name);
+
+/// <summary>
+/// Caption height for a window whose content extends into the title bar.
+/// Mirrors the Windows framework's enum (and <c>Microsoft.UI.Windowing.TitleBarHeightOption</c>).
+/// </summary>
+/// <remarks>
+/// Declared here rather than source-shared because it lives in the Windows-only
+/// <c>Hosting/WindowSpec.cs</c>, which the Uno port replaces — but the shared
+/// <c>Core/Element.cs</c> and <c>Elements/ElementExtensions.cs</c> reference the
+/// type (<c>TitleBarElement.HeightOption</c> / <c>.Tall()</c>, issue #917).
+/// Uno implements the underlying <c>AppWindowTitleBar.PreferredHeightOption</c>
+/// on the desktop heads, so this is honoured for real.
+/// </remarks>
+public enum WindowTitleBarHeight
+{
+    /// <summary>Standard 32 DIP caption.</summary>
+    Standard,
+    /// <summary>Tall 48 DIP caption — the layout used when the title bar hosts navigation chrome.</summary>
+    Tall,
+    /// <summary>No caption area at all.</summary>
+    Collapsed,
+}
+
+/// <summary>
+/// Declarative description of a window's chrome. Only the members the shared
+/// core reads are modelled; the rest of the Windows <c>WindowSpec</c> surface
+/// (backdrop, embed, persistence, splitters, …) is intentionally omitted.
+/// </summary>
+public sealed record WindowSpec
+{
+    public string Title { get; init; } = "Reactor App";
+
+    /// <summary>
+    /// Initial DIP width. <c>null</c> (the default) leaves the initial width to
+    /// the OS, matching the Windows framework (issue #924) — Reactor does not
+    /// override that axis. When both axes are <c>null</c> no resize is issued.
+    /// </summary>
+    public double? Width { get; init; }
+
+    /// <summary>Initial DIP height. <c>null</c> defers to the OS. See <see cref="Width"/>.</summary>
+    public double? Height { get; init; }
+
+    public bool FullScreen { get; init; }
+    public WindowKey? Key { get; init; }
+    /// <summary>Null = framework default; true/false = explicit opt-in/out.</summary>
+    public bool? ExtendsContentIntoTitleBar { get; init; }
+
+    /// <summary>
+    /// System caption height. <c>null</c> leaves the platform default. Honoured
+    /// on the Uno desktop heads via <c>AppWindow.TitleBar.PreferredHeightOption</c>.
+    /// </summary>
+    public WindowTitleBarHeight? TitleBarHeight { get; init; }
+}
+
+/// <summary>Tray-icon spec stub — tray icons are a Windows shell feature.</summary>
+public sealed record TrayIconSpec(WindowKey Key);
+
+/// <summary>Live tray-icon handle stub.</summary>
+public sealed class ReactorTrayIcon
+{
+    internal ReactorTrayIcon(TrayIconSpec spec) => Spec = spec;
+    public TrayIconSpec Spec { get; private set; }
+    public void Update(TrayIconSpec spec) => Spec = spec;
+    public void Close() { }
+}
+
+/// <summary>Snapshot of a single display. Minimal shape used by <c>UseDisplays</c>.</summary>
+public readonly record struct DisplayInfo(
+    string Name,
+    double X,
+    double Y,
+    double Width,
+    double Height,
+    double Scale,
+    bool IsPrimary);
+
+/// <summary>
+/// Display enumeration. Skia heads don't expose a portable multi-monitor query,
+/// so this returns an empty snapshot and never raises layout-change events.
+/// </summary>
+public static class ReactorDisplay
+{
+    public static IReadOnlyList<DisplayInfo> Displays { get; } = Array.Empty<DisplayInfo>();
+
+#pragma warning disable CS0067 // event is part of the API surface; never raised on Skia
+    public static event EventHandler? DisplayLayoutChanged;
+#pragma warning restore CS0067
+}
+
+/// <summary>Event args for <see cref="ReactorWindow.PositionChanged"/>.</summary>
+public sealed class WindowDipPositionChangedEventArgs : EventArgs
+{
+    public WindowDipPositionChangedEventArgs((double X, double Y) position) => Position = position;
+    public (double X, double Y) Position { get; }
+}
+
+/// <summary>Event args for <see cref="ReactorWindow.ZOrderChanged"/>.</summary>
+public sealed class WindowZOrderChangedEventArgs : EventArgs
+{
+    public WindowZOrderChangedEventArgs(bool movedToTop, bool isCovered)
+    {
+        MovedToTop = movedToTop;
+        IsCovered = isCovered;
+    }
+    public bool MovedToTop { get; }
+    public bool IsCovered { get; }
+}
+
+/// <summary>
+/// Uno wrapper over a <see cref="Microsoft.UI.Xaml.Window"/>. Bridges the
+/// shared windowing hooks to the live Skia window. Members the core never reads
+/// are best-effort/no-op on Skia.
+/// </summary>
+public sealed class ReactorWindow
+{
+    private readonly object _titleBarLock = new();
+    private bool _titleBarControlPresent;
+
+    internal ReactorWindow(WinUIWindow nativeWindow, WindowSpec spec)
+    {
+        NativeWindow = nativeWindow;
+        Spec = spec;
+
+        // Bridge the WinUI window's activation events to the simple EventHandler
+        // shape the shared hooks expect.
+        nativeWindow.Activated += (_, args) =>
+        {
+            bool deactivated =
+                args.WindowActivationState == global::Windows.UI.Core.CoreWindowActivationState.Deactivated;
+            if (deactivated)
+            {
+                IsActive = false;
+                Deactivated?.Invoke(this, EventArgs.Empty);
+            }
+            else
+            {
+                IsActive = true;
+                Activated?.Invoke(this, EventArgs.Empty);
+            }
+        };
+    }
+
+    /// <summary>The underlying WinUI/Uno window.</summary>
+    public WinUIWindow NativeWindow { get; }
+
+    /// <summary>The spec this window was opened with.</summary>
+    public WindowSpec Spec { get; private set; }
+
+    /// <summary>The Reactor host rendering into this window.</summary>
+    public Microsoft.UI.Reactor.Hosting.ReactorHost? Host { get; internal set; }
+
+    public bool IsActive { get; private set; } = true;
+    public WindowState State { get; private set; } = WindowState.Normal;
+    public (double X, double Y) Position { get; private set; }
+
+    /// <summary>Per-window persisted-state scope (backs <c>UsePersisted(PersistedScope.Window)</c>).</summary>
+    public Microsoft.UI.Reactor.Core.IPersistedStateScope PersistedScope { get; }
+        = new Microsoft.UI.Reactor.Core.WindowPersistedScope();
+
+    /// <summary>
+    /// Per-window DPI as a raw dots-per-inch value (96 = 100%). Derived from the
+    /// window's <c>XamlRoot.RasterizationScale</c> when available.
+    /// </summary>
+    public uint Dpi
+    {
+        get
+        {
+            try
+            {
+                var scale = NativeWindow.Content?.XamlRoot?.RasterizationScale ?? 1.0;
+                return (uint)Math.Round(96.0 * (scale <= 0 ? 1.0 : scale));
+            }
+            catch { return 96; }
+        }
+    }
+
+    /// <summary>Raised when this window's DPI changes (monitor move or display-scale change).</summary>
+    public event EventHandler<uint>? DpiChanged;
+
+    /// <summary>Raised when the window becomes active.</summary>
+    public event EventHandler? Activated;
+
+    /// <summary>Raised when the window is deactivated.</summary>
+    public event EventHandler? Deactivated;
+
+#pragma warning disable CS0067 // Skia heads don't surface these; kept as API surface.
+    public event EventHandler<WindowDipPositionChangedEventArgs>? PositionChanged;
+    public event EventHandler<WindowZOrderChangedEventArgs>? ZOrderChanged;
+    public event EventHandler<WindowState>? StateChanged;
+#pragma warning restore CS0067
+
+    // ── DPI-change notification ──
+    //
+    // Uno raises XamlRoot.Changed when the window's RasterizationScale changes
+    // (dragged to a monitor with a different scale, or the display scale is
+    // changed). It also fires for size changes, so only surface DpiChanged when
+    // the DPI value actually moved. Each window has its own XamlRoot, so this is
+    // correctly per-window under multi-window.
+    private Microsoft.UI.Xaml.XamlRoot? _xamlRoot;
+    private uint _lastDpi;
+
+    // Called by ReactorHost whenever it installs new content into this window —
+    // the XamlRoot only exists once content is attached.
+    internal void OnContentAttached(Microsoft.UI.Xaml.UIElement? content)
+    {
+        var root = content?.XamlRoot;
+
+        // XamlRoot is not assigned when Content is merely *set* — it appears
+        // when the element enters the live visual tree, which happens after
+        // Window.Activate(). Reactor attaches content from the render loop, so
+        // the first call here always arrives with a null XamlRoot. Returning
+        // early on that (null == null compares equal) would permanently skip
+        // both the DPI listener and the initial resize, so re-arm on Loaded and
+        // come back once the root really exists.
+        if (root is null)
+        {
+            if (content is Microsoft.UI.Xaml.FrameworkElement fe)
+            {
+                void OnLoaded(object sender, Microsoft.UI.Xaml.RoutedEventArgs args)
+                {
+                    fe.Loaded -= OnLoaded;
+                    OnContentAttached(fe);
+                }
+                fe.Loaded -= OnLoaded;
+                fe.Loaded += OnLoaded;
+            }
+            return;
+        }
+
+        if (ReferenceEquals(root, _xamlRoot)) return;
+
+        if (_xamlRoot is not null)
+            _xamlRoot.Changed -= OnXamlRootChanged;
+
+        _xamlRoot = root;
+
+        _lastDpi = Dpi;
+        _xamlRoot.Changed += OnXamlRootChanged;
+
+        // The XamlRoot has just appeared, so RasterizationScale is finally real —
+        // retry the initial resize if it had to be deferred (see ApplyInitialSize).
+        ApplyInitialSize();
+    }
+
+    private bool _initialSizeApplied;
+
+    /// <summary>
+    /// Applies <see cref="WindowSpec.Width"/>/<see cref="WindowSpec.Height"/> once.
+    /// </summary>
+    /// <remarks>
+    /// <para>Spec sizes are <b>DIPs</b>, but <c>AppWindow.Resize</c> takes
+    /// <b>physical pixels</b> — Uno's Win32 head hands the <c>SizeInt32</c>
+    /// straight to <c>SetWindowPos</c>, and Uno's own startup path multiplies by
+    /// <c>RasterizationScale</c> for exactly this reason. Without the conversion
+    /// every window is undersized above 100% scale (a 480x360 request measured
+    /// 320x240 DIP at 150%).</para>
+    /// <para>The scale is only knowable once the window has a <c>XamlRoot</c>,
+    /// which does not exist at <c>Activate</c> time because Reactor attaches
+    /// content from the dispatcher-queued render loop. So this is attempted
+    /// after activation and, if the scale isn't available yet, re-attempted from
+    /// <see cref="OnContentAttached"/>. It applies at most once either way.</para>
+    /// <para>A null axis means "let the OS pick" (issue #924); a spec with
+    /// neither axis set never resizes.</para>
+    /// </remarks>
+    internal void ApplyInitialSize()
+    {
+        if (_initialSizeApplied) return;
+
+        if (Spec.Width is null && Spec.Height is null)
+        {
+            _initialSizeApplied = true;
+            return;
+        }
+
+        var scale = NativeWindow.Content?.XamlRoot?.RasterizationScale ?? 0;
+        if (scale <= 0) return; // not realized yet — OnContentAttached retries
+
+        try
+        {
+            var appWindow = NativeWindow.AppWindow;
+            if (appWindow is null)
+            {
+                _initialSizeApplied = true;
+                return;
+            }
+
+            // Preserve the OS-chosen extent on whichever axis the spec leaves null.
+            var current = appWindow.Size;
+            int width = Spec.Width is { } w ? (int)Math.Round(w * scale) : current.Width;
+            int height = Spec.Height is { } h ? (int)Math.Round(h * scale) : current.Height;
+
+            appWindow.Resize(new global::Windows.Graphics.SizeInt32
+            {
+                Width = width,
+                Height = height,
+            });
+        }
+        catch { /* sizing unsupported on this head */ }
+
+        _initialSizeApplied = true;
+    }
+
+    private void OnXamlRootChanged(
+        Microsoft.UI.Xaml.XamlRoot sender,
+        Microsoft.UI.Xaml.XamlRootChangedEventArgs args)
+    {
+        uint dpi = Dpi;
+        if (dpi == _lastDpi) return;
+
+        _lastDpi = dpi;
+        DpiChanged?.Invoke(this, dpi);
+    }
+
+    /// <summary>Lifetime-bound aspect-ratio lock. No-op on Skia; returns a disposable token.</summary>
+    public IDisposable RegisterAspectRatioOverride(double? widthOverHeight) => NoopDisposable.Instance;
+
+    // ── closing guards ──
+    //
+    // Backed by Uno's AppWindow.Closing, which honours cancellation on the desktop
+    // heads (Windows / macOS / Linux). On Android, iOS and WebAssembly the event
+    // still fires but Cancel has no effect, so the close proceeds — matching Uno's
+    // documented behaviour rather than pretending to guard.
+    //
+    // AppWindow.Closing must be handled synchronously (async work does not delay the
+    // close), which is exactly the Func<bool> contract the shared UseClosingGuard
+    // hook exposes.
+    private readonly object _closingGuardsLock = new();
+    private readonly List<Func<bool>> _closingGuards = new();
+    private bool _closingHooked;
+
+    /// <summary>
+    /// Registers a synchronous "can the window close right now?" predicate.
+    /// Multiple guards stack — any returning <c>false</c> cancels the close.
+    /// Dispose the returned token to unregister.
+    /// </summary>
+    public IDisposable RegisterClosingGuard(Func<bool> canClose)
+    {
+        ArgumentNullException.ThrowIfNull(canClose);
+
+        lock (_closingGuardsLock)
+        {
+            _closingGuards.Add(canClose);
+            EnsureClosingHooked();
+        }
+
+        return new GuardToken(this, canClose);
+    }
+
+    // Subscribe lazily: a window that never registers a guard pays nothing, and by
+    // the time a guard arrives (from an effect, so post-mount) the AppWindow exists.
+    private void EnsureClosingHooked()
+    {
+        if (_closingHooked) return;
+
+        try
+        {
+            var appWindow = NativeWindow.AppWindow;
+            if (appWindow is null) return;
+
+            appWindow.Closing += OnAppWindowClosing;
+            _closingHooked = true;
+        }
+        catch { /* AppWindow unavailable on this head */ }
+    }
+
+    private void OnAppWindowClosing(
+        Microsoft.UI.Windowing.AppWindow sender,
+        Microsoft.UI.Windowing.AppWindowClosingEventArgs args)
+    {
+        Func<bool>[] guards;
+        lock (_closingGuardsLock) { guards = _closingGuards.ToArray(); }
+
+        for (int i = 0; i < guards.Length; i++)
+        {
+            bool canClose;
+
+            // A guard is app code. A throwing guard fail-safes to "cancel" rather
+            // than escaping mid-close, matching the Windows framework's behaviour.
+            try { canClose = guards[i](); }
+            catch { canClose = false; }
+
+            if (!canClose)
+            {
+                args.Cancel = true;
+                return;
+            }
+        }
+    }
+
+    private sealed class GuardToken : IDisposable
+    {
+        private readonly ReactorWindow _owner;
+        private Func<bool>? _guard;
+
+        public GuardToken(ReactorWindow owner, Func<bool> guard)
+        {
+            _owner = owner;
+            _guard = guard;
+        }
+
+        public void Dispose()
+        {
+            var g = Interlocked.Exchange(ref _guard, null);
+            if (g is null) return;
+            lock (_owner._closingGuardsLock) { _owner._closingGuards.Remove(g); }
+        }
+    }
+
+    /// <summary>Starts a framework-managed window drag/move loop. No-op on Skia.</summary>
+    public void BeginDragMove() { }
+
+    /// <summary>Records that a WinUI TitleBar control is mounted in this window.</summary>
+    public void MarkTitleBarControlPresent()
+    {
+        lock (_titleBarLock) { _titleBarControlPresent = true; }
+    }
+
+    internal bool TitleBarControlPresent
+    {
+        get { lock (_titleBarLock) { return _titleBarControlPresent; } }
+    }
+
+    // ── Caption height (issue #917) ────────────────────────────────────────
+    //
+    // The shared TitleBar element and reconciler call into these three members,
+    // so the Uno window has to provide them. They are NOT stubs: Uno implements
+    // AppWindowTitleBar.PreferredHeightOption for real on the desktop heads
+    // (Standard=32 / Tall=48 / Collapsed=0), so the caption half genuinely works.
+    //
+    // The *control* half (sizing the Microsoft.UI.Xaml.Controls.TitleBar so it
+    // agrees with the caption) is kept faithful to the Windows implementation
+    // even though Uno currently ships that control as a not-implemented stub —
+    // writing Height on it is harmless today and correct the moment Uno lands it.
+
+    private WeakReference<Microsoft.UI.Xaml.FrameworkElement>? _titleBarControl;
+    private bool _titleBarControlExplicitHeight;
+    private bool _titleBarControlHeightOwned;
+    private WindowTitleBarHeight? _elementTitleBarHeight;
+    private WindowTitleBarHeight? _effectiveTitleBarHeight;
+
+    /// <summary>
+    /// Withdraws a departing <c>TitleBar(...)</c> element's caption-height
+    /// contribution so a window that merely used to host one is not left tall
+    /// forever. Mirrors the Windows framework, including deliberately NOT
+    /// clearing <see cref="TitleBarControlPresent"/> (that latch drives
+    /// close-time teardown safety, where "was mounted at some point" is right).
+    /// </summary>
+    internal void ClearTitleBarControl()
+    {
+        _titleBarControl = null;
+        _titleBarControlExplicitHeight = false;
+        _titleBarControlHeightOwned = false;
+        _elementTitleBarHeight = null;
+        ApplyTitleBarHeight();
+    }
+
+    /// <summary>
+    /// Records the caption height declared by the mounted <c>TitleBar(...)</c>
+    /// element and applies both halves. <see cref="WindowSpec.TitleBarHeight"/>,
+    /// when set, wins over the element's declaration.
+    /// </summary>
+    internal void SetElementTitleBarHeight(
+        WindowTitleBarHeight? height,
+        Microsoft.UI.Xaml.FrameworkElement? control,
+        bool controlHasExplicitHeight)
+    {
+        _elementTitleBarHeight = height;
+        _titleBarControl = control is null
+            ? null
+            : new WeakReference<Microsoft.UI.Xaml.FrameworkElement>(control);
+        _titleBarControlExplicitHeight = controlHasExplicitHeight;
+        ApplyTitleBarHeight();
+    }
+
+    /// <summary>
+    /// Sizes the mounted WinUI <c>TitleBar</c> control to the caption height
+    /// Reactor actually applied — the control does not track the caption, so
+    /// Reactor pairs the two. An explicit <c>.Height(...)</c> owns the control
+    /// outright, and Reactor only clears a height it set itself.
+    /// </summary>
+    internal void SyncTitleBarControlHeight()
+    {
+        if (_titleBarControlExplicitHeight) return;
+        if (_titleBarControl is null || !_titleBarControl.TryGetTarget(out var control)) return;
+
+        try
+        {
+            if (_effectiveTitleBarHeight == WindowTitleBarHeight.Tall)
+            {
+                if (_titleBarControlHeightOwned
+                    && Math.Abs(control.Height - TitleBarElement.TallTitleBarControlHeight) < 0.5)
+                {
+                    return;
+                }
+                control.Height = TitleBarElement.TallTitleBarControlHeight;
+                _titleBarControlHeightOwned = true;
+            }
+            else if (_titleBarControlHeightOwned)
+            {
+                control.ClearValue(Microsoft.UI.Xaml.FrameworkElement.HeightProperty);
+                _titleBarControlHeightOwned = false;
+            }
+        }
+        catch { /* control not realized on this head */ }
+    }
+
+    // Writes the native caption height. The spec wins over the element; a
+    // non-extended window can't host a resized caption, so the control is held
+    // at Standard in that case (same rule as the Windows framework).
+    private void ApplyTitleBarHeight()
+    {
+        var resolved = Spec.TitleBarHeight ?? _elementTitleBarHeight;
+        if (resolved is null)
+        {
+            _effectiveTitleBarHeight = null;
+            SyncTitleBarControlHeight();
+            return;
+        }
+
+        try
+        {
+            var titleBar = NativeWindow.AppWindow?.TitleBar;
+            if (titleBar is null || !titleBar.ExtendsContentIntoTitleBar)
+            {
+                _effectiveTitleBarHeight = WindowTitleBarHeight.Standard;
+                SyncTitleBarControlHeight();
+                return;
+            }
+
+            titleBar.PreferredHeightOption = resolved.Value switch
+            {
+                WindowTitleBarHeight.Tall => TitleBarHeightOption.Tall,
+                WindowTitleBarHeight.Collapsed => TitleBarHeightOption.Collapsed,
+                _ => TitleBarHeightOption.Standard,
+            };
+            _effectiveTitleBarHeight = resolved;
+        }
+        catch { /* caption sizing unsupported on this head */ }
+
+        SyncTitleBarControlHeight();
+    }
+
+    /// <summary>Applies a changed spec to the live window (title only on Skia).</summary>
+    public void Update(WindowSpec spec)
+    {
+        Spec = spec;
+        try { NativeWindow.Title = spec.Title; } catch { /* best effort */ }
+    }
+
+    /// <summary>Closes the underlying window.</summary>
+    public void Close()
+    {
+        try { NativeWindow.Close(); } catch { /* best effort */ }
+    }
+
+    private sealed class NoopDisposable : IDisposable
+    {
+        public static readonly NoopDisposable Instance = new();
+        public void Dispose() { }
+    }
+}

--- a/src/Reactor.Uno/README.md
+++ b/src/Reactor.Uno/README.md
@@ -1,0 +1,339 @@
+# Microsoft.UI.Reactor on Uno Platform (Skia)
+
+A port of [Microsoft.UI.Reactor](../../README.md) — the declarative, hooks-based,
+component MVU framework for WinUI 3 — to **Uno Platform Skia** targets, so the
+exact same Reactor C# can run on **desktop and WebAssembly** (and, theoretically,
+mobile) instead of only Windows / Windows App SDK.
+
+Reactor renders *real `Microsoft.UI.Xaml` controls*. Uno Platform reimplements
+that same `Microsoft.UI.Xaml` API surface across Skia heads. So this port is
+fundamentally a **retargeting**: the Reactor reconciler, hooks, DSL, layout
+engine, charting, data grid, etc. are shared *verbatim* from `../Reactor`,
+recompiled against Uno's `Microsoft.UI.Xaml`, with a small Uno-specific hosting
+layer replacing the Windows-only windowing/shell stack.
+
+## Status
+
+| Target | TFM | State |
+|---|---|---|
+| Desktop (Win32 / X11 / macOS / Framebuffer) | `net10.0-desktop` | ✅ Builds **and runs** — interactive |
+| WebAssembly | `net10.0-browserwasm` | ✅ Builds **and runs** in the browser |
+| Android | `net10.0-android` | ✅ Builds to a **signed APK**; on-device run not yet verified |
+| iOS | `net10.0-ios` | ✅ **Compiles** (on Windows); device deploy needs a Mac and is not yet verified |
+
+Both samples are **single Uno projects targeting all four heads** — the component
+source is identical everywhere. Only the entry point differs: desktop and iOS use
+`ReactorApp.Run<T>()` (Uno gives the Apple heads the same host-builder shape as
+desktop), wasm uses `RunAsync` (the browser thread can't block), and Android — the
+only target with no console entry point — starts from an `Activity` that calls the
+new `ReactorApp.CreateApplication<TRoot>()`.
+
+Verified end-to-end: `UseState` → `Button` click → reconciler diff → patched
+`TextBlock` on Skia desktop, and the same app rendering **and responding to
+clicks** in the browser via WASM.
+
+## Quick start — a file-based, single-file Reactor app
+
+This mirrors the [xaml.dev "file-based WinUI apps with Microsoft.UI.Reactor"](https://xaml.dev/post/file-based-winui-apps-with-microsoft-ui-reactor)
+post, but cross-platform. The whole app is one `.cs` file
+([`samples/Uno/file-based/Counter.cs`](../../samples/Uno/file-based/Counter.cs)):
+
+```csharp
+#:sdk Uno.Sdk@6.7.0-dev.93
+#:project ../../../src/Reactor.Uno/Reactor.Uno.csproj
+#:property TargetFramework=net10.0-desktop
+#:property OutputType=Exe
+#:property UnoSingleProject=true
+#:property UnoFeatures=SkiaRenderer
+#:property PublishAot=false
+#:property PackAsTool=false
+
+using Microsoft.UI.Reactor;
+using Microsoft.UI.Reactor.Core;
+using static Microsoft.UI.Reactor.Factories;
+
+ReactorApp.Run<CounterApp>("Single-File Reactor on Uno", width: 520, height: 400);
+
+class CounterApp : Component
+{
+    public override Element Render()
+    {
+        var (name, setName) = UseState("Uno");
+        var (count, setCount) = UseState(0);
+
+        return VStack(12,
+            Heading($"Hello, {name}!"),
+            TextBox(name, setName, placeholderText: "Your name"),
+            Heading($"Count: {count}"),
+            HStack(8,
+                Button("-", () => setCount(count - 1)),
+                Button("+", () => setCount(count + 1))
+            )
+        ).Padding(24);
+    }
+}
+```
+
+Run it:
+
+```bash
+cd samples/Uno/file-based
+dotnet run Counter.cs
+```
+
+> **Versus the WinUI version.** The WinUI file-based app uses
+> `#:property TargetFramework=net10.0-windows10.0.22621.0` +
+> `#:property WindowsAppSDKSelfContained=true` and `dotnet run App.cs -a x64`.
+> Here we swap to `#:sdk Uno.Sdk`, `TargetFramework=net10.0-desktop`, and add the
+> Reactor.Uno reference. The Reactor code itself is **identical**.
+
+### Run on WebAssembly instead
+
+A single file-based app targets one TFM at a time. For WASM, set
+`#:property TargetFramework=net10.0-browserwasm` and use the async entry point
+(`await ReactorApp.RunAsync<CounterApp>(...)`) because the browser thread can't
+block. See [`samples/Uno/ReactorUnoCounter`](../../samples/Uno/ReactorUnoCounter) for a normal
+multi-targeted project that does both from one source via `#if __WASM__`:
+
+```bash
+cd samples/Uno/ReactorUnoCounter
+dotnet run -f net10.0-desktop          # desktop window
+dotnet run -f net10.0-browserwasm      # prints a localhost URL — open it
+```
+
+## Architecture
+
+The port lives under the repo's conventional `src/` and `samples/` folders, but
+**each Uno location carries its own build-isolation files** so it never inherits
+the Windows / Windows App SDK build infrastructure — the repo-root
+`Directory.Build.props` imports `Reactor.targets` and pins WinAppSDK, and the
+root `Directory.Packages.props` turns Central Package Management on. MSBuild
+stops walking up at the nearest match, so these shadow files pin the `Uno.Sdk`
+and turn CPM off for the Uno projects only; the Windows framework build is
+untouched (and the Uno projects stay out of the main `Reactor.slnx`, so CI never
+restores them).
+
+```
+src/Reactor.Uno/            # the port library (assembly `Reactor`, ns Microsoft.UI.Reactor)
+  Reactor.Uno.csproj        # shares ../Reactor source, targets Uno TFMs
+  GlobalUsings.cs           # disambiguation aliases (see below)
+  Hosting/
+    ReactorApp.cs           # ReactorApp.Run / RunAsync + the static surface the core needs
+    UnoBootstrap.cs         # UnoPlatformHostBuilder wiring + the code-only Application
+    ReactorHost.cs          # the render loop (reconcile → Window.Content → effects)
+    Windowing.cs            # minimal ReactorWindow + windowing types for the shared hooks
+  global.json               # pins Uno.Sdk 6.7.0-dev.93
+  nuget.config              # nuget.org (self-contained restore)
+  Directory.Build.props     # stops inheritance of the repo-root Windows build infra
+  Directory.Packages.props  # CPM off for this project
+
+samples/Uno/                # Uno samples — one shared isolation set for all three
+  global.json · nuget.config · Directory.Build.props · Directory.Packages.props
+  ReactorUnoCounter/        # normal Uno single-project app (desktop + wasm)
+  ReactorUnoShowcase/       # larger showcase app
+  file-based/Counter.cs     # the single-file app
+
+Reactor.Uno.slnx            # dedicated solution (kept out of the main Reactor.slnx)
+```
+
+### Source sharing
+
+`Reactor.Uno.csproj` pulls the portable framework folders in via explicit
+`<Compile Include>` globs, from **two** projects:
+
+- from `../Reactor` (core): `Core`, `Hooks`, `Elements`, `Input`,
+  `Accessibility`, `Animation`, `Yoga`, `Data`, `Controls`, `Diagnostics`, plus a
+  few portable `Hosting/*` files (the charting bridge, render stats, hot-reload
+  service, XAML interop);
+- from `../Reactor.Advanced`: `Charting`, `Markdown` and `Controls/DataGrid`.
+  Spec 062 Track B moved these out of core into a separate Windows-only
+  *project*, but the *source* is portable — verified free of Win2D and Docking
+  coupling. `Docking/` and `Win2D/` stay excluded.
+
+The wrapper source-generator (`Reactor.Wrappers.Generator`) runs as an analyzer
+to emit the control descriptors, exactly as in the Windows build.
+
+> **Source-share drift is the main hazard of this design.** A `<Compile Include>`
+> glob that matches zero files is completely silent in MSBuild, so when Track B
+> moved those three subsystems the port lost 74 files with a green build. The
+> `VerifySharedSourceRoots` target in `Reactor.Uno.csproj` now fails the build if
+> any shared root stops existing; `ci-uno.yml` is path-gated on both
+> `src/Reactor/**` and `src/Reactor.Advanced/**`.
+
+The assembly is named **`Reactor`** with root namespace
+**`Microsoft.UI.Reactor`** — identical to the Windows package — so consumer
+`using Microsoft.UI.Reactor;` and `ReactorApp.Run<T>` work unchanged.
+
+### What's replaced or excluded
+
+The Windows `Hosting/` stack is Win32/DWM/AppWindow/shell P/Invoke-heavy, so it
+is **not** shared; this project provides a slim Uno hosting layer instead:
+
+- **`ReactorApp`** — `Run` (sync, desktop) / `RunAsync` (async, WASM) build an
+  `UnoPlatformHostBuilder` and a code-only `Application`. Platform providers are
+  selected per-TFM (`UseX11`/`UseWin32`/`UseMacOS`/`UseLinuxFrameBuffer` on
+  desktop, `UseWebAssembly` on WASM).
+- **`ReactorHost`** — a trimmed render loop (keeps coalescing, reconcile, effects
+  flush, perf stats, and the charting-activation seam; drops the system-backdrop,
+  dev-overlay, focus-revalidation, and in-render accessibility machinery).
+- **`ReactorWindow` + windowing types** — minimal Uno-backed equivalents so the
+  shared windowing hooks (`UseWindow`, `UseWindowSize`, `UseDpi`, …) compile and
+  degrade gracefully.
+
+**Excluded subsystems:** `Docking/` (native tab tear-off / floating windows via
+Win32 — the dock event-fluent region in `ElementExtensions.Events.cs` is guarded
+with `#if !REACTOR_UNO`), the Windows shell integration (tray/jumplist/taskbar),
+window persistence, and the in-app devtools menu.
+
+### Surgical shared-source edits
+
+The port touches only **two** shared files, and just one of them carries a
+`REACTOR_UNO` conditional (the symbol is defined only by this project, so the
+Windows build is **unaffected** — verified green):
+
+- `Elements/ElementExtensions.Events.cs` — the Docking event fluents (`#if !REACTOR_UNO`),
+  since `Docking/` is excluded from the port.
+- `Core/Reconciler.Mount.cs` — `return null` → `return default` in a generic
+  helper. Not a conditional: semantically identical on both builds (`T` is
+  constrained to a reference type); it just satisfies Uno's nullable analysis.
+
+> A second conditional used to guard `Hyperlink.UnderlineStyle` (Uno declared the
+> `UnderlineStyleProperty` DP identifier `internal`). That was fixed upstream in
+> [unoplatform/uno#23652](https://github.com/unoplatform/uno/issues/23652), so as of
+> `Uno.Sdk 6.7.0-dev.117` the guard is gone and the shared DP-based updater compiles
+> unchanged.
+
+### Name disambiguation (`GlobalUsings.cs`)
+
+Uno's implicit `Microsoft.UI.Xaml.Controls` global using collides with Reactor's
+own `Controls`/`Core` types and with `Microsoft.UI.Xaml`. The shared source
+already carries its own `using` directives, so global aliases pin the few bare
+names that would otherwise be ambiguous (`SelectionMode` → Reactor's;
+`ElementFactoryGetArgs`/`RecycleArgs` → `Microsoft.UI.Xaml`).
+
+## Feature support on Uno Skia
+
+Legend: ✅ works · 🟡 partial / unverified · ❌ not supported (compiles, but no-ops or throws at runtime).
+
+| Area | Status | Notes |
+| --- | :---: | --- |
+| MVU core: hooks, state, effects, memo, reconciler | ✅ | Full parity with the Windows framework. |
+| Layout: Grid, Stack, panels, Yoga/Flex | ✅ | |
+| Core controls: Button, TextBlock, TextBox, ToggleSwitch, Slider, ProgressBar, CheckBox, ComboBox, ScrollView | ✅ | Sample-verified (desktop + wasm). |
+| Theming (Light/Dark) + live theme-change re-render | ✅ | |
+| Implicit animations & transitions (Scale/Rotation/Opacity/Translation transitions, spring / natural-motion, `ImplicitAnimationCollection`) | ❌ | Not implemented in Uno — the calls no-op. |
+| RichTextBlock / rich inline text / Markdown rendering | 🟡 | Most `RichTextBlock` members are not implemented in Uno; rich text and Markdown render incompletely. |
+| RichEditBox | ❌ | Not implemented in Uno. |
+| Custom TitleBar (drag regions, back button, panes) | ❌ | Not implemented in Uno. |
+| Specialty controls: ParallaxView, MapControl, SemanticZoom, LinedFlowLayout, AnnotatedScrollBar | ❌ | Not implemented in Uno. |
+| Gesture/access flags: `IsTapEnabled` / `IsHoldingEnabled` / `IsDoubleTapEnabled` / `IsRightTapEnabled`, `AccessKey`, `CharacterReceived` | 🟡 | Those specific flags no-op; basic pointer/click still works. |
+| High-contrast / forced-colors detection | ❌ | `AccessibilitySettings.HighContrast` not implemented — charts don't adapt to high contrast. |
+| Single window + render loop + error fallback | ✅ | |
+| Multi-window (`OpenWindow` / `UseOpenWindow`) | ✅ desktop | Real secondary windows on every desktop head (X11 / Win32 / macOS / FrameBuffer), each with its own `ReactorHost`, render loop and state. Android/iOS throw `InvalidOperationException` (Uno doesn't support secondary windows there) — `UseOpenWindow` catches it and degrades to a null handle. No OS windows in the browser (wasm). Demoed in `samples/Uno/ReactorUnoShowcase`. |
+| DPI (`UseDpi`) | ✅ | Per-window DPI from `XamlRoot.RasterizationScale`, and live changes (window dragged to a monitor with a different scale, or the display scale changed) re-render via `XamlRoot.Changed`. Correctly per-window, since each window has its own `XamlRoot`. |
+| File / folder pickers (`UseFilePickerAsync` / `UseFolderPickerAsync`) | ✅ desktop | Uno implements the WinRT pickers. The shared hook's `WindowNative.GetWindowHandle` + `InitializeWithWindow` association is exactly the initialization Uno's own docs prescribe for Uno.WinUI apps — it is not a Windows-only path. On **wasm** it depends on the browser: Uno uses the File System Access API where available (Chromium) and falls back to download/upload pickers; `FolderPicker` needs the File System Access API. Demoed in `samples/Uno/ReactorUnoShowcase`. |
+| Tray icons / shell (jump list, taskbar) | ❌ | Stub no-ops. |
+| Window persistence (placement save/restore) | ❌ | Not shared. |
+| System backdrop / Mica / DWM effects | ❌ | Not shared. |
+| Multi-monitor / display enumeration | ❌ | `ReactorDisplay.Displays` returns empty. |
+| Window closing guards (`UseClosingGuard`) | ✅ desktop | Backed by Uno's `AppWindow.Closing`. Guards stack; any returning `false` cancels the close, and a throwing guard fail-safes to "cancel" (same as the Windows framework). Honoured on desktop Windows / macOS / Linux. On Android, iOS and wasm the event still fires but cancellation has no effect (per Uno), so the close proceeds. Demoed on the Showcase's second window. |
+| Hot Reload (edit `Render()` while running) | ✅ | Reactor registers `[assembly: MetadataUpdateHandler]`, and Uno's own `HotReloadAgent` discovers and invokes **every** registered handler — so Reactor's re-render is driven by Uno's hot-reload pipeline on the targets `dotnet watch` alone can't reach. Needs no opt-in. `UseState` survives; hook add/remove/reorder recovers by remounting. See [Hot Reload](#hot-reload) below. |
+| Declarative caption height (`TitleBar(...).Tall()`, `WindowSpec.TitleBarHeight`) | ✅ desktop | Backed by Uno's `AppWindowTitleBar.PreferredHeightOption` (Standard 32 / Tall 48 / Collapsed 0), which Uno implements for real. The WinUI `TitleBar` *control* is still an Uno stub, so only the caption half is visible today. |
+| Window drag-move, aspect-ratio lock | ❌ | Still no-op stubs — **not yet audited** against Uno's API surface (multi-window, DPI, pickers and closing guards all turned out to be implementable, so these may be too). |
+| Docking (dock manager, tab tear-off, floating windows, splitters) | ❌ | Excluded from the port entirely. |
+| In-app devtools | ❌ | `DevtoolsEnabled` is `false`. |
+| Charting / DataGrid / PropertyGrid | 🟡 | Source-shared from `Reactor.Advanced` and compiling on all three TFMs; render path shared with WinUI, but not yet runtime-verified on Skia. |
+| Markdown rendering | 🟡 | Source-shared from `Reactor.Advanced`. Compiles, but depends on `RichTextBlock`, which Uno implements only partially — so rich output renders incompletely. |
+
+> The ❌ / 🟡 runtime rows line up with the `Uno0001` *not-implemented* build warnings: the code compiles, but those specific APIs no-op (or throw) on Uno. They don't affect the ✅ rows.
+
+## Hot Reload
+
+**Yes — editing a `Component.Render()` body updates the running app, and
+`UseState` survives.** Verified on Skia desktop:
+
+```
+dotnet watch ⌚ File updated: .\Program.cs
+dotnet watch 🔥 C# and Razor changes applied in 424ms.
+```
+…with the counter still reading the value it held before the edit.
+
+### How it composes with Uno's Hot Reload
+
+Reactor does **not** implement a competing mechanism. `Hosting/HotReloadService.cs`
+(source-shared from the Windows framework) registers the standard
+
+```csharp
+[assembly: MetadataUpdateHandler(typeof(HotReloadService))]
+```
+
+and Uno's own `ClientHotReloadProcessor` registers itself the same way. They are
+peers on one runtime mechanism, not layers. Crucially, Uno's `HotReloadAgent`
+scans **every** loaded assembly for `MetadataUpdateHandlerAttribute` and invokes
+what it finds:
+
+```csharp
+// Uno.UI.RemoteControl/HotReload/MetadataUpdater/HotReloadAgent.cs
+handlerActions.ClearCache.ForEach(a => a(updatedTypes));
+handlerActions.UpdateApplication.ForEach(a => a(updatedTypes));
+```
+
+So on the targets where the Uno **Dev Server** delivers the deltas rather than
+`dotnet watch` — WebAssembly, Android, iOS — Uno drives Reactor's re-render for
+free, with no Reactor-side work at all.
+
+Nothing has to be opted into for this. There is **no `HotReload` UnoFeature**
+(passing one just warns `Unable to parse 'hotreload' to a known Uno Feature` and
+is ignored); the dev-server client `Uno.WinUI.DevServer` / `Uno.UI.RemoteControl`
+is referenced automatically for Debug builds, and the Dev Server process itself is
+started by the IDE. `.UseStudio()` is likewise not needed — it lives in
+`Uno.UI.HotDesign` and turns on **Hot Design**, Uno's runtime *XAML* visual
+designer, which does not apply to a XAML-free framework like Reactor.
+
+On an update Reactor re-renders the whole tree with `force: true` (bypassing memo),
+migrates hook cells whose types were edited, and treats a `HookOrderException` as
+"the edit changed the hook shape" — it drops that context's hook state and
+remounts instead of showing the error overlay.
+
+### Caveat: multi-targeted heads under `dotnet watch`
+
+`dotnet watch -f <tfm>` against an app head whose csproj lists **more than one**
+TFM currently loads a Roslyn workspace with no references, and every edit fails
+with a wall of `CS0518: Predefined type 'System.Object' is not defined`. This is
+not Reactor-specific — it reproduces from the TFM list alone:
+
+| Head `TargetFrameworks` | Result |
+| --- | --- |
+| `net10.0-desktop;net10.0-browserwasm` | ❌ `CS0518` cascade, hot reload dead |
+| `net10.0-desktop` | ✅ `🔥 C# changes applied` |
+
+The referenced library may stay multi-targeted — only the **head** matters. So
+when hot-reloading from the CLI, either single-target the head or use an IDE
+(VS / VS Code / Rider), which drives the Uno Dev Server and picks one TFM per
+debug session. The unrelated `Found project reference without a matching
+metadata reference` warning is benign — it is present in the working case too.
+
+## Known limitations / notes
+
+- **Uno version.** The port requires Uno **6.7** APIs (`DispatcherQueueSynchronizationContext`,
+  the `TitleBar` drag-region APIs) that are absent from the current 6.5 GA, so it
+  pins the 6.7 preview — `Uno.Sdk 6.7.0-dev.117`, set in `global.json` (repo root,
+  `src/Reactor.Uno/`, `samples/Uno/`, and the file-based `Counter.cs` header).
+  Switch to 6.7 GA when it ships. The Skia runtime packages take their version from
+  `$(UnoVersion)`, which **Uno.Sdk supplies**, so they track the SDK automatically —
+  don't hardcode a version for them (it drifts and trips `NU1605`).
+- **Don't name a file-based app's root component `App`** — Uno.Sdk generates an
+  `App` type for single-project EXEs, which would clash. Use any other name
+  (`CounterApp`, `MyApp`, …); `ReactorApp.Run<T>` doesn't care.
+- See the **Feature support on Uno Skia** matrix above for what works, what's
+  partial, and what's unsupported. The unsupported/partial rows surface as
+  `Uno0001` *not-implemented* build warnings — runtime no-ops in Uno, not build
+  breaks — and only affect those specific features.
+
+## Mobile
+
+`Reactor.Uno` already **compiles for `net10.0-android`**. To actually deploy to
+Android/iOS you'd add a thin mobile *head* project (Uno single-project EXE) that
+references `Reactor.Uno`, wires the native entry point (Activity / AppDelegate),
+and mounts a root `Component` via a `ReactorHost`. The framework code itself is
+platform-agnostic `Microsoft.UI.Xaml`, so no Reactor changes are expected.

--- a/src/Reactor.Uno/Reactor.Uno.csproj
+++ b/src/Reactor.Uno/Reactor.Uno.csproj
@@ -1,0 +1,225 @@
+<Project Sdk="Uno.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net10.0-desktop;net10.0-browserwasm;net10.0-android;net10.0-ios</TargetFrameworks>
+
+    <UnoSingleProject>true</UnoSingleProject>
+    <OutputType>Library</OutputType>
+    <GenerateLibraryLayout>true</GenerateLibraryLayout>
+
+    <!-- Match the Windows framework's identity so consumer `using
+         Microsoft.UI.Reactor;` and assembly name line up. -->
+    <AssemblyName>Reactor</AssemblyName>
+    <RootNamespace>Microsoft.UI.Reactor</RootNamespace>
+
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+
+    <!-- Source-shared files guard Windows-only code paths with this symbol. -->
+    <DefineConstants>$(DefineConstants);REACTOR_UNO</DefineConstants>
+
+
+    <!-- The shared source carries AOT/trim annotations; we don't promote them
+         to errors in the Uno port. -->
+    <IsAotCompatible>false</IsAotCompatible>
+    <EnableTrimAnalyzer>false</EnableTrimAnalyzer>
+
+    <UnoFeatures>
+      SkiaRenderer;
+    </UnoFeatures>
+  </PropertyGroup>
+
+  <!-- ── Shared source from the Windows framework ──
+       Portable subsystems, source-shared verbatim from BOTH src/Reactor (core)
+       and src/Reactor.Advanced (the charting / markdown / data-grid subsystems,
+       moved out of core by spec 062 Track B). Windows-only Docking, Win2D, and
+       most of Hosting (windowing/shell/persistence/devtools) are excluded and
+       replaced by this project's Uno hosting layer; a few portable Hosting
+       files are pulled in explicitly below.
+
+       NOTE: an <Compile Include> glob that matches ZERO files is silent in
+       MSBuild — that is exactly how Track B dropped 74 files out of this port
+       with a green build. The VerifySharedSourceRoots target at the bottom of
+       this file turns that failure mode into a build error. -->
+  <!-- Hosting/ is cherry-picked file-by-file rather than globbed, so a NEW file
+       upstream is invisible here until something fails to compile (that is how
+       FrameNavigation.cs broke the port). Both lists below are checked against
+       the real folder by VerifyHostingTriage, so any new Hosting file forces an
+       explicit include-or-exclude decision. -->
+  <ItemGroup>
+    <!-- Portable: compiled into the port. -->
+    <SharedHostingFile Include="..\Reactor\Hosting\IChartingHostBridge.cs" />
+    <SharedHostingFile Include="..\Reactor\Hosting\ChartingActivation.cs" />
+    <SharedHostingFile Include="..\Reactor\Hosting\RenderStats.cs" />
+    <SharedHostingFile Include="..\Reactor\Hosting\RenderPriorityPolicy.cs" />
+    <SharedHostingFile Include="..\Reactor\Hosting\XamlInterop.cs" />
+    <SharedHostingFile Include="..\Reactor\Hosting\HotReloadService.cs" />
+    <SharedHostingFile Include="..\Reactor\Hosting\ReactorHotReloadCopier.cs" />
+    <SharedHostingFile Include="..\Reactor\Hosting\FrameNavigation.cs" />
+
+    <!-- Windows-only or replaced by this project's Uno hosting layer. Listed so
+         the triage check can tell "deliberately excluded" from "not yet seen". -->
+    <ExcludedHostingFile Include="..\Reactor\Hosting\BackdropApplier.cs" />
+    <ExcludedHostingFile Include="..\Reactor\Hosting\DwmInterop.cs" />
+    <ExcludedHostingFile Include="..\Reactor\Hosting\EmbedHostWatchdog.cs" />
+    <ExcludedHostingFile Include="..\Reactor\Hosting\OverlayHostWiring.cs" />
+    <!-- Depends on the excluded ReactorHostControl. -->
+    <ExcludedHostingFile Include="..\Reactor\Hosting\PageHelper.cs" />
+    <ExcludedHostingFile Include="..\Reactor\Hosting\ReactorApp.BuiltIns.cs" />
+    <ExcludedHostingFile Include="..\Reactor\Hosting\ReactorApp.cs" />
+    <ExcludedHostingFile Include="..\Reactor\Hosting\ReactorAppContext.cs" />
+    <ExcludedHostingFile Include="..\Reactor\Hosting\ReactorCoreXamlMetadataProvider.cs" />
+    <ExcludedHostingFile Include="..\Reactor\Hosting\ReactorDisplay.cs" />
+    <ExcludedHostingFile Include="..\Reactor\Hosting\ReactorFeatures.cs" />
+    <ExcludedHostingFile Include="..\Reactor\Hosting\ReactorHost.cs" />
+    <ExcludedHostingFile Include="..\Reactor\Hosting\ReactorHostControl.cs" />
+    <ExcludedHostingFile Include="..\Reactor\Hosting\ReactorWindow.cs" />
+    <ExcludedHostingFile Include="..\Reactor\Hosting\ReconcileHighlightOverlay.cs" />
+    <ExcludedHostingFile Include="..\Reactor\Hosting\ThreadAffinity.cs" />
+    <ExcludedHostingFile Include="..\Reactor\Hosting\UIThreadOnlyAttribute.cs" />
+    <!-- Declares WindowState, which this project's Hosting/Windowing.cs owns. -->
+    <ExcludedHostingFile Include="..\Reactor\Hosting\WindowEnums.cs" />
+    <ExcludedHostingFile Include="..\Reactor\Hosting\WindowEvents.cs" />
+    <ExcludedHostingFile Include="..\Reactor\Hosting\WindowIcon.cs" />
+    <ExcludedHostingFile Include="..\Reactor\Hosting\WindowKey.cs" />
+    <ExcludedHostingFile Include="..\Reactor\Hosting\WindowSpec.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Reactor\Core\**\*.cs" />
+    <Compile Include="..\Reactor\Hooks\**\*.cs" />
+    <Compile Include="..\Reactor\Elements\**\*.cs" />
+    <Compile Include="..\Reactor\Input\**\*.cs" />
+    <Compile Include="..\Reactor\Accessibility\**\*.cs" />
+    <Compile Include="..\Reactor\Animation\**\*.cs" />
+    <Compile Include="..\Reactor\Yoga\**\*.cs" />
+    <Compile Include="..\Reactor\Data\**\*.cs" />
+    <Compile Include="..\Reactor\Controls\**\*.cs" />
+
+    <!-- Reactor.Advanced subsystems that are portable to Skia. Verified free of
+         Win2D and Docking coupling, so they do NOT drag in the Win2D
+         PackageReference that Reactor.Advanced itself carries. Docking/ and
+         Win2D/ stay excluded (Win32 / D2D interop). -->
+    <Compile Include="..\Reactor.Advanced\Markdown\**\*.cs" />
+    <Compile Include="..\Reactor.Advanced\Charting\**\*.cs" />
+    <Compile Include="..\Reactor.Advanced\Controls\DataGrid\**\*.cs" />
+    <!-- The Markdown() factories, which live at the root of Reactor.Advanced
+         alongside the Win2D ones. Factories.cs itself is deliberately NOT shared:
+         it is entirely Win2D (CanvasControl et al), which Uno has no equivalent for. -->
+    <Compile Include="..\Reactor.Advanced\Factories.Markdown.cs" />
+
+    <!-- Top-level diagnostics (EventSource-based tracing; portable). -->
+    <Compile Include="..\Reactor\Diagnostics\**\*.cs" />
+
+    <!-- Portable Hosting files the shared core depends on. The rest of Hosting
+         (windowing/shell/persistence/devtools) is replaced by this project's
+         Uno hosting layer. Declared as an item so VerifyHostingTriage below can
+         diff it against the folder. -->
+    <Compile Include="@(SharedHostingFile)" />
+
+    <!-- Wrapper authoring attributes ([GenerateReactorDescriptor], …). Single
+         file; compiled in directly (no separate assembly, so no CS0436). -->
+    <Compile Include="..\Reactor.Wrappers.Abstractions\WrapperAttributes.cs" />
+  </ItemGroup>
+
+  <!-- Excludes (must follow the Include globs above to take effect). -->
+  <ItemGroup>
+    <!-- Devtools menu shim depends on Microsoft.UI.Reactor.Hosting.Devtools,
+         which is not part of the Uno port. -->
+    <Compile Remove="..\Reactor\Elements\DevtoolsMenuShim.cs" />
+  </ItemGroup>
+
+  <!-- The wrapper source generator emits ControlDescriptor partials from the
+       [GenerateReactorDescriptor] annotations on the shared Element records. -->
+  <ItemGroup>
+    <ProjectReference Include="..\Reactor.Wrappers.Generator\Reactor.Wrappers.Generator.csproj"
+                      OutputItemType="Analyzer"
+                      ReferenceOutputAssembly="false" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
+    <PackageReference Include="MessageFormat" Version="8.0.0" />
+  </ItemGroup>
+
+  <!-- Skia host-builder providers (UseX11/UseWin32/UseMacOS/UseLinuxFrameBuffer,
+       UseWebAssembly). These ship in the per-platform Skia runtime packages that
+       Uno.Sdk normally injects only into EXE heads; the Reactor.Uno library owns
+       the host bootstrap (ReactorApp.Run), so it references them directly and they
+       flow transitively to the consuming app head. $(UnoVersion) is supplied by
+       Uno.Sdk, so these track the SDK pinned in global.json automatically — never
+       hardcode a version here (it would drift and trip NU1605). -->
+  <!-- Desktop Skia host providers: UseX11/UseWin32/UseMacOS/UseLinuxFrameBuffer. -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0-desktop'">
+    <PackageReference Include="Uno.WinUI.Runtime.Skia" Version="$(UnoVersion)" />
+    <PackageReference Include="Uno.WinUI.Runtime.Skia.X11" Version="$(UnoVersion)" />
+    <PackageReference Include="Uno.WinUI.Runtime.Skia.Win32" Version="$(UnoVersion)" />
+    <PackageReference Include="Uno.WinUI.Runtime.Skia.MacOS" Version="$(UnoVersion)" />
+    <PackageReference Include="Uno.WinUI.Runtime.Skia.Linux.FrameBuffer" Version="$(UnoVersion)" />
+  </ItemGroup>
+
+  <!-- WebAssembly Skia host provider: UseWebAssembly. -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0-browserwasm'">
+    <PackageReference Include="Uno.WinUI.Runtime.Skia.WebAssembly.Browser" Version="$(UnoVersion)" />
+  </ItemGroup>
+
+  <!-- Android Skia runtime. The head supplies the Activity entry point and
+       calls ReactorApp.CreateApplication<TRoot>(). -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0-android'">
+    <PackageReference Include="Uno.WinUI.Runtime.Skia.Android" Version="$(UnoVersion)" />
+  </ItemGroup>
+
+  <!-- Apple (UIKit) Skia runtime: UseAppleUIKit. Unlike Android, the Apple heads
+       start from a real Main and take the same UnoPlatformHostBuilder shape as
+       desktop, so ReactorApp.Run works there unchanged. -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0-ios'">
+    <PackageReference Include="Uno.WinUI.Runtime.Skia.AppleUIKit" Version="$(UnoVersion)" />
+  </ItemGroup>
+
+  <!-- Source-share drift guard.
+       This project consumes the Windows framework by globbing folders out of
+       sibling projects. When upstream MOVES one of those folders, the glob
+       quietly matches nothing and the subsystem disappears from the port with a
+       perfectly green build. That is not hypothetical: spec 062 Track B moved
+       Charting/, Markdown/ and the DataGrid into Reactor.Advanced and this port
+       silently lost 74 files.
+
+       Asserting the roots exist converts that into an immediate, legible build
+       error. Keep this list in sync with the Compile globs above. -->
+  <Target Name="VerifySharedSourceRoots" BeforeTargets="CoreCompile">
+    <ItemGroup>
+      <SharedSourceRoot Include="..\Reactor\Core" />
+      <SharedSourceRoot Include="..\Reactor\Hooks" />
+      <SharedSourceRoot Include="..\Reactor\Elements" />
+      <SharedSourceRoot Include="..\Reactor\Input" />
+      <SharedSourceRoot Include="..\Reactor\Accessibility" />
+      <SharedSourceRoot Include="..\Reactor\Animation" />
+      <SharedSourceRoot Include="..\Reactor\Yoga" />
+      <SharedSourceRoot Include="..\Reactor\Data" />
+      <SharedSourceRoot Include="..\Reactor\Controls" />
+      <SharedSourceRoot Include="..\Reactor\Diagnostics" />
+      <SharedSourceRoot Include="..\Reactor.Advanced\Markdown" />
+      <SharedSourceRoot Include="..\Reactor.Advanced\Charting" />
+      <SharedSourceRoot Include="..\Reactor.Advanced\Controls\DataGrid" />
+    </ItemGroup>
+    <Error Condition="!Exists('%(SharedSourceRoot.Identity)')"
+           Text="Source-share root '%(SharedSourceRoot.Identity)' no longer exists. Upstream moved or renamed it, so the matching &lt;Compile Include&gt; glob is now matching zero files and that subsystem has silently dropped out of the Uno port. Re-point the glob (and this list) at the new location." />
+  </Target>
+
+  <!-- Companion guard for the cherry-picked Hosting/ folder.
+       The glob-based check above cannot help there: Hosting/ is picked
+       file-by-file, so a NEW upstream file is simply absent from the port until
+       some unrelated file fails to compile against it. Diff the folder against
+       the two declared lists and make the decision explicit instead. -->
+  <Target Name="VerifyHostingTriage" BeforeTargets="CoreCompile">
+    <ItemGroup>
+      <_AllHostingFiles Include="..\Reactor\Hosting\*.cs" />
+      <_TriagedHostingFiles Include="@(SharedHostingFile);@(ExcludedHostingFile)" />
+      <_UntriagedHostingFiles Include="@(_AllHostingFiles)" Exclude="@(_TriagedHostingFiles)" />
+    </ItemGroup>
+    <Error Condition="'@(_UntriagedHostingFiles)' != ''"
+           Text="New file(s) in src/Reactor/Hosting/ that the Uno port has not triaged: @(_UntriagedHostingFiles->'%(Filename)%(Extension)', ', '). Decide whether each is portable — add it to SharedHostingFile to compile it into the port, or to ExcludedHostingFile if it is Windows-only / replaced by the Uno hosting layer." />
+  </Target>
+
+</Project>

--- a/src/Reactor.Uno/WinRTShims.cs
+++ b/src/Reactor.Uno/WinRTShims.cs
@@ -1,0 +1,35 @@
+// Shims for CsWinRT types the shared source references but Uno does not have.
+//
+// On Windows, Reactor is compiled against the C#/WinRT projection, so WinUI types
+// like Microsoft.UI.Xaml.Controls.Page carry [WinRT.WindowsRuntimeTypeAttribute]
+// and live in the native WinRT type system. Uno has no projection at all — every
+// type, WinUI's included, is an ordinary managed type.
+//
+// Declaring the attribute here rather than guarding the shared source with
+// #if REACTOR_UNO keeps the port at *zero* conditionals in src/Reactor, and the
+// behaviour is right by construction: nothing in an Uno app is WinRT-projected,
+// so `IsDefined(typeof(WindowsRuntimeTypeAttribute), ...)` is correctly always
+// false and FrameNavigation falls through to asking the XAML type resolver —
+// which is the whole point of that check.
+
+namespace WinRT;
+
+/// <summary>
+/// Uno-side stand-in for CsWinRT's marker attribute. Deliberately never applied
+/// to anything: on Uno there are no WinRT-projected types.
+/// </summary>
+[global::System.AttributeUsage(
+    global::System.AttributeTargets.Class
+    | global::System.AttributeTargets.Interface
+    | global::System.AttributeTargets.Struct
+    | global::System.AttributeTargets.Enum
+    | global::System.AttributeTargets.Delegate,
+    Inherited = false)]
+internal sealed class WindowsRuntimeTypeAttribute : global::System.Attribute
+{
+    public WindowsRuntimeTypeAttribute() { }
+
+    public WindowsRuntimeTypeAttribute(string sourceMetadata) => SourceMetadata = sourceMetadata;
+
+    public string? SourceMetadata { get; }
+}

--- a/src/Reactor.Uno/global.json
+++ b/src/Reactor.Uno/global.json
@@ -1,0 +1,10 @@
+{
+  "msbuild-sdks": {
+    "Uno.Sdk": "6.7.0-dev.117"
+  },
+  "sdk": {
+    "version": "10.0.100",
+    "rollForward": "latestFeature",
+    "allowPrerelease": false
+  }
+}

--- a/src/Reactor.Uno/nuget.config
+++ b/src/Reactor.Uno/nuget.config
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <!-- Isolated NuGet sources for the Uno port. nuget.org carries Uno.Sdk
+       (incl. the 6.7.0-dev.* builds) and the .NET runtime packages. We clear
+       first so inherited/authenticated enterprise feeds don't slow restore. -->
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+  </packageSources>
+  <disabledPackageSources>
+    <clear />
+  </disabledPackageSources>
+</configuration>

--- a/src/Reactor.Uno/reactor-uno-explainer.html
+++ b/src/Reactor.Uno/reactor-uno-explainer.html
@@ -1,0 +1,301 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Microsoft.UI.Reactor → Uno Platform (Skia)</title>
+<style>
+  :root{
+    --bg:#0d1117; --panel:#161b22; --panel2:#1c2330; --border:#2a3340;
+    --txt:#e6edf3; --dim:#8b949e; --accent:#58a6ff; --accent2:#7ee787;
+    --warn:#f0b72f; --kw:#ff7b72; --str:#a5d6ff; --cmt:#8b949e; --type:#79c0ff;
+    --mono:'Cascadia Code','Consolas',ui-monospace,Menlo,monospace;
+  }
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--bg);color:var(--txt);
+    font-family:system-ui,-apple-system,Segoe UI,Roboto,sans-serif;line-height:1.5}
+  header{padding:22px 28px 14px;border-bottom:1px solid var(--border)}
+  header h1{margin:0;font-size:20px;font-weight:650;letter-spacing:.2px}
+  header h1 .arrow{color:var(--accent)}
+  header p{margin:6px 0 0;color:var(--dim);font-size:13px}
+  .wrap{display:grid;grid-template-columns:300px 1fr;gap:0;min-height:calc(100vh - 150px)}
+  .controls{padding:20px 22px;border-right:1px solid var(--border);background:var(--panel)}
+  .preview{padding:22px 26px;overflow:auto}
+  .lbl{font-size:11px;text-transform:uppercase;letter-spacing:.8px;color:var(--dim);margin:0 0 10px}
+  .targets{display:flex;flex-direction:column;gap:8px;margin-bottom:24px}
+  .target{display:flex;align-items:center;gap:10px;padding:11px 13px;border:1px solid var(--border);
+    border-radius:9px;cursor:pointer;background:var(--panel2);transition:.15s;font-size:14px}
+  .target:hover{border-color:#3d4a5c}
+  .target.sel{border-color:var(--accent);box-shadow:0 0 0 1px var(--accent) inset;background:#162132}
+  .target .dot{width:9px;height:9px;border-radius:50%;flex:0 0 auto}
+  .target .meta{margin-left:auto;font-size:11px;color:var(--dim)}
+  .badge{display:inline-block;padding:3px 9px;border-radius:20px;font-size:11px;font-weight:600}
+  .badge.runs{background:rgba(126,231,135,.15);color:var(--accent2);border:1px solid rgba(126,231,135,.35)}
+  .badge.compiles{background:rgba(240,183,47,.13);color:var(--warn);border:1px solid rgba(240,183,47,.35)}
+  .badge.native{background:rgba(88,166,255,.13);color:var(--accent);border:1px solid rgba(88,166,255,.35)}
+  .card{background:var(--panel);border:1px solid var(--border);border-radius:11px;margin-bottom:18px;overflow:hidden}
+  .card .head{display:flex;align-items:center;gap:10px;padding:11px 15px;border-bottom:1px solid var(--border);font-size:13px;font-weight:600;background:var(--panel2)}
+  .card .head .tag{margin-left:auto;font-weight:500;font-size:11px;color:var(--dim)}
+  pre{margin:0;padding:15px;overflow:auto;font-family:var(--mono);font-size:12.5px;line-height:1.62;tab-size:2}
+  .cmt{color:var(--cmt)} .kw{color:var(--kw)} .str{color:var(--str)} .type{color:var(--type)}
+  .dir{color:var(--accent2)} .prop{color:var(--type)}
+  .run{font-family:var(--mono);font-size:12.5px;background:#0a0e14;border:1px solid var(--border);border-radius:8px;padding:11px 14px;color:var(--accent2)}
+  .run::before{content:"$ ";color:var(--dim)}
+  .note{font-size:12.5px;color:var(--dim);padding:0 2px;margin:8px 0 0}
+  .same{display:inline-block;margin-left:8px;font-size:11px;color:var(--accent2);font-weight:600}
+  .arch{display:grid;grid-template-columns:1fr;gap:10px}
+  .layer{border:1px solid var(--border);border-radius:9px;padding:12px 14px;background:var(--panel2)}
+  .layer h4{margin:0 0 7px;font-size:13px}
+  .chips{display:flex;flex-wrap:wrap;gap:6px}
+  .chip{font-family:var(--mono);font-size:11px;padding:3px 8px;border-radius:6px;background:#0a0e14;border:1px solid var(--border);color:var(--txt)}
+  .chip.host{border-color:rgba(88,166,255,.4);color:var(--accent)}
+  .chip.excl{border-color:rgba(255,123,114,.4);color:var(--kw);text-decoration:line-through;opacity:.8}
+  .flowarrow{text-align:center;color:var(--dim);font-size:16px;margin:-4px 0}
+  .copybar{position:sticky;bottom:0;display:flex;align-items:center;gap:12px;padding:13px 28px;border-top:1px solid var(--border);background:rgba(13,17,23,.92);backdrop-filter:blur(6px)}
+  .copybar button{font:inherit;font-size:13px;font-weight:600;padding:9px 18px;border-radius:8px;border:1px solid var(--accent);background:var(--accent);color:#04101f;cursor:pointer}
+  .copybar button:hover{filter:brightness(1.08)}
+  .copybar .hint{color:var(--dim);font-size:12.5px}
+  .legend{display:flex;gap:14px;margin-top:6px;flex-wrap:wrap;font-size:11px;color:var(--dim)}
+  .legend span{display:inline-flex;align-items:center;gap:5px}
+  .sw{width:9px;height:9px;border-radius:2px;display:inline-block}
+</style>
+</head>
+<body>
+<header>
+  <h1>Microsoft.UI.Reactor <span class="arrow">→</span> Uno Platform (Skia)</h1>
+  <p>The same Reactor C# — reconciler, hooks, DSL — recompiled against Uno's <code>Microsoft.UI.Xaml</code>. Pick a target to see what changes (spoiler: only the directives &amp; host).</p>
+</header>
+
+<div class="wrap">
+  <aside class="controls">
+    <p class="lbl">Target</p>
+    <div class="targets" id="targets"></div>
+    <p class="lbl">What stays the same</p>
+    <div class="card" style="margin:0">
+      <div class="head">Your Reactor component <span class="same" id="sameBadge">identical ✓</span></div>
+      <pre id="component"></pre>
+    </div>
+    <div class="legend">
+      <span><i class="sw" style="background:var(--accent2)"></i>shared verbatim</span>
+      <span><i class="sw" style="background:var(--accent)"></i>Uno hosting</span>
+      <span><i class="sw" style="background:var(--kw)"></i>excluded</span>
+    </div>
+  </aside>
+
+  <main class="preview">
+    <div class="card">
+      <div class="head">
+        <span id="tname">—</span>
+        <span class="tag" id="tdesc"></span>
+      </div>
+      <div style="padding:14px 15px 4px"><span class="badge" id="tbadge"></span> <span class="note" id="tstatus" style="margin:0"></span></div>
+      <pre id="directives"></pre>
+    </div>
+
+    <p class="lbl">Run it</p>
+    <div class="run" id="runcmd" style="margin-bottom:18px"></div>
+
+    <p class="lbl">How the port is wired</p>
+    <div class="arch">
+      <div class="layer">
+        <h4>① Shared source — <code>src/Reactor/**</code> <span style="color:var(--accent2)">(compiled verbatim, 0 edits except 3 #if guards)</span></h4>
+        <div class="chips">
+          <span class="chip">Core / reconciler</span><span class="chip">Hooks</span><span class="chip">Elements (DSL)</span>
+          <span class="chip">Yoga</span><span class="chip">Flex</span><span class="chip">Animation</span><span class="chip">Input</span>
+          <span class="chip">Accessibility</span><span class="chip">Data / DataGrid</span><span class="chip">Controls</span>
+          <span class="chip">Markdown</span><span class="chip">Charting (D3)</span><span class="chip">Diagnostics</span>
+        </div>
+      </div>
+      <div class="flowarrow">▼ recompiled against ▼</div>
+      <div class="layer" style="border-color:rgba(88,166,255,.35)">
+        <h4>② Uno's <code>Microsoft.UI.Xaml</code> (Skia renderer)</h4>
+        <div class="note" style="margin:0">Same API surface Reactor already targets — Button, TextBox, NavigationView, … now drawn by Skia on every head.</div>
+      </div>
+      <div class="flowarrow">▼ hosted by ▼</div>
+      <div class="layer" style="border-color:rgba(88,166,255,.35)">
+        <h4>③ Slim Uno hosting layer <span style="color:var(--accent)">(replaces Windows windowing/shell/DWM P/Invoke)</span></h4>
+        <div class="chips">
+          <span class="chip host">ReactorApp.Run / RunAsync</span><span class="chip host">UnoBootstrap → UnoPlatformHostBuilder</span>
+          <span class="chip host">ReactorHost (render loop)</span><span class="chip host">Windowing (ReactorWindow)</span>
+        </div>
+      </div>
+      <div class="layer" style="border-color:rgba(255,123,114,.3);margin-top:2px">
+        <h4 style="color:var(--kw)">Excluded on Skia</h4>
+        <div class="chips">
+          <span class="chip excl">Docking (native tear-off)</span><span class="chip excl">Shell (tray/jumplist/taskbar)</span>
+          <span class="chip excl">Window persistence</span><span class="chip excl">Devtools menu</span>
+        </div>
+      </div>
+    </div>
+  </main>
+</div>
+
+<div class="copybar">
+  <button id="copyBtn">Copy file for this target</button>
+  <span class="hint" id="copyHint">copies the <code>#:</code> directives + the component as one runnable .cs file</span>
+</div>
+
+<script>
+const COMPONENT = [
+  ['cmt','// Identical on every target — this is the whole point.'],
+  ['kw','class '],['type','CounterApp'],['','  : '],['type','Component'],['','\n{'],
+  ['','\n    '],['kw','public override '],['type','Element'],['',' '],['type','Render'],['','()'],
+  ['','\n    {'],
+  ['','\n        '],['kw','var'],['',' (name, setName) = '],['type','UseState'],['','('],['str','"Uno"'],['',');'],
+  ['','\n        '],['kw','var'],['',' (count, setCount) = '],['type','UseState'],['','('],['str','0'],['',');'],
+  ['','\n        '],['kw','return'],['',' '],['type','VStack'],['','('],['str','12'],['',','],
+  ['','\n            '],['type','Heading'],['','('],['str','$"Hello, {name}!"'],['','),'],
+  ['','\n            '],['type','TextBox'],['','(name, setName),'],
+  ['','\n            '],['type','Heading'],['','('],['str','$"Count: {count}"'],['','),'],
+  ['','\n            '],['type','HStack'],['','('],['str','8'],['',','],
+  ['','\n                '],['type','Button'],['','('],['str','"-"'],['',', () => setCount(count - '],['str','1'],['','))'],['',','],
+  ['','\n                '],['type','Button'],['','('],['str','"+"'],['',', () => setCount(count + '],['str','1'],['','))'],
+  ['','\n            )'],
+  ['','\n        ).'],['type','Padding'],['','('],['str','24'],['','); '],
+  ['','\n    }\n}'],
+];
+const COMPONENT_RAW = `class CounterApp : Component
+{
+    public override Element Render()
+    {
+        var (name, setName) = UseState("Uno");
+        var (count, setCount) = UseState(0);
+        return VStack(12,
+            Heading($"Hello, {name}!"),
+            TextBox(name, setName),
+            Heading($"Count: {count}"),
+            HStack(8,
+                Button("-", () => setCount(count - 1)),
+                Button("+", () => setCount(count + 1))
+            )
+        ).Padding(24);
+    }
+}`;
+
+const TARGETS = {
+  winui: {
+    name:'Windows · WinUI 3', color:'#4cc2ff', desc:'the original (Windows App SDK)',
+    badge:'runs', badgeClass:'runs', status:'Runs natively on Windows — the upstream framework.',
+    run:'dotnet run App.cs -a x64',
+    entry:'ReactorApp.Run<CounterApp>("Counter", width: 520, height: 400);',
+    directives:[
+      ['dir','#:property '],['prop','TargetFramework'],['','=net10.0-windows10.0.22621.0'],
+      ['dir','\n#:property '],['prop','WindowsAppSDKSelfContained'],['','=true'],
+      ['dir','\n#:package '],['','Microsoft.UI.Reactor@0.1.0-*'],
+    ],
+    raw:`#:property TargetFramework=net10.0-windows10.0.22621.0
+#:property WindowsAppSDKSelfContained=true
+#:package Microsoft.UI.Reactor@0.1.0-*`
+  },
+  desktop: {
+    name:'Uno · Desktop (Skia)', color:'#7ee787', desc:'Win32 / X11 / macOS / Framebuffer',
+    badge:'runs ✓ verified', badgeClass:'runs', status:'Built & run interactively — counter + two-way TextBox confirmed on screen.',
+    run:'dotnet run Counter.cs',
+    entry:'ReactorApp.Run<CounterApp>("Counter", width: 520, height: 400);',
+    directives:[
+      ['dir','#:sdk '],['','Uno.Sdk@6.7.0-dev.93'],
+      ['dir','\n#:project '],['','../../../src/Reactor.Uno/Reactor.Uno.csproj'],
+      ['dir','\n#:property '],['prop','TargetFramework'],['','=net10.0-desktop'],
+      ['dir','\n#:property '],['prop','OutputType'],['','=Exe'],
+      ['dir','\n#:property '],['prop','UnoSingleProject'],['','=true'],
+      ['dir','\n#:property '],['prop','UnoFeatures'],['','=SkiaRenderer'],
+      ['dir','\n#:property '],['prop','PublishAot'],['','=false'],
+      ['dir','\n#:property '],['prop','PackAsTool'],['','=false'],
+    ],
+    raw:`#:sdk Uno.Sdk@6.7.0-dev.93
+#:project ../../../src/Reactor.Uno/Reactor.Uno.csproj
+#:property TargetFramework=net10.0-desktop
+#:property OutputType=Exe
+#:property UnoSingleProject=true
+#:property UnoFeatures=SkiaRenderer
+#:property PublishAot=false
+#:property PackAsTool=false`
+  },
+  wasm: {
+    name:'Uno · WebAssembly', color:'#58a6ff', desc:'Skia → HTML canvas',
+    badge:'runs ✓ verified', badgeClass:'runs', status:'Built & rendered in the browser. Note the async entry — the browser thread can’t block.',
+    run:'dotnet run -f net10.0-browserwasm   # opens a localhost URL',
+    entry:'await ReactorApp.RunAsync<CounterApp>("Counter", 520, 400);',
+    directives:[
+      ['dir','#:sdk '],['','Uno.Sdk@6.7.0-dev.93'],
+      ['dir','\n#:project '],['','../../../src/Reactor.Uno/Reactor.Uno.csproj'],
+      ['dir','\n#:property '],['prop','TargetFramework'],['','=net10.0-browserwasm'],
+      ['dir','\n#:property '],['prop','OutputType'],['','=Exe'],
+      ['dir','\n#:property '],['prop','UnoSingleProject'],['','=true'],
+      ['dir','\n#:property '],['prop','UnoFeatures'],['','=SkiaRenderer'],
+      ['cmt','\n// entry uses await ReactorApp.RunAsync<...> (see #if __WASM__)'],
+    ],
+    raw:`#:sdk Uno.Sdk@6.7.0-dev.93
+#:project ../../../src/Reactor.Uno/Reactor.Uno.csproj
+#:property TargetFramework=net10.0-browserwasm
+#:property OutputType=Exe
+#:property UnoSingleProject=true
+#:property UnoFeatures=SkiaRenderer
+// WASM can't block the UI thread — use the async entry:
+// await ReactorApp.RunAsync<CounterApp>("Counter", 520, 400);`
+  },
+  android: {
+    name:'Uno · Android', color:'#f0b72f', desc:'theoretical mobile',
+    badge:'compiles ✓', badgeClass:'compiles', status:'Library compiles for net10.0-android. Deploying needs a thin mobile head (Activity) that mounts a ReactorHost — no framework changes expected.',
+    run:'# add a mobile head (Activity) that references Reactor.Uno, then deploy',
+    entry:'// mounted from MainActivity via a ReactorHost',
+    directives:[
+      ['cmt','// Mobile deploys from a project head, not a single .cs file.'],
+      ['cmt','// Reactor.Uno already targets net10.0-android:'],
+      ['dir','\n<TargetFrameworks>'],['','net10.0-desktop;net10.0-browserwasm;net10.0-android'],['dir','</TargetFrameworks>'],
+    ],
+    raw:`<!-- Mobile deploys from a project head (Activity), not a single .cs file. -->
+<!-- Reactor.Uno already multi-targets Android: -->
+<TargetFrameworks>net10.0-desktop;net10.0-browserwasm;net10.0-android</TargetFrameworks>`
+  },
+};
+
+const state = { target:'desktop' };
+
+function paint(spans, el){
+  el.innerHTML='';
+  for(const [cls,txt] of spans){
+    const s=document.createElement('span');
+    if(cls) s.className=cls;
+    s.textContent=txt;
+    el.appendChild(s);
+  }
+}
+
+function renderTargets(){
+  const c=document.getElementById('targets'); c.innerHTML='';
+  for(const [k,t] of Object.entries(TARGETS)){
+    const d=document.createElement('div');
+    d.className='target'+(k===state.target?' sel':'');
+    d.innerHTML=`<span class="dot" style="background:${t.color}"></span><span>${t.name}</span><span class="meta">${t.badge.split(' ')[0]}</span>`;
+    d.onclick=()=>{state.target=k;updateAll();};
+    c.appendChild(d);
+  }
+}
+
+function updateAll(){
+  renderTargets();
+  const t=TARGETS[state.target];
+  document.getElementById('tname').textContent=t.name;
+  document.getElementById('tdesc').textContent=t.desc;
+  const b=document.getElementById('tbadge');
+  b.textContent=t.badge; b.className='badge '+t.badgeClass;
+  document.getElementById('tstatus').textContent=t.status;
+  paint(t.directives, document.getElementById('directives'));
+  document.getElementById('runcmd').textContent=t.run;
+  paint(COMPONENT, document.getElementById('component'));
+}
+
+document.getElementById('copyBtn').onclick=()=>{
+  const t=TARGETS[state.target];
+  const text=`${t.raw}\n\n${t.entry}\n\n${COMPONENT_RAW}\n`;
+  navigator.clipboard.writeText(text).then(()=>{
+    const btn=document.getElementById('copyBtn'); const o=btn.textContent;
+    btn.textContent='Copied! ✓'; setTimeout(()=>btn.textContent=o,1400);
+  });
+};
+
+updateAll();
+</script>
+</body>
+</html>

--- a/src/Reactor/Core/Reconciler.Mount.cs
+++ b/src/Reactor/Core/Reconciler.Mount.cs
@@ -380,7 +380,10 @@ public sealed partial class Reconciler
             var nested = FindDescendant<T>(child);
             if (nested is not null) return nested;
         }
-        return null;
+        // `default` (== null; T is constrained to a reference type) rather than
+        // `null` to satisfy Uno's nullable analysis on the shared build; identical
+        // behavior on Windows.
+        return default;
     }
 
     internal static void HandleNumberBoxImmediateTextChanged(WinUI.NumberBox box, string text)


### PR DESCRIPTION
Adds **Reactor.Uno**, a port of the framework to Uno Platform's Skia targets, so the same Reactor C# runs on **desktop (Win32/X11/macOS/FrameBuffer), WebAssembly, Android and iOS**, not only Windows / Windows App SDK.

Opening as a **draft**: the framework port is in good shape, but the gallery sample has known rendering gaps (below) and there are open questions for maintainers about how this should ship.

## Approach

This is a **retargeting, not a fork**. Reactor renders real `Microsoft.UI.Xaml` controls, and Uno reimplements that API surface so the reconciler, hooks, DSL, layout engine, charting, markdown and data grid are **source-shared verbatim** from `src/Reactor` and `src/Reactor.Advanced` via `<Compile Include>`. Only the Windows-only hosting stack (windowing/shell/DWM/persistence/devtools) plus Docking and Win2D are excluded, replaced by a slim Uno hosting layer.

**Footprint on existing code is deliberately tiny.** Outside the new projects, this PR touches exactly three things:

| File | Change |
|---|---|
| `src/Reactor/Core/Reconciler.Mount.cs` | **one line** — `return null` → `return default` in a generic helper. `T` is constrained to a reference type, so this is behaviour-identical on Windows; it only satisfies Uno's nullable analysis. |
| `global.json` | adds an `Uno.Sdk` `msbuild-sdks` pin. Inert for Windows (no Windows project declares `Sdk="Uno.Sdk"`), but required because solution-level SDK resolution reads the repo-root `global.json`. |
| `Reactor.Uno.slnx` | new, deliberately **separate** from `Reactor.slnx` so Windows CI never restores Uno.Sdk. |

There are **zero `#if REACTOR_UNO` conditionals** in shared source. Where a Windows-only type was needed, the port declares an Uno-side counterpart instead of branching the shared code (e.g. `WinRT.WindowsRuntimeTypeAttribute`, which cannot exist on Uno because there is no CsWinRT projection — so the attribute probe is correctly always false).

## What works

| Target | TFM | State |
|---|---|---|
| Desktop (Win32 / X11 / macOS / FrameBuffer) | `net10.0-desktop` | Builds and **runs**, interactive |
| WebAssembly | `net10.0-browserwasm` | Builds and **runs** in-browser, interactive |
| Android | `net10.0-android` | Builds a signed APK; **verified on device** (Galaxy Z Fold 7, Android 16, arm64-v8a) |
| iOS | `net10.0-ios` | Builds .ipa; tested on Simulator |

Beyond compiling, these are implemented for real rather than stubbed: multi-window on every desktop head (each with its own host, render loop and state), per-window DPI tracking via `XamlRoot.RasterizationScale`, window closing guards via `AppWindow.Closing`, file/folder pickers, and declarative caption height via `AppWindowTitleBar.PreferredHeightOption`.

An honest feature-support matrix — including what **doesn't** work on Uno (implicit animations, RichEditBox, custom title bar chrome, tray/shell, docking, devtools) — is in [`src/Reactor.Uno/README.md`](src/Reactor.Uno/README.md).

## Hot Reload

**Works, and composes with Uno's by construction rather than by coincidence.** Reactor registers the standard `[assembly: MetadataUpdateHandler]`; so does Uno's `ClientHotReloadProcessor`. They are peers on one runtime mechanism. Crucially Uno's `HotReloadAgent` discovers handlers by scanning *all* loaded assemblies for the attribute and invokes what it finds — so wherever the Uno **Dev Server** delivers deltas instead of `dotnet watch` (wasm, Android, iOS), Uno drives Reactor's re-render with **no opt-in and no Reactor-side work**.

The Uno render loop implements the full spec 049 pass, not just a re-render: hook-cell migration for edited types, and `HookOrderException` recovery (drop hook state and remount) when an edit changes a component's hook shape.

Measured on Skia desktop: `🔥 C# and Razor changes applied in ~0.9s`, with `UseState` preserved across the edit.

⚠️ **Caveat:** `dotnet watch -f <tfm>` only hot-reloads a **single-targeted** head. Against a multi-targeted head the Roslyn workspace loads with no references and every edit dies in `CS0518: Predefined type 'System.Object' is not defined`. This reproduces on a stock Uno app with no Reactor involved, and IDEs are unaffected (they pick one TFM per session).

## Guarding source-share drift

Source-sharing's failure mode is silent: **an `<Compile Include>` glob that matches zero files is not an error in MSBuild**. This is not hypothetical — moving charting/markdown/data-grid into `Reactor.Advanced` dropped **74 files** out of the port with a perfectly green build, and a later new file in `Hosting/` broke it another way.

Two build-time guards now make both failure modes loud:
- `VerifySharedSourceRoots` — errors if any globbed root stops existing.
- `VerifyHostingTriage` — `Hosting/` is cherry-picked file-by-file, so it diffs the folder against two declared lists and fails on anything untriaged, naming the file and the decision to make.

`ci-uno.yml` is path-gated on `src/Reactor/**` and `src/Reactor.Advanced/**` as well as the port itself, because a change there can break the Uno build without touching a single ported file.

## Building

```bash
dotnet build Reactor.Uno.slnx -f net10.0-desktop
dotnet build Reactor.Uno.slnx -f net10.0-browserwasm
dotnet build Reactor.Uno.slnx -f net10.0-android
dotnet build Reactor.Uno.slnx -f net10.0-ios

cd samples/Uno/ReactorUnoCounter && dotnet run -f net10.0-desktop
```

The Windows build is unaffected — `Reactor.slnx` and `Reactor.Advanced` still build clean.

## Known gaps

**`ReactorGalleryUno` (last commit) has rendering defects.** It source-shares ~10k lines from `samples/ReactorGallery` verbatim (105 of 108 files compile untouched) and builds on all four heads, but at runtime:
- `NavigationView` stays in overlay display mode with a scrim over the content at any window width, instead of switching to Expanded as it does on Windows.
- The Home page's category and "Recently Added" cards do not render.

Both are pending investigation (hence draft state of the PR).

Three files needed Uno-side stand-ins, each documented in `Shims/`: `GalleryActivation`/`GalleryProtocol` (WinAppSDK `AppInstance` + Win32 registry), `DockingPage` (docking is excluded from the port for now), and `WebView2Page` — where `WebView2` resolves to a *namespace* on Uno that shadows Reactor's `WebView2(...)` factory. That last one is a naming collision in the sample, **not** a missing Uno feature, and is worth fixing upstream so the page can be shared too.

## Open questions for maintainers

1. **Uno.Sdk version.** The port needs Uno 6.7 APIs (`DispatcherQueueSynchronizationContext`, `TitleBar.IsDragRegion*`) absent from 6.5 GA, so it pins the preview `6.7.0-dev.117`. Switch to 6.7 GA when it ships.
2. **Packaging.** Should this ship as `Microsoft.UI.Reactor.Uno`, or stay sample-only for now?
3. **Gallery scope** — land it with the gaps documented, or hold it back?
4. **CI cost.** The mobile job installs the `android` + `ios` workloads; happy to drop it to android-only or gate it further.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
