### PR TITLE
Gate DeliberatelyExcludedAttached rows that name an instance owner

### DIFF
--- a/src/Reactor.Analyzers/ModifierTable.cs
+++ b/src/Reactor.Analyzers/ModifierTable.cs
@@ -705,7 +705,11 @@ internal static class ModifierTable
     /// <c>Grid.Padding</c> is instance while <c>Grid.Row</c> is attached, and neither needs an
     /// entry here. Suppressing that kind of entry would be actively harmful, because a genuinely
     /// attached <c>Grid.*</c> reset added later would land in the same bucket and read as
-    /// already-triaged.
+    /// already-triaged. That is now mechanically enforced rather than merely described:
+    /// <c>PoolResetSetConsistencyTests.Excluded_Attached_Rows_Never_Name_An_Instance_Owner</c>
+    /// rejects any key here whose owner the classification list already covers, so re-adding one of
+    /// those rows — by hand or by a merge that reconciles this list against an older revision's —
+    /// fails the build instead of silently reverting the fix (#1066).
     /// </remarks>
     public static readonly IReadOnlyDictionary<string, string> DeliberatelyExcludedAttached =
         new Dictionary<string, string>(System.StringComparer.Ordinal)

--- a/tests/Reactor.Tests/AnalyzerTests/PoolResetSetConsistencyTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/PoolResetSetConsistencyTests.cs
@@ -302,7 +302,9 @@ class C
 
     /// <summary>
     /// No <c>DeliberatelyExcludedAttached</c> row may name an owner that
-    /// <see cref="InstancePropertyOwnerProbes"/> classifies per property.
+    /// <see cref="InstancePropertyOwnerProbes"/> classifies per property — and every key must stay
+    /// in the <c>Owner.Property</c> form both that check and the owner split in
+    /// <see cref="Attached_Reset_Scan_Sees_Every_Owner_The_Table_Names"/> read it as.
     /// </summary>
     /// <remarks>
     /// <para>
