### PR TITLE
Fix #1090: don't arm echo suppression for a SelectedIndex write WinUI can't honor

### DIFF
--- a/docs/_pipeline/templates/threading-and-dispatch.md.dt
+++ b/docs/_pipeline/templates/threading-and-dispatch.md.dt
@@ -148,6 +148,19 @@ than a `ConditionalWeakTable` because [WinRT projection](reactor-vs-xaml.md)
 can hand the same native object back as different managed wrappers,
 and only the attached DP survives that round-trip.
 
+An equality guard only works when the caller can decide up front
+whether an event is coming. A few writes are genuinely
+unpredictable — reassigning `ItemsSource` drops the selection and
+raises `SelectionChanged` on some WinUI versions but preserves it
+silently on others — and there the counter has no way to notice that
+the promised event never arrived. The token simply waits, and the
+next *real* user interaction is consumed instead (issue #1090). For
+those, arm with `BeginSuppressCancelable`, perform the write, then
+observe the control and call `CancelIfUnconsumed()` when the value
+provably did not move. The retraction is baseline-guarded, so it is a
+safe no-op on the branch where the event did fire — which is what
+lets one code path stay correct under both behaviours.
+
 ## Tips
 
 **Don't `Thread.Sleep` on the UI thread.** Block the dispatcher and

--- a/docs/guide/threading-and-dispatch.md
+++ b/docs/guide/threading-and-dispatch.md
@@ -219,6 +219,19 @@ than a `ConditionalWeakTable` because [WinRT projection](reactor-vs-xaml.md)
 can hand the same native object back as different managed wrappers,
 and only the attached DP survives that round-trip.
 
+An equality guard only works when the caller can decide up front
+whether an event is coming. A few writes are genuinely
+unpredictable — reassigning `ItemsSource` drops the selection and
+raises `SelectionChanged` on some WinUI versions but preserves it
+silently on others — and there the counter has no way to notice that
+the promised event never arrived. The token simply waits, and the
+next *real* user interaction is consumed instead (issue #1090). For
+those, arm with `BeginSuppressCancelable`, perform the write, then
+observe the control and call `CancelIfUnconsumed()` when the value
+provably did not move. The retraction is baseline-guarded, so it is a
+safe no-op on the branch where the event did fire — which is what
+lets one code path stay correct under both behaviours.
+
 ## Tips
 
 **Don't `Thread.Sleep` on the UI thread.** Block the dispatcher and

--- a/src/Reactor/Core/ChangeEchoSuppressor.cs
+++ b/src/Reactor/Core/ChangeEchoSuppressor.cs
@@ -97,6 +97,80 @@ internal static class ChangeEchoSuppressor
     // </snippet:change-echo>
 
     /// <summary>
+    /// Issue #1090 — arms a suppression token that can be <em>retracted</em> if
+    /// the write it was armed for turns out not to have raised an event.
+    ///
+    /// <para><see cref="BeginSuppress(UIElement)"/> is a promise: "an event is
+    /// coming, drop it." When a caller can only <em>predict</em> that an event
+    /// is coming — because the platform's behavior is version-dependent — that
+    /// promise can be broken in a way the counter cannot detect. The token then
+    /// outlives the write and <see cref="ShouldSuppress(Reconciler.ReactorState)"/>
+    /// consumes it on the user's next genuine interaction, silently swallowing
+    /// it. Arming through this method instead lets the caller observe the
+    /// control after the write and retract the token when the predicted event
+    /// provably did not happen.</para>
+    ///
+    /// <para>Pair with <see cref="EchoSuppressArm.CancelIfUnconsumed"/>. The
+    /// retraction is baseline-guarded, so calling it after the event <em>did</em>
+    /// fire (and consumed the token) is a safe no-op — a caller that cannot tell
+    /// the two apart may always call it.</para>
+    /// </summary>
+    internal static EchoSuppressArm BeginSuppressCancelable(UIElement control)
+    {
+        if (control is not FrameworkElement fe) return default;
+        return BeginSuppressCancelable(Reconciler.GetOrCreateReactorState(fe));
+    }
+
+    /// <summary>
+    /// <see cref="Reconciler.ReactorState"/> overload of
+    /// <see cref="BeginSuppressCancelable(UIElement)"/>, so the arm/retract
+    /// arithmetic is reachable from headless tests (no live WinUI control).
+    /// </summary>
+    internal static EchoSuppressArm BeginSuppressCancelable(Reconciler.ReactorState state)
+        => new(state, ++state.EchoSuppressCount);
+
+    /// <summary>
+    /// Issue #1090 — a retractable handle for one suppression token armed via
+    /// <see cref="BeginSuppressCancelable(UIElement)"/>.
+    ///
+    /// <para><c>default</c> is the "never armed" value and every operation on it
+    /// is a no-op, so a caller that arms conditionally does not need a parallel
+    /// bool.</para>
+    /// </summary>
+    internal readonly struct EchoSuppressArm
+    {
+        private readonly Reconciler.ReactorState? _state;
+        /// <summary>Counter value immediately AFTER this token was added.</summary>
+        private readonly int _countWhenArmed;
+
+        internal EchoSuppressArm(Reconciler.ReactorState state, int countWhenArmed)
+        {
+            _state = state;
+            _countWhenArmed = countWhenArmed;
+        }
+
+        /// <summary>True when this handle actually holds a token.</summary>
+        internal bool IsArmed => _state is not null;
+
+        /// <summary>
+        /// Give the token back if it is still outstanding.
+        ///
+        /// <para>The guard compares against the counter value captured at arming
+        /// rather than blindly decrementing: if the predicted event <em>did</em>
+        /// fire, <see cref="ShouldSuppress(Reconciler.ReactorState)"/> already
+        /// decremented past that watermark and this is a no-op. That keeps the
+        /// counter from going negative and, more importantly, stops a retraction
+        /// from cancelling somebody <em>else's</em> still-pending token.</para>
+        /// </summary>
+        internal void CancelIfUnconsumed()
+        {
+            if (_state is null) return;
+            if (_state.EchoSuppressCount >= _countWhenArmed)
+                _state.EchoSuppressCount--;
+        }
+    }
+
+    /// <summary>
     /// Spec 047 §8 value-diff echo suppression. Arms a one-shot predicate that
     /// recognizes the engine-synthesized change event for a programmatic
     /// controlled write by its readback value. Pair with a bare write (no

--- a/src/Reactor/Core/V1Protocol/Handlers/GridViewHandler.cs
+++ b/src/Reactor/Core/V1Protocol/Handlers/GridViewHandler.cs
@@ -113,8 +113,16 @@ internal sealed class GridViewHandler : IElementHandler<GridViewElement, WinUI.G
         // "deselect", so write it through the same drift gate. Optional<int>.Unset
         // (HasValue == false) means "control owns the selection" and falls
         // through without a write.
+        // Issue #1090 — the drift gate alone is not enough: a write of an index
+        // that does not exist in the CURRENT ItemsSource (common on mount, while
+        // the items list is still empty) cannot be honored by WinUI. No
+        // SelectionChanged is raised, so the token armed by WriteSuppressed
+        // strands and later swallows the user's first real selection. Only write
+        // when the index is reachable; the Update that brings the items in
+        // performs the write instead, where it lands and echoes normally.
         if (gv.SelectedIndex is { HasValue: true } mountIndex
-            && gridView.SelectedIndex != mountIndex.Value)
+            && gridView.SelectedIndex != mountIndex.Value
+            && IsReachable(mountIndex.Value, gv.Items.Length))
         {
             ReactorBinding.WriteSuppressed(gridView, () => gridView.SelectedIndex = mountIndex.Value);
         }
@@ -188,13 +196,29 @@ internal sealed class GridViewHandler : IElementHandler<GridViewElement, WinUI.G
         // increments, ShouldSuppress only consumes on a real event, so an
         // unconsumed token swallows the next user input). Spec 050: -1 is
         // the explicit force-clear sentinel; Unset means "control owns it".
+        // Issue #1090 — same reachability guard as Mount: a write WinUI cannot
+        // honor (index past the end of the current source) raises no event, so
+        // arming for it strands a token that later eats a real selection.
         if (n.SelectedIndex is { HasValue: true } updateIndex
-            && gv.SelectedIndex != updateIndex.Value)
+            && gv.SelectedIndex != updateIndex.Value
+            && IsReachable(updateIndex.Value, n.Items.Length))
         {
             ReactorBinding.WriteSuppressed(gv, () => gv.SelectedIndex = updateIndex.Value);
         }
         Reconciler.ApplySetters(n.Setters, gv);
     }
+
+    /// <summary>
+    /// Issue #1090 — can a controlled <c>SelectedIndex</c> write of
+    /// <paramref name="index"/> actually land on a source of
+    /// <paramref name="itemCount"/> items? See the ListViewHandler analog for
+    /// the full rationale: WinUI will not honor a selection past the end of its
+    /// <c>ItemsSource</c> and raises no <c>SelectionChanged</c>, so arming
+    /// suppression for such a write strands a token. <c>-1</c> is always
+    /// reachable — it is the spec-050 force-clear sentinel.
+    /// </summary>
+    private static bool IsReachable(int index, int itemCount)
+        => index < 0 || index < itemCount;
 
     public ChildrenStrategy<GridViewElement, WinUI.GridView>? Children => null;
 }

--- a/src/Reactor/Core/V1Protocol/Handlers/GridViewHandler.cs
+++ b/src/Reactor/Core/V1Protocol/Handlers/GridViewHandler.cs
@@ -146,17 +146,28 @@ internal sealed class GridViewHandler : IElementHandler<GridViewElement, WinUI.G
         // when only their content changes
         // (see Issue495_GridView_SameLengthContentChange_RefreshesContainers).
         //
