### PR TITLE
Update js-yaml and shell-quote in committed RN harness lockfiles

### DIFF
--- a/tests/startup_perf/BlankRNW/package-lock.json
+++ b/tests/startup_perf/BlankRNW/package-lock.json
@@ -2242,9 +2242,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
@@ -7250,9 +7250,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "devOptional": true,
       "funding": [
         {
@@ -9559,9 +9559,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
-      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz",
+      "integrity": "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"

--- a/tests/stress_perf_rn/StocksGrid/package-lock.json
+++ b/tests/stress_perf_rn/StocksGrid/package-lock.json
@@ -2265,9 +2265,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
@@ -8204,9 +8204,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -10695,9 +10695,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
-      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz",
+      "integrity": "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"

--- a/tests/stress_perf_rn/VirtualList/package-lock.json
+++ b/tests/stress_perf_rn/VirtualList/package-lock.json
@@ -2265,9 +2265,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
@@ -8204,9 +8204,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
The React Native harnesses under tests/ carry committed package-lock.json files, so an upstream advisory fix never reaches us until the lockfile is updated.

Note that js-yaml 3.15.0 and 4.3.0 are NOT sufficient. Those releases fix CVE-2026-59869 (merge-key chains forcing quadratic CPU), but the follow-up CVE-2026-59870 / GHSA-5p4m-2wfm-xmqj (quadratic CPU in !!omap resolution) was not included in them; both the 3.x and 4.x lines remained vulnerable. The first patched releases are 3.15.1 and 4.3.1.

  js-yaml      3.14.2, 3.15.0 -> 3.15.1
  js-yaml      4.1.1,  4.3.0  -> 4.3.1
  shell-quote  1.8.4          -> 1.10.0   GHSA-395f-4hp3-45gv

Affected: tests/startup_perf/BlankRNW, tests/stress_perf_rn/StocksGrid, tests/stress_perf_rn/VirtualList. VirtualList already carried shell-quote 1.10.0 and is left untouched.

None of these are direct dependencies, and every declaring range already permitted the patched version (js-yaml ^4.1.0 and ^3.13.1, shell-quote ^1.8.4, ^1.8.3 and ^1.6.1) - only the lockfile held the vulnerable versions, so package.json needs no change.

Edited surgically rather than regenerated. A previous attempt with `npm audit fix` rewrote ~70 unrelated entries and, because it resolved through a proxy registry that strips dist.integrity, silently downgraded those entries from sha512 to sha1. This change touches only the eight affected entries (version, resolved, integrity), leaving every other line byte-identical: 24 changed lines total.

Both the dependency and bin sets are unchanged across all three bumps (js-yaml 3.x: argparse ^1.0.7 + esprima ^4.0.0; js-yaml 4.x: argparse ^2.0.1; shell-quote: none), so no other lockfile entries are affected. All integrity values are sha512, computed by hashing the published tarballs; the method was validated against the shell-quote 1.10.0 integrity already present in this repo, which it reproduces exactly. All resolved URLs remain on registry.npmjs.org.

Verified: `npm ci` succeeds in all three projects and leaves the lockfiles unmodified, which also confirms every integrity value validates against the real tarball; the patched versions are the ones installed on disk; `npm audit` no longer reports js-yaml or shell-quote in any of the three (it still reports unrelated advisories, so the check is not vacuous); and all three packages load and parse correctly, including the !!omap path covered by the newer advisory.

<!--
Thanks for contributing to Reactor! A few notes before you open this PR:

- Link the issue or spec this PR addresses (Fixes #..., Implements docs/specs/0XX-...).
- Keep the change focused. Smaller, well-scoped PRs land faster.
- Include tests. See CONTRIBUTING.md for the unit / selftest / e2e split.
- Run `dotnet build Reactor.slnx` and `dotnet test tests/Reactor.Tests` locally.
- First-time contributors: the Microsoft CLA bot will comment automatically; sign once and you're set.
-->

## Summary

<!-- One or two sentences: what changes, and why. -->

## Linked issue / spec

<!-- Fixes #...  /  Implements docs/specs/0XX-...  /  Part of #... -->

## Test plan

<!-- Bulleted list of how this was verified. Examples:
- [ ] Added unit tests in tests/Reactor.Tests/...
- [ ] Added selftest fixture in tests/Reactor.AppTests.Host/SelfTest/Fixtures/...
- [ ] Ran `dotnet test tests/Reactor.Tests`
- [ ] Manually ran `dotnet run --project samples/Reactor.TestApp`
-->

## Risk / breaking changes

<!-- Any public-API change, behavior shift, or perf-sensitive path? Flag it here. -->
