### PR TITLE
templates: Always use latest winappsdk

### DIFF
--- a/tools/Templates/templates/WinUIApp-CSharp/.template.config/template.json
+++ b/tools/Templates/templates/WinUIApp-CSharp/.template.config/template.json
@@ -84,6 +84,16 @@
   ],
   "defaultName": "WinUIApp1",
   "postActions": [
+     {
+      "actionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
+      "continueOnError": true,
+      "description": "Update Microsoft.WindowsAppSDK to the latest stable version.",
+      "args": {
+        "referenceType": "package",
+        "reference": "Microsoft.WindowsAppSDK"
+      },
+      "manualInstructions": [ { "text": "Run 'dotnet add package Microsoft.WindowsAppSDK'" } ]
+    },
     {
       "id": "restore",
       "condition": "(!skipRestore)",

--- a/tools/Templates/templates/WinUIApp-CSharp/Company.ReactorApp1.csproj
+++ b/tools/Templates/templates/WinUIApp-CSharp/Company.ReactorApp1.csproj
@@ -47,7 +47,6 @@
     <!-- </snippet:template-shape> -->
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.WindowsAppSDK" Version="2.1.3" />
         <PackageReference Include="Microsoft.UI.Reactor" Version="MS_UI_REACTOR_VERSION" />
     </ItemGroup>
 


### PR DESCRIPTION
## Summary

This ensures that the dotnet new templates will always use the latest Windows App SDK.
See https://github.com/dotnet/templating/wiki/Post-Action-Registry#add-a-reference-to-a-project-file for a reference on how this works.

I'd like to do the same for the Reactor reference as well, so you don't really have to ever install the project templates more than once, but the conditional section for the devtools isn't supported. See https://github.com/dotnet/sdk/issues/55927
As an alternative, if Microsoft.UI.Reactor were to declare a property like `MSREACTOR_VERSION`, then the devtools could reference the package by this property.

## Test plan

- [x] Ran `dotnet test Reactor.IntegrationTests`

## Risk / breaking changes

None, except if newer WinAppSDK releases breaks Reactor (unlikely)