-        // WinUI drops SelectedIndex to -1 on ItemsSource reassignment when
-        // there's an active selection, firing SelectionChanged(-1). Arm
-        // BeginSuppress immediately before the swap so the trampoline's
-        // ShouldSuppress gate consumes that transient event. Only arm when
-        // there's a selection to clear — else the token strands and
-        // swallows the next real user input. Matches the ListView fix.
+        // Issue #1090 — arm-then-observe rather than arming on an assumption
+        // about WinUI's reassignment behavior, which is version-dependent: WASDK
+        // 2.1.x resets SelectedIndex to -1 synchronously and fires, while newer
+        // runtimes can preserve a still-valid selection and raise nothing. An
+        // unconditional arm strands its token on the second behavior and eats
+        // the user's next genuine selection; not arming reopens the #495 echo
+        // storm on the first. SelectedIndex reads back its post-swap value
+        // synchronously with the assignment even when the event is queued, so an
+        // unchanged index proves no drop occurred and the token can be handed
+        // back. CancelIfUnconsumed is baseline-guarded, so it is a safe no-op in
+        // the branch where the echo already fired. Mirrors ListViewHandler.
         if (!ReferenceEquals(o.Items, n.Items))
         {
-            if (gv.SelectedIndex >= 0)
-                ChangeEchoSuppressor.BeginSuppress(gv);
+            int selectionBeforeSwap = gv.SelectedIndex;
+            var arm = selectionBeforeSwap >= 0
+                ? ChangeEchoSuppressor.BeginSuppressCancelable(gv)
+                : default;
+
             gv.ItemsSource = Enumerable.Range(0, n.Items.Length).ToList();
+
+            if (gv.SelectedIndex == selectionBeforeSwap)
+                arm.CancelIfUnconsumed();
         }
 
         Reconciler.SetElementTag(gv, n);

--- a/src/Reactor/Core/V1Protocol/Handlers/ListViewHandler.cs
+++ b/src/Reactor/Core/V1Protocol/Handlers/ListViewHandler.cs
@@ -159,20 +159,42 @@ internal sealed class ListViewHandler : IElementHandler<ListViewElement, WinUI.L
         // would silently freeze visible items when only their content changes
         // (see Issue495_ListView_SameLengthContentChange_RefreshesContainers).
         //
-        // WinUI synchronously drops SelectedIndex to -1 on ItemsSource
-        // reassignment when there's an active selection, and fires
-        // SelectionChanged(-1). Arm BeginSuppress immediately before the
-        // swap so that transient event is consumed by the trampoline's
-        // ShouldSuppress gate instead of looping back through
-        // OnSelectedIndexChanged → setState → re-render → swap → … (the
-        // 50+-render storm reported in #495). Only arm when there's actually
-        // a selection to clear — otherwise the token strands and swallows
-        // the next real user input.
+        // WinUI's behavior on ItemsSource reassignment is VERSION-DEPENDENT, and
+        // the suppression must not depend on which way it goes:
+        //
+        //   * The runtime bundled with Windows App SDK 2.1.x resets
+        //     SelectedIndex to -1 synchronously inside the assignment and fires
+        //     SelectionChanged(-1) — measured by the Issue1090_Probe_* selftest.
+        //     Something must consume that echo or it loops back through
+        //     OnSelectedIndexChanged → setState → re-render → swap → … (the
+        //     50+-render storm reported in #495).
+        //   * Newer runtimes can PRESERVE a still-valid selection and raise
+        //     nothing at all (issue #1090, reported against installed runtime
+        //     2.3.1). A token armed unconditionally on the older assumption is
+        //     then never consumed, and ShouldSuppress eats the user's next
+        //     genuine SelectionChanged instead.
+        //
+        // Arming unconditionally breaks on the second; not arming breaks on the
+        // first. So arm, then OBSERVE: SelectedIndex reads back its post-swap
+        // value synchronously with the assignment even when the event itself is
+        // queued (also pinned by the probe fixture), so an unchanged index
+        // proves no drop happened and the token can be handed back. A deferred
+        // drop still shows the changed index, so its token is correctly kept
+        // until the queued event arrives.
+        //
+        // CancelIfUnconsumed is baseline-guarded and therefore safe to call even
+        // in the branch where the echo already fired and consumed the token.
         if (!ReferenceEquals(o.Items, n.Items))
         {
-            if (lv.SelectedIndex >= 0)
-                ChangeEchoSuppressor.BeginSuppress(lv);
+            int selectionBeforeSwap = lv.SelectedIndex;
+            var arm = selectionBeforeSwap >= 0
+                ? ChangeEchoSuppressor.BeginSuppressCancelable(lv)
+                : default;
+
             lv.ItemsSource = Enumerable.Range(0, n.Items.Length).ToList();
+
+            if (lv.SelectedIndex == selectionBeforeSwap)
+                arm.CancelIfUnconsumed();
         }
 
         Reconciler.SetElementTag(lv, n);

--- a/src/Reactor/Core/V1Protocol/Handlers/ListViewHandler.cs
+++ b/src/Reactor/Core/V1Protocol/Handlers/ListViewHandler.cs
@@ -125,8 +125,19 @@ internal sealed class ListViewHandler : IElementHandler<ListViewElement, WinUI.L
         // "deselect", so write it through the same drift gate. Optional<int>.Unset
         // (HasValue == false) means "control owns the selection" and falls
         // through without a write.
+        //
+        // Issue #1090 — the drift gate is not sufficient on its own. A write of
+        // an index that does not exist in the CURRENT ItemsSource (very common
+        // on mount: the list is still empty while its data loads) cannot be
+        // honored by WinUI. The control stays at -1, no SelectionChanged is
+        // raised, and the token armed by WriteSuppressed strands — later
+        // swallowing the user's first real selection. Only write when the index
+        // is actually reachable; when it is not, the subsequent Update that
+        // brings the items in performs the write instead, at which point it
+        // lands and echoes normally.
         if (lv.SelectedIndex is { HasValue: true } mountIndex
-            && listView.SelectedIndex != mountIndex.Value)
+            && listView.SelectedIndex != mountIndex.Value
+            && IsReachable(mountIndex.Value, lv.Items.Length))
         {
             ReactorBinding.WriteSuppressed(listView, () => listView.SelectedIndex = mountIndex.Value);
         }
@@ -212,13 +223,39 @@ internal sealed class ListViewHandler : IElementHandler<ListViewElement, WinUI.L
         // OnSelectedIndexChanged. Only arm on real drift (see Mount comment
         // above and the GridView analog wired for issue #464). Spec 050: -1
         // is the explicit force-clear sentinel; Unset means "control owns it".
+        //
+        // Issue #1090 — same reachability guard as Mount: a write WinUI cannot
+        // honor (index past the end of the current source) raises no event, so
+        // arming for it strands a token that later eats a real selection.
         if (n.SelectedIndex is { HasValue: true } updateIndex
-            && lv.SelectedIndex != updateIndex.Value)
+            && lv.SelectedIndex != updateIndex.Value
+            && IsReachable(updateIndex.Value, n.Items.Length))
         {
             ReactorBinding.WriteSuppressed(lv, () => lv.SelectedIndex = updateIndex.Value);
         }
         Reconciler.ApplySetters(n.Setters, lv);
     }
