### PR TITLE
Select the newest Reactor.xml for doc reference generation

### DIFF
--- a/docs/contributing/doc-pipeline.md
+++ b/docs/contributing/doc-pipeline.md
@@ -152,7 +152,11 @@ compiler emits, so it needs a *built* `src/Reactor`. It reads the **most recentl
 written** `Reactor.xml` anywhere under `src/Reactor/bin` — configuration plays no
 part in the choice, and neither does the directory layout, so flat
 `bin/<config>/<tfm>/`, platform-stamped `bin/<arch>/<config>/<tfm>/` and
-RID-nested publish outputs are all candidates.
+RID-nested publish outputs are all candidates. The one thing it won't descend
+into is a junction or symlink *nested* inside `bin`: what's behind one isn't this
+build's output, and a link pointing back at an ancestor would loop. Redirecting
+`bin` itself is fine — the exclusion applies to what the walk finds, not to where
+it starts.
 
 It prints what it picked:
 
@@ -175,9 +179,19 @@ separately: the phase compares the chosen XML against the newest `.cs` under
 with [`REACTOR_DOC_REFGEN_W002`](#6-snippet--image--diagram-error-codes) when the
 source is newer. Run `dotnet build src/Reactor` and compile again.
 
-If no `Reactor.xml` exists at all the phase prints `(Reactor.xml not found — run
-dotnet build src/Reactor first)` and skips reference generation rather than
-failing, which is what CI does on a clean checkout.
+If no `Reactor.xml` exists at all the phase skips reference generation rather
+than failing, printing:
+
+```
+  (Reactor.xml not found — run `dotnet build src/Reactor` first)
+```
+
+CI does build it. The `docs-build` job runs `docs compile --no-screenshots --ci`
+*without* `--no-build`, so Phase 2 builds every doc app, each of which
+`ProjectReference`s `src/Reactor/Reactor.csproj` — reference generation therefore
+runs for real on every PR. `REACTOR_DOC_REFGEN_W002` still stays quiet there, for
+an ordering reason rather than a missing-build one: `actions/checkout` writes the
+sources before that build runs, so the emitted XML always postdates every `.cs`.
 
 [i1068]: https://github.com/microsoft/microsoft-ui-reactor/issues/1068
 
@@ -421,7 +435,7 @@ reference-generation codes.
 | `REACTOR_DOC_SHOT_002`     | Manifest screenshot id ends in the reserved `-thumb` suffix without `kind: catalog-thumb`. Matched against the whole id, so a dotted id (`widget.v2-thumb`) is caught too |
 | `REACTOR_DOC_REGISTRY_W001`| Registry rule maps to a category with no `guide-pages`     |
 | `REACTOR_DOC_REGISTRY_W002`| Registry-declared guide page has no inbound `<!-- ref:Member -->` marker (doc-coverage gate, spec [041 §5.3](../specs/041-docs-comprehensive-uplift.md)) |
-| `REACTOR_DOC_REFGEN_W002`  | *(warning — does **not** fail `--ci`)* The `Reactor.xml` the reference phase selected is older than the newest `.cs` under `src/Reactor`, so `docs/guide/reference/**` is being generated from a build that predates the source it documents — an edited `<summary>` will not appear and a deleted one comes back. Run `dotnet build src/Reactor` and compile again. Warning, not error, because it reports that the *input* may be stale rather than a defect in the tree: CI compiles on a clean checkout with no `src/Reactor` build at all, so this never fires there. See [§4](#which-reactorxml-the-reference-phase-reads) |
+| `REACTOR_DOC_REFGEN_W002`  | *(warning — does **not** fail `--ci`)* The `Reactor.xml` the reference phase selected is older than the newest `.cs` under `src/Reactor`, so `docs/guide/reference/**` is being generated from a build that predates the source it documents — an edited `<summary>` will not appear and a deleted one comes back. Run `dotnet build src/Reactor` and compile again. Warning, not error, because it reports that the *input* may be stale rather than a defect in the tree. It does not fire in CI: the docs job builds `src/Reactor` (via Phase 2's doc-app builds) *after* checkout has written the sources, so the XML always postdates them. See [§4](#which-reactorxml-the-reference-phase-reads) |
 
 ## 7. Quarterly tier audit (spec 041 §5.4)
 

--- a/docs/contributing/doc-pipeline.md
+++ b/docs/contributing/doc-pipeline.md
@@ -145,6 +145,42 @@ mur docs render-diagrams --topic architecture-overview
 mur docs new-diagram architecture-overview overview
 ```
 
+### Which `Reactor.xml` the reference phase reads
+
+Phase 5.7 generates `docs/guide/reference/**` from the XML doc comments the C#
+compiler emits, so it needs a *built* `src/Reactor`. It reads the **most recently
+written** `Reactor.xml` anywhere under `src/Reactor/bin` — configuration plays no
+part in the choice, and neither does the directory layout, so flat
+`bin/<config>/<tfm>/`, platform-stamped `bin/<arch>/<config>/<tfm>/` and
+RID-nested publish outputs are all candidates.
+
+It prints what it picked:
+
+```
+═══ Phase 5.7: Reference ═══
+  XML: src/Reactor/bin/x64/Release/net10.0-windows10.0.22621.0/Reactor.xml (2026-08-01T19:45:14Z, newest of 3 candidate(s))
+```
+
+Read that line if a regenerated reference page disagrees with the source you just
+edited. Until [issue #1068][i1068] this phase took the first hit of a fixed
+`Debug`-then-`Release` sweep, so a months-old Debug build quietly beat a
+just-built Release one and the generator rewrote pages from it — reintroducing a
+sentence the commit had deleted — while exiting 0.
+
+Selecting the newest build does not make the newest build *fresh*. If you edit a
+`<summary>` and don't rebuild, every candidate predates your source and the
+regenerated page is wrong in exactly the same way. That case is caught
+separately: the phase compares the chosen XML against the newest `.cs` under
+`src/Reactor` (ignoring `bin`/`obj`, which the build writes itself) and warns
+with [`REACTOR_DOC_REFGEN_W002`](#6-snippet--image--diagram-error-codes) when the
+source is newer. Run `dotnet build src/Reactor` and compile again.
+
+If no `Reactor.xml` exists at all the phase prints `(Reactor.xml not found — run
+dotnet build src/Reactor first)` and skips reference generation rather than
+failing, which is what CI does on a clean checkout.
+
+[i1068]: https://github.com/microsoft/microsoft-ui-reactor/issues/1068
+
 ### Screenshots and committed images
 
 Phase 3 (capture) is the **only** phase that writes a screenshot — the only
@@ -385,6 +421,7 @@ reference-generation codes.
 | `REACTOR_DOC_SHOT_002`     | Manifest screenshot id ends in the reserved `-thumb` suffix without `kind: catalog-thumb`. Matched against the whole id, so a dotted id (`widget.v2-thumb`) is caught too |
 | `REACTOR_DOC_REGISTRY_W001`| Registry rule maps to a category with no `guide-pages`     |
 | `REACTOR_DOC_REGISTRY_W002`| Registry-declared guide page has no inbound `<!-- ref:Member -->` marker (doc-coverage gate, spec [041 §5.3](../specs/041-docs-comprehensive-uplift.md)) |
+| `REACTOR_DOC_REFGEN_W002`  | *(warning — does **not** fail `--ci`)* The `Reactor.xml` the reference phase selected is older than the newest `.cs` under `src/Reactor`, so `docs/guide/reference/**` is being generated from a build that predates the source it documents — an edited `<summary>` will not appear and a deleted one comes back. Run `dotnet build src/Reactor` and compile again. Warning, not error, because it reports that the *input* may be stale rather than a defect in the tree: CI compiles on a clean checkout with no `src/Reactor` build at all, so this never fires there. See [§4](#which-reactorxml-the-reference-phase-reads) |
 
 ## 7. Quarterly tier audit (spec 041 §5.4)
 

--- a/src/Reactor.Cli/Docs/CompileCommand.cs
+++ b/src/Reactor.Cli/Docs/CompileCommand.cs
@@ -995,6 +995,13 @@ internal static partial class CompileCommand
             .FirstOrDefault();
 
     /// <summary>
+    /// What <see cref="EnumerationOptions"/> skips by default. Named so the two
+    /// recursive walks below can add <see cref="FileAttributes.ReparsePoint"/>
+    /// to it without silently dropping the default.
+    /// </summary>
+    private const FileAttributes DefaultSkip = FileAttributes.Hidden | FileAttributes.System;
+
+    /// <summary>
     /// Every <c>Reactor.xml</c> under <c>src/Reactor/bin</c>, at any depth.
     /// </summary>
     /// <remarks>
@@ -1026,6 +1033,14 @@ internal static partial class CompileCommand
             // A locked or permission-denied subtree is not this command's
             // business; skipping it beats aborting reference generation.
             IgnoreInaccessible = true,
+            // Don't descend through junctions/symlinks. Two reasons: a nested
+            // reparse point can point anywhere, so a candidate found through
+            // one isn't this build's output at all; and a loop (bin/x -> bin)
+            // has no cycle detection in the runtime's walker, so it recurses
+            // until the path length gives out. Skipping applies to entries the
+            // walk discovers, not to the root — a `bin` that is itself a
+            // junction still enumerates normally.
+            AttributesToSkip = DefaultSkip | FileAttributes.ReparsePoint,
         });
     }
 
@@ -1046,9 +1061,19 @@ internal static partial class CompileCommand
     /// <para>
     /// Warning severity, deliberately. The pages this produces are internally
     /// consistent with the build they came from — the claim is "your input may
-    /// predate your source", which an author can act on and CI cannot. The CI
-    /// docs job compiles on a clean checkout with no <c>src/Reactor</c> build
-    /// at all, so selection returns <c>null</c> there and this never runs.
+    /// predate your source", which an author can act on and CI cannot.
+    /// </para>
+    /// <para>
+    /// It stays quiet in CI, but not for the reason it might appear: the docs
+    /// job does build <c>src/Reactor</c>. It runs
+    /// <c>docs compile --no-screenshots --ci</c> without <c>--no-build</c>
+    /// (<c>.github/workflows/ci.yml</c>, <c>docs-build</c>), so Phase 2 builds
+    /// every doc app, and each one <c>ProjectReference</c>s
+    /// <c>src/Reactor/Reactor.csproj</c> — which sets
+    /// <c>GenerateDocumentationFile</c>. Phase 5.7 therefore finds a real
+    /// <c>Reactor.xml</c> and generates pages. What makes the warning quiet is
+    /// the ordering: <c>actions/checkout</c> writes the sources before that
+    /// build runs, so the emitted XML always postdates every <c>.cs</c>.
     /// </para>
     /// <para>
     /// Strict comparison, no grace window: a build writes its XML after
@@ -1096,6 +1121,9 @@ internal static partial class CompileCommand
         {
             RecurseSubdirectories = true,
             IgnoreInaccessible = true,
+            // Same reasoning as the candidate walk: don't follow nested
+            // junctions/symlinks out of the tree, and don't risk a cycle.
+            AttributesToSkip = DefaultSkip | FileAttributes.ReparsePoint,
         }))
         {
             if (IsUnderBuildOutput(srcDir, file)) continue;

--- a/src/Reactor.Cli/Docs/CompileCommand.cs
+++ b/src/Reactor.Cli/Docs/CompileCommand.cs
@@ -826,10 +826,10 @@ internal static partial class CompileCommand
     }
 
     /// <summary>
-    /// Locate the freshly-built <c>Reactor.xml</c> (preferring Debug, then
-    /// Release) and run the reference generator restricted to the Hooks
-    /// category. Returns <c>null</c> when the XML doc file isn't on disk
-    /// yet — typical on first compile before <c>dotnet build src/Reactor</c>
+    /// Locate the most recently built <c>Reactor.xml</c> (see
+    /// <see cref="FindReactorXml"/>) and run the reference generator restricted
+    /// to the Hooks category. Returns <c>null</c> when the XML doc file isn't on
+    /// disk yet — typical on first compile before <c>dotnet build src/Reactor</c>
     /// has run. The caller can decide whether to surface that as a warning;
     /// for Phase 1B it's silent because the unit tests are the canonical
     /// surface.
@@ -857,12 +857,24 @@ internal static partial class CompileCommand
                     TierLintSeverity.Error) });
         }
 
-        var xmlPath = FindReactorXml(repoRoot);
-        if (xmlPath is null)
+        var choice = FindReactorXml(repoRoot);
+        if (choice is null)
         {
             Console.WriteLine("  (Reactor.xml not found — run `dotnet build src/Reactor` first)");
             return null;
         }
+
+        // Issue #1068: name the input. Selection used to be by configuration
+        // order, so a stale Debug build silently won over a fresh Release one
+        // and the regenerated pages looked like a legitimate diff. Newest-wins
+        // fixes the choice; printing it is what makes a future recurrence
+        // diagnosable instead of invisible.
+        var xmlPath = choice.Value.Path;
+        Console.WriteLine(
+            $"  XML: {Rel(repoRoot, xmlPath)} " +
+            $"({Stamp(choice.Value.WriteUtc)}, newest of {choice.Value.CandidateCount} candidate(s))");
+
+        var staleFinding = BuildStaleXmlFinding(repoRoot, xmlPath);
 
         var generator = new ReferenceGen.ReferenceGenerator();
         var result = generator.Generate(
@@ -906,51 +918,224 @@ internal static partial class CompileCommand
         injectionFindings.AddRange(ReferenceLinkInjector.LintOrphanedGuidePages(
             declaredGuidePages, templateIds, reverseIndex));
 
-        // Merge findings; the injector findings join the generator's.
+        // Merge findings; the injector findings join the generator's, and the
+        // stale-input warning (issue #1068) joins both. It is a warning, so the
+        // caller prints it and `--ci` does not fail on it: it reports that the
+        // input *may* predate source, which is a local-loop hazard rather than
+        // a defect in the emitted pages.
         var combined = new ReferenceGen.ReferenceGenResult(
             injectedPages,
-            result.Findings.Concat(injectionFindings).ToList());
+            result.Findings
+                .Concat(injectionFindings)
+                .Concat(staleFinding is null
+                    ? Array.Empty<ReferenceGen.RefGenFinding>()
+                    : new[] { staleFinding })
+                .ToList());
 
         // Write pages to disk so authors and lints can see the output.
         generator.WriteToDisk(combined, outputDir);
         return combined;
     }
 
-    private static string? FindReactorXml(string repoRoot)
+    /// <summary>
+    /// The <c>Reactor.xml</c> the reference generator reads, together with the
+    /// facts the operator needs to judge it: when it was written, and how many
+    /// candidates it beat. <c>null</c> when <c>bin</c> is absent or holds no
+    /// such file.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Issue #1068. This used to sweep <c>Debug</c> then <c>Release</c> and
+    /// return the first hit. A leftover Debug build therefore shadowed a
+    /// freshly-built Release one, and the generator rewrote
+    /// <c>docs/guide/reference/**</c> from stale input while exiting 0 — the
+    /// observed symptom being a generated page reintroducing a sentence the
+    /// commit had just deleted from source. Configuration order carries no
+    /// information about freshness, so it is not used at all now.
+    /// </para>
+    /// <para>
+    /// Returning the timestamp and count rather than just the path is what lets
+    /// the caller print the choice without walking <c>bin</c> a second time.
+    /// </para>
+    /// </remarks>
+    internal static (string Path, DateTime WriteUtc, int CandidateCount)? FindReactorXml(string repoRoot)
+    {
+        var candidates = EnumerateReactorXmlCandidates(repoRoot).ToList();
+        var chosen = SelectNewest(candidates);
+        return chosen is null
+            ? null
+            : (chosen, File.GetLastWriteTimeUtc(chosen), candidates.Count);
+    }
+
+    /// <summary>
+    /// The freshness rule itself, split from discovery so it can be measured:
+    /// the newest candidate by last-write time, ties broken on the ordinal
+    /// path.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Ties break on the path so two candidates stamped the same instant still
+    /// resolve to the same file on every run. Last-write ordering alone would
+    /// leave that choice to enumeration order, which the filesystem does not
+    /// promise to keep stable.
+    /// </para>
+    /// <para>
+    /// Taking the sequence as a parameter is what makes that tie-break testable
+    /// at all. Fused with the directory walk it is not: a caller cannot choose
+    /// the enumeration order, so a fixture cannot tell "sorted deterministically"
+    /// apart from "arrived in that order" — a test written that way stayed green
+    /// with the <c>ThenBy</c> deleted. Here both orderings are the caller's to
+    /// pick.
+    /// </para>
+    /// </remarks>
+    internal static string? SelectNewest(IEnumerable<string> candidates) =>
+        candidates
+            .OrderByDescending(File.GetLastWriteTimeUtc)
+            .ThenBy(p => p, StringComparer.Ordinal)
+            .FirstOrDefault();
+
+    /// <summary>
+    /// Every <c>Reactor.xml</c> under <c>src/Reactor/bin</c>, at any depth.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Recursive by design. The previous enumeration hard-coded two shapes
+    /// (<c>bin/&lt;config&gt;/&lt;tfm&gt;/</c> and
+    /// <c>bin/&lt;arch&gt;/&lt;config&gt;/&lt;tfm&gt;/</c>) and an arch
+    /// allow-list of <c>x64</c>/<c>ARM64</c>, so any layout outside that set —
+    /// a RID-nested publish output, a future architecture — was invisible.
+    /// That is the same failure mode as the bug this fixes: an incomplete
+    /// enumeration producing a confident answer.
+    /// </para>
+    /// <para>
+    /// Widening to every depth means a copy inside a publish or packaging
+    /// output is now a candidate. That is safe rather than merely tolerable:
+    /// both MSBuild's <c>Copy</c> task and <see cref="File.Copy(string,string)"/>
+    /// preserve the source's last-write time, so a copy carries its origin
+    /// build's timestamp and can only win when that build would have won.
+    /// </para>
+    /// </remarks>
+    internal static IEnumerable<string> EnumerateReactorXmlCandidates(string repoRoot)
     {
         var binDir = Path.Combine(repoRoot, "src", "Reactor", "bin");
-        if (!Directory.Exists(binDir)) return null;
+        if (!Directory.Exists(binDir)) return Array.Empty<string>();
 
-        foreach (var config in new[] { "Debug", "Release" })
+        return Directory.EnumerateFiles(binDir, "Reactor.xml", new EnumerationOptions
         {
-            // Walk the standard bin layout: bin/<config>/<tfm>/Reactor.xml
-            // and the platform-stamped variants bin/<arch>/<config>/<tfm>/Reactor.xml.
-            foreach (var candidate in EnumerateCandidates(binDir, config))
+            RecurseSubdirectories = true,
+            // A locked or permission-denied subtree is not this command's
+            // business; skipping it beats aborting reference generation.
+            IgnoreInaccessible = true,
+        });
+    }
+
+    /// <summary>
+    /// Warn when the selected <c>Reactor.xml</c> predates the newest C# source
+    /// under <c>src/Reactor</c>. Returns <c>null</c> when the XML is at least
+    /// as new as every source file.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Newest-wins fixes the *choice* between builds but not the case where
+    /// every build is stale — source edited, nothing rebuilt — which produces
+    /// exactly the same wrong output: pages regenerated from an XML that no
+    /// longer reflects the summaries in source. Comparing against source is
+    /// what closes that residue; comparing candidates against each other
+    /// cannot, because the winner is the newest candidate by construction.
+    /// </para>
+    /// <para>
+    /// Warning severity, deliberately. The pages this produces are internally
+    /// consistent with the build they came from — the claim is "your input may
+    /// predate your source", which an author can act on and CI cannot. The CI
+    /// docs job compiles on a clean checkout with no <c>src/Reactor</c> build
+    /// at all, so selection returns <c>null</c> there and this never runs.
+    /// </para>
+    /// <para>
+    /// Strict comparison, no grace window: a build writes its XML after
+    /// compiling its inputs, so a source file stamped after the XML genuinely
+    /// postdates the build.
+    /// </para>
+    /// </remarks>
+    internal static ReferenceGen.RefGenFinding? BuildStaleXmlFinding(string repoRoot, string xmlPath)
+    {
+        var newest = FindNewestReactorSource(repoRoot);
+        if (newest is null) return null;
+
+        var xmlUtc = File.GetLastWriteTimeUtc(xmlPath);
+        var (sourcePath, sourceUtc) = newest.Value;
+        if (sourceUtc <= xmlUtc) return null;
+
+        return new ReferenceGen.RefGenFinding(
+            "REACTOR_DOC_REFGEN_W002",
+            $"Reactor.xml ({Stamp(xmlUtc)}) predates {Rel(repoRoot, sourcePath)} ({Stamp(sourceUtc)}) — " +
+            "the reference pages under docs/guide/reference/ are being generated from a build that " +
+            "is older than the source it documents, so an edited <summary> will not appear (and a " +
+            "deleted one will come back). Run `dotnet build src/Reactor` and re-run this command.",
+            Rel(repoRoot, xmlPath),
+            TierLintSeverity.Warning);
+    }
+
+    /// <summary>
+    /// The newest C# file under <c>src/Reactor</c>, ignoring build output.
+    /// Returns <c>null</c> when the directory is absent or holds no sources.
+    /// </summary>
+    /// <remarks>
+    /// <c>bin</c> and <c>obj</c> are excluded because they are *written by* the
+    /// build whose age is being questioned: a generated <c>.g.cs</c> under
+    /// <c>obj</c> is always newer than the XML emitted moments later in the
+    /// same build, so including them would fire the warning after every
+    /// successful build and train readers to ignore it.
+    /// </remarks>
+    internal static (string Path, DateTime WriteUtc)? FindNewestReactorSource(string repoRoot)
+    {
+        var srcDir = Path.Combine(repoRoot, "src", "Reactor");
+        if (!Directory.Exists(srcDir)) return null;
+
+        (string Path, DateTime WriteUtc)? newest = null;
+        foreach (var file in Directory.EnumerateFiles(srcDir, "*.cs", new EnumerationOptions
+        {
+            RecurseSubdirectories = true,
+            IgnoreInaccessible = true,
+        }))
+        {
+            if (IsUnderBuildOutput(srcDir, file)) continue;
+            var writeUtc = File.GetLastWriteTimeUtc(file);
+            if (newest is null || writeUtc > newest.Value.WriteUtc)
+                newest = (file, writeUtc);
+        }
+        return newest;
+    }
+
+    /// <summary>
+    /// True when <paramref name="file"/> sits under a <c>bin</c> or <c>obj</c>
+    /// directory somewhere below <paramref name="root"/>.
+    /// </summary>
+    /// <remarks>
+    /// Matched on path *segments* below the root rather than with a substring
+    /// test, so a source directory whose name merely contains "bin" (or a repo
+    /// checked out under one) is not swept up with the build output.
+    /// </remarks>
+    private static bool IsUnderBuildOutput(string root, string file)
+    {
+        var rel = Path.GetRelativePath(root, file);
+        foreach (var segment in rel.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar))
+        {
+            if (segment.Equals("bin", StringComparison.OrdinalIgnoreCase) ||
+                segment.Equals("obj", StringComparison.OrdinalIgnoreCase))
             {
-                if (File.Exists(candidate)) return candidate;
+                return true;
             }
         }
-        return null;
+        return false;
     }
 
-    private static IEnumerable<string> EnumerateCandidates(string binDir, string config)
-    {
-        // Flat layout: bin/<config>/<tfm>/Reactor.xml
-        var configRoot = Path.Combine(binDir, config);
-        if (Directory.Exists(configRoot))
-        {
-            foreach (var tfm in Directory.GetDirectories(configRoot))
-                yield return Path.Combine(tfm, "Reactor.xml");
-        }
-        // Platform-stamped: bin/<arch>/<config>/<tfm>/Reactor.xml
-        foreach (var arch in new[] { "x64", "ARM64" })
-        {
-            var archConfigRoot = Path.Combine(binDir, arch, config);
-            if (!Directory.Exists(archConfigRoot)) continue;
-            foreach (var tfm in Directory.GetDirectories(archConfigRoot))
-                yield return Path.Combine(tfm, "Reactor.xml");
-        }
-    }
+    /// <summary>Repo-relative, forward-slashed path for operator-facing output.</summary>
+    private static string Rel(string repoRoot, string path) =>
+        Path.GetRelativePath(repoRoot, path).Replace('\\', '/');
+
+    /// <summary>Fixed-width UTC stamp so two of these can be compared by eye.</summary>
+    private static string Stamp(DateTime utc) =>
+        utc.ToString("yyyy-MM-ddTHH:mm:ssZ", global::System.Globalization.CultureInfo.InvariantCulture);
 
     // Normalize emitted Markdown to the host's native line endings. The
     // assembler concatenates template + snippet text with `\n` regardless of

--- a/src/Reactor.Cli/Docs/CompileCommand.cs
+++ b/src/Reactor.Cli/Docs/CompileCommand.cs
@@ -1105,33 +1105,43 @@ internal static partial class CompileCommand
     /// Returns <c>null</c> when the directory is absent or holds no sources.
     /// </summary>
     /// <remarks>
+    /// Shares <see cref="SelectNewest"/> with candidate selection rather than
+    /// carrying its own max loop, so both get the same ordinal tie-break. That
+    /// matters more here than it looks: a fresh <c>git clone</c> or
+    /// <c>actions/checkout</c> stamps every file it writes at essentially the
+    /// same instant, so ties are the normal case rather than the exotic one,
+    /// and a plain "strictly newer wins" scan would let enumeration order pick
+    /// which file <c>REACTOR_DOC_REFGEN_W002</c> names.
+    /// </remarks>
+    internal static (string Path, DateTime WriteUtc)? FindNewestReactorSource(string repoRoot)
+    {
+        var chosen = SelectNewest(EnumerateReactorSources(repoRoot));
+        return chosen is null ? null : (chosen, File.GetLastWriteTimeUtc(chosen));
+    }
+
+    /// <summary>
+    /// Every <c>.cs</c> file under <c>src/Reactor</c> that is actually source.
+    /// </summary>
+    /// <remarks>
     /// <c>bin</c> and <c>obj</c> are excluded because they are *written by* the
     /// build whose age is being questioned: a generated <c>.g.cs</c> under
     /// <c>obj</c> is always newer than the XML emitted moments later in the
     /// same build, so including them would fire the warning after every
     /// successful build and train readers to ignore it.
     /// </remarks>
-    internal static (string Path, DateTime WriteUtc)? FindNewestReactorSource(string repoRoot)
+    internal static IEnumerable<string> EnumerateReactorSources(string repoRoot)
     {
         var srcDir = Path.Combine(repoRoot, "src", "Reactor");
-        if (!Directory.Exists(srcDir)) return null;
+        if (!Directory.Exists(srcDir)) return Array.Empty<string>();
 
-        (string Path, DateTime WriteUtc)? newest = null;
-        foreach (var file in Directory.EnumerateFiles(srcDir, "*.cs", new EnumerationOptions
+        return Directory.EnumerateFiles(srcDir, "*.cs", new EnumerationOptions
         {
             RecurseSubdirectories = true,
             IgnoreInaccessible = true,
             // Same reasoning as the candidate walk: don't follow nested
             // junctions/symlinks out of the tree, and don't risk a cycle.
             AttributesToSkip = DefaultSkip | FileAttributes.ReparsePoint,
-        }))
-        {
-            if (IsUnderBuildOutput(srcDir, file)) continue;
-            var writeUtc = File.GetLastWriteTimeUtc(file);
-            if (newest is null || writeUtc > newest.Value.WriteUtc)
-                newest = (file, writeUtc);
-        }
-        return newest;
+        }).Where(f => !IsUnderBuildOutput(srcDir, f));
     }
 
     /// <summary>

--- a/tests/Reactor.DocPipeline.Tests/ReactorXmlSelectionTests.cs
+++ b/tests/Reactor.DocPipeline.Tests/ReactorXmlSelectionTests.cs
@@ -54,6 +54,13 @@ namespace Microsoft.UI.Reactor.Cli.Docs.Tests;
 ///     <description><see cref="A_junction_nested_in_bin_is_not_followed_out_of_the_tree"/>.
 ///     Added after that mutation came back green — the hardening had shipped
 ///     with nothing pinning it.</description></item>
+///   <item><term>Give the source scan its own first-wins max loop again</term>
+///     <description><see cref="Equally_stamped_sources_resolve_to_the_same_one_either_way"/>
+///     — but only with filenames whose enumeration and ordinal orders disagree;
+///     see that test's note.</description></item>
+///   <item><term>Drop the bin/obj filter from source enumeration</term>
+///     <description><see cref="Source_enumeration_omits_build_output"/> and
+///     <see cref="Build_output_under_src_Reactor_does_not_count_as_source"/>.</description></item>
 /// </list>
 /// <para>
 /// These all drive the helpers directly. What they cannot show is that Phase
@@ -423,6 +430,68 @@ public class ReactorXmlSelectionTests
         var xml = fx.Xml("x64/Release/net10.0-windows10.0.22621.0", Base);
 
         Assert.Null(CompileCommand.BuildStaleXmlFinding(fx.Root, xml));
+    }
+
+    /// <summary>
+    /// Ties among source files are the normal case, not the exotic one: a fresh
+    /// clone or <c>actions/checkout</c> stamps everything it writes at
+    /// essentially one instant. The file the warning names must therefore not
+    /// be whichever the directory walk happened to reach first.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Driven through <see cref="CompileCommand.SelectNewest"/> in both input
+    /// orders for the same reason the candidate tie-break is
+    /// (<see cref="Equal_timestamps_break_on_the_ordinal_path"/>): a fixture
+    /// cannot choose enumeration order, so going through
+    /// <c>FindNewestReactorSource</c> alone could not tell a deterministic sort
+    /// from a lucky one.
+    /// </para>
+    /// <para>
+    /// The filenames are load-bearing and deliberately ugly. NTFS enumerates
+    /// case-insensitively while <see cref="StringComparer.Ordinal"/> puts
+    /// uppercase first, so <c>aardvark.cs</c> comes out of the directory walk
+    /// first while <c>B.cs</c> is the ordinal-least — the two orders disagree,
+    /// which is exactly what the last assertion needs. Measured: with the
+    /// obvious <c>Alpha.cs</c>/<c>Widget.cs</c> pair the orders coincide, and
+    /// restoring a first-wins max loop left this test green.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public void Equally_stamped_sources_resolve_to_the_same_one_either_way()
+    {
+        using var fx = new RepoFixture();
+        var lower = fx.Source("Core/aardvark.cs", Base.AddMinutes(5));
+        var upper = fx.Source("Core/B.cs", Base.AddMinutes(5));
+
+        Assert.Equal(File.GetLastWriteTimeUtc(lower), File.GetLastWriteTimeUtc(upper));
+        Assert.True(string.CompareOrdinal(upper, lower) < 0,
+            "fixture: the uppercase name must sort first ordinally, or this proves nothing");
+
+        var expected = upper;
+        Assert.Equal(expected, CompileCommand.SelectNewest(new[] { lower, upper }));
+        Assert.Equal(expected, CompileCommand.SelectNewest(new[] { upper, lower }));
+
+        // And the source scan really does route through that selector, rather
+        // than carrying a max loop of its own that ties would break. This is
+        // the assertion the filename choice above exists for.
+        Assert.Equal(expected, CompileCommand.FindNewestReactorSource(fx.Root)?.Path);
+    }
+
+    /// <summary>
+    /// The exclusion belongs to the enumeration, so assert it there too — the
+    /// staleness tests reach it only through a timestamp comparison, which
+    /// cannot distinguish "filtered out" from "older".
+    /// </summary>
+    [Fact]
+    public void Source_enumeration_omits_build_output()
+    {
+        using var fx = new RepoFixture();
+        var real = fx.Source("Core/Widget.cs", Base);
+        fx.Source("obj/x64/Release/Reactor.GlobalUsings.g.cs", Base);
+        fx.Source("bin/x64/Release/net10.0-windows10.0.22621.0/Embedded.cs", Base);
+
+        Assert.Equal(new[] { real }, CompileCommand.EnumerateReactorSources(fx.Root));
     }
 
     // ── Fixture ──────────────────────────────────────────────────────────────

--- a/tests/Reactor.DocPipeline.Tests/ReactorXmlSelectionTests.cs
+++ b/tests/Reactor.DocPipeline.Tests/ReactorXmlSelectionTests.cs
@@ -50,7 +50,16 @@ namespace Microsoft.UI.Reactor.Cli.Docs.Tests;
 ///     <description><see cref="Source_at_the_same_instant_is_not_stale"/>.</description></item>
 ///   <item><term>Segment match → prefix match for build output</term>
 ///     <description><see cref="A_source_directory_whose_name_merely_starts_with_bin_still_counts"/>.</description></item>
+///   <item><term>Drop the <c>ReparsePoint</c> skip on the candidate walk</term>
+///     <description><see cref="A_junction_nested_in_bin_is_not_followed_out_of_the_tree"/>.
+///     Added after that mutation came back green — the hardening had shipped
+///     with nothing pinning it.</description></item>
 /// </list>
+/// <para>
+/// These all drive the helpers directly. What they cannot show is that Phase
+/// 5.7 still calls them — see <see cref="ReferenceStalenessWiringTests"/>, which
+/// runs the real command.
+/// </para>
 /// </remarks>
 public class ReactorXmlSelectionTests
 {
@@ -196,6 +205,58 @@ public class ReactorXmlSelectionTests
         Assert.Equal(newest, choice!.Value.Path);
         Assert.Equal(Base.AddMinutes(9), choice.Value.WriteUtc);
         Assert.Equal(3, choice.Value.CandidateCount);
+    }
+
+    /// <summary>
+    /// A junction nested inside <c>bin</c> must not be descended into: a file
+    /// reached through one is not this build's output, and a junction that
+    /// points back at an ancestor has no cycle detection in the runtime's
+    /// walker.
+    /// </summary>
+    /// <remarks>
+    /// The first two assertions are the positive control and they are what make
+    /// the third a measurement. A junction that silently failed to be created
+    /// would leave the "not a candidate" assertion passing for the wrong reason,
+    /// so the test first proves the target really is reachable through the link
+    /// — i.e. that the default walk *would* have found it.
+    /// </remarks>
+    [Fact]
+    public void A_junction_nested_in_bin_is_not_followed_out_of_the_tree()
+    {
+        using var fx = new RepoFixture();
+        var real = fx.Xml("x64/Debug/net10.0-windows10.0.22621.0", Base);
+
+        // Newer than the real candidate, so following the link would change the
+        // answer rather than merely add a tie.
+        var outside = fx.OutsideXml("elsewhere", Base.AddMinutes(45));
+        var linked = fx.JunctionInsideBin("linked", Path.GetDirectoryName(outside)!);
+
+        Assert.True(File.Exists(Path.Combine(linked, "Reactor.xml")),
+            "fixture: the junction must resolve, or the exclusion below proves nothing");
+        Assert.Equal(Base.AddMinutes(45), File.GetLastWriteTimeUtc(Path.Combine(linked, "Reactor.xml")));
+
+        var candidates = CompileCommand.EnumerateReactorXmlCandidates(fx.Root).ToList();
+
+        Assert.Equal(new[] { real }, candidates);
+        Assert.Equal(real, CompileCommand.FindReactorXml(fx.Root)?.Path);
+    }
+
+    /// <summary>
+    /// Skipping reparse points must not disqualify the enumeration root itself
+    /// — redirecting <c>bin</c> to another volume is a normal thing to do, and
+    /// it would be a poor trade to break it while hardening against nested
+    /// links.
+    /// </summary>
+    [Fact]
+    public void A_bin_directory_that_is_itself_a_junction_still_enumerates()
+    {
+        using var fx = new RepoFixture();
+        var expected = fx.XmlBehindJunctionedBin("x64/Release/net10.0-windows10.0.22621.0", Base);
+
+        var candidates = CompileCommand.EnumerateReactorXmlCandidates(fx.Root).ToList();
+
+        Assert.Single(candidates);
+        Assert.Equal(expected, CompileCommand.FindReactorXml(fx.Root)?.Path);
     }
 
     /// <summary>
@@ -406,9 +467,112 @@ public class ReactorXmlSelectionTests
             return path;
         }
 
+        /// <summary>
+        /// Writes a <c>Reactor.xml</c> outside the repo root entirely — the
+        /// thing a junction inside <c>bin</c> could otherwise drag in.
+        /// </summary>
+        public string OutsideXml(string dirName, DateTime writeUtc)
+        {
+            var dir = Path.Combine(Root + "-outside", dirName);
+            Directory.CreateDirectory(dir);
+            var path = Path.Combine(dir, "Reactor.xml");
+            File.WriteAllText(path, "// fixture\n");
+            File.SetLastWriteTimeUtc(path, writeUtc);
+            return path;
+        }
+
+        private readonly List<string> _junctions = new();
+
+        /// <summary>
+        /// Creates <c>src/Reactor/bin/&lt;name&gt;</c> as a junction to
+        /// <paramref name="target"/> and returns the link path.
+        /// </summary>
+        public string JunctionInsideBin(string name, string target)
+        {
+            var link = Path.Combine(Root, "src", "Reactor", "bin", name);
+            Directory.CreateDirectory(Path.GetDirectoryName(link)!);
+            CreateJunction(link, target);
+            return link;
+        }
+
+        /// <summary>
+        /// Makes <c>src/Reactor/bin</c> itself a junction to a real directory
+        /// holding the given layout, and returns the candidate's path as seen
+        /// through the link.
+        /// </summary>
+        public string XmlBehindJunctionedBin(string layout, DateTime writeUtc)
+        {
+            var realBin = Path.Combine(Root + "-realbin");
+            var dir = Path.Combine(realBin, Native(layout));
+            Directory.CreateDirectory(dir);
+            var path = Path.Combine(dir, "Reactor.xml");
+            File.WriteAllText(path, "// fixture\n");
+            File.SetLastWriteTimeUtc(path, writeUtc);
+
+            var link = Path.Combine(Root, "src", "Reactor", "bin");
+            Directory.CreateDirectory(Path.GetDirectoryName(link)!);
+            CreateJunction(link, realBin);
+            return Path.Combine(link, Native(layout), "Reactor.xml");
+        }
+
+        /// <summary>
+        /// Junctions rather than symlinks: <c>mklink /J</c> needs no elevation
+        /// or Developer Mode, so this works for an ordinary user and on the CI
+        /// runner. Throws rather than skipping — a test that quietly opts out
+        /// when its fixture fails is a test that cannot fail.
+        /// </summary>
+        private void CreateJunction(string link, string target)
+        {
+            using var p = global::System.Diagnostics.Process.Start(
+                new global::System.Diagnostics.ProcessStartInfo
+                {
+                    FileName = "cmd.exe",
+                    ArgumentList = { "/c", "mklink", "/J", link, target },
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true,
+                })!;
+            p.WaitForExit();
+            if (p.ExitCode != 0 || !Directory.Exists(link))
+            {
+                throw new InvalidOperationException(
+                    $"could not create junction {link} -> {target}: " +
+                    $"exit {p.ExitCode}, {p.StandardError.ReadToEnd().Trim()}");
+            }
+            _junctions.Add(link);
+        }
+
         private static string Native(string path) =>
             path.Replace('/', Path.DirectorySeparatorChar);
 
-        public void Dispose() => FixtureCleanup.DeleteTree(Root);
+        /// <summary>
+        /// The junction fixtures put their targets in sibling directories so a
+        /// link can point genuinely outside the repo root; tear those down too,
+        /// or each run leaks two trees into TEMP.
+        /// </summary>
+        /// <remarks>
+        /// Junctions are removed first, as links. Measured, not assumed:
+        /// <c>Directory.Delete(root, recursive: true)</c> over a tree
+        /// containing one throws <c>UnauthorizedAccessException</c> ("Access to
+        /// the path 'linked' is denied") — which
+        /// <see cref="FixtureCleanup.DeleteTree"/> swallows by design, so the
+        /// whole tree leaks silently. It did, twelve directories' worth, before
+        /// this loop existed. Deleting the junction non-recursively removes the
+        /// link and leaves its target intact.
+        /// </remarks>
+        public void Dispose()
+        {
+            foreach (var link in _junctions)
+            {
+                try { Directory.Delete(link, recursive: false); }
+                catch (IOException) { }
+                catch (UnauthorizedAccessException) { }
+            }
+
+            FixtureCleanup.DeleteTree(Root);
+            FixtureCleanup.DeleteTree(Root + "-outside");
+            FixtureCleanup.DeleteTree(Root + "-realbin");
+        }
     }
 }

--- a/tests/Reactor.DocPipeline.Tests/ReactorXmlSelectionTests.cs
+++ b/tests/Reactor.DocPipeline.Tests/ReactorXmlSelectionTests.cs
@@ -209,9 +209,10 @@ public class ReactorXmlSelectionTests
         var choice = CompileCommand.FindReactorXml(fx.Root);
 
         Assert.NotNull(choice);
-        Assert.Equal(newest, choice!.Value.Path);
-        Assert.Equal(Base.AddMinutes(9), choice.Value.WriteUtc);
-        Assert.Equal(3, choice.Value.CandidateCount);
+        var selected = choice!.Value;
+        Assert.Equal(newest, selected.Path);
+        Assert.Equal(Base.AddMinutes(9), selected.WriteUtc);
+        Assert.Equal(3, selected.CandidateCount);
     }
 
     /// <summary>
@@ -238,9 +239,9 @@ public class ReactorXmlSelectionTests
         var outside = fx.OutsideXml("elsewhere", Base.AddMinutes(45));
         var linked = fx.JunctionInsideBin("linked", Path.GetDirectoryName(outside)!);
 
-        Assert.True(File.Exists(Path.Combine(linked, "Reactor.xml")),
+        Assert.True(File.Exists(Path.Join(linked, "Reactor.xml")),
             "fixture: the junction must resolve, or the exclusion below proves nothing");
-        Assert.Equal(Base.AddMinutes(45), File.GetLastWriteTimeUtc(Path.Combine(linked, "Reactor.xml")));
+        Assert.Equal(Base.AddMinutes(45), File.GetLastWriteTimeUtc(Path.Join(linked, "Reactor.xml")));
 
         var candidates = CompileCommand.EnumerateReactorXmlCandidates(fx.Root).ToList();
 
@@ -522,7 +523,11 @@ public class ReactorXmlSelectionTests
     /// </summary>
     private sealed class RepoFixture : IDisposable
     {
-        public string Root { get; } = Path.Combine(
+        // Path.Join rather than Path.Combine throughout this fixture: the tail
+        // segments are test inputs (layout, relativePath), and Combine resets
+        // to the last rooted segment while Join always appends. Matches the
+        // sibling fixture in CompileCaptureSkipTests.
+        public string Root { get; } = Path.Join(
             Path.GetTempPath(), "reactor-xml-selection-" + Guid.NewGuid().ToString("N"));
 
         public RepoFixture() => Directory.CreateDirectory(Root);
@@ -532,7 +537,7 @@ public class ReactorXmlSelectionTests
             BinFile(layout, "Reactor.xml", writeUtc);
 
         public string BinFile(string layout, string fileName, DateTime writeUtc) =>
-            Write(Path.Combine("src", "Reactor", "bin", Native(layout)), fileName, writeUtc);
+            Write(Path.Join("src", "Reactor", "bin", Native(layout)), fileName, writeUtc);
 
         /// <summary>Writes a C# file at <c>src/Reactor/&lt;relativePath&gt;</c>.</summary>
         public string Source(string relativePath, DateTime writeUtc)
@@ -540,16 +545,16 @@ public class ReactorXmlSelectionTests
             var native = Native(relativePath);
             var dir = Path.GetDirectoryName(native);
             return Write(
-                Path.Combine("src", "Reactor", dir ?? string.Empty),
+                Path.Join("src", "Reactor", dir ?? string.Empty),
                 Path.GetFileName(native),
                 writeUtc);
         }
 
         private string Write(string relativeDir, string fileName, DateTime writeUtc)
         {
-            var dir = Path.Combine(Root, relativeDir);
+            var dir = Path.Join(Root, relativeDir);
             Directory.CreateDirectory(dir);
-            var path = Path.Combine(dir, fileName);
+            var path = Path.Join(dir, fileName);
             File.WriteAllText(path, "// fixture\n");
             // Set after the write: writing stamps the file with "now".
             File.SetLastWriteTimeUtc(path, writeUtc);
@@ -562,9 +567,9 @@ public class ReactorXmlSelectionTests
         /// </summary>
         public string OutsideXml(string dirName, DateTime writeUtc)
         {
-            var dir = Path.Combine(Root + "-outside", dirName);
+            var dir = Path.Join(Root + "-outside", dirName);
             Directory.CreateDirectory(dir);
-            var path = Path.Combine(dir, "Reactor.xml");
+            var path = Path.Join(dir, "Reactor.xml");
             File.WriteAllText(path, "// fixture\n");
             File.SetLastWriteTimeUtc(path, writeUtc);
             return path;
@@ -578,7 +583,7 @@ public class ReactorXmlSelectionTests
         /// </summary>
         public string JunctionInsideBin(string name, string target)
         {
-            var link = Path.Combine(Root, "src", "Reactor", "bin", name);
+            var link = Path.Join(Root, "src", "Reactor", "bin", name);
             Directory.CreateDirectory(Path.GetDirectoryName(link)!);
             CreateJunction(link, target);
             return link;
@@ -591,17 +596,17 @@ public class ReactorXmlSelectionTests
         /// </summary>
         public string XmlBehindJunctionedBin(string layout, DateTime writeUtc)
         {
-            var realBin = Path.Combine(Root + "-realbin");
-            var dir = Path.Combine(realBin, Native(layout));
+            var realBin = Root + "-realbin";
+            var dir = Path.Join(realBin, Native(layout));
             Directory.CreateDirectory(dir);
-            var path = Path.Combine(dir, "Reactor.xml");
+            var path = Path.Join(dir, "Reactor.xml");
             File.WriteAllText(path, "// fixture\n");
             File.SetLastWriteTimeUtc(path, writeUtc);
 
-            var link = Path.Combine(Root, "src", "Reactor", "bin");
+            var link = Path.Join(Root, "src", "Reactor", "bin");
             Directory.CreateDirectory(Path.GetDirectoryName(link)!);
             CreateJunction(link, realBin);
-            return Path.Combine(link, Native(layout), "Reactor.xml");
+            return Path.Join(link, Native(layout), "Reactor.xml");
         }
 
         /// <summary>
@@ -672,8 +677,16 @@ public class ReactorXmlSelectionTests
             foreach (var link in _junctions)
             {
                 try { Directory.Delete(link, recursive: false); }
-                catch (IOException) { }
-                catch (UnauthorizedAccessException) { }
+                catch (IOException)
+                {
+                    // Already gone, or a handle is open on it — either way the
+                    // tree delete below is the thing that matters, and neither
+                    // is something this suite asserts.
+                }
+                catch (UnauthorizedAccessException)
+                {
+                    // Read-only entry, or AV/indexer holding it — likewise.
+                }
             }
 
             FixtureCleanup.DeleteTree(Root);

--- a/tests/Reactor.DocPipeline.Tests/ReactorXmlSelectionTests.cs
+++ b/tests/Reactor.DocPipeline.Tests/ReactorXmlSelectionTests.cs
@@ -326,6 +326,26 @@ public class ReactorXmlSelectionTests
         Assert.Null(CompileCommand.SelectNewest(Array.Empty<string>()));
     }
 
+    /// <summary>
+    /// The fixture guard above throws rather than skipping, so its message is
+    /// the only thing whoever hits it in CI has to go on. A bare exit code
+    /// would not be enough.
+    /// </summary>
+    [Fact]
+    public void A_failed_junction_reports_why_rather_than_just_a_code()
+    {
+        using var fx = new RepoFixture();
+        var target = Path.GetDirectoryName(fx.OutsideXml("elsewhere", Base))!;
+        fx.JunctionInsideBin("taken", target);
+
+        // The same link path twice: the second attempt must fail.
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => fx.JunctionInsideBin("taken", target));
+
+        Assert.Contains("already exists", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("no output on either stream", ex.Message, StringComparison.Ordinal);
+    }
+
     // ── Staleness (REACTOR_DOC_REFGEN_W002) ──────────────────────────────────
 
     /// <summary>
@@ -602,12 +622,29 @@ public class ReactorXmlSelectionTests
                     UseShellExecute = false,
                     CreateNoWindow = true,
                 })!;
+
+            // Start both reads before waiting. With both streams redirected, a
+            // child that fills a pipe buffer blocks on the write while the
+            // parent blocks in WaitForExit — mklink's output is far too small
+            // to hit that, but the ordering is the bug either way, and reading
+            // one stream to end before the other has the same shape.
+            var stdoutTask = p.StandardOutput.ReadToEndAsync();
+            var stderrTask = p.StandardError.ReadToEndAsync();
             p.WaitForExit();
+
             if (p.ExitCode != 0 || !Directory.Exists(link))
             {
+                // Both streams, because the message is the only thing whoever
+                // hits this in CI will see. Measured on this platform: an
+                // invalid switch, an existing link path and a non-local volume
+                // all report on stderr — but the cost of also carrying stdout
+                // is nothing next to a bare "exit 1".
+                var detail = string.Join(" ", new[] { stderrTask.Result, stdoutTask.Result }
+                    .Select(s => s.Trim())
+                    .Where(s => s.Length > 0));
                 throw new InvalidOperationException(
-                    $"could not create junction {link} -> {target}: " +
-                    $"exit {p.ExitCode}, {p.StandardError.ReadToEnd().Trim()}");
+                    $"could not create junction {link} -> {target}: exit {p.ExitCode}" +
+                    (detail.Length > 0 ? $", {detail}" : " (no output on either stream)"));
             }
             _junctions.Add(link);
         }

--- a/tests/Reactor.DocPipeline.Tests/ReactorXmlSelectionTests.cs
+++ b/tests/Reactor.DocPipeline.Tests/ReactorXmlSelectionTests.cs
@@ -1,0 +1,414 @@
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Cli.Docs.Tests;
+
+/// <summary>
+/// Issue #1068 — which <c>Reactor.xml</c> Phase 5.7 reads, and whether it
+/// admits to being older than the source it documents.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The defect was that <c>FindReactorXml</c> returned the first candidate in a
+/// fixed <c>Debug</c>-then-<c>Release</c> sweep, so a leftover Debug build
+/// shadowed a fresh Release one and the generator rewrote
+/// <c>docs/guide/reference/**</c> from stale input while exiting 0.
+/// </para>
+/// <para>
+/// Direction is the whole design of this file. A newest-wins test whose fixture
+/// happens to put the newest file in <c>Debug</c> passes against the *buggy*
+/// code — it asserts nothing, because both rules agree there. Every ordering
+/// claim below is therefore made twice, once in each direction, so exactly one
+/// half is the discriminating case and the other half guards the
+/// over-correction (a fixed <c>Release</c>-first order would satisfy the first
+/// half alone).
+/// </para>
+/// <para>
+/// Mutation results, measured rather than asserted — each row lists every test
+/// that actually reddened, which is not always the set the fix "obviously"
+/// protects:
+/// </para>
+/// <list type="table">
+///   <item><term>Restore the config-order sweep (the original bug)</term>
+///     <description><see cref="Newest_wins_when_the_newer_build_is_Release"/>,
+///     <see cref="Flat_layout_beats_an_older_platform_stamped_build"/>,
+///     <see cref="Ordinal_order_does_not_override_a_newer_timestamp"/>,
+///     <see cref="The_selection_reports_the_timestamp_and_how_many_it_beat"/>
+///     and all three
+///     <see cref="Layouts_outside_the_old_hardcoded_shapes_are_discovered"/>
+///     cases. Note what stays green: the two fixtures whose newest file sits in
+///     <c>Debug</c>, exactly as predicted.</description></item>
+///   <item><term>Restore the hardcoded layout shapes</term>
+///     <description>the three
+///     <see cref="Layouts_outside_the_old_hardcoded_shapes_are_discovered"/>
+///     cases.</description></item>
+///   <item><term>Drop the ordinal tie-break</term>
+///     <description><see cref="Equal_timestamps_break_on_the_ordinal_path"/> —
+///     but only in its present form; see that test's own note.</description></item>
+///   <item><term>Drop the bin/obj exclusion</term>
+///     <description><see cref="Build_output_under_src_Reactor_does_not_count_as_source"/>.</description></item>
+///   <item><term>Loosen the staleness comparison to <c>&lt;</c></term>
+///     <description><see cref="Source_at_the_same_instant_is_not_stale"/>.</description></item>
+///   <item><term>Segment match → prefix match for build output</term>
+///     <description><see cref="A_source_directory_whose_name_merely_starts_with_bin_still_counts"/>.</description></item>
+/// </list>
+/// </remarks>
+public class ReactorXmlSelectionTests
+{
+    /// <summary>
+    /// Fixed clock. Timestamps are asserted against each other, never against
+    /// "now", so nothing here depends on how long the suite takes to run.
+    /// </summary>
+    private static readonly DateTime Base = new(2026, 8, 1, 19, 0, 0, DateTimeKind.Utc);
+
+    // ── Selection ────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The discriminating half: a fresh Release build must win over a stale
+    /// Debug one. This is the reported scenario — build Release only, compile
+    /// docs, get pages generated from an older Debug tree.
+    /// </summary>
+    [Fact]
+    public void Newest_wins_when_the_newer_build_is_Release()
+    {
+        using var fx = new RepoFixture();
+        var debug = fx.Xml("Debug/net10.0-windows10.0.22621.0", Base);
+        var release = fx.Xml("Release/net10.0-windows10.0.22621.0", Base.AddMinutes(16));
+
+        Assert.Equal(release, CompileCommand.FindReactorXml(fx.Root)?.Path);
+        Assert.NotEqual(debug, CompileCommand.FindReactorXml(fx.Root)?.Path);
+    }
+
+    /// <summary>
+    /// The other half. Debug is not disfavoured — it wins when it is newer, so
+    /// the rule is freshness and not a reversed configuration preference.
+    /// </summary>
+    [Fact]
+    public void Newest_wins_when_the_newer_build_is_Debug()
+    {
+        using var fx = new RepoFixture();
+        var debug = fx.Xml("Debug/net10.0-windows10.0.22621.0", Base.AddMinutes(16));
+        fx.Xml("Release/net10.0-windows10.0.22621.0", Base);
+
+        Assert.Equal(debug, CompileCommand.FindReactorXml(fx.Root)?.Path);
+    }
+
+    /// <summary>
+    /// The layout the issue's repro actually selected on a real tree:
+    /// <c>bin/&lt;arch&gt;/&lt;config&gt;/&lt;tfm&gt;/</c>. Reproduced with the
+    /// arch-stamped tree as the *newer* one so a correct answer here requires
+    /// both reaching that shape and comparing timestamps.
+    /// </summary>
+    [Fact]
+    public void Platform_stamped_layout_beats_a_flat_Release_build()
+    {
+        using var fx = new RepoFixture();
+        fx.Xml("Release/net10.0-windows10.0.22621.0", Base.AddMinutes(12));
+        var stamped = fx.Xml("x64/Debug/net10.0-windows10.0.22621.0", Base.AddMinutes(20));
+
+        Assert.Equal(stamped, CompileCommand.FindReactorXml(fx.Root)?.Path);
+    }
+
+    /// <summary>
+    /// And the inverse, so the arch-stamped path is not merely preferred: a
+    /// newer flat build beats an older arch-stamped one.
+    /// </summary>
+    [Fact]
+    public void Flat_layout_beats_an_older_platform_stamped_build()
+    {
+        using var fx = new RepoFixture();
+        var flat = fx.Xml("Release/net10.0-windows10.0.22621.0", Base.AddMinutes(20));
+        fx.Xml("x64/Debug/net10.0-windows10.0.22621.0", Base.AddMinutes(12));
+
+        Assert.Equal(flat, CompileCommand.FindReactorXml(fx.Root)?.Path);
+    }
+
+    /// <summary>
+    /// The enumeration used to hard-code two directory shapes and an arch
+    /// allow-list of <c>x64</c>/<c>ARM64</c>. Anything else — a future
+    /// architecture, a RID-nested publish output — was invisible, which is the
+    /// same "incomplete enumeration, confident answer" failure as the ordering
+    /// bug itself.
+    /// </summary>
+    /// <remarks>
+    /// The stale x64 build present alongside is the positive control: without
+    /// it, a hard-coded enumerator would return <c>null</c> and the test would
+    /// have to assert on a no-match, which proves nothing. With it, the broken
+    /// implementation returns a *specific wrong file* instead.
+    /// </remarks>
+    [Theory]
+    [InlineData("x86/Release/net10.0-windows10.0.22621.0")]
+    [InlineData("x64/Release/net10.0-windows10.0.22621.0/win-x64")]
+    [InlineData("x64/Release/net10.0-windows10.0.22621.0/publish")]
+    public void Layouts_outside_the_old_hardcoded_shapes_are_discovered(string layout)
+    {
+        using var fx = new RepoFixture();
+        var stale = fx.Xml("x64/Debug/net10.0-windows10.0.22621.0", Base);
+        var newest = fx.Xml(layout, Base.AddMinutes(30));
+
+        var selected = CompileCommand.FindReactorXml(fx.Root)?.Path;
+
+        Assert.Equal(newest, selected);
+        Assert.NotEqual(stale, selected);
+    }
+
+    [Fact]
+    public void No_bin_directory_selects_nothing()
+    {
+        using var fx = new RepoFixture();
+        fx.Source("Core/Widget.cs", Base);
+
+        Assert.Null(CompileCommand.FindReactorXml(fx.Root));
+        Assert.Empty(CompileCommand.EnumerateReactorXmlCandidates(fx.Root));
+    }
+
+    /// <summary>
+    /// A populated <c>bin</c> that happens to contain no <c>Reactor.xml</c> is
+    /// still "nothing to read" — distinct from the case above, because it
+    /// exercises the enumeration rather than the existence guard.
+    /// </summary>
+    [Fact]
+    public void Bin_without_a_Reactor_xml_selects_nothing()
+    {
+        using var fx = new RepoFixture();
+        fx.BinFile("Debug/net10.0-windows10.0.22621.0", "Reactor.Cli.xml", Base);
+        fx.BinFile("Debug/net10.0-windows10.0.22621.0", "Reactor.dll", Base);
+
+        Assert.Null(CompileCommand.FindReactorXml(fx.Root));
+    }
+
+    /// <summary>
+    /// The timestamp and candidate count are the printed diagnostic, so they
+    /// are load-bearing rather than incidental: an operator reading
+    /// <c>newest of 1 candidate(s)</c> on a tree they know has three builds is
+    /// being told the enumeration is broken.
+    /// </summary>
+    [Fact]
+    public void The_selection_reports_the_timestamp_and_how_many_it_beat()
+    {
+        using var fx = new RepoFixture();
+        fx.Xml("Debug/net10.0-windows10.0.22621.0", Base);
+        fx.Xml("x64/Debug/net10.0-windows10.0.22621.0", Base.AddMinutes(4));
+        var newest = fx.Xml("x64/Release/net10.0-windows10.0.22621.0", Base.AddMinutes(9));
+
+        var choice = CompileCommand.FindReactorXml(fx.Root);
+
+        Assert.NotNull(choice);
+        Assert.Equal(newest, choice!.Value.Path);
+        Assert.Equal(Base.AddMinutes(9), choice.Value.WriteUtc);
+        Assert.Equal(3, choice.Value.CandidateCount);
+    }
+
+    /// <summary>
+    /// Equal timestamps must not leave the choice to enumeration order, which
+    /// the filesystem does not promise to keep stable.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Driven through <see cref="CompileCommand.SelectNewest"/> with the same
+    /// two files in both input orders, because that is the only form of this
+    /// test that can fail. The first attempt went through
+    /// <c>FindReactorXml</c> and asserted the ordinal-least path: it passed —
+    /// and it passed just as happily with the <c>ThenBy</c> deleted, because
+    /// the directory walk handed the sorter its candidates in an order that
+    /// already agreed. Feeding both orders is what turns "the answer looked
+    /// right once" into "order of arrival does not decide it".
+    /// </para>
+    /// <para>
+    /// The expectation is computed rather than memorised so the assertion
+    /// states the rule and not a path that happens to sort that way today.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public void Equal_timestamps_break_on_the_ordinal_path()
+    {
+        using var fx = new RepoFixture();
+        var debug = fx.Xml("Debug/net10.0-windows10.0.22621.0", Base);
+        var release = fx.Xml("Release/net10.0-windows10.0.22621.0", Base);
+
+        // Positive control on the fixture: the tie-break can only be exercised
+        // if the filesystem actually recorded a tie. Without this, a rig that
+        // failed to make them equal would look like a defect in SelectNewest.
+        Assert.Equal(File.GetLastWriteTimeUtc(debug), File.GetLastWriteTimeUtc(release));
+
+        var expected = string.CompareOrdinal(debug, release) <= 0 ? debug : release;
+
+        Assert.Equal(expected, CompileCommand.SelectNewest(new[] { debug, release }));
+        Assert.Equal(expected, CompileCommand.SelectNewest(new[] { release, debug }));
+    }
+
+    /// <summary>
+    /// The tie-break is a tie-break, not the primary key: an older file that
+    /// sorts earlier must still lose. Without this, "always return the
+    /// ordinal-least path" would satisfy the test above.
+    /// </summary>
+    [Fact]
+    public void Ordinal_order_does_not_override_a_newer_timestamp()
+    {
+        using var fx = new RepoFixture();
+        var debug = fx.Xml("Debug/net10.0-windows10.0.22621.0", Base);
+        var release = fx.Xml("Release/net10.0-windows10.0.22621.0", Base.AddMinutes(1));
+
+        Assert.True(string.CompareOrdinal(debug, release) < 0, "fixture assumes Debug sorts first");
+        Assert.Equal(release, CompileCommand.SelectNewest(new[] { debug, release }));
+    }
+
+    [Fact]
+    public void Selecting_from_nothing_yields_nothing()
+    {
+        Assert.Null(CompileCommand.SelectNewest(Array.Empty<string>()));
+    }
+
+    // ── Staleness (REACTOR_DOC_REFGEN_W002) ──────────────────────────────────
+
+    /// <summary>
+    /// The residue newest-wins cannot reach: every build is stale because
+    /// nothing was rebuilt after the edit. Selection is correct and the output
+    /// is still wrong, so the only signal available is the comparison against
+    /// source.
+    /// </summary>
+    [Fact]
+    public void Source_newer_than_the_xml_is_reported_as_stale()
+    {
+        using var fx = new RepoFixture();
+        var xml = fx.Xml("x64/Release/net10.0-windows10.0.22621.0", Base);
+        fx.Source("Core/Widget.cs", Base.AddMinutes(5));
+
+        var finding = CompileCommand.BuildStaleXmlFinding(fx.Root, xml);
+
+        Assert.NotNull(finding);
+        Assert.Equal("REACTOR_DOC_REFGEN_W002", finding!.Code);
+        Assert.Equal(TierLintSeverity.Warning, finding.Severity);
+        // Both operands named, so the reader can act without re-deriving them.
+        Assert.Contains("src/Reactor/Core/Widget.cs", finding.Message, StringComparison.Ordinal);
+        Assert.Contains("2026-08-01T19:00:00Z", finding.Message, StringComparison.Ordinal);
+        Assert.Contains("2026-08-01T19:05:00Z", finding.Message, StringComparison.Ordinal);
+        Assert.Contains("src/Reactor/bin/x64/Release", finding.FilePath, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Xml_newer_than_every_source_is_not_stale()
+    {
+        using var fx = new RepoFixture();
+        var xml = fx.Xml("x64/Release/net10.0-windows10.0.22621.0", Base.AddMinutes(5));
+        fx.Source("Core/Widget.cs", Base);
+        fx.Source("Elements/Dsl.cs", Base.AddMinutes(4));
+
+        Assert.Null(CompileCommand.BuildStaleXmlFinding(fx.Root, xml));
+    }
+
+    /// <summary>
+    /// Boundary. The comparison is strict, so a source file stamped at exactly
+    /// the XML's instant does not fire — it did not postdate the build.
+    /// </summary>
+    [Fact]
+    public void Source_at_the_same_instant_is_not_stale()
+    {
+        using var fx = new RepoFixture();
+        var xml = fx.Xml("x64/Release/net10.0-windows10.0.22621.0", Base);
+        fx.Source("Core/Widget.cs", Base);
+
+        Assert.Null(CompileCommand.BuildStaleXmlFinding(fx.Root, xml));
+    }
+
+    /// <summary>
+    /// Generated code under <c>obj</c> and copied sources under <c>bin</c> are
+    /// written *by* the build whose age is in question, so counting them would
+    /// fire the warning after every successful build.
+    /// </summary>
+    /// <remarks>
+    /// The second half is the positive control, and it is what makes the first
+    /// half a measurement: it plants a real source file at the *same* newer
+    /// timestamp and shows the probe does fire there. Without it, a null return
+    /// could equally mean the scan found nothing at all.
+    /// </remarks>
+    [Fact]
+    public void Build_output_under_src_Reactor_does_not_count_as_source()
+    {
+        using var fx = new RepoFixture();
+        var xml = fx.Xml("x64/Release/net10.0-windows10.0.22621.0", Base.AddMinutes(5));
+        fx.Source("Core/Widget.cs", Base);
+        fx.Source("obj/x64/Release/Reactor.GlobalUsings.g.cs", Base.AddMinutes(30));
+        fx.Source("bin/x64/Release/net10.0-windows10.0.22621.0/Embedded.cs", Base.AddMinutes(30));
+
+        Assert.Null(CompileCommand.BuildStaleXmlFinding(fx.Root, xml));
+
+        fx.Source("Core/Later.cs", Base.AddMinutes(30));
+        var finding = CompileCommand.BuildStaleXmlFinding(fx.Root, xml);
+        Assert.NotNull(finding);
+        Assert.Contains("src/Reactor/Core/Later.cs", finding!.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// A directory named <c>bin</c>-something is not build output. Segment
+    /// matching rather than a substring test is what separates them.
+    /// </summary>
+    [Fact]
+    public void A_source_directory_whose_name_merely_starts_with_bin_still_counts()
+    {
+        using var fx = new RepoFixture();
+        var xml = fx.Xml("x64/Release/net10.0-windows10.0.22621.0", Base);
+        fx.Source("binding/Converter.cs", Base.AddMinutes(5));
+
+        var finding = CompileCommand.BuildStaleXmlFinding(fx.Root, xml);
+
+        Assert.NotNull(finding);
+        Assert.Contains("src/Reactor/binding/Converter.cs", finding!.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void No_sources_at_all_yields_no_finding()
+    {
+        using var fx = new RepoFixture();
+        var xml = fx.Xml("x64/Release/net10.0-windows10.0.22621.0", Base);
+
+        Assert.Null(CompileCommand.BuildStaleXmlFinding(fx.Root, xml));
+    }
+
+    // ── Fixture ──────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// A throwaway repo root holding only the two directories the selection
+    /// code looks at: <c>src/Reactor/bin</c> and <c>src/Reactor</c>.
+    /// </summary>
+    private sealed class RepoFixture : IDisposable
+    {
+        public string Root { get; } = Path.Combine(
+            Path.GetTempPath(), "reactor-xml-selection-" + Guid.NewGuid().ToString("N"));
+
+        public RepoFixture() => Directory.CreateDirectory(Root);
+
+        /// <summary>Writes <c>src/Reactor/bin/&lt;layout&gt;/Reactor.xml</c>.</summary>
+        public string Xml(string layout, DateTime writeUtc) =>
+            BinFile(layout, "Reactor.xml", writeUtc);
+
+        public string BinFile(string layout, string fileName, DateTime writeUtc) =>
+            Write(Path.Combine("src", "Reactor", "bin", Native(layout)), fileName, writeUtc);
+
+        /// <summary>Writes a C# file at <c>src/Reactor/&lt;relativePath&gt;</c>.</summary>
+        public string Source(string relativePath, DateTime writeUtc)
+        {
+            var native = Native(relativePath);
+            var dir = Path.GetDirectoryName(native);
+            return Write(
+                Path.Combine("src", "Reactor", dir ?? string.Empty),
+                Path.GetFileName(native),
+                writeUtc);
+        }
+
+        private string Write(string relativeDir, string fileName, DateTime writeUtc)
+        {
+            var dir = Path.Combine(Root, relativeDir);
+            Directory.CreateDirectory(dir);
+            var path = Path.Combine(dir, fileName);
+            File.WriteAllText(path, "// fixture\n");
+            // Set after the write: writing stamps the file with "now".
+            File.SetLastWriteTimeUtc(path, writeUtc);
+            return path;
+        }
+
+        private static string Native(string path) =>
+            path.Replace('/', Path.DirectorySeparatorChar);
+
+        public void Dispose() => FixtureCleanup.DeleteTree(Root);
+    }
+}

--- a/tests/Reactor.DocPipeline.Tests/ReferenceStalenessWiringTests.cs
+++ b/tests/Reactor.DocPipeline.Tests/ReferenceStalenessWiringTests.cs
@@ -1,0 +1,278 @@
+using Microsoft.UI.Reactor.Cli.Docs;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Cli.Docs.Tests;
+
+/// <summary>
+/// Issue #1068, wiring tier: the selection rule and the staleness warning as
+/// <c>mur docs compile</c> actually uses them, rather than as helpers called
+/// directly.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="ReactorXmlSelectionTests"/> pins the rules themselves. It cannot
+/// pin that Phase 5.7 <em>applies</em> them: deleting the
+/// <c>staleFinding</c> concat that merges the warning into
+/// <c>ReferenceGenResult.Findings</c>, or dropping the selection call, leaves
+/// every one of those tests green. That is the gap this file closes — it drives
+/// <see cref="CompileCommand.Run"/> end to end and reads stdout.
+/// </para>
+/// <para>
+/// The severity claim is the other half. <c>REACTOR_DOC_REFGEN_W002</c> is a
+/// warning specifically so <c>--ci</c> keeps passing, and that is a property of
+/// the Phase 5.7 gate (<c>if (f.Severity == TierLintSeverity.Error) hasErrors =
+/// true;</c>), not of the finding. Asserting the exit code with the warning
+/// present is what would catch someone "promoting" it later.
+/// </para>
+/// <para>
+/// Every warning assertion here is paired with a run of the same fixture that
+/// must <em>not</em> produce it, so a test that always passes — because the
+/// pipeline never reached Phase 5.7 at all, say — shows up as the pair
+/// disagreeing rather than as a comforting green.
+/// </para>
+/// <para>
+/// <see cref="CompileCommand.Run"/> resolves the repo root from the process
+/// working directory and writes to <see cref="Console"/>, both process-global,
+/// so this class shares the repo's console-isolation collection.
+/// </para>
+/// </remarks>
+[Collection("ConsoleTests")]
+public class ReferenceStalenessWiringTests
+{
+    private static readonly DateTime Base = new(2026, 8, 1, 19, 0, 0, DateTimeKind.Utc);
+
+    /// <summary>
+    /// The residue case, end to end: nothing was rebuilt after the edit, so the
+    /// pages are generated from an XML that no longer matches source. The
+    /// warning must reach stdout, and it must not fail <c>--ci</c>.
+    /// </summary>
+    [Fact]
+    public void Stale_xml_warns_through_the_pipeline_and_still_passes_ci()
+    {
+        using var repo = new FakeRepo();
+        repo.PlantXml("x64/Release/net10.0-windows10.0.22621.0", Base);
+        repo.PlantSource("Core/Widget.cs", Base.AddMinutes(30));
+
+        var (exitCode, output) = repo.CompileWithReference();
+
+        Assert.Contains("Phase 5.7: Reference", output);
+        Assert.Contains("REACTOR_DOC_REFGEN_W002", output);
+        Assert.Contains("src/Reactor/Core/Widget.cs", output);
+        // The whole point of Warning severity: --ci must still pass.
+        Assert.Equal(0, exitCode);
+    }
+
+    /// <summary>
+    /// The paired control. Same fixture, same flags, only the timestamps
+    /// reversed — so the assertion above is measuring the comparison and not
+    /// merely observing that the pipeline prints warnings.
+    /// </summary>
+    [Fact]
+    public void Fresh_xml_produces_no_staleness_warning()
+    {
+        using var repo = new FakeRepo();
+        repo.PlantXml("x64/Release/net10.0-windows10.0.22621.0", Base.AddMinutes(30));
+        repo.PlantSource("Core/Widget.cs", Base);
+
+        var (exitCode, output) = repo.CompileWithReference();
+
+        Assert.Contains("Phase 5.7: Reference", output);
+        Assert.DoesNotContain("REACTOR_DOC_REFGEN_W002", output);
+        Assert.Equal(0, exitCode);
+    }
+
+    /// <summary>
+    /// The fix itself, through the command rather than the helper: with a stale
+    /// Debug build beside a newer Release one — the exact shape reported in
+    /// #1068 — the phase must announce the Release file.
+    /// </summary>
+    /// <remarks>
+    /// Asserting on the printed line is what makes this a test of the pipeline's
+    /// choice. It also pins the diagnostic line itself, which is the only thing
+    /// an author has to go on when a regenerated page looks wrong.
+    /// </remarks>
+    [Fact]
+    public void The_phase_announces_the_newest_candidate_it_selected()
+    {
+        using var repo = new FakeRepo();
+        repo.PlantXml("x64/Debug/net10.0-windows10.0.22621.0", Base);
+        repo.PlantXml("x64/Release/net10.0-windows10.0.22621.0", Base.AddMinutes(28));
+        repo.PlantSource("Core/Widget.cs", Base.AddMinutes(-5));
+
+        var (exitCode, output) = repo.CompileWithReference();
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains(
+            "XML: src/Reactor/bin/x64/Release/net10.0-windows10.0.22621.0/Reactor.xml " +
+            "(2026-08-01T19:28:00Z, newest of 2 candidate(s))",
+            output);
+        Assert.DoesNotContain("bin/x64/Debug/net10.0-windows10.0.22621.0/Reactor.xml", output);
+    }
+
+    /// <summary>
+    /// No build at all is a skip, not a failure — the first-compile case, and
+    /// the one the "not found" message exists for.
+    /// </summary>
+    [Fact]
+    public void No_build_at_all_skips_reference_generation_without_failing()
+    {
+        using var repo = new FakeRepo();
+        repo.PlantSource("Core/Widget.cs", Base);
+
+        var (exitCode, output) = repo.CompileWithReference();
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("Reactor.xml not found", output);
+        Assert.DoesNotContain("REACTOR_DOC_REFGEN_W002", output);
+    }
+
+    /// <summary>
+    /// Minimal repo the doc compiler accepts, plus the two trees issue #1068 is
+    /// about: <c>src/Reactor/bin</c> (candidates) and <c>src/Reactor</c>
+    /// (sources). Modelled on the fixture in
+    /// <see cref="CompileCaptureSkipTests"/>.
+    /// </summary>
+    private sealed class FakeRepo : IDisposable
+    {
+        private readonly string _root;
+        private readonly string _originalCwd;
+
+        public FakeRepo()
+        {
+            _originalCwd = Directory.GetCurrentDirectory();
+            _root = Path.Join(Path.GetTempPath(),
+                "reactor-refgen-stale-" + Guid.NewGuid().ToString("N"));
+
+            Directory.CreateDirectory(Path.Join(_root, ".git"));
+            Directory.CreateDirectory(Path.Join(_root, "docs", "guide", "images"));
+            File.WriteAllText(
+                Path.Join(_root, "Directory.Build.props"),
+                "<Project>\n  <PropertyGroup>\n    <ReactorPublicVersion>0.1.0-test</ReactorPublicVersion>\n  </PropertyGroup>\n</Project>\n");
+
+            // DiscoverApps requires at least one .cs file beside the manifest.
+            var appDir = Path.Join(_root, "docs", "_pipeline", "apps", "demo");
+            Directory.CreateDirectory(appDir);
+            File.WriteAllText(Path.Join(appDir, "App.cs"), "// Fixture marker.\n");
+            File.WriteAllText(Path.Join(appDir, "doc-manifest.yaml"),
+                """
+                app:
+                  title: "Demo"
+                  width: 400
+                  height: 300
+                  startup-delay: 0
+
+                screenshots: []
+
+                """);
+
+            var templatesDir = Path.Join(_root, "docs", "_pipeline", "templates");
+            Directory.CreateDirectory(templatesDir);
+            File.WriteAllText(Path.Join(templatesDir, "demo.md.dt"),
+                """
+                ---
+                title: "Demo"
+                app: demo
+                order: 1
+                audience: beginner
+                goal: |
+                  Fixture template for the reference-staleness wiring tests.
+                tier: stub
+                ---
+
+                # Demo
+
+                Placeholder body.
+
+                """);
+
+            // Phase 5.7 returns early without this, so the tests would pass on a
+            // pipeline that never reached the selection code at all.
+            File.WriteAllText(
+                Path.Join(_root, "docs", "_pipeline", "reference-map.yaml"),
+                """
+                defaults:
+                  - match: "Microsoft.UI.Reactor.Hooks.*"
+                    category: hooks
+                    guide-pages: [demo]
+                """);
+        }
+
+        /// <summary>
+        /// Writes a routable <c>Reactor.xml</c> at
+        /// <c>src/Reactor/bin/&lt;layout&gt;/</c>. The member is under
+        /// <c>Hooks</c> because Phase 5.7 restricts generation to that category,
+        /// so anything else would produce zero pages and exercise less.
+        /// </summary>
+        public string PlantXml(string layout, DateTime writeUtc) =>
+            Write(Path.Join("src", "Reactor", "bin", Native(layout)), "Reactor.xml",
+                """
+                <?xml version="1.0"?>
+                <doc>
+                  <assembly><name>Reactor</name></assembly>
+                  <members>
+                    <member name="T:Microsoft.UI.Reactor.Hooks.UseState">
+                      <summary>State hook.</summary>
+                    </member>
+                  </members>
+                </doc>
+                """,
+                writeUtc);
+
+        /// <summary>Writes a C# file at <c>src/Reactor/&lt;relativePath&gt;</c>.</summary>
+        public string PlantSource(string relativePath, DateTime writeUtc)
+        {
+            var native = Native(relativePath);
+            return Write(
+                Path.Join("src", "Reactor", Path.GetDirectoryName(native) ?? string.Empty),
+                Path.GetFileName(native),
+                "// fixture\n",
+                writeUtc);
+        }
+
+        private string Write(string relativeDir, string fileName, string content, DateTime writeUtc)
+        {
+            var dir = Path.Join(_root, relativeDir);
+            Directory.CreateDirectory(dir);
+            var path = Path.Join(dir, fileName);
+            File.WriteAllText(path, content);
+            // After the write: writing stamps the file with "now".
+            File.SetLastWriteTimeUtc(path, writeUtc);
+            return path;
+        }
+
+        private static string Native(string path) =>
+            path.Replace('/', Path.DirectorySeparatorChar);
+
+        /// <summary>
+        /// Runs the compile with reference generation ON (no
+        /// <c>--skip-reference</c>) and <c>--ci</c>, which is the combination CI
+        /// uses. Everything requiring a build, a desktop, a network or a
+        /// mermaid-cli is switched off.
+        /// </summary>
+        public (int ExitCode, string Output) CompileWithReference() =>
+            Compile("--no-screenshots", "--no-build", "--skip-diagrams", "--no-ai", "--ci");
+
+        private (int ExitCode, string Output) Compile(params string[] args)
+        {
+            var stdout = Console.Out;
+            var stderr = Console.Error;
+            using var buffer = new StringWriter();
+            try
+            {
+                Directory.SetCurrentDirectory(_root);
+                Console.SetOut(buffer);
+                Console.SetError(buffer);
+                var exit = CompileCommand.Run(args);
+                return (exit, buffer.ToString());
+            }
+            finally
+            {
+                Console.SetOut(stdout);
+                Console.SetError(stderr);
+                Directory.SetCurrentDirectory(_originalCwd);
+            }
+        }
+
+        public void Dispose() => FixtureCleanup.DeleteTree(_root);
+    }
+}


### PR DESCRIPTION
Fixes #1068.

## The bug

`mur docs compile` phase 5.7 generates `docs/guide/reference/**` from `Reactor.xml` — the XML doc-comment output of building `src/Reactor`. It picked the **first** `Reactor.xml` found in a fixed `Debug`-then-`Release` sweep, using a hardcoded directory-shape enumeration.

Configuration order says nothing about freshness. A leftover Debug build therefore shadowed a just-built Release one, and the generator rewrote the reference pages from stale XML **while exiting 0** — observed as a generated page reintroducing a sentence the commit had just deleted from source.

## The fix

**Newest-wins selection.** Candidates are enumerated recursively under `src/Reactor/bin` and ordered by last-write time, ties broken on the ordinal path. The old enumerator hardcoded two directory shapes plus an `x64`/`ARM64` allow-list, so RID-nested and publish layouts were invisible — the same incomplete-enumeration failure as the ordering bug. Widening to every depth is safe because both MSBuild's `Copy` task and `File.Copy` preserve last-write time, so a copy can only win when its origin build would have. Nested junctions/symlinks are skipped: what's behind one isn't this build's output, and a link pointing back at an ancestor would recurse until the path length gave out.

**The input is now named.** Phase 5.7 prints what it chose, which is what makes a recurrence diagnosable instead of invisible:

```
═══ Phase 5.7: Reference ═══
  XML: src/Reactor/bin/x64/Release/net10.0-windows10.0.22621.0/Reactor.xml (2026-08-01T19:45:14Z, newest of 3 candidate(s))
```

**`REACTOR_DOC_REFGEN_W002`.** Newest-wins fixes the choice *between* builds but not the case where every build is stale — source edited, nothing rebuilt — which produces identical wrong output. The phase now compares the chosen XML against the newest `.cs` under `src/Reactor` (excluding `bin`/`obj`, which the build writes itself) and warns when source is newer. Warning severity, so `--ci` cannot start failing on it.

## Testing

Tests assert every ordering claim in **both directions** — a newest-wins test whose fixture happens to put the newest file in `Debug` passes against the buggy code too, so half of each pair is the discriminating case and half guards the over-correction.

Two tiers: `ReactorXmlSelectionTests` pins the rules; `ReferenceStalenessWiringTests` drives `CompileCommand.Run` end to end, because helper-level tests stay green if Phase 5.7 stops calling them. Each warning assertion is paired with a run of the same fixture that must *not* produce it.

Every oracle was mutation-checked and reddens its target: config-order sweep, hardcoded layouts, dropped tie-break, dropped `bin`/`obj` exclusion, loosened comparison, prefix-vs-segment match, dropped merge, promoted severity, dropped reparse-point skip.

Two of those mutations came back **green** on the first pass and drove real changes:

- Driving the tie-break through `FindReactorXml` couldn't distinguish "sorted deterministically" from "arrived in that order" — the directory walk handed the sorter an already-agreeing order. `SelectNewest(IEnumerable<string>)` is split out so a test can feed both input orders.
- The reparse-point hardening had shipped with nothing pinning it, which prompted the junction tests.

## Review

Reviewed with the repo's own `.github/skills/pr-review` skill across eight dimensions plus a cross-model check. The most consequential finding was mine: I'd written, in a code comment *and* the docs, that CI "compiles on a clean checkout with no `src/Reactor` build at all". That's false — CI runs `docs compile --ci` without `--no-build`, Phase 2 builds all 49 doc apps, and each `ProjectReference`s `src/Reactor`. Reference generation runs for real on every PR. The warning stays quiet there for a verifiable reason instead: `actions/checkout` writes the sources before that build runs, so the XML always postdates them. Both places corrected.

## Validation

- 328/328 `Reactor.DocPipeline.Tests` pass
- `Reactor.Cli` Release compile: 0 warnings, 0 errors
- Real-repo `docs compile --ci` exits 0 with no doc churn
- No fixture temp-directory leaks (a junction in a fixture tree makes `Directory.Delete(recursive: true)` throw `UnauthorizedAccessException`, which `FixtureCleanup` swallows by design — measured 12 leaked directories before the teardown fix, 0 after)

## Out of scope

The CI path filter gap that let this land unnoticed. `docs/contributing/doc-pipeline.md` documents the selection rule, the diagnostic, and the actual CI behavior.