@@ -339,6 +341,35 @@ class C
     [Fact]
     public void Excluded_Attached_Rows_Never_Name_An_Instance_Owner()
     {
+        // Guard the join key before trusting a zero below. Both this check and the owner split in
+        // Attached_Reset_Scan_Sees_Every_Owner_The_Table_Names recover the owner as the text before
+        // the first '.', so a table re-keyed with qualified owners resolves every row to
+        // "Microsoft" and the membership assertion below reports zero offenders for all of them at
+        // once — including any a merge restored.
+        //
+        // MEASURED, re-keying one row to
+        // "Microsoft.UI.Xaml.Automation.AutomationProperties.DescribedBy": that is not silent
+        // overall — Every_Reset_Attached_Property_Is_Classified reports DescribedBy as being in
+        // neither table, and the scan test reports a missing owner "Microsoft" — but neither names
+        // the key shape, and the one check that would have caught a restored Grid.* row is exactly
+        // the one that goes quiet. So pin the spelling rather than let a green offender count stand
+        // in for a check that is no longer running.
+        var misshapen = ModifierTable.DeliberatelyExcludedAttached.Keys
+            .Where(key => key.Split('.').Length != 2
+                || key.StartsWith(".", StringComparison.Ordinal)
+                || key.EndsWith(".", StringComparison.Ordinal))
+            .ToList();
+
+        Assert.True(
+            misshapen.Count == 0,
+            "These ModifierTable.DeliberatelyExcludedAttached keys are not in 'Owner.Property' " +
+            $"form: [{string.Join(", ", misshapen)}]. The owner is recovered as the text before " +
+            "the first '.', so 'Microsoft.UI.Xaml.Automation.AutomationProperties.DescribedBy' " +
+            "resolves to owner 'Microsoft', matches no probe, and empties the offender list below " +
+            "for every row at once — including any a merge restored. Re-key the table in short " +
+            "form, or update this test and Attached_Reset_Scan_Sees_Every_Owner_The_Table_Names' " +
+            "owner splits together.");
+
         var offenders = ExclusionRowsOnInstanceOwners(ModifierTable.DeliberatelyExcludedAttached.Keys);
 
         Assert.True(
@@ -365,23 +396,32 @@ class C
     // which would wave both rows through.
     [InlineData("Grid.Row", true)]
     [InlineData("Control.IsTemplateFocusTarget", true)]
-    // …and the shape the list exists for, live in it today: an attached property whose owner is not
-    // an instance owner at all.
+    // Non-offenders, because none of these owners is classified per property at all.
+    // AutomationProperties.DescribedBy is a live DeliberatelyExcludedAttached row;
+    // ToolTipService.ToolTip and FlexPanel.Grow are mapped in AttachedProperties instead. Both
+    // sides of the attached split have to answer "false", since the predicate is owner membership
+    // and being attached is not what makes a row an offender.
     [InlineData("AutomationProperties.DescribedBy", false)]
     [InlineData("ToolTipService.ToolTip", false)]
     [InlineData("FlexPanel.Grow", false)]
+    // The spelling the key-shape assertion in the [Fact] above exists to reject, pinned here as a
+    // measurement rather than left as a claim in a comment: a qualified owner resolves to
+    // "Microsoft", matches no probe, and so the detector answers "not an offender" for a row that
+    // plainly is one. This row and that assertion are one guard in two halves — teaching the
+    // detector to split qualified names correctly should fail here, and should retire both.
+    [InlineData("Microsoft.UI.Xaml.Controls.Grid.Row", false)]
     public void Instance_Owner_Exclusion_Detector_Distinguishes_Offenders_From_Legitimate_Rows(
         string key, bool expectedOffender)
     {
         // The instrument check for the [Fact] above, which is absence-shaped over a three-row table
         // whose owners are currently disjoint from the probed ones — so it reports zero today and
-        // would report zero just as calmly if the join key stopped working. That is not
-        // hypothetical: the owner is recovered by splitting on the first '.', so re-keying
-        // DeliberatelyExcludedAttached with a qualified owner
-        // ("Microsoft.UI.Xaml.Automation.AutomationProperties.DescribedBy") yields "Microsoft",
-        // which matches no probe, and the invariant is silently switched off for every row at once.
-        // Driving the same detector with keys that must and must not match proves it can still
-        // answer both ways in the spelling the real table uses.
+        // would report zero just as calmly if the detector stopped discriminating. Driving that same
+        // detector with keys that must and must not match proves it can still answer both ways.
+        //
+        // This does NOT by itself make the [Fact] non-vacuous, and the division of labour matters:
+        // these keys are literals, so a re-keyed real table leaves every row here green. Detecting
+        // that is the [Fact]'s own 'Owner.Property' key-shape assertion; the qualified InlineData
+        // row above is what establishes that the spelling it rejects really does mis-answer.
         Assert.Equal(
             expectedOffender,
             ExclusionRowsOnInstanceOwners(new[] { key }).Count == 1);

--- a/tests/Reactor.Tests/AnalyzerTests/PoolResetSetConsistencyTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/PoolResetSetConsistencyTests.cs
@@ -300,6 +300,104 @@ class C
             "when it interrogates the type that owns the property being classified.");
     }
 
+    /// <summary>
+    /// No <c>DeliberatelyExcludedAttached</c> row may name an owner that
+    /// <see cref="InstancePropertyOwnerProbes"/> classifies per property.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The two tables answer different questions and a key in both is wrong in <em>either</em>
+    /// direction, which is why owner membership — not <see cref="IsAttachedReset"/> — is the
+    /// predicate. If the property has a static <c>Owner.SetPROP</c>, the probe calls it attached,
+    /// <c>REACTOR_POOL_001</c> can match a <c>.Set(...)</c> write to it, and it belongs in
+    /// <c>AttachedProperties</c> where the analyzer will use it. If it has none, the probe calls it
+    /// an instance DP, it never reaches the attached scan at all, and the row suppresses nothing.
+    /// </para>
+    /// <para>
+    /// The inert case is the dangerous one, because inert is not harmless: the row is a standing
+    /// allow-list entry for that owner, so a genuinely attached <c>Grid.*</c> reset added later
+    /// lands beside it and reads as already-triaged. <c>Grid.Padding</c>, <c>Grid.CornerRadius</c>
+    /// and <c>StackPanel.CornerRadius</c> sat in that list on <c>main</c> until #1015 removed them
+    /// in favour of classifying the owners (#1048), so this branch's list is a strict
+    /// <em>subset</em> of the older one — and a merge that reconciles the two by taking the other
+    /// side's rows restores all three. Git merges the file cleanly and nothing objects, which is
+    /// #1066.
+    /// </para>
+    /// <para>
+    /// MEASURED at <c>2b4385f7</c>, before this test existed: restoring <c>["Grid.Padding"]</c>
+    /// reddened exactly one test, <c>Attached_Reset_Scan_Sees_Every_Owner_The_Table_Names</c>
+    /// (this class plus <c>ModifierTableIntegrityTests</c> went 87/0 -> 86/1), and its message
+    /// reads "found no ClearValue at all for these owners: [Grid] … or
+    /// <c>ReadResetAttachedProperties</c>' regex no longer matches" — a true statement pointing at
+    /// the wrong repair. That neighbour also only fires while the probed owners happen to be
+    /// disjoint from the owners with attached clears; give <c>Grid</c> one attached clear in the
+    /// scanned block (the #1067 shape) and it goes quiet while the bogus row survives. This test
+    /// depends on neither coincidence, and was measured failing under <c>--filter</c> on its own
+    /// name so its verdict is not borrowed from that neighbour.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public void Excluded_Attached_Rows_Never_Name_An_Instance_Owner()
+    {
+        var offenders = ExclusionRowsOnInstanceOwners(ModifierTable.DeliberatelyExcludedAttached.Keys);
+
+        Assert.True(
+            offenders.Count == 0,
+            "These ModifierTable.DeliberatelyExcludedAttached rows name an owner that " +
+            $"InstancePropertyOwnerProbes already classifies per property: [{string.Join(", ", offenders)}]. " +
+            "Delete them. That list suppresses genuinely attached properties the " +
+            "'Owner.SetPROP(x, v)' rule cannot match, and neither thing a probed owner's property " +
+            "can be needs suppressing: if it declares the static setter it is matchable, so map it " +
+            "in ModifierTable.AttachedProperties instead; if it does not, it is an ordinary " +
+            "instance dependency property that never reaches the attached scan, so the row " +
+            "suppresses nothing and merely pre-approves the next genuinely attached reset added " +
+            "under the same owner.");
+    }
+
+    [Theory]
+    // The three rows #1015 deleted from main — the exact mutation #1066 reproduces.
+    [InlineData("Grid.Padding", true)]
+    [InlineData("Grid.CornerRadius", true)]
+    [InlineData("StackPanel.CornerRadius", true)]
+    // Attached, on a mixed owner, and still offenders: Grid.SetRow and
+    // Control.SetIsTemplateFocusTarget both exist, so the rule can match them and they belong in
+    // AttachedProperties. Pins that the predicate is owner membership rather than IsAttachedReset,
+    // which would wave both rows through.
+    [InlineData("Grid.Row", true)]
+    [InlineData("Control.IsTemplateFocusTarget", true)]
+    // …and the shape the list exists for, live in it today: an attached property whose owner is not
+    // an instance owner at all.
+    [InlineData("AutomationProperties.DescribedBy", false)]
+    [InlineData("ToolTipService.ToolTip", false)]
+    [InlineData("FlexPanel.Grow", false)]
+    public void Instance_Owner_Exclusion_Detector_Distinguishes_Offenders_From_Legitimate_Rows(
+        string key, bool expectedOffender)
+    {
+        // The instrument check for the [Fact] above, which is absence-shaped over a three-row table
+        // whose owners are currently disjoint from the probed ones — so it reports zero today and
+        // would report zero just as calmly if the join key stopped working. That is not
+        // hypothetical: the owner is recovered by splitting on the first '.', so re-keying
+        // DeliberatelyExcludedAttached with a qualified owner
+        // ("Microsoft.UI.Xaml.Automation.AutomationProperties.DescribedBy") yields "Microsoft",
+        // which matches no probe, and the invariant is silently switched off for every row at once.
+        // Driving the same detector with keys that must and must not match proves it can still
+        // answer both ways in the spelling the real table uses.
+        Assert.Equal(
+            expectedOffender,
+            ExclusionRowsOnInstanceOwners(new[] { key }).Count == 1);
+    }
+
+    /// <summary>
+    /// The <paramref name="keys"/> whose owner segment names an entry of
+    /// <see cref="InstancePropertyOwnerProbes"/>, in ordinal order.
+    /// </summary>
+    private static List<string> ExclusionRowsOnInstanceOwners(IEnumerable<string> keys) =>
+        keys.Where(key =>
+                key.IndexOf('.') > 0
+                && InstancePropertyOwnerProbes.ContainsKey(key.Substring(0, key.IndexOf('.'))))
+            .OrderBy(key => key, StringComparer.Ordinal)
+            .ToList();
+
     [Fact]
     public void Attached_Reset_Scan_Sees_Every_Owner_The_Table_Names()
     {
@@ -311,8 +409,11 @@ class C
             .Select(key => key.Substring(0, key.IndexOf('.')))
             .ToHashSet(StringComparer.Ordinal);
 
-        var expected = ModifierTable.AttachedProperties.Values
+        var mapped = ModifierTable.AttachedProperties.Values
             .Select(info => info.Owner)
+            .ToHashSet(StringComparer.Ordinal);
+
+        var expected = mapped
             .Concat(ModifierTable.DeliberatelyExcludedAttached.Keys
                 .Select(key => key.Substring(0, key.IndexOf('.'))))
             .Distinct(StringComparer.Ordinal)
@@ -321,12 +422,26 @@ class C
 
         var unseen = expected.Where(owner => !scanned.Contains(owner)).ToList();
 
+        // An owner reaching this list *only* through an exclusion row is a different failure with a
+        // different repair, and the sentence below would send its reader at the regex. That is the
+        // one shape this test is measured to catch before Excluded_Attached_Rows_Never_Name_An_
+        // Instance_Owner existed (see its remarks), so name the alternative rather than let the
+        // scan-drift wording stand as the only reading.
+        var exclusionOnly = unseen.Where(owner => !mapped.Contains(owner)).ToList();
+
         Assert.True(
             unseen.Count == 0,
             "The CleanElement attached-reset scan found no ClearValue at all for these owners: " +
             $"[{string.Join(", ", unseen)}]. Either the resets were removed (drop the table " +
             "entries) or ReadResetAttachedProperties' regex no longer matches how they are " +
-            "written in ElementPool.cs.");
+            "written in ElementPool.cs." +
+            (exclusionOnly.Count == 0
+                ? string.Empty
+                : $" Note: [{string.Join(", ", exclusionOnly)}] are named only by " +
+                  "ModifierTable.DeliberatelyExcludedAttached, never by AttachedProperties. If the " +
+                  "row was added to silence a classification failure rather than to suppress a " +
+                  "genuinely unmatchable attached property, the repair is to delete the row, not " +
+                  "to touch the scan — see Excluded_Attached_Rows_Never_Name_An_Instance_Owner."));
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #1066.

## What was wrong

`ModifierTable.DeliberatelyExcludedAttached` is a **suppression** list — genuinely attached properties `CleanElement` clears that the `Owner.SetPROP(x, v)` rule can't match. `PoolResetSetConsistencyTests.InstancePropertyOwnerProbes` is the **classification** input. A row whose owner appears in the probes is wrong in *both* directions:

- The owner declares a static `Owner.SetPROP` → the probe calls the property attached, the rule *can* match it, so it belongs in `AttachedProperties`, not the suppression list.
- It doesn't → the probe calls it an instance DP, it never reaches the attached scan, and the row is inert-but-harmful: a standing allow-list entry that pre-approves a future genuinely-attached reset on that owner.

`main` carried exactly this shape (`Grid.Padding`, `Grid.CornerRadius`, `StackPanel.CornerRadius`) until it was cleaned up. The current list is a strict **subset** of the older one, so a merge that reconciles by taking the other side's rows restores the misclassification and builds green.

## Correcting the issue's premise

The issue was measured at `89f2bdd2`, before #1099 replaced the bare `InstancePropertyOwners` set with the per-property `InstancePropertyOwnerProbes` map. I re-measured rather than assuming: **the mutation is not fully silent today.** Restoring `["Grid.Padding"]` reddens exactly one test.

| | `PoolResetSetConsistencyTests` + `ModifierTableIntegrityTests` |
|---|---|
| baseline | 87 passed, 0 failed |
| `["Grid.Padding"]` restored | 86 passed, **1 failed** — `Attached_Reset_Scan_Sees_Every_Owner_The_Table_Names` |

But that coverage is incidental and points at the wrong repair. Its message reads:

> The `CleanElement` attached-reset scan found no `ClearValue` at all for these owners: `[Grid]`. Either the resets were removed (drop the table entries) or `ReadResetAttachedProperties`' regex no longer matches how they are written in `ElementPool.cs`.

Both suggested repairs are wrong — the row is the defect. And it only fires while the 8 probed owners happen to be **disjoint** from the owners with attached clears in the scanned block (`{AutomationProperties, TitleBar, ToolTipService, FlexPanel}`). Give `Grid` one attached clear there — the #1067 shape — and the neighbour goes quiet while the bogus row survives. So the gate is still warranted; it just isn't closing a total blind spot.

## What this adds

`Excluded_Attached_Rows_Never_Name_An_Instance_Owner` over the real table, naming the offending keys and the actual remedy. Owner **membership** is the predicate rather than `IsAttachedReset`, since a row on a probed owner is wrong either way — and membership also correctly rejects `["Grid.Row"]`, which `IsAttachedReset` would wave through.

Plus a positive-control `[Theory]` driving the same detector, and a key-shape assertion inside the `[Fact]` itself (see the review section below for why that second half is load-bearing).

Also appends a conditional clause to `Attached_Reset_Scan_Sees_Every_Owner_The_Table_Names` — emitted only when an unseen owner is contributed *solely* by a `DeliberatelyExcludedAttached` key — so the two failures don't argue with each other during merge triage. And one line in the `DeliberatelyExcludedAttached` remarks recording that the rule is now enforced rather than described.

## Second commit: what the PR review caught

I ran the repo's `pr-review` skill on the first commit. The multi-model cross-check and the correctness pass independently landed on the same defect, and it was a real one — **the first draft's positive control did not guard the hazard its own comment claimed it guarded.**

The `[Fact]` is absence-shaped over a join key recovered by `key.Substring(0, key.IndexOf('.'))`. The comment argued that re-keying the table with a qualified owner (`Microsoft.UI.Xaml.Automation.AutomationProperties.DescribedBy` → `"Microsoft"`) would match no probe and switch the invariant off for every row at once. True — but the `[Theory]` drives the detector with *hardcoded short-form literals*, so it stays green through exactly that mutation. The control demonstrated the detector worked; it did nothing to establish the real table still spoke the detector's language. I'd written the hazard down and then not closed it.

Fixed by pinning the key shape in the `[Fact]` itself, so the gate is self-guarding rather than dependent on a spelling nobody asserts, plus a qualified-owner theory row so the mis-answer is a measurement rather than a claim in a comment.

Measuring the re-key then corrected a second overclaim of mine. It is **not** globally silent — three tests fail:

| test | message |
|---|---|
| `Every_Reset_Attached_Property_Is_Classified` | `DescribedBy` is "in neither table" |
| `Attached_Reset_Scan_Sees_Every_Owner_The_Table_Names` | missing owner `[Microsoft]` — and the new Note clause correctly names the exclusion list |
| the new key-shape assertion | names the key shape and the two owner splits to keep in sync |

So the assertion message now makes the narrower true claim: the one check that would catch a restored `Grid.*` row is exactly the one that goes quiet.

The review also caught a plain factual error — the comment introducing the three `false` theory rows called them all live exclusion rows, but only `AutomationProperties.DescribedBy` is; `ToolTipService.ToolTip` and `FlexPanel.Grow` are in `AttachedProperties`.

One finding I **rejected**: that "fails the build" in the `ModifierTable` remarks overclaims for a test-enforced invariant. `AdvancedInternalSurfaceTests.cs:26` uses the identical phrase for the identical kind of gate, and `ci.yml` runs `Reactor.Tests` as a required step — so it's repo convention, and changing it would be churn. The cross-check adjudicated the same way.

## Evidence

Every assertion was mutation-checked; none is vacuous.

- **Gate**: with `["Grid.Padding"]` restored and `--filter` naming *only* the new test — so the verdict isn't borrowed from the neighbour — it fails naming `[Grid.Padding]` with the correct remedy. Re-confirmed after the second commit's edits.
- **Key shape**: re-keying a row to the qualified form fails it naming the offending key.
- **Detector**: replacing the `ContainsKey(...)` clause with `false` reddens all 5 offender rows and leaves the legitimate rows green.
- Affected classes: **97 passed**.
- Full unit suite: **13299 passed, 64 skipped, 0 failed**.
- Release build of the changed projects: **0 warnings, 0 errors** (`TreatWarningsAsErrors` is Release-only, so this is what proves the new XML doc crefs resolve).

Full-solution `-c Release` couldn't complete on my machine — 4 `NU1301` **restore** failures for `Reactor.VsExtension` ×3 and `Reactor.Compile.Analyzer.Tests`, none of them touched here, all network-unreachability at restore time. **CI has since covered that gap**: 22 check runs against `74fa680c`, 19 success + 3 skipped, 0 failures — including `Build solution`, `Unit Tests`, `Selftests`, `E2E Tests (winapp ui)`, `AOT Trim Proof` and `Docs build`. Build metrics show every artifact delta at 0 B, and merged coverage is 85.84% → 85.87%.

## Scope

Test-only plus a doc comment; no product behaviour changes. No new `REACTOR_*` diagnostic, so no `AnalyzerReleases.Unshipped.md` row, no `mur check` rule, no API index regeneration, no docs recompile.

#1048 remains open and is complementary — it asks for a *content* oracle over the exclusion **reason** text, which this doesn't touch.