+
+    /// <summary>
+    /// Issue #1090 — can a controlled <c>SelectedIndex</c> write of
+    /// <paramref name="index"/> actually land on a source of
+    /// <paramref name="itemCount"/> items?
+    ///
+    /// <para>WinUI will not honor a selection past the end of its
+    /// <c>ItemsSource</c> — the property stays where it was (and the set can even
+    /// throw) so no <c>SelectionChanged</c> is raised. Suppression is armed per
+    /// <em>expected event</em>, so arming for a write that cannot land leaves a
+    /// token behind that swallows the user's next genuine selection. The common
+    /// trigger is an items list that is still empty on mount while its data
+    /// loads.</para>
+    ///
+    /// <para><c>-1</c> is always reachable: it is the explicit force-clear
+    /// sentinel (spec 050), and clearing a selection is meaningful on any source.
+    /// The caller's drift gate has already established the control is not
+    /// already at -1, so the write will land and echo.</para>
+    /// </summary>
+    private static bool IsReachable(int index, int itemCount)
+        => index < 0 || index < itemCount;
 
     public ChildrenStrategy<ListViewElement, WinUI.ListView>? Children => null;
 }

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/Issue1090SelectionStrandFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/Issue1090SelectionStrandFixtures.cs
@@ -1,0 +1,565 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.UI.Reactor;
+using Microsoft.UI.Reactor.Core;
+using Microsoft.UI.Reactor.AppTests.Host.SelfTest;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+using Windows.UI;
+using WinUI = Microsoft.UI.Xaml.Controls;
+using static Microsoft.UI.Reactor.Factories;
+
+namespace Microsoft.UI.Reactor.AppTests.Host.SelfTest.Fixtures;
+
+/// <summary>
+/// Issue #1090 — <c>ListView</c>/<c>GridView</c> swallow the first genuine
+/// <c>SelectionChanged</c> after an <c>ItemsSource</c> rebuild when the
+/// selection survives the reassignment.
+///
+/// <para><b>Mechanism.</b> <c>ListViewHandler.Update</c> arms
+/// <c>ChangeEchoSuppressor.BeginSuppress</c> <em>speculatively</em> — before the
+/// swap, on the premise that WinUI always drops <c>SelectedIndex</c> to -1 and
+/// fires a <c>SelectionChanged(-1)</c> echo that consumes the token. When the
+/// old index is still valid in the new source WinUI keeps the selection and
+/// raises nothing, so the token strands. The subsequent drift-gated
+/// <c>WriteSuppressed</c> selection write is also skipped (control already at
+/// the requested index), so nothing else consumes it either. The next real user
+/// selection is then eaten by the trampoline's <c>ShouldSuppress</c> gate.</para>
+///
+/// <para><b>This file is the shared oracle for the #1090 fix bake-off.</b> Every
+/// candidate mechanism is judged against these fixtures unmodified. A candidate
+/// that requires an assertion here to be relaxed has failed, not passed — the
+/// point of freezing the harness before the fix is that the instrument cannot be
+/// bent to fit the result.</para>
+///
+/// <para><b>The two failure modes every candidate trades off.</b>
+/// <list type="bullet">
+/// <item><description><b>Strand</b> — a token outlives the write it was armed
+/// for and swallows the user's next genuine selection. That is #1090, covered by
+/// <c>SelectionSurvivesRebuild_NextSelectionFires</c> and
+/// <c>DeselectAfterSurvivingRebuild_Fires</c>.</description></item>
+/// <item><description><b>Leak</b> — an engine-synthesized event reaches the user
+/// callback, which calls <c>setIndex</c>, which re-renders, which swaps
+/// <c>ItemsSource</c> again: the #495 render storm. Covered by
+/// <c>SelectionDroppedByRebuild_NoEchoLeak</c> and by the six existing
+/// <c>Issue495_*</c> fixtures, which must stay green.</description></item>
+/// </list>
+/// Fixing one by reintroducing the other is not a fix.</para>
+///
+/// <para><b>Positive controls.</b> Every fixture that asserts "the callback did
+/// NOT fire" first drives an interaction that proves the callback path is live
+/// on this control instance. A zero from a correctly-suppressed echo and a zero
+/// from a callback that was never wired look identical in the log.</para>
+/// </summary>
+internal static class Issue1090SelectionStrandFixtures
+{
+    private static readonly Action _noOp = static () => { };
+
+    private static Element[] MakeItems(int count, string tag)
+    {
+        var items = new Element[count];
+        for (int i = 0; i < count; i++)
+            items[i] = new TextBlockElement($"{tag}-item{i}");
+        return items;
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    //  1. The bug: selection survives the rebuild → next real selection is
+    //     swallowed by the stranded token.
+    // ─────────────────────────────────────────────────────────────────────
+
+    /// <summary>Issue #1090 — grow the item array while the selected index stays
+    /// valid, then make a genuine selection. The rebuild must not leave a
+    /// suppression token behind that eats it.</summary>
+    internal class ListView_SelectionSurvivesRebuild_NextSelectionFires(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var rec = new Reconciler();
+            var parent = new Grid { Background = new SolidColorBrush(Colors.Transparent) };
+            H.SetContent(parent);
+
+            int fireCount = 0;
+            int lastIdx = -99;
+            var el1 = new ListViewElement(MakeItems(2, "lv1090a"))
+            {
+                SelectedIndex = 0,
+                OnSelectedIndexChanged = i => { fireCount++; lastIdx = i; },
+            };
+
+            if (rec.Mount(el1, _noOp) is not WinUI.ListView lv)
+            {
+                H.Check("Issue1090_LVSurvive_Mounted", false);
+                return;
+            }
+
+            parent.Children.Add(lv);
+            await Harness.Render();
+            H.Check("Issue1090_LVSurvive_MountValue", lv.SelectedIndex == 0);
+
+            // ListView's SelectionChanged is deferred to container realization, so
+            // the mount-time SelectedIndex=0 write echoes once after the trampoline
+            // subscribes. Pre-existing behavior; baseline-reset so the assertions
+            // below measure only what the rebuild did.
+            fireCount = 0;
+            lastIdx = -99;
+
+            // Positive control: the callback path is live on THIS control before
+            // we assert anything about it not firing.
+            lv.SelectedIndex = 1;
+            await Harness.Render();
+            H.Check("Issue1090_LVSurvive_CallbackWiredControl", fireCount == 1 && lastIdx == 1);
+            fireCount = 0;
+            lastIdx = -99;
+
+            // The customer's render: a fresh Element[] (so ItemsSource rebuilds)
+            // that GROWS, with the selected index still valid in the new source.
+            // This is the exact shape reported in #1090 — the reporter's ComboBox
+            // went from ["a","b"] to ["a","b","c"] with the selection intact.
+            var el2 = el1 with { Items = MakeItems(3, "lv1090a"), SelectedIndex = 1 };
+            rec.UpdateChild(el1, el2, lv, _noOp);
+            await Harness.Render();
+
+            int firesFromRebuild = fireCount;
+            int indexAfterRebuild = lv.SelectedIndex;
+            Console.WriteLine(
+                $"# Issue1090 LVSurvive diag: indexAfterRebuild={indexAfterRebuild} " +
+                $"firesFromRebuild={firesFromRebuild}");
+
+            // The rebuild is engine work, not user intent: it must not reach the
+            // callback whether WinUI kept the selection (no event at all) or
+            // dropped it (event consumed by the suppressor).
+            H.Check("Issue1090_LVSurvive_RebuildNoLeak", firesFromRebuild == 0);
+            fireCount = 0;
+            lastIdx = -99;
+
+            // THE BUG. A genuine user selection of the newly-added item. On the
+            // unfixed handler the speculative token armed before the swap is
+            // still outstanding and ShouldSuppress eats this event.
+            lv.SelectedIndex = 2;
+            await Harness.Render();
+            H.Check("Issue1090_LVSurvive_RealSelectFires", fireCount == 1 && lastIdx == 2);
+
+            // The selection must still land on the control even when the callback
+            // is swallowed — this separates "event suppressed" from "write lost".
+            H.Check("Issue1090_LVSurvive_ControlAtUserSelection", lv.SelectedIndex == 2);
+
+            rec.UnmountChild(lv);
+            parent.Children.Clear();
+        }
+    }
+
+    /// <summary>Issue #1090 — the GridView handler carries a byte-identical
+    /// speculative arm, so it carries the identical defect.</summary>
+    internal class GridView_SelectionSurvivesRebuild_NextSelectionFires(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var rec = new Reconciler();
+            var parent = new Grid { Background = new SolidColorBrush(Colors.Transparent) };
+            H.SetContent(parent);
+
+            int fireCount = 0;
+            int lastIdx = -99;
+            var el1 = new GridViewElement(MakeItems(2, "gv1090a"))
+            {
+                SelectedIndex = 0,
+                OnSelectedIndexChanged = i => { fireCount++; lastIdx = i; },
+            };
+
+            if (rec.Mount(el1, _noOp) is not WinUI.GridView gv)
+            {
+                H.Check("Issue1090_GVSurvive_Mounted", false);
+                return;
+            }
+
+            parent.Children.Add(gv);
+            await Harness.Render();
+            H.Check("Issue1090_GVSurvive_MountValue", gv.SelectedIndex == 0);
+
+            fireCount = 0;
+            lastIdx = -99;
+
+            gv.SelectedIndex = 1;
+            await Harness.Render();
+            H.Check("Issue1090_GVSurvive_CallbackWiredControl", fireCount == 1 && lastIdx == 1);
+            fireCount = 0;
+            lastIdx = -99;
+
+            var el2 = el1 with { Items = MakeItems(3, "gv1090a"), SelectedIndex = 1 };
+            rec.UpdateChild(el1, el2, gv, _noOp);
+            await Harness.Render();
+
+            Console.WriteLine(
+                $"# Issue1090 GVSurvive diag: indexAfterRebuild={gv.SelectedIndex} " +
+                $"firesFromRebuild={fireCount}");
+
+            H.Check("Issue1090_GVSurvive_RebuildNoLeak", fireCount == 0);
+            fireCount = 0;
+            lastIdx = -99;
+
+            gv.SelectedIndex = 2;
+            await Harness.Render();
+            H.Check("Issue1090_GVSurvive_RealSelectFires", fireCount == 1 && lastIdx == 2);
+            H.Check("Issue1090_GVSurvive_ControlAtUserSelection", gv.SelectedIndex == 2);
+
+            rec.UnmountChild(gv);
+            parent.Children.Clear();
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    //  2. The discriminator: a genuine DESELECT after a surviving rebuild.
+    // ─────────────────────────────────────────────────────────────────────
+
+    /// <summary>Issue #1090 — selection AND deselection must both survive a
+    /// rebuild round-trip.
+    ///
+    /// <para>Both interactions are driven <em>after</em> the rebuild, so each
+    /// assertion is a real state transition rather than a no-op write WinUI
+    /// ignores. The deselect leg matters because its readback is -1 — the same
+    /// value a rebuild's drop echo carries — so a suppression scheme keyed on
+    /// "the echo will read back negative" cannot tell the two apart and eats
+    /// this event.</para></summary>
+    internal class ListView_SelectAndDeselectAcrossRebuild_BothFire(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var rec = new Reconciler();
+            var parent = new Grid { Background = new SolidColorBrush(Colors.Transparent) };
+            H.SetContent(parent);
+
+            int fireCount = 0;
+            int lastIdx = -99;
+            // Multiple mode is where a user can genuinely deselect down to an
+            // empty selection by clicking the selected item again.
+            var el1 = new ListViewElement(MakeItems(3, "lv1090b"))
+            {
+                SelectionMode = ListViewSelectionMode.Multiple,
+                OnSelectedIndexChanged = i => { fireCount++; lastIdx = i; },
+            };
+
+            if (rec.Mount(el1, _noOp) is not WinUI.ListView lv)
+            {
+                H.Check("Issue1090_LVDeselect_Mounted", false);
+                return;
+            }
+
+            parent.Children.Add(lv);
+            await Harness.Render();
+
+            fireCount = 0;
+            lastIdx = -99;
+
+            // Positive control: a real selection fires. If this check fails the
+            // rest of the fixture is measuring a dead callback, not the product.
+            lv.SelectedIndex = 1;
+            await Harness.Render();
+            H.Check("Issue1090_LVDeselect_CallbackWiredControl", fireCount == 1 && lastIdx == 1);
+            fireCount = 0;
+            lastIdx = -99;
+
+            // Rebuild with a fresh Element[] — the ItemsSource swap.
+            var el2 = el1 with { Items = MakeItems(3, "lv1090b-gen2") };
+            rec.UpdateChild(el1, el2, lv, _noOp);
+            await Harness.Render();
+
+            int indexAfterRebuild = lv.SelectedIndex;
+            Console.WriteLine(
+                $"# Issue1090 LVDeselect diag: indexAfterRebuild={indexAfterRebuild} " +
+                $"firesFromRebuild={fireCount}");
+            H.Check("Issue1090_LVDeselect_RebuildNoLeak", fireCount == 0);
+            fireCount = 0;
+            lastIdx = -99;
+
+            // A genuine selection AFTER the rebuild. Guarded so the write is a
+            // real transition on either platform branch (whether the rebuild
+            // preserved index 1 or reset it to -1).
+            int target = indexAfterRebuild == 2 ? 1 : 2;
+            lv.SelectedIndex = target;
+            await Harness.Render();
+            H.Check("Issue1090_LVDeselect_SelectAfterRebuildFires", fireCount == 1 && lastIdx == target);
+            fireCount = 0;
+            lastIdx = -99;
+
+            // Genuine user deselect. The control is definitely selected here, so
+            // this is a real transition and the readback is -1.
+            lv.SelectedIndex = -1;
+            await Harness.Render();
+            H.Check("Issue1090_LVDeselect_RealDeselectFires", fireCount == 1 && lastIdx == -1);
+
+            rec.UnmountChild(lv);
+            parent.Children.Clear();
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    //  3. Negative control: the #495 leak must not reopen.
+    // ─────────────────────────────────────────────────────────────────────
+
+    /// <summary>Issue #1090 / #495 guard — when the rebuild genuinely DOES drop
+    /// the selection (the new source is too short to hold it), the resulting
+    /// engine-synthesized <c>SelectionChanged</c> must still be suppressed.
+    ///
+    /// <para>This is the fixture that fails if a candidate "fixes" #1090 by
+    /// simply not arming at all. Bound to <c>UseState</c> that leaked echo is
+    /// the #495 render storm.</para></summary>
+    internal class ListView_SelectionDroppedByRebuild_NoEchoLeak(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var rec = new Reconciler();
+            var parent = new Grid { Background = new SolidColorBrush(Colors.Transparent) };
+            H.SetContent(parent);
+
+            int fireCount = 0;
+            int lastIdx = -99;
+            // SelectedIndex deliberately Unset: the control owns the selection, so
+            // the handler performs no drift write and the ONLY event in play is
+            // the one the ItemsSource swap itself produces.
+            var el1 = new ListViewElement(MakeItems(3, "lv1090c"))
+            {
+                OnSelectedIndexChanged = i => { fireCount++; lastIdx = i; },
+            };
+
+            if (rec.Mount(el1, _noOp) is not WinUI.ListView lv)
+            {
+                H.Check("Issue1090_LVDrop_Mounted", false);
+                return;
+            }
+
+            parent.Children.Add(lv);
+            await Harness.Render();
+
+            fireCount = 0;
+            lastIdx = -99;
+
+            // Positive control + setup: user selects the last item.
+            lv.SelectedIndex = 2;
+            await Harness.Render();
+            H.Check("Issue1090_LVDrop_CallbackWiredControl", fireCount == 1 && lastIdx == 2);
+            fireCount = 0;
+            lastIdx = -99;
+
+            // Shrink the source so index 2 cannot survive. WinUI drops the
+            // selection and raises SelectionChanged(-1) — engine work, not user
+            // intent, so it must not reach the callback.
+            var el2 = el1 with { Items = MakeItems(1, "lv1090c") };
+            rec.UpdateChild(el1, el2, lv, _noOp);
+            await Harness.Render();
+
+            Console.WriteLine(
+                $"# Issue1090 LVDrop diag: indexAfterRebuild={lv.SelectedIndex} " +
+                $"firesFromRebuild={fireCount} lastIdx={lastIdx}");
+
+            H.Check("Issue1090_LVDrop_DropEchoSuppressed", fireCount == 0);
+
+            // And the control must be left genuinely deselected, not merely quiet.
+            H.Check("Issue1090_LVDrop_SelectionActuallyDropped", lv.SelectedIndex == -1);
+
+            // A real selection in the shrunken source must still work afterwards —
+            // suppressing the drop must not strand a token either.
+            lv.SelectedIndex = 0;
+            await Harness.Render();
+            H.Check("Issue1090_LVDrop_RealSelectAfterDropFires", fireCount == 1 && lastIdx == 0);
+
+            rec.UnmountChild(lv);
+            parent.Children.Clear();
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    //  4. Platform probe.
+    // ─────────────────────────────────────────────────────────────────────
+
+    /// <summary>Issue #1090 — measures the raw WinUI <c>ItemsSource</c>-swap
+    /// behavior the handler's suppression strategy is built on. No Reactor code
+    /// is involved: this is the platform premise, isolated.
+    ///
+    /// <para><b>What it must NOT assert.</b> Whether a swap that keeps the index
+    /// valid preserves the selection is <em>version-dependent</em> — that is the
+    /// whole of issue #1090. The runtime bundled with WASDK 2.1.x (which this
+    /// self-contained host binds) resets the selection and fires; the reporter's
+    /// newer runtime preserves it and raises nothing. Asserting either one pins
+    /// this suite to one WinUI build.</para>
+    ///
+    /// <para><b>What it does assert</b> — the two properties the arm-then-observe
+    /// fix actually relies on, both of which hold on either behavior:</para>
+    /// <list type="number">
+    /// <item><description><c>SelectedIndex</c> is stable across the dispatcher
+    /// drain: whatever it reads immediately after the assignment is what it still
+    /// reads once everything settles. If WinUI ever updated the index
+    /// asynchronously, observing the control right after the swap would be
+    /// meaningless and the fix would silently mis-decide.</description></item>
+    /// <item><description>The index and the event agree: the selection changing
+    /// implies at least one <c>SelectionChanged</c>, and the selection not
+    /// changing implies none. That equivalence is exactly what lets an unchanged
+    /// index stand in for "no echo is coming."</description></item>
+    /// </list>
+    /// <para>The branch this machine actually takes, and whether the drop echo is
+    /// synchronous or deferred, are logged rather than asserted.</para></summary>
+    internal class Probe_ItemsSourceSwapBehavior(Harness h) : SelfTestFixtureBase(h)
+    {
+        /// <summary>Swaps ItemsSource under an active selection and checks the two
+        /// version-independent invariants.</summary>
+        private async Task MeasureAsync(
+            Grid parent, string label, List<int> initial, int selectIndex, List<int> replacement)
+        {
+            var lv = new WinUI.ListView { Width = 240, Height = 160 };
+            parent.Children.Add(lv);
+            lv.ItemsSource = initial;
+            await Harness.Render();
+            lv.SelectedIndex = selectIndex;
+            await Harness.Render();
+            H.Check($"Issue1090_Probe_{label}_Setup", lv.SelectedIndex == selectIndex);
+
+            int fires = 0, firesInside = 0;
+            bool inside = false;
+            lv.SelectionChanged += (_, _) => { fires++; if (inside) firesInside++; };
+
+            inside = true;
+            lv.ItemsSource = replacement;
+            int idxImmediate = lv.SelectedIndex;
+            inside = false;
+
+            await Harness.Render();
+            int idxSettled = lv.SelectedIndex;
+
+            bool selectionMoved = idxSettled != selectIndex;
+            Console.WriteLine(
+                $"# Issue1090 probe {label}: setup={selectIndex} idxImmediate={idxImmediate} " +
+                $"idxSettled={idxSettled} firesInsideAssignment={firesInside} firesSettled={fires} " +
+                $"=> selection={(selectionMoved ? "RESET" : "PRESERVED")}, " +
+                $"echo={(fires == 0 ? "NONE" : firesInside > 0 ? "SYNCHRONOUS" : "DEFERRED")}");
+
+            // Invariant 1 — the post-swap index is readable synchronously and does
+            // not drift afterwards, so observing it right after the assignment is
+            // a sound basis for deciding whether an echo is coming.
+            H.Check($"Issue1090_Probe_{label}_IndexStableAcrossDrain", idxImmediate == idxSettled);
+
+            // Invariant 2 — index movement and event delivery agree in both
+            // directions. This is what makes "index unchanged" a valid proxy for
+            // "no echo will arrive".
+            H.Check($"Issue1090_Probe_{label}_MovedImpliesEvent", !selectionMoved || fires >= 1);
+            H.Check($"Issue1090_Probe_{label}_UnmovedImpliesNoEvent", selectionMoved || fires == 0);
+
+            parent.Children.Remove(lv);
+        }
+
+        public override async Task RunAsync()
+        {
+            var parent = new Grid { Background = new SolidColorBrush(Colors.Transparent) };
+            H.SetContent(parent);
+
+            // Grow — the selected index stays valid in the new source. This is the
+            // case whose outcome differs between WinUI versions.
+            await MeasureAsync(parent, "Grow", new List<int> { 0, 1 }, 0, new List<int> { 0, 1, 2 });
+
+            // Same length, new list instance — the shape the handler always
+            // produces (Enumerable.Range(...).ToList() on every rebuild).
+            await MeasureAsync(parent, "SameLen", new List<int> { 0, 1, 2 }, 1, new List<int> { 0, 1, 2 });
+
+            // Shrink — the selected index cannot survive, so every version must
+            // drop the selection and raise.
+            await MeasureAsync(parent, "Shrink", new List<int> { 0, 1, 2 }, 2, new List<int> { 0 });
+
+            parent.Children.Clear();
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    //  5. The reporter's end-to-end repro, verbatim.
+    // ─────────────────────────────────────────────────────────────────────
+
+    /// <summary>Issue #1090 — the reporter's scenario, driven end to end through
+    /// <c>Component</c> + <c>UseState</c>: grow the bound item array while the
+    /// selected index stays valid, then make a genuine selection of the new item.
+    /// The state must follow.</summary>
+    private class ReproComponent : Component
+    {
+        public static int CallbackCount;
+        public static int RenderCount;
+        public static int StateIndex = -99;
+        public static Action<int>? SwitchSource;
+
+        public static void Reset()
+        {
+            CallbackCount = 0;
+            RenderCount = 0;
+            StateIndex = -99;
+            SwitchSource = null;
+        }
+
+        public override Element Render()
+        {
+            RenderCount++;
+            var (which, setWhich) = UseState(0);
+            var (index, setIndex) = UseState(0);
+            StateIndex = index;
+
+            // Mirrors the reporter's ComboBox callback: switch source AND reset
+            // the index in one batch.
+            SwitchSource = w => { setWhich(w); setIndex(0); };
+
+            var labels = which == 0 ? new[] { "a", "b" } : new[] { "a", "b", "c" };
+            // Fresh Element[] every render — idiomatic Reactor, and the trigger
+            // for the ItemsSource rebuild.
+            return new ListViewElement(labels.Select(s => TextBlock(s)).ToArray())
+            {
+                SelectedIndex = index,
+                OnSelectedIndexChanged = i => { CallbackCount++; setIndex(i); },
+            }.Set(l => l.Name = "lv1090repro");
+        }
+    }
+
+    internal class Repro_GrowSourceThenSelectNewItem(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            ReproComponent.Reset();
+
+            var host = H.CreateHost();
+            host.Mount(new ReproComponent());
+            await Harness.Render();
+
+            var lv = H.FindControl<ListView>(l => l.Name == "lv1090repro");
+            H.Check("Issue1090_Repro_Mounted", lv is not null);
+            if (lv is null) return;
+
+            H.Check("Issue1090_Repro_InitialSelection", lv.SelectedIndex == 0 && ReproComponent.StateIndex == 0);
+
+            // Step 2 of the repro: switch the combo to L2 — items become a,b,c
+            // and the selection (0) is still valid in the new source.
+            ReproComponent.SwitchSource!(1);
+            await Harness.Render();
+
+            Console.WriteLine(
+                $"# Issue1090 Repro after-grow: controlIndex={lv.SelectedIndex} stateIndex={ReproComponent.StateIndex} " +
+                $"itemCount={(lv.ItemsSource as global::System.Collections.ICollection)?.Count} " +
+                $"callbacks={ReproComponent.CallbackCount} renders={ReproComponent.RenderCount}");
+
+            H.Check("Issue1090_Repro_GrewToThreeItems",
+                (lv.ItemsSource as global::System.Collections.ICollection)?.Count == 3);
+            H.Check("Issue1090_Repro_SelectionStillZeroAfterGrow",
+                lv.SelectedIndex == 0 && ReproComponent.StateIndex == 0);
+
+            int callbacksBeforeClick = ReproComponent.CallbackCount;
+
+            // Step 3: click `c`. THE BUG — the control highlights it but the
+            // callback never runs, so the state stays stale at 0.
+            lv.SelectedIndex = 2;
+            await Harness.Render();
+
+            Console.WriteLine(
+                $"# Issue1090 Repro after-click: controlIndex={lv.SelectedIndex} stateIndex={ReproComponent.StateIndex} " +
+                $"callbacks+={ReproComponent.CallbackCount - callbacksBeforeClick}");
+
+            H.Check("Issue1090_Repro_ClickFiredCallback",
+                ReproComponent.CallbackCount - callbacksBeforeClick >= 1);
+            H.Check("Issue1090_Repro_StateFollowedSelection", ReproComponent.StateIndex == 2);
+            H.Check("Issue1090_Repro_ControlAtSelection", lv.SelectedIndex == 2);
+        }
+    }
+}

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/Issue1090SelectionStrandFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/Issue1090SelectionStrandFixtures.cs
@@ -14,43 +14,57 @@ using static Microsoft.UI.Reactor.Factories;
 namespace Microsoft.UI.Reactor.AppTests.Host.SelfTest.Fixtures;
 
 /// <summary>
-/// Issue #1090 — <c>ListView</c>/<c>GridView</c> swallow the first genuine
-/// <c>SelectionChanged</c> after an <c>ItemsSource</c> rebuild when the
-/// selection survives the reassignment.
+/// Issue #1090 — <c>ListView</c>/<c>GridView</c> swallow the user's first
+/// genuine <c>SelectionChanged</c> after mounting with an <b>empty</b> items
+/// list.
 ///
-/// <para><b>Mechanism.</b> <c>ListViewHandler.Update</c> arms
-/// <c>ChangeEchoSuppressor.BeginSuppress</c> <em>speculatively</em> — before the
-/// swap, on the premise that WinUI always drops <c>SelectedIndex</c> to -1 and
-/// fires a <c>SelectionChanged(-1)</c> echo that consumes the token. When the
-/// old index is still valid in the new source WinUI keeps the selection and
-/// raises nothing, so the token strands. The subsequent drift-gated
-/// <c>WriteSuppressed</c> selection write is also skipped (control already at
-/// the requested index), so nothing else consumes it either. The next real user
-/// selection is then eaten by the trampoline's <c>ShouldSuppress</c> gate.</para>
+/// <para><b>Mechanism (confirmed by instrumented ledger against a live
+/// framework-dependent app).</b> Echo suppression arms one token per
+/// <em>expected</em> change event. A controlled <c>SelectedIndex</c> write is
+/// gated on drift (<c>control != requested</c>), which is not sufficient: WinUI
+/// silently <b>clamps</b> a selection past the end of its <c>ItemsSource</c>.
+/// The property stays put, no <c>SelectionChanged</c> is raised, and the token
+/// armed for that write strands.</para>
 ///
-/// <para><b>This file is the shared oracle for the #1090 fix bake-off.</b> Every
-/// candidate mechanism is judged against these fixtures unmodified. A candidate
-/// that requires an assertion here to be relaxed has failed, not passed — the
-/// point of freezing the harness before the fix is that the instrument cannot be
-/// bent to fit the result.</para>
+/// <para>The common trigger is an items array that is still empty on mount while
+/// its data loads — idiomatic for <c>UseState&lt;T[]&gt;([])</c> plus a fetch.
+/// Mount writes <c>SelectedIndex = 0</c> against an empty source (clamped,
+/// token #1), an intermediate render writes it again while still empty (clamped,
+/// token #2), then the items arrive and WinUI materializes the selection with a
+/// single coalesced event that consumes only <em>one</em> token. The leftover
+/// swallows the user's first real click. Observed ledger on the unfixed code:</para>
+/// <code>
+/// MOUNT  write: itemsCount=0 current=-1 -> 0
+/// BEGIN  count=1
+/// MOUNT  write done: readback=-1        // clamped — no event
+/// UPDATE write: itemsCount=0 current=-1 -> 0
+/// BEGIN  count=2
+/// UPDATE write done: readback=-1        // clamped — no event
+/// SHOULD consumed -> count=1            // items arrive: ONE coalesced event
+/// ...                                   // counter never returns to 0
+/// SHOULD consumed -> count=0            // the user's real click, swallowed
+/// </code>
 ///
-/// <para><b>The two failure modes every candidate trades off.</b>
+/// <para><b>The fix</b> is a reachability guard: only write (and therefore only
+/// arm) when the requested index actually exists in the current source. A write
+/// that can only clamp is skipped; the later update that brings the items in
+/// performs it instead, where it lands and echoes normally.</para>
+///
+/// <para><b>The two failure modes any fix here trades off.</b>
 /// <list type="bullet">
 /// <item><description><b>Strand</b> — a token outlives the write it was armed
-/// for and swallows the user's next genuine selection. That is #1090, covered by
-/// <c>SelectionSurvivesRebuild_NextSelectionFires</c> and
-/// <c>DeselectAfterSurvivingRebuild_Fires</c>.</description></item>
+/// for and swallows a genuine selection. That is #1090.</description></item>
 /// <item><description><b>Leak</b> — an engine-synthesized event reaches the user
-/// callback, which calls <c>setIndex</c>, which re-renders, which swaps
-/// <c>ItemsSource</c> again: the #495 render storm. Covered by
-/// <c>SelectionDroppedByRebuild_NoEchoLeak</c> and by the six existing
+/// callback, which calls <c>setIndex</c>, which re-renders and rebuilds
+/// <c>ItemsSource</c> again: the #495 render storm. Guarded by
+/// <c>SelectionDroppedByRebuild_NoEchoLeak</c> here and by the six existing
 /// <c>Issue495_*</c> fixtures, which must stay green.</description></item>
 /// </list>
 /// Fixing one by reintroducing the other is not a fix.</para>
 ///
 /// <para><b>Positive controls.</b> Every fixture that asserts "the callback did
-/// NOT fire" first drives an interaction that proves the callback path is live
-/// on this control instance. A zero from a correctly-suppressed echo and a zero
+/// NOT fire" first drives an interaction proving the callback path is live on
+/// that control instance. A zero from a correctly-suppressed echo and a zero
 /// from a callback that was never wired look identical in the log.</para>
 /// </summary>
 internal static class Issue1090SelectionStrandFixtures
@@ -560,6 +574,194 @@ internal static class Issue1090SelectionStrandFixtures
                 ReproComponent.CallbackCount - callbacksBeforeClick >= 1);
             H.Check("Issue1090_Repro_StateFollowedSelection", ReproComponent.StateIndex == 2);
             H.Check("Issue1090_Repro_ControlAtSelection", lv.SelectedIndex == 2);
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    //  6. The confirmed #1090 mechanism: clamped writes against an empty
+    //     (or too-short) source strand tokens.
+    // ─────────────────────────────────────────────────────────────────────
+
+    /// <summary>Issue #1090 — mount with an EMPTY items array while
+    /// <c>SelectedIndex</c> is controlled at 0, then let the items arrive. The
+    /// mount write is clamped by WinUI, so it must not arm a suppression token;
+    /// otherwise that token swallows the user's first real selection.
+    ///
+    /// <para>This is the reporter's confirmed scenario, reduced to the reconciler
+    /// level. Two writes land against the empty source (mount + an intermediate
+    /// update, mirroring a component that re-renders before its data loads);
+    /// unfixed, both arm, and only one is ever consumed.</para></summary>
+    internal class ListView_EmptyMountThenItemsArrive_FirstRealSelectionFires(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var rec = new Reconciler();
+            var parent = new Grid { Background = new SolidColorBrush(Colors.Transparent) };
+            H.SetContent(parent);
+
+            int fireCount = 0;
+            int lastIdx = -99;
+
+            // Mount EMPTY with a controlled selection — the write can only clamp.
+            var el0 = new ListViewElement([])
+            {
+                SelectedIndex = 0,
+                OnSelectedIndexChanged = i => { fireCount++; lastIdx = i; },
+            };
+
+            if (rec.Mount(el0, _noOp) is not WinUI.ListView lv)
+            {
+                H.Check("Issue1090_EmptyMount_Mounted", false);
+                return;
+            }
+
+            parent.Children.Add(lv);
+            await Harness.Render();
+            H.Check("Issue1090_EmptyMount_ClampedToMinusOne", lv.SelectedIndex == -1);
+
+            // Intermediate render, still empty (fresh array => a real update).
+            var el1 = el0 with { Items = [] };
+            rec.UpdateChild(el0, el1, lv, _noOp);
+            await Harness.Render();
+
+            // Items arrive.
+            var el2 = el1 with { Items = MakeItems(3, "lv1090e") };
+            rec.UpdateChild(el1, el2, lv, _noOp);
+            await Harness.Render();
+
+            Console.WriteLine(
+                $"# Issue1090 EmptyMount diag: afterItemsArrive index={lv.SelectedIndex} fires={fireCount}");
+
+            H.Check("Issue1090_EmptyMount_SelectionMaterialized", lv.SelectedIndex == 0);
+            // Materializing the controlled selection is engine work, not user
+            // intent — it must not reach the callback.
+            H.Check("Issue1090_EmptyMount_NoEchoLeak", fireCount == 0);
+
+            fireCount = 0;
+            lastIdx = -99;
+
+            // THE BUG: the user's first genuine selection. Unfixed, a token left
+            // over from the clamped write(s) eats this.
+            lv.SelectedIndex = 2;
+            await Harness.Render();
+            H.Check("Issue1090_EmptyMount_FirstRealSelectionFires", fireCount == 1 && lastIdx == 2);
+
+            // And the one after it, proving no second token is lurking.
+            fireCount = 0;
+            lv.SelectedIndex = 1;
+            await Harness.Render();
+            H.Check("Issue1090_EmptyMount_SecondRealSelectionFires", fireCount == 1 && lastIdx == 1);
+
+            rec.UnmountChild(lv);
+            parent.Children.Clear();
+        }
+    }
+
+    /// <summary>Issue #1090 — the GridView sibling carries the same clamped-write
+    /// shape and therefore the same defect.</summary>
+    internal class GridView_EmptyMountThenItemsArrive_FirstRealSelectionFires(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var rec = new Reconciler();
+            var parent = new Grid { Background = new SolidColorBrush(Colors.Transparent) };
+            H.SetContent(parent);
+
+            int fireCount = 0;
+            int lastIdx = -99;
+            var el0 = new GridViewElement([])
+            {
+                SelectedIndex = 0,
+                OnSelectedIndexChanged = i => { fireCount++; lastIdx = i; },
+            };
+
+            if (rec.Mount(el0, _noOp) is not WinUI.GridView gv)
+            {
+                H.Check("Issue1090_GVEmptyMount_Mounted", false);
+                return;
+            }
+
+            parent.Children.Add(gv);
+            await Harness.Render();
+            H.Check("Issue1090_GVEmptyMount_ClampedToMinusOne", gv.SelectedIndex == -1);
+
+            var el1 = el0 with { Items = [] };
+            rec.UpdateChild(el0, el1, gv, _noOp);
+            await Harness.Render();
+
+            var el2 = el1 with { Items = MakeItems(3, "gv1090e") };
+            rec.UpdateChild(el1, el2, gv, _noOp);
+            await Harness.Render();
+
+            Console.WriteLine(
+                $"# Issue1090 GVEmptyMount diag: afterItemsArrive index={gv.SelectedIndex} fires={fireCount}");
+
+            H.Check("Issue1090_GVEmptyMount_SelectionMaterialized", gv.SelectedIndex == 0);
+            H.Check("Issue1090_GVEmptyMount_NoEchoLeak", fireCount == 0);
+
+            fireCount = 0;
+            lastIdx = -99;
+
+            gv.SelectedIndex = 2;
+            await Harness.Render();
+            H.Check("Issue1090_GVEmptyMount_FirstRealSelectionFires", fireCount == 1 && lastIdx == 2);
+
+            rec.UnmountChild(gv);
+            parent.Children.Clear();
+        }
+    }
+
+    /// <summary>Issue #1090 — the general form: a controlled index past the end
+    /// of a NON-empty source is clamped too, so it must not arm either.
+    ///
+    /// <para>Empty is just the common case. This pins the actual invariant —
+    /// "only arm for a write that can land" — rather than a special-case
+    /// <c>Items.Length == 0</c> check, which would leave this variant broken.</para></summary>
+    internal class ListView_IndexPastEndOfShortSource_FirstRealSelectionFires(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var rec = new Reconciler();
+            var parent = new Grid { Background = new SolidColorBrush(Colors.Transparent) };
+            H.SetContent(parent);
+
+            int fireCount = 0;
+            int lastIdx = -99;
+
+            // Two items, but the controlled selection asks for index 5.
+            var el0 = new ListViewElement(MakeItems(2, "lv1090f"))
+            {
+                SelectedIndex = 5,
+                OnSelectedIndexChanged = i => { fireCount++; lastIdx = i; },
+            };
+
+            if (rec.Mount(el0, _noOp) is not WinUI.ListView lv)
+            {
+                H.Check("Issue1090_PastEnd_Mounted", false);
+                return;
+            }
+
+            parent.Children.Add(lv);
+            await Harness.Render();
+
+            Console.WriteLine(
+                $"# Issue1090 PastEnd diag: afterMount index={lv.SelectedIndex} fires={fireCount}");
+
+            // WinUI cannot honor index 5 against 2 items.
+            H.Check("Issue1090_PastEnd_Clamped", lv.SelectedIndex == -1);
+            H.Check("Issue1090_PastEnd_NoEchoLeak", fireCount == 0);
+
+            fireCount = 0;
+            lastIdx = -99;
+
+            // A genuine selection must not be swallowed by a token armed for the
+            // write that could never land.
+            lv.SelectedIndex = 1;
+            await Harness.Render();
+            H.Check("Issue1090_PastEnd_FirstRealSelectionFires", fireCount == 1 && lastIdx == 1);
+
+            rec.UnmountChild(lv);
+            parent.Children.Clear();
         }
     }
 }

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/Issue1090SelectionStrandFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/Issue1090SelectionStrandFixtures.cs
@@ -490,21 +490,19 @@ internal static class Issue1090SelectionStrandFixtures
     /// <summary>Issue #1090 — the reporter's scenario, driven end to end through
     /// <c>Component</c> + <c>UseState</c>: grow the bound item array while the
     /// selected index stays valid, then make a genuine selection of the new item.
