### PR TITLE
Fix widget-creator build: Windows App SDK version pin, runtime preflight check, retired model

### DIFF
--- a/samples/apps/widget-creator/Program.cs
+++ b/samples/apps/widget-creator/Program.cs
@@ -16,8 +16,33 @@ using static Microsoft.UI.Reactor.Factories;
 SessionLog.Init();
 SessionLog.Write($"[Program] launched args={string.Join(' ', System.Environment.GetCommandLineArgs())}");
 
+// Headless diagnostic: report whether the machine-wide Windows App Runtime that
+// generated widgets bind at launch is installed, then exit. Useful from a
+// terminal or CI without opening the window, and it exercises exactly the same
+// probe the in-app banner uses.
+//   exit 0 = satisfied, 1 = missing/outdated.
+if (System.Array.Exists(System.Environment.GetCommandLineArgs(),
+        a => string.Equals(a, "--check-runtime", System.StringComparison.OrdinalIgnoreCase)))
+{
+    var info = WindowsAppRuntimeCheck.Detect();
+    System.Console.WriteLine($"status    : {info.Status}");
+    System.Console.WriteLine($"package   : {info.PackageFamilyName} ({info.Architecture})");
+    System.Console.WriteLine($"required  : {info.RequiredVersion}");
+    System.Console.WriteLine($"installed : {info.InstalledVersion?.ToString() ?? "(none)"}");
+    System.Console.WriteLine($"message   : {info.Message}");
+    if (!info.IsSatisfied)
+    {
+        System.Console.WriteLine($"installer : {info.InstallerUrl}");
+        System.Console.WriteLine($"downloads : {info.DownloadsUrl}");
+        System.Console.WriteLine($"winget    : {info.WingetCommand}");
+    }
+    return info.IsSatisfied ? 0 : 1;
+}
+
 ReactorApp.Run<WidgetCreatorShell>(
     "Widget Creator",
     width: 1180,
     height: 820,
     configure: host => Microsoft.UI.Reactor.Docking.Native.DockingNativeInterop.Register(host.Reconciler));
+
+return 0;

--- a/samples/apps/widget-creator/README.md
+++ b/samples/apps/widget-creator/README.md
@@ -59,7 +59,34 @@ dotnet run --project samples/apps/widget-creator/widget-creator.csproj -p:Platfo
    `WIDGET_CREATOR_MODEL` (e.g. `gpt-5.4`) if that model is retired or you want
    a different one — `session.create` fails with *Model "…" is not available*
    when the id is no longer served.