-    /// The state must follow.</summary>
+    /// The state must follow.
+    ///
+    /// <para>Observable state is held in <em>instance</em> fields rather than the
+    /// static counters used by the older repro fixtures in this folder: the
+    /// fixture constructs the component itself, so it can simply keep the
+    /// reference. That removes the shared mutable state (and its <c>Reset()</c>
+    /// ceremony), so a fixture cannot be contaminated by a previous run.</para></summary>
     private class ReproComponent : Component
     {
-        public static int CallbackCount;
-        public static int RenderCount;
-        public static int StateIndex = -99;
-        public static Action<int>? SwitchSource;
-
-        public static void Reset()
-        {
-            CallbackCount = 0;
-            RenderCount = 0;
-            StateIndex = -99;
-            SwitchSource = null;
-        }
+        public int CallbackCount;
+        public int RenderCount;
+        public int StateIndex = -99;
+        public Action<int>? SwitchSource;
 
         public override Element Render()
         {
@@ -532,34 +530,34 @@ internal static class Issue1090SelectionStrandFixtures
     {
         public override async Task RunAsync()
         {
-            ReproComponent.Reset();
+            var component = new ReproComponent();
 
             var host = H.CreateHost();
-            host.Mount(new ReproComponent());
+            host.Mount(component);
             await Harness.Render();
 
             var lv = H.FindControl<ListView>(l => l.Name == "lv1090repro");
             H.Check("Issue1090_Repro_Mounted", lv is not null);
             if (lv is null) return;
 
-            H.Check("Issue1090_Repro_InitialSelection", lv.SelectedIndex == 0 && ReproComponent.StateIndex == 0);
+            H.Check("Issue1090_Repro_InitialSelection", lv.SelectedIndex == 0 && component.StateIndex == 0);
 
             // Step 2 of the repro: switch the combo to L2 — items become a,b,c
             // and the selection (0) is still valid in the new source.
-            ReproComponent.SwitchSource!(1);
+            component.SwitchSource!(1);
             await Harness.Render();
 
             Console.WriteLine(
-                $"# Issue1090 Repro after-grow: controlIndex={lv.SelectedIndex} stateIndex={ReproComponent.StateIndex} " +
+                $"# Issue1090 Repro after-grow: controlIndex={lv.SelectedIndex} stateIndex={component.StateIndex} " +
                 $"itemCount={(lv.ItemsSource as global::System.Collections.ICollection)?.Count} " +
-                $"callbacks={ReproComponent.CallbackCount} renders={ReproComponent.RenderCount}");
+                $"callbacks={component.CallbackCount} renders={component.RenderCount}");
 
             H.Check("Issue1090_Repro_GrewToThreeItems",
                 (lv.ItemsSource as global::System.Collections.ICollection)?.Count == 3);
             H.Check("Issue1090_Repro_SelectionStillZeroAfterGrow",
-                lv.SelectedIndex == 0 && ReproComponent.StateIndex == 0);
+                lv.SelectedIndex == 0 && component.StateIndex == 0);
 
-            int callbacksBeforeClick = ReproComponent.CallbackCount;
+            int callbacksBeforeClick = component.CallbackCount;
 
             // Step 3: click `c`. THE BUG — the control highlights it but the
             // callback never runs, so the state stays stale at 0.
@@ -567,12 +565,12 @@ internal static class Issue1090SelectionStrandFixtures
             await Harness.Render();
 
             Console.WriteLine(
-                $"# Issue1090 Repro after-click: controlIndex={lv.SelectedIndex} stateIndex={ReproComponent.StateIndex} " +
-                $"callbacks+={ReproComponent.CallbackCount - callbacksBeforeClick}");
+                $"# Issue1090 Repro after-click: controlIndex={lv.SelectedIndex} stateIndex={component.StateIndex} " +
+                $"callbacks+={component.CallbackCount - callbacksBeforeClick}");
 
             H.Check("Issue1090_Repro_ClickFiredCallback",
-                ReproComponent.CallbackCount - callbacksBeforeClick >= 1);
-            H.Check("Issue1090_Repro_StateFollowedSelection", ReproComponent.StateIndex == 2);
+                component.CallbackCount - callbacksBeforeClick >= 1);
+            H.Check("Issue1090_Repro_StateFollowedSelection", component.StateIndex == 2);
             H.Check("Issue1090_Repro_ControlAtSelection", lv.SelectedIndex == 2);
         }
     }

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -1528,6 +1528,16 @@ internal static class SelfTestFixtureRegistry
         "Issue495_ListView_SameLengthContentChange_RefreshesContainers",
         "Issue495_GridView_SameLengthContentChange_RefreshesContainers",
 
+        // Issue #1090 — ItemsSource rebuild strands a speculative echo-suppress
+        // token when the selection survives the swap, swallowing the user's next
+        // genuine SelectionChanged. Shared oracle for the fix bake-off.
+        "Issue1090_Probe_ItemsSourceSwapBehavior",
+        "Issue1090_ListView_SelectionSurvivesRebuild_NextSelectionFires",
+        "Issue1090_GridView_SelectionSurvivesRebuild_NextSelectionFires",
+        "Issue1090_ListView_SelectAndDeselectAcrossRebuild_BothFire",
+        "Issue1090_ListView_SelectionDroppedByRebuild_NoEchoLeak",
+        "Issue1090_Repro_GrowSourceThenSelectNewItem",
+
         // Spec 047 §14 Phase 1 (1.16) — external-assembly proof fixtures.
         // The MarqueeHandler is authored in tests/external_proof/
         // Reactor.External.TestControl, references Reactor as a regular
@@ -3162,6 +3172,14 @@ internal static class SelfTestFixtureRegistry
         "Issue495_TypedGridViewLoop_StateBound_NoLoopAfterSelection" => new ListViewLoopReproFixtures.TypedGridView_StateBound_NoLoopAfterSelection(harness),
         "Issue495_ListView_SameLengthContentChange_RefreshesContainers" => new ListViewLoopReproFixtures.ListView_SameLengthContentChange_RefreshesContainers(harness),
         "Issue495_GridView_SameLengthContentChange_RefreshesContainers" => new ListViewLoopReproFixtures.GridView_SameLengthContentChange_RefreshesContainers(harness),