-2. **MXC** — a build of `wxc-exec.exe`. By default the app uses the **pinned,
+2. **Windows App Runtime** — generated widgets are *framework-dependent*
+   (`WindowsAppSDKSelfContained=false`), so they bind the machine-wide
+   Windows App Runtime at launch instead of carrying a ~220 MB copy each.
+   Widget Creator probes for it on startup and, if it is missing or older than
+   the version widgets are built against, shows a banner with buttons that open
+   the [direct installer](https://aka.ms/windowsappsdk) or the
+   [downloads page](https://learn.microsoft.com/windows/apps/windows-app-sdk/downloads)
+   in your browser. You can also install it up front:
+
+   ```pwsh
+   winget install Microsoft.WindowsAppRuntime.2.1
+   ```
+
+   To check without opening the window:
+
+   ```pwsh
+   WidgetCreator.exe --check-runtime   # exit 0 = satisfied, 1 = missing/outdated
+   ```
+
+   The required package family and minimum version are not hardcoded — they come
+   from the Windows App SDK's own generated `WindowsAppSDK-VersionInfo.cs`
+   (compiled in via `WindowsAppSdkIncludeVersionInfo`), so the check tracks
+   `WindowsAppSDKVersion` in `Directory.Build.props` automatically. Two env
+   overrides exist to exercise the failure paths on a healthy machine:
+   `WIDGET_CREATOR_MIN_WINAPPRUNTIME` (minimum version) and
+   `WIDGET_CREATOR_WINAPPRUNTIME_FAMILY` (package family).
+
+3. **MXC** — a build of `wxc-exec.exe`. By default the app uses the **pinned,
    vendored** copy shipped next to it (`…\mxc\<rid>\wxc-exec.exe`), which is known
    to auto-fall back off BaseContainer. Override with:
    - `WIDGET_CREATOR_WXC_EXEC` — full path to `wxc-exec.exe`,
@@ -69,10 +96,15 @@ dotnet run --project samples/apps/widget-creator/widget-creator.csproj -p:Platfo
      vendored copy, for developers iterating on the MXC CLI itself, or
    - `WIDGET_CREATOR_MXC_ROOT` — the MXC checkout root used by the opt-in above
      (default `%USERPROFILE%\Code\mxc`).
-3. **Local Reactor package** — generated widgets reference
+
+4. **Local Reactor package** — generated widgets reference
    `Microsoft.UI.Reactor 0.0.0-local`, resolved from this repo's `local-nupkgs`
    feed. Run `mur pack-local` if it's missing. Override the feed path with
-   `WIDGET_CREATOR_NUPKGS`.
+   `WIDGET_CREATOR_NUPKGS`. The widget's Windows App SDK references
+   (`Microsoft.WindowsAppSDK.WinUI` + `.Runtime`) are pinned to the same versions
+   this repo builds with — they are generated into the app from
+   `Directory.Build.props`, because a widget that pins a different version fails
+   its build in `Microsoft.WindowsAppSDK.ComponentReference.targets`.
 
 Type a prompt, click **Generate & Run**. The generated source streams into the
 right panel; the build + `wxc-exec` log streams below it. The widget window opens
@@ -152,6 +184,7 @@ samples/apps/widget-creator/
     WidgetWorkspace.cs       ← scaffolds widget.cs + widget.csproj + nuget.config
     WidgetBuilder.cs         ← dotnet publish (no ACL edits — MXC grants the app dir)
     MxcSandbox.cs            ← builds the ContainerConfig + runs wxc-exec
+    WindowsAppRuntimeCheck.cs ← probes the machine-wide Windows App Runtime
     SessionLog.cs
   Resources/SystemPrompt.txt ← instructs the model to emit one single-file Reactor app
 ```

--- a/samples/apps/widget-creator/README.md
+++ b/samples/apps/widget-creator/README.md
@@ -54,6 +54,11 @@ dotnet run --project samples/apps/widget-creator/widget-creator.csproj -p:Platfo
 1. **Copilot auth** — install the [GitHub CLI](https://cli.github.com/) and run
    `gh auth login --web` with a Copilot-enabled account (`gh auth status` to
    confirm). The bundled Copilot CLI rides that account.
+
+   The model defaults to `claude-sonnet-4.6`. Override it with
+   `WIDGET_CREATOR_MODEL` (e.g. `gpt-5.4`) if that model is retired or you want
+   a different one — `session.create` fails with *Model "…" is not available*
+   when the id is no longer served.
 2. **MXC** — a build of `wxc-exec.exe`. By default the app uses the **pinned,
    vendored** copy shipped next to it (`…\mxc\<rid>\wxc-exec.exe`), which is known
    to auto-fall back off BaseContainer. Override with:

--- a/samples/apps/widget-creator/Services/CopilotSdkClient.cs
+++ b/samples/apps/widget-creator/Services/CopilotSdkClient.cs
@@ -24,13 +24,18 @@ public sealed class AuthExpiredException(string message) : Exception(message);
 /// </summary>
 public sealed class CopilotSdkClient : IModelClient, IAsyncDisposable
 {
-    const string DefaultModel = "claude-sonnet-4.5";
+    const string DefaultModel = "claude-sonnet-4.6";
 
     readonly string _model;
     readonly SemaphoreSlim _initLock = new(1, 1);
     CopilotClient? _client;
 
-    public CopilotSdkClient(string? model = null) => _model = model ?? DefaultModel;
+    public CopilotSdkClient(string? model = null)
+    {
+        var configured = Environment.GetEnvironmentVariable("WIDGET_CREATOR_MODEL");
+        _model = model
+            ?? (string.IsNullOrWhiteSpace(configured) ? DefaultModel : configured.Trim());
+    }
 
     public string ModelId => _model;
 

--- a/samples/apps/widget-creator/Services/WidgetWorkspace.cs
+++ b/samples/apps/widget-creator/Services/WidgetWorkspace.cs
@@ -77,7 +77,19 @@ public sealed class WidgetWorkspace
 
         await File.WriteAllTextAsync(csFile, source).ConfigureAwait(false);
         if (NeedsCsprojRewrite(csprojFile))
+        {
             await File.WriteAllTextAsync(csprojFile, CsprojTemplate()).ConfigureAwait(false);
+            // The csproj declares RestorePackagesWithLockFile, so a widget scaffolded
+            // by an older Widget Creator has a packages.lock.json pinned to the
+            // previous package set. Drop it when the project changes so restore
+            // re-evaluates the graph instead of resolving against a stale lock.
+            var lockFile = Path.Combine(dir, "packages.lock.json");
+            if (File.Exists(lockFile))
+            {
+                try { File.Delete(lockFile); }
+                catch (IOException ex) { SessionLog.Write($"[Workspace] could not delete stale lock file: {ex.Message}"); }
+            }
+        }
         if (NeedsNugetRewrite(nugetFile))
             await File.WriteAllTextAsync(nugetFile, NugetConfigTemplate(LocalNupkgsFeed)).ConfigureAwait(false);
 
@@ -87,21 +99,16 @@ public sealed class WidgetWorkspace
 
     static bool NeedsCsprojRewrite(string csprojFile)
     {
+        // Content comparison rather than a growing list of "does it contain X?"
+        // probes: the csproj is entirely generated (the model only ever writes
+        // widget.cs), so any drift from the current template — a stale Windows App
+        // SDK pin, a missing hardening property — should simply be overwritten.
+        // A list of feature probes has to be extended for every template change and
+        // silently leaves old widgets on a broken csproj when someone forgets.
         if (!File.Exists(csprojFile))
             return true;
 
-        var text = File.ReadAllText(csprojFile);
-        return text.Contains("<Compile Remove=\"**\\*.cs\" />", StringComparison.Ordinal) ||
-            !text.Contains("<Platforms>x64;ARM64;X86</Platforms>", StringComparison.Ordinal) ||
-            text.Contains("<RuntimeIdentifier>win-", StringComparison.Ordinal) ||
-            !text.Contains("<TargetPlatformMinVersion>", StringComparison.Ordinal) ||
-            !text.Contains("<SupportedOSPlatformVersion>", StringComparison.Ordinal) ||
-            !text.Contains("Microsoft.UI.Reactor.Advanced", StringComparison.Ordinal) ||
-            // Framework-dependent switch: force a rewrite so existing widgets stop
-            // bundling the full Windows App SDK runtime (~220 MB per widget).
-            text.Contains("<WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>", StringComparison.Ordinal) ||
-            // H-1: force a rewrite so existing widgets pick up the build-lockdown props.
-            !text.Contains("RestorePackagesWithLockFile", StringComparison.Ordinal);
+        return !string.Equals(File.ReadAllText(csprojFile), CsprojTemplate(), StringComparison.Ordinal);
     }
 
     /// <summary>
@@ -154,7 +161,17 @@ public sealed class WidgetWorkspace
           <ItemGroup>
             <PackageReference Include="Microsoft.UI.Reactor" Version="0.0.0-local" />
             <PackageReference Include="Microsoft.UI.Reactor.Advanced" Version="0.0.0-local" />
-            <PackageReference Include="Microsoft.WindowsAppSDK" Version="2.0.1" />
+            <!-- Windows App SDK 2.0 split the metapackage into independently-versioned
+                 sub-packages. A framework-dependent WinUI *executable* takes the lean
+                 WinUI slice plus Runtime (Microsoft.WindowsAppSDK.Base.targets rejects a
+                 framework-dependent app that references neither Runtime nor
+                 WindowsAppSDKSelfContained) — mirroring the injection rule in this repo's
+                 Directory.Build.targets. The versions are generated from
+                 Directory.Build.props so they always match the Microsoft.UI.Reactor
+                 0.0.0-local package the widget links against; a mismatch fails the build
+                 in Microsoft.WindowsAppSDK.ComponentReference.targets. -->
+            <PackageReference Include="Microsoft.WindowsAppSDK.WinUI" Version="{WidgetSdkVersions.WindowsAppSdkWinUI}" />
+            <PackageReference Include="Microsoft.WindowsAppSDK.Runtime" Version="{WidgetSdkVersions.WindowsAppSdk}" />
           </ItemGroup>
 
         </Project>

--- a/samples/apps/widget-creator/Services/WindowsAppRuntimeCheck.cs
+++ b/samples/apps/widget-creator/Services/WindowsAppRuntimeCheck.cs
@@ -1,0 +1,194 @@
+using System;
+using System.Runtime.InteropServices;
+using Windows.Management.Deployment;
+
+// The Windows App SDK's own generated version info (compiled in via
+// WindowsAppSdkIncludeVersionInfo). Aliased because its namespace segments —
+// Runtime.Version, Runtime.Packages.Framework — collide with System.Version and
+// read badly fully-qualified.
+using SdkRelease = Microsoft.WindowsAppSDK.Release;
+using SdkRuntimeFramework = Microsoft.WindowsAppSDK.Runtime.Packages.Framework;
+using SdkRuntimeVersion = Microsoft.WindowsAppSDK.Runtime.Version;
+
+namespace WidgetCreator.Services;
+
+/// <summary>Outcome of probing the machine for the Windows App Runtime.</summary>
+public enum WindowsAppRuntimeStatus
+{
+    /// <summary>A framework package at or above the required version is installed.</summary>
+    Ok,
+
+    /// <summary>The runtime is installed but older than the version widgets are built against.</summary>
+    Outdated,
+
+    /// <summary>No framework package for this architecture is registered for the user.</summary>
+    Missing,
+
+    /// <summary>The probe itself could not run; treat as "unknown", never as a failure.</summary>
+    Unknown,
+}
+
+/// <summary>What the probe found, plus everything the UI needs to explain and fix it.</summary>
+public sealed record WindowsAppRuntimeInfo(
+    WindowsAppRuntimeStatus Status,
+    string PackageFamilyName,
+    Version RequiredVersion,
+    Version? InstalledVersion,
+    string Architecture,
+    string InstallerUrl,
+    string DownloadsUrl,
+    string WingetCommand,
+    string Message)
+{
+    /// <summary>True when generated widgets can actually launch on this machine.</summary>
+    public bool IsSatisfied => Status is WindowsAppRuntimeStatus.Ok or WindowsAppRuntimeStatus.Unknown;
+}
+
+/// <summary>
+/// Checks that the machine-wide <b>Windows App Runtime</b> a generated widget needs
+/// is installed.
+///
+/// <para>Generated widgets are framework-dependent
+/// (<c>WindowsAppSDKSelfContained=false</c>) so they do not carry the ~220 MB native
+/// Windows App SDK runtime in their publish dir — they bind the runtime registered on
+/// the machine at launch. Without it a widget builds fine and then dies at startup
+/// inside the MXC sandbox, where the failure is close to undiagnosable. Probing up
+/// front turns that into an actionable prompt.</para>
+///
+/// <para>The required identity is not hardcoded: it comes from the Windows App SDK's
+/// own generated <c>WindowsAppSDK-VersionInfo.cs</c> (compiled in via
+/// <c>WindowsAppSdkIncludeVersionInfo</c>), so it tracks
+/// <c>WindowsAppSDKVersion</c> in <c>Directory.Build.props</c> automatically.</para>
+/// </summary>
+public static class WindowsAppRuntimeCheck
+{
+    /// <summary>
+    /// Framework package family the SDK we build against binds, e.g.
+    /// <c>Microsoft.WindowsAppRuntime.2_8wekyb3d8bbwe</c>.
+    /// <c>WIDGET_CREATOR_WINAPPRUNTIME_FAMILY</c> overrides it — pointing it at a
+    /// family that cannot exist is how the not-installed path (and its banner) gets
+    /// exercised on a machine that already has the runtime.
+    /// </summary>
+    public static string PackageFamilyName
+    {
+        get
+        {
+            var over = Environment.GetEnvironmentVariable("WIDGET_CREATOR_WINAPPRUNTIME_FAMILY");
+            return string.IsNullOrWhiteSpace(over) ? SdkRuntimeFramework.PackageFamilyName : over.Trim();
+        }
+    }
+
+    /// <summary>Learn page listing every Windows App SDK download.</summary>
+    public const string DownloadsUrl = "https://learn.microsoft.com/windows/apps/windows-app-sdk/downloads";
+
+    /// <summary>
+    /// Minimum runtime version, from the SDK's own version info (e.g. <c>2.1.3.0</c>).
+    /// <c>WIDGET_CREATOR_MIN_WINAPPRUNTIME</c> overrides it — used to exercise the
+    /// missing/outdated paths without uninstalling anything.
+    /// </summary>
+    public static Version RequiredVersion
+    {
+        get
+        {
+            var over = Environment.GetEnvironmentVariable("WIDGET_CREATOR_MIN_WINAPPRUNTIME");
+            if (!string.IsNullOrWhiteSpace(over) && Version.TryParse(over.Trim(), out var parsed))
+                return parsed;
+
+            return new Version(
+                SdkRuntimeVersion.Major,
+                SdkRuntimeVersion.Minor,
+                SdkRuntimeVersion.Build,
+                SdkRuntimeVersion.Revision);
+        }
+    }
+
+    /// <summary>
+    /// Direct installer for the SDK's release band and this machine's architecture —
+    /// e.g. <c>https://aka.ms/windowsappsdk/2.1/latest/windowsappruntimeinstall-x64.exe</c>.
+    /// Opening it in a browser downloads the runtime installer.
+    /// </summary>
+    public static string InstallerUrl =>
+        $"https://aka.ms/windowsappsdk/{SdkRelease.Major}.{SdkRelease.Minor}" +
+        $"/latest/windowsappruntimeinstall-{ArchitectureMoniker}.exe";
+
+    /// <summary>winget id for the SDK's release band, e.g. <c>Microsoft.WindowsAppRuntime.2.1</c>.</summary>
+    public static string WingetCommand =>
+        $"winget install Microsoft.WindowsAppRuntime.{SdkRelease.Major}.{SdkRelease.Minor}";
+
+    /// <summary>Architecture moniker used by the installer URLs (<c>x64</c> / <c>arm64</c> / <c>x86</c>).</summary>
+    public static string ArchitectureMoniker => RuntimeInformation.ProcessArchitecture switch
+    {
+        Architecture.Arm64 => "arm64",
+        Architecture.X86 => "x86",
+        _ => "x64",
+    };
+
+    static Windows.System.ProcessorArchitecture ProcessArchitecture => RuntimeInformation.ProcessArchitecture switch
+    {
+        Architecture.Arm64 => Windows.System.ProcessorArchitecture.Arm64,
+        Architecture.X86 => Windows.System.ProcessorArchitecture.X86,
+        _ => Windows.System.ProcessorArchitecture.X64,
+    };
+
+    /// <summary>
+    /// Probe the packages registered for the current user. Never throws: a probe
+    /// that cannot run reports <see cref="WindowsAppRuntimeStatus.Unknown"/> so a
+    /// diagnostic can never block generation.
+    /// </summary>
+    public static WindowsAppRuntimeInfo Detect()
+    {
+        var required = RequiredVersion;
+        var family = PackageFamilyName;
+        var arch = ArchitectureMoniker;
+
+        WindowsAppRuntimeInfo Result(WindowsAppRuntimeStatus status, Version? installed, string message) =>
+            new(status, family, required, installed, arch, InstallerUrl, DownloadsUrl, WingetCommand, message);
+
+        Version? best = null;
+        try
+        {
+            var manager = new PackageManager();
+            foreach (var package in manager.FindPackagesForUser(string.Empty))
+            {
+                var id = package.Id;
+                if (!string.Equals(id.FamilyName, family, StringComparison.OrdinalIgnoreCase))
+                    continue;
+                if (id.Architecture != ProcessArchitecture)
+                    continue;
+
+                var v = new Version(id.Version.Major, id.Version.Minor, id.Version.Build, id.Version.Revision);
+                if (best is null || v > best)
+                    best = v;
+            }
+        }
+        catch (Exception ex)
+        {
+            // FindPackagesForUser can fail on locked-down or unusual configurations.
+            // Widget Creator is itself a framework-dependent WinUI app, so if we got
+            // this far a runtime clearly loaded — refusing to guess is the safe answer.
+            SessionLog.Write($"[WinAppRuntime] probe failed ({ex.GetType().Name}: {ex.Message}); reporting Unknown");
+            return Result(WindowsAppRuntimeStatus.Unknown, null,
+                $"Could not check for the Windows App Runtime ({ex.Message}). Widgets may fail to launch.");
+        }
+
+        if (best is null)
+        {
+            SessionLog.Write($"[WinAppRuntime] MISSING {family} ({arch}); widgets need >= {required}");
+            return Result(WindowsAppRuntimeStatus.Missing, null,
+                $"Windows App Runtime {required} ({arch}) is not installed. Generated widgets are "
+                + "framework-dependent and will not launch without it.");
+        }
+
+        if (best < required)
+        {
+            SessionLog.Write($"[WinAppRuntime] OUTDATED {family} ({arch}) installed={best} required>={required}");
+            return Result(WindowsAppRuntimeStatus.Outdated, best,
+                $"Windows App Runtime {best} ({arch}) is older than the {required} that generated "
+                + "widgets are built against. They may fail to launch.");
+        }
+
+        SessionLog.Write($"[WinAppRuntime] OK {family} ({arch}) installed={best} required>={required}");
+        return Result(WindowsAppRuntimeStatus.Ok, best,
+            $"Windows App Runtime {best} ({arch}) installed.");
+    }
+}

--- a/samples/apps/widget-creator/WidgetCreatorShell.cs
+++ b/samples/apps/widget-creator/WidgetCreatorShell.cs
@@ -104,10 +104,17 @@ public sealed class WidgetCreatorShell : Component
             _ = Task.Run(() =>
             {
                 var info = WindowsAppRuntimeCheck.Detect();
+                // Safe after the cleanup below disposes the source:
+                // IsCancellationRequested has no disposed-check, so this read
+                // cannot race Dispose() into an ObjectDisposedException.
                 if (!cts.IsCancellationRequested)
                     setRuntime(info);
             });
-            return () => cts.Cancel();
+            return () =>
+            {
+                cts.Cancel();
+                cts.Dispose();
+            };
         }, runtimeChecks);
 
         UseEffect(() =>

--- a/samples/apps/widget-creator/WidgetCreatorShell.cs
+++ b/samples/apps/widget-creator/WidgetCreatorShell.cs
@@ -90,6 +90,26 @@ public sealed class WidgetCreatorShell : Component
         var (policyJson, setPolicyJson) = UseState("", threadSafe: true);
         var (policyAdvanced, setPolicyAdvanced) = UseState(false, threadSafe: true);
 
+        // Machine-wide Windows App Runtime probe. Generated widgets are
+        // framework-dependent, so without it they build fine and then die at
+        // startup inside the sandbox. Probed off the UI thread (package
+        // enumeration is not instant) and re-runnable, so the banner clears once
+        // the user has installed it.
+        var (runtime, setRuntime) = UseState<WindowsAppRuntimeInfo?>(null, threadSafe: true);
+        var (runtimeChecks, setRuntimeChecks) = UseState(0, threadSafe: true);
+
+        UseEffect(() =>
+        {
+            var cts = new CancellationTokenSource();
+            _ = Task.Run(() =>
+            {
+                var info = WindowsAppRuntimeCheck.Detect();
+                if (!cts.IsCancellationRequested)
+                    setRuntime(info);
+            });
+            return () => cts.Cancel();
+        }, runtimeChecks);
+
         UseEffect(() =>
         {
             void OnTurnStart() => ReplaceSource("", setSource);
@@ -168,6 +188,20 @@ public sealed class WidgetCreatorShell : Component
             {
                 SessionLog.Write($"[Shell] reveal failed: {ex}");
                 setBanner($"Reveal failed: {ex.Message}");
+            }
+        }
+
+        void OpenUrl(string url)
+        {
+            try
+            {
+                SessionLog.Write($"[Shell] opening browser: {url}");
+                Process.Start(new ProcessStartInfo(url) { UseShellExecute = true });
+            }
+            catch (Exception ex)
+            {
+                SessionLog.Write($"[Shell] open url failed: {ex}");
+                setBanner($"Could not open {url}: {ex.Message}");
             }
         }
 
@@ -704,6 +738,7 @@ public sealed class WidgetCreatorShell : Component
             (FlexColumn(
                 titleBar,
                 (FlexColumn(
+                    runtime is null || runtime.IsSatisfied ? Empty() : RuntimeBanner(runtime),
                     banner is null ? Empty() : Banner(banner),
                     dock)
                     with { RowGap = 12 })
@@ -711,6 +746,46 @@ public sealed class WidgetCreatorShell : Component
                 .Flex(grow: 1, basis: 0))),
             permApp is null ? null : PermissionsOverlay(permApp))
             .Backdrop(BackdropKind.Mica);
+
+        // Windows App Runtime prompt. Generated widgets are framework-dependent, so
+        // a missing/older machine-wide runtime means every widget builds and then
+        // fails to launch. Offer the two install routes plus a re-check that clears
+        // the banner without restarting Widget Creator.
+        Element RuntimeBanner(WindowsAppRuntimeInfo info)
+        {
+            var missing = info.Status == WindowsAppRuntimeStatus.Missing;
+            var accent = missing ? Theme.SystemCritical : Theme.SystemCaution;
+            var background = missing ? Theme.SystemCriticalBackground : Theme.SystemCautionBackground;
+
+            return Border(
+                FlexColumn(
+                    TextBlock(missing ? "Windows App Runtime not installed" : "Windows App Runtime is out of date")
+                        .Bold()
+                        .Foreground(Theme.PrimaryText)
+                        .TextWrapping(TextWrapping.Wrap),
+                    Caption(info.Message)
+                        .Foreground(Theme.SecondaryText)
+                        .TextWrapping(TextWrapping.Wrap),
+                    Caption($"Need {info.PackageFamilyName} >= {info.RequiredVersion} ({info.Architecture}). "
+                        + $"Or install from a terminal:  {info.WingetCommand}")
+                        .FontFamily("Cascadia Mono")
+                        .Foreground(Theme.TertiaryText)
+                        .TextWrapping(TextWrapping.Wrap),
+                    HStack(8,
+                        Button("Download the runtime", () => OpenUrl(info.InstallerUrl))
+                            .AccentButton()
+                            .AutomationName("Download the Windows App Runtime installer"),
+                        Button("All downloads", () => OpenUrl(info.DownloadsUrl))
+                            .AutomationName("Open the Windows App SDK downloads page"),
+                        Button("Check again", () => setRuntimeChecks(runtimeChecks + 1))
+                            .SubtleButton()
+                            .AutomationName("Re-check for the Windows App Runtime")))
+                    with { RowGap = 8 })
+            .Background(background)
+            .WithBorder(accent)
+            .CornerRadius(8)
+            .Padding(horizontal: 12, vertical: 10);
+        }
 
         // Inline modal overlay (rendered in the root Grid so it reconciles on
         // every render — unlike Reactor's ContentDialog, whose content is a

--- a/samples/apps/widget-creator/widget-creator.csproj
+++ b/samples/apps/widget-creator/widget-creator.csproj
@@ -14,6 +14,16 @@
     <WindowsPackageType>None</WindowsPackageType>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
 
+    <!-- Compile the Windows App SDK's own generated WindowsAppSDK-VersionInfo.cs
+         (Microsoft.WindowsAppSDK.Runtime\include\) into the app. It carries the
+         authoritative Windows App *Runtime* identity for the SDK version we build
+         against — framework package family name and minimum DotQuad version —
+         which WindowsAppRuntimeCheck uses to tell whether the machine-wide runtime
+         a generated widget needs is actually installed. Using the SDK's own
+         constants means the check tracks WindowsAppSDKVersion automatically
+         instead of hardcoding a version that silently rots. -->
+    <WindowsAppSdkIncludeVersionInfo>true</WindowsAppSdkIncludeVersionInfo>
+
     <!-- AOT: this sample IS trim/AOT-analyzed (no ReactorSkipAotAnalysis opt-out).
          Directory.Build.targets turns on IsAotCompatible=true + promotes the IL2*/IL3*
          trim/AOT warnings to errors for net10+, so any un-annotated reflection is caught
@@ -82,6 +92,59 @@
   <ItemGroup>
     <EmbeddedResource Include="Resources\SystemPrompt.txt" />
   </ItemGroup>
+
+  <!--
+    Flow the repo-central Windows App SDK package versions (Directory.Build.props)
+    into the app as compile-time constants so WidgetWorkspace can pin them in every
+    generated widget.csproj.
+
+    Why this matters: a generated widget references Microsoft.UI.Reactor 0.0.0-local,
+    which was packed from THIS repo and therefore drags in the Windows App SDK
+    component packages at $(WindowsAppSDKVersion). If the widget's own
+    Microsoft.WindowsAppSDK.Runtime reference is pinned to a different (older)
+    literal, Microsoft.WindowsAppSDK.ComponentReference.targets fails the widget
+    build with "One or more referenced Windows App SDK components are newer than the
+    versions expected by the Microsoft.WindowsAppSDK.Runtime package". Generating the
+    versions here keeps Directory.Build.props the single source of truth — a
+    hardcoded literal in WidgetWorkspace.cs is a second one that drifts on every
+    SDK bump and breaks widget builds (with the model then burning repair attempts
+    on a failure its source code did not cause).
+  -->
+  <PropertyGroup>
+    <!-- Note: IntermediateOutputPath is NOT set while the csproj body is evaluated
+         (the SDK's implicit .targets import comes after), so this must be resolved
+         inside the target below or the file lands in the project directory and gets
+         swept up by the default **/*.cs glob. -->
+    <_WidgetSdkVersionsFileName>WidgetSdkVersions.g.cs</_WidgetSdkVersionsFileName>
+  </PropertyGroup>
+
+  <Target Name="_GenerateWidgetSdkVersions" BeforeTargets="BeforeCompile">
+    <Error Condition="'$(WindowsAppSDKVersion)' == ''" Text="WindowsAppSDKVersion is not set; expected it from Directory.Build.props." />
+    <Error Condition="'$(WindowsAppSDKWinUIVersion)' == ''" Text="WindowsAppSDKWinUIVersion is not set; expected it from Directory.Build.props." />
+    <PropertyGroup>
+      <_WidgetSdkVersionsFile>$(IntermediateOutputPath)$(_WidgetSdkVersionsFileName)</_WidgetSdkVersionsFile>
+    </PropertyGroup>
+    <ItemGroup>
+      <!-- ';' is escaped as %3B so MSBuild does not split each C# statement into
+           separate items. -->
+      <_WidgetSdkVersionsLines Include="// &lt;auto-generated /&gt; Written by the _GenerateWidgetSdkVersions target in widget-creator.csproj." />
+      <_WidgetSdkVersionsLines Include="// Source of truth: WindowsAppSDKVersion / WindowsAppSDKWinUIVersion in Directory.Build.props. Do not edit." />
+      <_WidgetSdkVersionsLines Include="namespace WidgetCreator.Services%3B" />
+      <_WidgetSdkVersionsLines Include="/// &lt;summary&gt;Windows App SDK package versions this build of Widget Creator was compiled against.&lt;/summary&gt;" />
+      <_WidgetSdkVersionsLines Include="internal static class WidgetSdkVersions" />
+      <_WidgetSdkVersionsLines Include="{" />
+      <_WidgetSdkVersionsLines Include="    /// &lt;summary&gt;Version for Microsoft.WindowsAppSDK.Runtime (the aggregate SDK version).&lt;/summary&gt;" />
+      <_WidgetSdkVersionsLines Include="    internal const string WindowsAppSdk = &quot;$(WindowsAppSDKVersion)&quot;%3B" />
+      <_WidgetSdkVersionsLines Include="    /// &lt;summary&gt;Version for Microsoft.WindowsAppSDK.WinUI, which tracks its own version.&lt;/summary&gt;" />
+      <_WidgetSdkVersionsLines Include="    internal const string WindowsAppSdkWinUI = &quot;$(WindowsAppSDKWinUIVersion)&quot;%3B" />
+      <_WidgetSdkVersionsLines Include="}" />
+    </ItemGroup>
+    <WriteLinesToFile File="$(_WidgetSdkVersionsFile)" Lines="@(_WidgetSdkVersionsLines)" Overwrite="true" WriteOnlyWhenDifferent="true" />
+    <ItemGroup>
+      <Compile Include="$(_WidgetSdkVersionsFile)" />
+      <FileWrites Include="$(_WidgetSdkVersionsFile)" />
+    </ItemGroup>
+  </Target>
 
   <!-- Vendored MXC sandbox runtime (no NuGet exists for it). These prebuilt
        wxc-exec binaries + helpers are copied next to the app under mxc/<rid>/ so


### PR DESCRIPTION
## Summary

Generated widgets could not build. `WidgetWorkspace`'s csproj template hardcoded
`Microsoft.WindowsAppSDK 2.0.1` while the repo builds against
`WindowsAppSDKVersion` 2.1.3 / WinUI 2.1.0, so every widget failed with:

```
Microsoft.WindowsAppSDK.ComponentReference.targets: One or more referenced Windows
App SDK components are newer than the versions expected by the
Microsoft.WindowsAppSDK.Runtime package:
    Microsoft.WindowsAppSDK.Foundation: expected 2.0.20, but 2.0.21 was referenced
    Microsoft.WindowsAppSDK.WinUI:      expected 2.0.12, but 2.1.0 was referenced
```

A widget references `Microsoft.UI.Reactor 0.0.0-local`, packed from this repo, so
it pulls the newer components in transitively and the pin conflicts. Because the
failure surfaces as a build error, the repair agent spent its entire retry budget
regenerating source to fix a fault its source never caused.

This PR fixes that, adds a preflight check for the machine-wide Windows App
Runtime, and unpins a retired Copilot model.

### 1. Pin generated widgets to the repo's Windows App SDK versions

- New `_GenerateWidgetSdkVersions` target flows `WindowsAppSDKVersion` /
  `WindowsAppSDKWinUIVersion` from `Directory.Build.props` into the app as
  constants. A literal in `WidgetWorkspace.cs` is a second source of truth that
  silently rots on every SDK bump — this removes the drift path entirely (the
  target hard-errors if either property is unset).
- Emit the split sub-packages (`Microsoft.WindowsAppSDK.WinUI` + `.Runtime`)
  instead of the metapackage, mirroring the framework-dependent injection rule in
  `Directory.Build.targets`.
- `NeedsCsprojRewrite` was a growing list of "does it contain X?" probes that had
  to be extended for every template change; it is now a content comparison. A
  stale `packages.lock.json` is dropped on rewrite, so widgets scaffolded by an
  older Widget Creator migrate instead of failing on a locked graph.

### 2. Windows App Runtime preflight check

Generated widgets are framework-dependent (`WindowsAppSDKSelfContained=false`), so
they bind the machine-wide runtime at launch rather than carrying a ~220 MB copy
each. If it is missing, a widget builds cleanly and then dies at startup *inside
the MXC sandbox*, where the failure is close to undiagnosable.

`WindowsAppRuntimeCheck` probes the packages registered for the current user and
raises a banner offering the arch-aware direct installer, the downloads page, and
a re-check. `--check-runtime` exposes the same probe headlessly (exit 0 =
satisfied, 1 = missing/outdated).

The required package family and minimum version are **not hardcoded** — they come
from the Windows App SDK's own generated `WindowsAppSDK-VersionInfo.cs` (compiled
in via `WindowsAppSdkIncludeVersionInfo`), so the check tracks
`WindowsAppSDKVersion` automatically.

### 3. Retired Copilot model

`claude-sonnet-4.5` is no longer served — every Generate & Run failed at
`session.create` with `Model "claude-sonnet-4.5" is not available`. The Copilot
model catalog no longer lists it at all (absent, not policy-disabled), so this is
an upstream retirement rather than a per-tenant block. Defaults to
`claude-sonnet-4.6`, plus a `WIDGET_CREATOR_MODEL` override so the next
retirement needs no code change.

## Linked issue / spec

None — found while running the sample.

## Test plan

No automated tests: this is sample-only code, and the fix is structural rather
than behavioural (the version now comes from `Directory.Build.props` with a
build-time `<Error>` guard, so there is no drift path left for a unit test to
watch). Verified differentially instead — each check was confirmed to fail when
its target is broken:

- [x] **Old pin reproduces the bug.** Reverted the template to
      `Microsoft.WindowsAppSDK 2.0.1` and rebuilt the same `widget.cs` — the exact
      `ComponentReference` error returns.
- [x] **New pin fixes it.** Same `widget.cs`, regenerated csproj → build
      succeeded, `widget.exe` produced.
- [x] **Migration path.** A widget dir with a stale 2.0.1 csproj + stale
      `packages.lock.json` is rewritten, the lock dropped, and rebuilds clean.
- [x] **Scaffolding tested through the real code.** The verification harness
      compiled the actual `WidgetWorkspace.cs` in place rather than a copy, so the
      template under test cannot drift from what ships.
- [x] **Runtime probe, all three branches.** `Ok` on this machine (installed
      2.3.1.0 ≥ required 2.1.3.0, exit 0); `Missing` + exit 1 via
      `WIDGET_CREATOR_WINAPPRUNTIME_FAMILY`; `Outdated` via
      `WIDGET_CREATOR_MIN_WINAPPRUNTIME=99.0.0.0`.
- [x] **Banner is differential, checked over UIA.** With the runtime forced
      missing, all three buttons appear in the automation tree; on a healthy
      machine they are absent and only `Generate & Run` / `Open library` /
      `Reveal session log` remain.
- [x] **Model fix.** A harness calling the same `CopilotClient.CreateSessionAsync`
      path fails on `4.5` with the reported message and succeeds on `4.6`.
- [x] `dotnet build Reactor.slnx -c Release` — succeeded, 0 errors.
- [x] `dotnet test tests/Reactor.Tests --filter WinAppSDKReferenceGuard` — 2/2
      passed (the split-package references are the shape this guard wants).
- [x] Each commit builds standalone (verified in a separate worktree), so the two
      can be split if a reviewer prefers.

## Risk / breaking changes

- **Existing widgets are auto-migrated.** The csproj content comparison rewrites
  any widget scaffolded by an older Widget Creator on its next generate/refine,
  and deletes its `packages.lock.json`. The lock is regenerated on the next
  restore; no user action needed. Only generated widget projects under
  `%LOCALAPPDATA%\WidgetCreator\apps` are touched.
- **No public API change.** Sample-only; nothing in `src/Reactor`.
- **New CLI surface on a GUI sample:** `--check-runtime`. Worth calling out — it
  is there so the probe is scriptable/CI-usable, but it is new surface.
- **Two diagnostic-only env overrides** (`WIDGET_CREATOR_MIN_WINAPPRUNTIME`,
  `WIDGET_CREATOR_WINAPPRUNTIME_FAMILY`) exist so the missing/outdated paths can
  be exercised on a healthy machine — that is how the banner above was verified.
  If test-only surface in product code is unwelcome, the family override is the
  one to drop; the check still works without it.