+
+        // Issue #1090 — echo-suppress token stranding on ItemsSource rebuild.
+        "Issue1090_Probe_ItemsSourceSwapBehavior" => new Issue1090SelectionStrandFixtures.Probe_ItemsSourceSwapBehavior(harness),
+        "Issue1090_ListView_SelectionSurvivesRebuild_NextSelectionFires" => new Issue1090SelectionStrandFixtures.ListView_SelectionSurvivesRebuild_NextSelectionFires(harness),
+        "Issue1090_GridView_SelectionSurvivesRebuild_NextSelectionFires" => new Issue1090SelectionStrandFixtures.GridView_SelectionSurvivesRebuild_NextSelectionFires(harness),
+        "Issue1090_ListView_SelectAndDeselectAcrossRebuild_BothFire" => new Issue1090SelectionStrandFixtures.ListView_SelectAndDeselectAcrossRebuild_BothFire(harness),
+        "Issue1090_ListView_SelectionDroppedByRebuild_NoEchoLeak" => new Issue1090SelectionStrandFixtures.ListView_SelectionDroppedByRebuild_NoEchoLeak(harness),
+        "Issue1090_Repro_GrowSourceThenSelectNewItem" => new Issue1090SelectionStrandFixtures.Repro_GrowSourceThenSelectNewItem(harness),
 
         // Spec 047 §14 Phase 1 (1.16) — external-assembly proof fixtures.
         "Spec047ExternalProof_Marquee_MountUpdate" => new Spec047ExternalProofFixtures.MarqueeMountUpdate(harness),

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -1537,6 +1537,9 @@ internal static class SelfTestFixtureRegistry
         "Issue1090_ListView_SelectAndDeselectAcrossRebuild_BothFire",
         "Issue1090_ListView_SelectionDroppedByRebuild_NoEchoLeak",
         "Issue1090_Repro_GrowSourceThenSelectNewItem",
+        "Issue1090_ListView_EmptyMountThenItemsArrive_FirstRealSelectionFires",
+        "Issue1090_GridView_EmptyMountThenItemsArrive_FirstRealSelectionFires",
+        "Issue1090_ListView_IndexPastEndOfShortSource_FirstRealSelectionFires",
 
         // Spec 047 §14 Phase 1 (1.16) — external-assembly proof fixtures.
         // The MarqueeHandler is authored in tests/external_proof/
@@ -3180,6 +3183,9 @@ internal static class SelfTestFixtureRegistry
         "Issue1090_ListView_SelectAndDeselectAcrossRebuild_BothFire" => new Issue1090SelectionStrandFixtures.ListView_SelectAndDeselectAcrossRebuild_BothFire(harness),
         "Issue1090_ListView_SelectionDroppedByRebuild_NoEchoLeak" => new Issue1090SelectionStrandFixtures.ListView_SelectionDroppedByRebuild_NoEchoLeak(harness),
         "Issue1090_Repro_GrowSourceThenSelectNewItem" => new Issue1090SelectionStrandFixtures.Repro_GrowSourceThenSelectNewItem(harness),
+        "Issue1090_ListView_EmptyMountThenItemsArrive_FirstRealSelectionFires" => new Issue1090SelectionStrandFixtures.ListView_EmptyMountThenItemsArrive_FirstRealSelectionFires(harness),
+        "Issue1090_GridView_EmptyMountThenItemsArrive_FirstRealSelectionFires" => new Issue1090SelectionStrandFixtures.GridView_EmptyMountThenItemsArrive_FirstRealSelectionFires(harness),
+        "Issue1090_ListView_IndexPastEndOfShortSource_FirstRealSelectionFires" => new Issue1090SelectionStrandFixtures.ListView_IndexPastEndOfShortSource_FirstRealSelectionFires(harness),
 
         // Spec 047 §14 Phase 1 (1.16) — external-assembly proof fixtures.
         "Spec047ExternalProof_Marquee_MountUpdate" => new Spec047ExternalProofFixtures.MarqueeMountUpdate(harness),

--- a/tests/Reactor.Tests/EchoSuppressArmTests.cs
+++ b/tests/Reactor.Tests/EchoSuppressArmTests.cs
@@ -1,0 +1,241 @@
+using Microsoft.UI.Reactor.Core;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests;
+
+/// <summary>
+/// Issue #1090 — <c>BeginSuppressCancelable</c> / <c>EchoSuppressArm</c>, the
+/// retractable form of the echo-suppress counter token.
+///
+/// <para><b>Why the primitive exists.</b> <c>BeginSuppress</c> is a promise that
+/// an event is coming. <c>ListViewHandler.Update</c> could only <em>predict</em>
+/// one: it armed a token and then reassigned <c>ItemsSource</c>, assuming WinUI
+/// would drop the selection and fire. That assumption is version-dependent —
+/// the runtime in Windows App SDK 2.1.x resets the selection synchronously and
+/// fires, while newer runtimes can preserve a still-valid selection and raise
+/// nothing. On the second behavior the token strands and
+/// <c>ShouldSuppress</c> consumes it on the user's next genuine selection,
+/// silently dropping it.</para>
+///
+/// <para><b>Why these tests are headless.</b> Which branch a live control takes
+/// is decided by the WinUI version the host binds, and Reactor's selftest host
+/// is self-contained and pinned. A live fixture can therefore only ever exercise
+/// <em>one</em> of the two branches on a given machine. Driving
+/// <see cref="Reconciler.ReactorState"/> directly reaches both deterministically,
+/// which is the only place the retraction contract can actually be pinned.</para>
+///
+/// <para>Each test names the platform branch it models.</para>
+/// </summary>
+public class EchoSuppressArmTests
+{
+    /// <summary>Models the trampoline: consume a token if one is outstanding.</summary>
+    private static bool RaiseEvent(Reconciler.ReactorState state)
+        => ChangeEchoSuppressor.ShouldSuppress(state);
+
+    [Fact]
+    public void BeginSuppressCancelable_ArmsExactlyOneToken()
+    {
+        var state = new Reconciler.ReactorState();
+
+        var arm = ChangeEchoSuppressor.BeginSuppressCancelable(state);
+
+        Assert.True(arm.IsArmed);
+        Assert.Equal(1, state.EchoSuppressCount);
+    }
+
+    /// <summary>
+    /// Platform branch A — the selection SURVIVES the swap, so the predicted
+    /// echo never happens. This is issue #1090: without retraction the token
+    /// outlives the write and eats the user's next genuine selection.
+    /// </summary>
+    [Fact]
+    public void SelectionPreserved_NoEcho_RetractionLetsNextRealEventThrough()
+    {
+        var state = new Reconciler.ReactorState();
+
+        var arm = ChangeEchoSuppressor.BeginSuppressCancelable(state);
+        // ...ItemsSource swap happens here and raises NOTHING...
+        arm.CancelIfUnconsumed();
+
+        Assert.Equal(0, state.EchoSuppressCount);
+        // The user's next genuine selection must reach the callback.
+        Assert.False(RaiseEvent(state));
+    }
+
+    /// <summary>
+    /// The same branch WITHOUT retraction, pinning the defect the primitive
+    /// exists to prevent: a plain <c>BeginSuppress</c> strands, and the next
+    /// genuine event is swallowed. If this ever stops being true the strand
+    /// hazard is gone and the retraction is dead weight.
+    /// </summary>
+    [Fact]
+    public void SelectionPreserved_NoEcho_WithoutRetraction_SwallowsNextRealEvent()
+    {
+        var state = new Reconciler.ReactorState();
+
+        ChangeEchoSuppressor.BeginSuppressCancelable(state);   // armed, never retracted
+        // ...ItemsSource swap happens here and raises NOTHING...
+
+        Assert.True(RaiseEvent(state));      // the user's real selection is eaten
+        Assert.Equal(0, state.EchoSuppressCount);
+    }
+
+    /// <summary>
+    /// Platform branch B — the selection IS dropped and the echo fires
+    /// synchronously inside the assignment (measured behavior on WASDK 2.1.x).
+    /// The echo consumes the token; the retraction must then be a no-op, and
+    /// must not drive the counter negative.
+    /// </summary>
+    [Fact]
+    public void SelectionDropped_SynchronousEcho_RetractionIsNoOp()
+    {
+        var state = new Reconciler.ReactorState();
+
+        var arm = ChangeEchoSuppressor.BeginSuppressCancelable(state);
+        Assert.True(RaiseEvent(state));       // the drop echo is suppressed
+        arm.CancelIfUnconsumed();             // caller cannot tell — calls anyway
+
+        Assert.Equal(0, state.EchoSuppressCount);
+        Assert.False(RaiseEvent(state));      // next real event still gets through
+    }
+
+    /// <summary>
+    /// Platform branch C — the selection is dropped but the echo is DEFERRED to
+    /// the dispatcher. The caller sees a changed index and keeps the token, which
+    /// must still be there when the queued event finally arrives.
+    /// </summary>
+    [Fact]
+    public void SelectionDropped_DeferredEcho_TokenSurvivesUntilEventArrives()
+    {
+        var state = new Reconciler.ReactorState();
+
+        var arm = ChangeEchoSuppressor.BeginSuppressCancelable(state);
+        // Index changed, so the handler does NOT retract.
+        Assert.True(arm.IsArmed);
+        Assert.Equal(1, state.EchoSuppressCount);
+
+        // ...dispatcher drains later...
+        Assert.True(RaiseEvent(state));       // the deferred drop echo is suppressed
+        Assert.False(RaiseEvent(state));      // and nothing is left over
+    }
+
+    /// <summary>
+    /// The handler's usage pattern, end to end, across every platform branch:
+    /// arm when there is a selection to lose, swap, then retract iff the index
+    /// did not move. The invariant that matters is the one the trampoline sees —
+    /// after the swap settles, no token may be left over to eat real input, and
+    /// no genuine drop echo may escape.
+    /// </summary>
+    /// <param name="dropsSelection">Whether the platform clears the selection.</param>
+    /// <param name="echoIsDeferred">Whether that drop echo is queued rather than
+    /// raised inside the assignment.</param>
+    [Theory]
+    [InlineData(false, false)]  // selection preserved, no echo   → issue #1090's branch
+    [InlineData(true, false)]   // dropped, synchronous echo      → WASDK 2.1.x branch
+    [InlineData(true, true)]    // dropped, deferred echo         → dispatcher branch
+    public void HandlerPattern_LeavesNoStrandedTokenAndSwallowsOnlyTheDropEcho(
+        bool dropsSelection, bool echoIsDeferred)
+    {
+        var state = new Reconciler.ReactorState();
+        int selection = 0;                 // a selection exists before the swap
+
+        // --- the handler's rebuild block -------------------------------------
+        int before = selection;
+        var arm = before >= 0
+            ? ChangeEchoSuppressor.BeginSuppressCancelable(state)
+            : default;
+
+        bool dropEchoEscaped = false;
+        if (dropsSelection)
+        {
+            selection = -1;
+            if (!echoIsDeferred)
+                dropEchoEscaped = !RaiseEvent(state);   // fires inside the assignment
+        }
+
+        if (selection == before)
+            arm.CancelIfUnconsumed();
+        // ---------------------------------------------------------------------
+
+        if (dropsSelection && echoIsDeferred)
+            dropEchoEscaped = !RaiseEvent(state);       // dispatcher drains later
+
+        // The engine-synthesized drop must never reach the user callback: that is
+        // the #495 render storm.
+        Assert.False(dropEchoEscaped);
+
+        // And nothing may be left over: the user's next genuine selection must
+        // reach the callback. That is #1090.
+        Assert.Equal(0, state.EchoSuppressCount);
+        Assert.False(RaiseEvent(state));
+    }
+
+    /// <summary>Retraction is idempotent — calling it twice returns one token.</summary>
+    [Fact]
+    public void CancelIfUnconsumed_CalledTwice_ReturnsOnlyOneToken()
+    {
+        var state = new Reconciler.ReactorState { EchoSuppressCount = 1 };  // someone else's token
+
+        var arm = ChangeEchoSuppressor.BeginSuppressCancelable(state);      // now 2
+        arm.CancelIfUnconsumed();
+        arm.CancelIfUnconsumed();
+
+        // The pre-existing token must survive both calls.
+        Assert.Equal(1, state.EchoSuppressCount);
+    }
+
+    /// <summary>
+    /// A retraction must not cancel a token that belonged to an unrelated write
+    /// already pending when we armed.
+    /// </summary>
+    [Fact]
+    public void CancelIfUnconsumed_LeavesAPreExistingTokenIntact()
+    {
+        var state = new Reconciler.ReactorState { EchoSuppressCount = 1 };  // unrelated pending write
+
+        var arm = ChangeEchoSuppressor.BeginSuppressCancelable(state);
+        arm.CancelIfUnconsumed();
+
+        Assert.Equal(1, state.EchoSuppressCount);
+        Assert.True(RaiseEvent(state));     // the unrelated echo is still suppressed
+        Assert.False(RaiseEvent(state));    // and only that one
+    }
+
+    /// <summary>
+    /// <c>default</c> is the "never armed" value — the shape a handler uses when
+    /// there was no selection to lose. Every operation on it is inert.
+    /// </summary>
+    [Fact]
+    public void DefaultArm_IsNotArmedAndCancelIsInert()
+    {
+        var state = new Reconciler.ReactorState();
+        var arm = default(ChangeEchoSuppressor.EchoSuppressArm);
+
+        Assert.False(arm.IsArmed);
+        arm.CancelIfUnconsumed();
+
+        Assert.Equal(0, state.EchoSuppressCount);
+        Assert.False(RaiseEvent(state));
+    }
+
+    /// <summary>
+    /// The retraction returns a counter token, so it must not disturb the
+    /// non-consuming setter scope or a pending value-diff arm.
+    /// </summary>
+    [Fact]
+    public void CancelIfUnconsumed_DoesNotDisturbScopeOrValueDiffArm()
+    {
+        var state = new Reconciler.ReactorState
+        {
+            EchoSuppressScopeDepth = 1,
+            PendingEchoMatch = _ => true,
+        };
+
+        var arm = ChangeEchoSuppressor.BeginSuppressCancelable(state);
+        arm.CancelIfUnconsumed();
+
+        Assert.Equal(0, state.EchoSuppressCount);
+        Assert.Equal(1, state.EchoSuppressScopeDepth);
+        Assert.NotNull(state.PendingEchoMatch);
+    }
+}


### PR DESCRIPTION
Fixes #1090.

Credit to @kouhe3, who reproduced my counter-experiments, retracted their original theory, and supplied the corrected mechanism plus a minimal repro. That is what made this fix possible.

## Root cause (confirmed)

Echo suppression arms one token per **expected** change event. The controlled `SelectedIndex` write was gated only on drift (`control != requested`), which is not sufficient: **WinUI will not honor a selection past the end of its `ItemsSource`.** The property stays put, no `SelectionChanged` is raised, and the armed token strands — later swallowing the user's next genuine selection.

The common trigger is an items array that is still empty on mount while its data loads — idiomatic for `UseState<T[]>([])` plus a fetch.

Instrumented ledger on unfixed code, driving the repro with **real mouse clicks** against the installed runtime:

```
MOUNT  write: itemsCount=0 current=-1 -> 0
BEGIN  count=1
MOUNT  write done: readback=-1        // clamped - no event
UPDATE write: itemsCount=0 current=-1 -> 0
BEGIN  count=2
UPDATE write done: readback=-1        // clamped - no event
SHOULD consumed -> count=1            // items arrive: ONE coalesced event
...                                   // counter never returns to 0
SHOULD consumed -> count=0            // the user's first real click, eaten
```

Two clamped writes arm two tokens; the single coalesced materialization event consumes only one. The leftover eats the first real click. **The counter never returns to 0 after startup** - that is the signature.

## The fix

A reachability guard: only write - and therefore only arm - when the requested index actually exists in the current source.

```csharp
if (lv.SelectedIndex is { HasValue: true } mountIndex
    && listView.SelectedIndex != mountIndex.Value
    && IsReachable(mountIndex.Value, lv.Items.Length))
{
    ReactorBinding.WriteSuppressed(listView, () => listView.SelectedIndex = mountIndex.Value);
}

private static bool IsReachable(int index, int itemCount)
    => index < 0 || index < itemCount;
```

A write that cannot land is skipped; the later update that brings the items in performs it instead, where it lands and echoes normally. `-1` stays always-reachable - it is the spec-050 force-clear sentinel and is meaningful against any source.

Keyed on **reachability**, not `Items.Length == 0`. Empty is just the common case: an index past the end of a *short non-empty* source has the same defect. Unguarded, that variant additionally throws `ArgumentException` from the setter - surfaced by its own fixture.

Applied identically to `ListViewHandler` and `GridViewHandler` (Mount + Update).

## Verification

**End to end, real mouse input.** The reporter's repro as a framework-dependent unpackaged app binding the installed `WindowsAppRuntime 2.3.1`, clicks driven through the accessibility tree:

| | before | after |
|---|---|---|
| click `b` after the combo switch | row highlights, `state index: 0` (callback never ran) | row highlights, **`state index: 1`**, `LISTVIEW CALLBACK #1: i=1` |

**Mutation-checked.** Removing just the two guard clauses makes all three new fixtures fail:

```
not ok Issue1090_EmptyMount_FirstRealSelectionFires
not ok Issue1090_GVEmptyMount_FirstRealSelectionFires
not ok Issue1090_ListView_IndexPastEndOfShortSource_FirstRealSelectionFires_CRASH - ArgumentException
```

**Suites.** 13288 unit tests pass; 1439 selftest fixtures pass (including all six `Issue495_*` render-storm guards and the `ValueDiff_*` / `Issue464_*` echo guards); Release builds of `src/Reactor` and the selftest host are clean.

## About the first commit on this branch

`12b500a8` addressed a *different*, unconfirmed hypothesis - that the `ItemsSource` swap could preserve a selection and strand a token. **I could not reproduce that on any runtime**; both WASDK 2.1 and 2.3.1 always reset the selection and always fire. That commit's `BeginSuppressCancelable` / `EchoSuppressArm` primitive is therefore hardening, not a fix, and is a no-op on observed behavior.

It is retained here because it removes an unverified platform assumption from the same code path and carries 12 mutation-checked headless tests. **If reviewers would rather keep this PR minimal, say so and I will drop that commit** - the actual #1090 fix is entirely in `56988bc6` and stands alone.

## Sibling audit

Every other `BeginSuppress` call site is drift-gated. Worth noting the same *class* of defect could exist wherever a suppressed write can be rejected or coerced by the control - this fix addresses the `SelectedIndex`/`ItemsSource` pair specifically.

One unrelated observation, recorded rather than changed: `TemplatedListLifecycle.ApplyKeyedDiffOrFallback` reassigns `ItemsSource` with no suppression on its bailout path. That is a potential *leak*, not a strand, and no fixture demonstrates a defect there.
