### PR TITLE
Guard text matching of ModifierTable receiver gates

### DIFF
--- a/.github/skills/analyzer-dym/SKILL.md
+++ b/.github/skills/analyzer-dym/SKILL.md
@@ -40,11 +40,15 @@ directly).
   names in `ModifierTable.cs` are their receiver lists concatenated, so a wider gate
   *necessarily* has a name containing the narrower one (`ControlBorder` ⊏
   `ControlBorderGridStack` ⊏ …). Read `ModifierInfo.ControlGate` / `PoolResetGate` and
-  compare type **sets**. Only if your artifact really is text (a prose-parity gate over a
-  doc or skill file) match with the boundary-anchored form `SLOT:\s*NAME\s*[,)]` —
-  `tests/Reactor.Tests/AnalyzerTests/ModifierGateSource.cs` already owns that matcher. A
-  bare `Contains(NAME)` passes on every wider gate, i.e. it silently green-lights exactly
-  the mis-widening you were checking for.
+  compare type **sets** — prose gates name receiver *types*, so a doc-parity check compares
+  sets too (see `ModifierGateProseParityTests`). Only when no typed property is reachable
+  should you match the table as text, and then anchor it: `SLOT:\s*NAME\s*[,)]`. A bare
+  `Contains(NAME)` passes on every wider gate, i.e. it silently green-lights exactly the
+  mis-widening you were checking for.
+  `tests/Reactor.Tests/AnalyzerTests/ModifierGateSource.cs` is the **test-only** reference
+  implementation of that matcher — it is `internal` to `Reactor.Tests`, so a `mur check`
+  rule cannot call it; copy the pattern and add a parity test, as with other analyzer/CLI
+  shared logic.
 
 ## Workflow
 

--- a/.github/skills/analyzer-dym/SKILL.md
+++ b/.github/skills/analyzer-dym/SKILL.md
@@ -36,6 +36,15 @@ directly).
   / `GetSymbolInfo` — never off raw syntax text.
 - `mur check` rules are **reflection-discovered** in `RuleRegistry.cs`: add or remove the
   rule *file*, do not hand-edit a registry list.
+- **Compare what a `ModifierTable` gate contains, not what it is called.** The gate group
+  names in `ModifierTable.cs` are their receiver lists concatenated, so a wider gate
+  *necessarily* has a name containing the narrower one (`ControlBorder` ⊏
+  `ControlBorderGridStack` ⊏ …). Read `ModifierInfo.ControlGate` / `PoolResetGate` and
+  compare type **sets**. Only if your artifact really is text (a prose-parity gate over a
+  doc or skill file) match with the boundary-anchored form `SLOT:\s*NAME\s*[,)]` —
+  `tests/Reactor.Tests/AnalyzerTests/ModifierGateSource.cs` already owns that matcher. A
+  bare `Contains(NAME)` passes on every wider gate, i.e. it silently green-lights exactly
+  the mis-widening you were checking for.
 
 ## Workflow
 

--- a/src/Reactor.Analyzers/ModifierTable.cs
+++ b/src/Reactor.Analyzers/ModifierTable.cs
@@ -278,13 +278,17 @@ internal static class ModifierTable
     //
     // So: compare what a gate CONTAINS, not what it is CALLED. Read ModifierInfo.ControlGate /
     // ModifierInfo.PoolResetGate and compare the type sets — that is what every check in
-    // ModifierTableIntegrityTests does, and it is why none of them can be fooled here.
+    // ModifierTableIntegrityTests does, and it is why none of them can be fooled here. It is also
+    // what ModifierGateProseParityTests does for the REACTOR_MOD_003 gate list in the shipped
+    // reactor-build-and-check skill: prose names receiver TYPES, so it compares sets too.
     //
-    // Only when the artifact genuinely is text — a prose-parity gate over a doc or skill file, where
-    // no typed property is reachable — match with a boundary-anchored pattern, `SLOT:\s*NAME\s*[,)]`.
+    // Only when the artifact genuinely leaves no typed property reachable should you match this
+    // file as text, and then anchor on the delimiters the C# syntax guarantees: `SLOT:\s*NAME\s*[,)]`.
     // A bare Contains(NAME) selects every wider gate as well, silently passing the very assertion
-    // meant to catch a mis-widened gate. tests/Reactor.Tests/AnalyzerTests/ModifierGateSource.cs owns
-    // the vetted matcher and ModifierGateIdentifierTests pins it to this table. Issue #1062.
+    // meant to catch a mis-widened gate. tests/Reactor.Tests/AnalyzerTests/ModifierGateSource.cs is
+    // the test-only reference implementation of that matcher — it is internal to Reactor.Tests, so
+    // CLI and analyzer code must copy the pattern and add a parity test rather than call it —
+    // and ModifierGateIdentifierTests pins it to this table. Issue #1062.
     private static readonly string[] ControlBorderGridStackRelativeText = { "Control", "Border", "Grid", "StackPanel", "RelativePanel", "TextBlock" };
     private static readonly string[] ControlBorderGridStackRelative = { "Control", "Border", "Grid", "StackPanel", "RelativePanel" };
     private static readonly string[] ControlBorder = { "Control", "Border" };

--- a/src/Reactor.Analyzers/ModifierTable.cs
+++ b/src/Reactor.Analyzers/ModifierTable.cs
@@ -269,7 +269,22 @@ internal sealed class AttachedModifierInfo
 /// </remarks>
 internal static class ModifierTable
 {
-    // Type groups, named once so the intent is legible at each use site.
+    // Type groups, named once so the intent is legible at each use site. Each name is its receiver
+    // list concatenated, which is deliberate — and it makes set inclusion equivalent to string
+    // inclusion. A gate that is a superset of another therefore *necessarily* has a name that
+    // contains the narrower one: ControlBorder is a prefix of ControlBorderGridStack, which is a
+    // prefix of ControlBorderGridStackRelative, which is a prefix of the ...Text form (8 such strict
+    // prefix pairs today), and PanelControlBorder contains ControlBorder without starting with it.
+    //
+    // So: compare what a gate CONTAINS, not what it is CALLED. Read ModifierInfo.ControlGate /
+    // ModifierInfo.PoolResetGate and compare the type sets — that is what every check in
+    // ModifierTableIntegrityTests does, and it is why none of them can be fooled here.
+    //
+    // Only when the artifact genuinely is text — a prose-parity gate over a doc or skill file, where
+    // no typed property is reachable — match with a boundary-anchored pattern, `SLOT:\s*NAME\s*[,)]`.
+    // A bare Contains(NAME) selects every wider gate as well, silently passing the very assertion
+    // meant to catch a mis-widened gate. tests/Reactor.Tests/AnalyzerTests/ModifierGateSource.cs owns
+    // the vetted matcher and ModifierGateIdentifierTests pins it to this table. Issue #1062.
     private static readonly string[] ControlBorderGridStackRelativeText = { "Control", "Border", "Grid", "StackPanel", "RelativePanel", "TextBlock" };
     private static readonly string[] ControlBorderGridStackRelative = { "Control", "Border", "Grid", "StackPanel", "RelativePanel" };
     private static readonly string[] ControlBorder = { "Control", "Border" };

--- a/tests/Reactor.Tests/AnalyzerTests/ModifierGateIdentifierTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/ModifierGateIdentifierTests.cs
@@ -104,10 +104,11 @@ public class ModifierGateIdentifierTests
         // The other direction: a gate the typed table carries but the reader did not see.
         foreach (var property in ModifierTable.Properties.Keys)
         {
-            foreach (var slotName in ModifierGateSource.SlotNames)
+            var typedSlots = ModifierGateSource.SlotNames
+                .Where(slotName => TypedGate(property, slotName) is not null);
+
+            foreach (var slotName in typedSlots)
             {
-                if (TypedGate(property, slotName) is null)
-                    continue;
                 if (slots.Any(slot => slot.Property == property && slot.Slot == slotName))
                     continue;
 

--- a/tests/Reactor.Tests/AnalyzerTests/ModifierGateIdentifierTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/ModifierGateIdentifierTests.cs
@@ -1,0 +1,297 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.UI.Reactor.Analyzers;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests.AnalyzerTests;
+
+/// <summary>
+/// Guards the one way a check is allowed to read <see cref="ModifierTable"/>'s receiver gates as
+/// text. Issue #1062.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The gate groups are named by concatenating their receiver list, which makes <b>set inclusion
+/// equivalent to string prefixing</b>: <c>ControlBorder</c> ⊏ <c>ControlBorderGridStack</c> ⊏
+/// <c>ControlBorderGridStackRelative</c> ⊏ <c>…RelativeText</c>. A superset gate cannot help but
+/// have a superset name, so the collision set grows with every gate added and a fix applied to one
+/// pair falls behind on the next.
+/// </para>
+/// <para>
+/// <see cref="ModifierTableIntegrityTests"/> is immune to all of it, because it reads the typed
+/// <see cref="ModifierInfo.ControlGate"/> and compares type <em>sets</em> — which is the pattern to
+/// copy. These facts exist for the consumer that has no such option: a <c>mur check</c> rule, a
+/// docs or prose-parity gate, a review script. For those, matching must be anchored on the
+/// delimiter the C# syntax already guarantees, and this pins that matcher to the typed authority
+/// so it cannot quietly regress to a substring.
+/// </para>
+/// </remarks>
+public class ModifierGateIdentifierTests
+{
+    /// <summary>
+    /// Positive control for the reader itself: a broken reader and a table with no gates read the
+    /// same on screen, so pin the syntax reader to the typed table in both directions before
+    /// anything else measures with it.
+    /// </summary>
+    [Fact]
+    public void Gate_Reader_Agrees_With_The_Typed_Table()
+    {
+        var groups = ModifierGateSource.DeclaredGroups;
+        var slots = ModifierGateSource.GateSlots;
+
+        // Floors measured on this table: 9 declared string[] groups, 11 gate arguments across
+        // 7 distinct identifiers. They are a non-vacuity guard, not a target — raise them when the
+        // table grows, never lower them to make a stalled reader pass.
+        Assert.True(
+            groups.Count >= 9,
+            $"Only {groups.Count} string[] gate groups were read out of ModifierTable.cs; expected at " +
+            "least 9. The declaration reader has probably stopped matching — fix it rather than " +
+            "lowering this floor.");
+        Assert.True(
+            slots.Count >= 11,
+            $"Only {slots.Count} controlGate/poolResetGate arguments were read out of " +
+            "ModifierTable.Properties; expected at least 11. The entry reader has probably stopped " +
+            "matching — fix it rather than lowering this floor.");
+        Assert.True(
+            slots.Select(slot => slot.Identifier).Distinct(StringComparer.Ordinal).Count() >= 7,
+            "Fewer than 7 distinct gate identifiers were read; the reader has probably stopped " +
+            "matching.");
+
+        // Set-equality is how a name is resolved back to a gate everywhere below, so it has to
+        // identify one unambiguously.
+        var ambiguous = (from a in groups
+                         from b in groups
+                         where StringComparer.Ordinal.Compare(a.Key, b.Key) < 0
+                         where SameSet(a.Value, b.Value)
+                         select $"{a.Key} and {b.Key} declare the same types").ToList();
+
+        Assert.True(
+            ambiguous.Count == 0,
+            "Two gate groups now declare identical type sets, so a gate can no longer be resolved " +
+            "from its contents and the matcher tests below would compare against the wrong one. " +
+            "Merge them, or give this file a different identity function:\n  " +
+            string.Join("\n  ", ambiguous));
+
+        var problems = new List<string>();
+
+        foreach (var slot in slots)
+        {
+            if (!groups.TryGetValue(slot.Identifier, out var declared))
+            {
+                problems.Add(
+                    $"{slot.Property}: {slot.Slot} names '{slot.Identifier}', which is not a declared " +
+                    "string[] group in ModifierTable");
+                continue;
+            }
+
+            var typed = TypedGate(slot.Property, slot.Slot);
+            if (typed is null)
+            {
+                problems.Add(
+                    $"{slot.Property}: the source has {slot.Slot}: {slot.Identifier}, but the typed " +
+                    $"ModifierInfo.{TypedMemberName(slot.Slot)} is null");
+            }
+            else if (!SameSet(typed, declared))
+            {
+                problems.Add(
+                    $"{slot.Property}: {slot.Slot} names '{slot.Identifier}' " +
+                    $"([{string.Join("|", declared)}]) but the typed value is " +
+                    $"[{string.Join("|", typed)}]");
+            }
+        }
+
+        // The other direction: a gate the typed table carries but the reader did not see.
+        foreach (var property in ModifierTable.Properties.Keys)
+        {
+            foreach (var slotName in ModifierGateSource.SlotNames)
+            {
+                if (TypedGate(property, slotName) is null)
+                    continue;
+                if (slots.Any(slot => slot.Property == property && slot.Slot == slotName))
+                    continue;
+
+                problems.Add(
+                    $"{property}: the typed ModifierInfo.{TypedMemberName(slotName)} is set, but the " +
+                    $"reader found no '{slotName}:' argument for it — the entry is probably written " +
+                    "in a shape the reader does not handle (a positional argument, or a group built " +
+                    "inline).");
+            }
+        }
+
+        Assert.True(
+            problems.Count == 0,
+            "The ModifierTable.cs gate reader has drifted from the typed table it is supposed to " +
+            "mirror, so every text-matching fact below would be measuring the wrong thing:\n  " +
+            string.Join("\n  ", problems));
+    }
+
+    /// <summary>
+    /// The invariant: text matching, done with the delimiter, agrees exactly with the typed gate.
+    /// </summary>
+    [Fact]
+    public void Boundary_Matching_Selects_Exactly_The_Properties_The_Typed_Gate_Names()
+    {
+        var problems = new List<string>();
+        var selected = 0;
+
+        foreach (var (name, types) in ModifierGateSource.DeclaredGroups
+                     .OrderBy(group => group.Key, StringComparer.Ordinal))
+        {
+            var union = new HashSet<string>(StringComparer.Ordinal);
+
+            foreach (var slot in ModifierGateSource.SlotNames)
+            {
+                var matched = ModifierGateSource.MatchAnchored(slot, name);
+                var typed = PropertiesCarrying(slot, types);
+                selected += matched.Count;
+                union.UnionWith(typed);
+
+                if (!matched.SetEquals(typed))
+                {
+                    problems.Add(
+                        $"{slot} '{name}': anchored matching selects " +
+                        $"[{Join(matched)}] but the typed gate is carried by [{Join(typed)}]");
+                }
+            }
+
+            // The alternation the issue's suggested fix is written with, over both slots at once.
+            var either = ModifierGateSource.MatchAnchored(ModifierGateSource.AnySlot, name);
+            if (!either.SetEquals(union))
+            {
+                problems.Add(
+                    $"either-slot '{name}': anchored matching selects [{Join(either)}] but the typed " +
+                    $"gate is carried by [{Join(union)}]");
+            }
+        }
+
+        Assert.True(
+            problems.Count == 0,
+            "Anchored gate matching disagrees with ModifierTable's typed ControlGate/PoolResetGate, " +
+            "which is the authority. Either the matcher is wrong, or an entry is written in a shape " +
+            "it cannot see (a positional argument, a trailing comment inside the call):\n  " +
+            string.Join("\n  ", problems));
+
+        // Every real gate argument must be reachable by the matcher, or the agreement above could
+        // be two empty sets agreeing with each other.
+        Assert.True(
+            selected == ModifierGateSource.GateSlots.Count,
+            $"Anchored matching selected {selected} gate slots but the syntax tree has " +
+            $"{ModifierGateSource.GateSlots.Count}. The matcher is missing real slots (or matching " +
+            "text outside the table), so its agreement with the typed gate above is not a measurement.");
+    }
+
+    /// <summary>
+    /// The differential oracle: on the real collision pairs, substring matching accepts a property
+    /// whose gate is <em>wider</em> than the one asked about, and anchored matching does not.
+    /// </summary>
+    /// <remarks>
+    /// Relax <c>ModifierGateSource.AnchoredPattern</c> to a substring and the first assertion
+    /// reddens — that is what makes it a guard rather than a restatement. The two floors under it
+    /// keep the guard from passing vacuously once the naming stops colliding.
+    /// </remarks>
+    [Fact]
+    public void Substring_Matching_Accepts_A_Wider_Gate_Where_Boundary_Matching_Does_Not()
+    {
+        var identifiers = ModifierGateSource.GateSlots
+            .Select(slot => slot.Identifier)
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(name => name, StringComparer.Ordinal)
+            .ToList();
+
+        var anchoredFalseAccepts = new List<string>();
+        var prefixFalseAccepts = new List<string>();
+        var substringOnlyFalseAccepts = new List<string>();
+
+        foreach (var narrow in identifiers)
+        {
+            foreach (var wide in identifiers)
+            {
+                if (StringComparer.Ordinal.Equals(narrow, wide)
+                    || !wide.Contains(narrow, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                // `PanelControlBorder` contains `ControlBorder` without starting with it, so it is
+                // invisible to a prefix-only fix but not to a bare Contains. The issue enumerates
+                // both classes; both are floored below.
+                var isPrefix = wide.StartsWith(narrow, StringComparison.Ordinal);
+
+                foreach (var slot in ModifierGateSource.SlotNames)
+                {
+                    // Properties carrying the WIDE gate in this slot. A check asking "does this
+                    // property have the NARROW gate?" must answer no for every one of them.
+                    var exposed = PropertiesCarrying(slot, ModifierGateSource.DeclaredGroups[wide])
+                        .Except(
+                            PropertiesCarrying(slot, ModifierGateSource.DeclaredGroups[narrow]),
+                            StringComparer.Ordinal)
+                        .ToList();
+
+                    if (exposed.Count == 0)
+                        continue;
+
+                    var anchored = ModifierGateSource.MatchAnchored(slot, narrow);
+                    var naive = ModifierGateSource.MatchNaive(slot, narrow);
+                    var bare = ModifierGateSource.MatchNaiveBare(narrow);
+
+                    foreach (var property in exposed)
+                    {
+                        var where = $"{property}/{slot}: asked for '{narrow}', actually carries '{wide}'";
+
+                        if (anchored.Contains(property))
+                            anchoredFalseAccepts.Add(where);
+
+                        if (isPrefix && naive.Contains(property))
+                            prefixFalseAccepts.Add(where);
+
+                        if (!isPrefix && bare.Contains(property))
+                            substringOnlyFalseAccepts.Add(where);
+                    }
+                }
+            }
+        }
+
+        Assert.True(
+            anchoredFalseAccepts.Count == 0,
+            "Anchored gate matching accepted a property whose gate is WIDER than the one asked " +
+            "about — the exact false PASS issue #1062 is about, now in the matcher that is supposed " +
+            "to prevent it:\n  " + string.Join("\n  ", anchoredFalseAccepts));
+
+        Assert.True(
+            prefixFalseAccepts.Count > 0,
+            "No gate identifier is a strict prefix of another any more, so the assertion above " +
+            "passes without being tested and this guard has outlived its reason. If the cumulative " +
+            "naming was deliberately abandoned, retire these facts with it — do not leave a matcher " +
+            "guard that measures nothing.");
+
+        Assert.True(
+            substringOnlyFalseAccepts.Count > 0,
+            "No gate identifier CONTAINS another without also starting with it (it was " +
+            "PanelControlBorder ⊃ ControlBorder), so the harder half of issue #1062 — the one a " +
+            "prefix-only fix misses — is no longer exercised. Confirm that is deliberate before " +
+            "dropping this floor.");
+    }
+
+    private static string TypedMemberName(string slot) =>
+        slot == ModifierGateSource.ControlGate ? nameof(ModifierInfo.ControlGate) : nameof(ModifierInfo.PoolResetGate);
+
+    private static string[]? TypedGate(string property, string slot) =>
+        !ModifierTable.Properties.TryGetValue(property, out var info) ? null
+            : slot == ModifierGateSource.ControlGate ? info.ControlGate
+            : info.PoolResetGate;
+
+    /// <summary>Properties whose typed gate in <paramref name="slot"/> is exactly these types.</summary>
+    private static ISet<string> PropertiesCarrying(string slot, string[] types) =>
+        new HashSet<string>(
+            ModifierTable.Properties
+                .Where(entry => TypedGate(entry.Key, slot) is { } gate && SameSet(gate, types))
+                .Select(entry => entry.Key),
+            StringComparer.Ordinal);
+
+    private static bool SameSet(string[] left, string[] right) =>
+        new HashSet<string>(left, StringComparer.Ordinal).SetEquals(right);
+
+    private static string Join(IEnumerable<string> values) =>
+        string.Join("|", values.OrderBy(value => value, StringComparer.Ordinal));
+}

--- a/tests/Reactor.Tests/AnalyzerTests/ModifierGateIdentifierTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/ModifierGateIdentifierTests.cs
@@ -301,8 +301,10 @@ public class ModifierGateIdentifierTests
         {
             foreach (var slot in ModifierGateSource.SlotNames)
             {
-                // The needle is `slot + ": " + id`, so it accepts any gate name in that slot that
-                // STARTS WITH the identifier — that is precisely the hazard, stated positively.
+                // The needle is the slot and identifier with no closing delimiter, so it accepts any
+                // gate name in that slot that STARTS WITH the identifier — the hazard, stated
+                // positively. Whitespace between the two is tolerated, so this prediction holds
+                // regardless of how the table is formatted.
                 var predicted = PropertiesWhere(argument =>
                     argument.Slot == slot
                     && argument.Identifier.StartsWith(identifier, StringComparison.Ordinal));
@@ -337,9 +339,9 @@ public class ModifierGateIdentifierTests
             "A hazard matcher no longer selects what ModifierTable's argument list predicts, so the " +
             "non-vacuity floors in " +
             nameof(Substring_Matching_Accepts_A_Wider_Gate_Where_Boundary_Matching_Does_Not) +
-            " are not measuring the hazard they claim to. Either a matcher is broken, or the table's " +
-            "formatting changed so the naive needle ('slot: Name', exactly one space) no longer " +
-            "reflects how the gates are written:\n  " + string.Join("\n  ", problems));
+            " are not measuring the hazard they claim to. Both matchers are whitespace-tolerant, so " +
+            "reformatting the table is not an explanation — a matcher is broken:\n  " +
+            string.Join("\n  ", problems));
 
         // Negative control: an identifier that appears nowhere must select nothing in all three
         // matchers. Without this, a matcher that returns everything could still agree above if the

--- a/tests/Reactor.Tests/AnalyzerTests/ModifierGateIdentifierTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/ModifierGateIdentifierTests.cs
@@ -188,7 +188,9 @@ public class ModifierGateIdentifierTests
     /// <remarks>
     /// Relax <c>ModifierGateSource.AnchoredPattern</c> to a substring and the first assertion
     /// reddens — that is what makes it a guard rather than a restatement. The two floors under it
-    /// keep the guard from passing vacuously once the naming stops colliding.
+    /// keep the guard from passing vacuously once the naming stops colliding, and
+    /// <see cref="Hazard_Matchers_Select_Exactly_What_The_Syntax_Model_Predicts"/> keeps the
+    /// matchers those floors are measured with honest.
     /// </remarks>
     [Fact]
     public void Substring_Matching_Accepts_A_Wider_Gate_Where_Boundary_Matching_Does_Not()
@@ -232,8 +234,8 @@ public class ModifierGateIdentifierTests
                         continue;
 
                     var anchored = ModifierGateSource.MatchAnchored(slot, narrow);
-                    var naive = ModifierGateSource.MatchNaive(slot, narrow);
-                    var bare = ModifierGateSource.MatchNaiveBare(narrow);
+                    var naive = ModifierGateSource.Hazard.SlotPrefixed(slot, narrow);
+                    var bare = ModifierGateSource.Hazard.Bare(narrow);
 
                     foreach (var property in exposed)
                     {
@@ -273,6 +275,92 @@ public class ModifierGateIdentifierTests
             "dropping this floor.");
     }
 
+    /// <summary>
+    /// Positive control for the hazard matchers themselves: they must select exactly what the
+    /// syntax model predicts, not merely "at least the properties fact C looks at".
+    /// </summary>
+    /// <remarks>
+    /// Fact C only inspects the sites where a false accept is expected, so a hazard matcher that
+    /// stopped discriminating — <c>Select(_ =&gt; true)</c> is the degenerate case — would satisfy
+    /// its floors while proving nothing. A broken instrument is trusted by default, so pin it:
+    /// the expectation here is computed from the Roslyn argument list, independently of the text
+    /// matching under test.
+    /// </remarks>
+    [Fact]
+    public void Hazard_Matchers_Select_Exactly_What_The_Syntax_Model_Predicts()
+    {
+        var identifiers = ModifierGateSource.GateSlots
+            .Select(slot => slot.Identifier)
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(name => name, StringComparer.Ordinal)
+            .ToList();
+
+        var problems = new List<string>();
+
+        foreach (var identifier in identifiers)
+        {
+            foreach (var slot in ModifierGateSource.SlotNames)
+            {
+                // The needle is `slot + ": " + id`, so it accepts any gate name in that slot that
+                // STARTS WITH the identifier — that is precisely the hazard, stated positively.
+                var predicted = PropertiesWhere(argument =>
+                    argument.Slot == slot
+                    && argument.Identifier.StartsWith(identifier, StringComparison.Ordinal));
+
+                var actual = ModifierGateSource.Hazard.SlotPrefixed(slot, identifier);
+
+                if (!actual.SetEquals(predicted))
+                {
+                    problems.Add(
+                        $"Hazard.SlotPrefixed({slot}, '{identifier}') selected [{Join(actual)}] but the " +
+                        $"argument list predicts [{Join(predicted)}]");
+                }
+            }
+
+            // Slot-blind: any referenced group name that contains the identifier anywhere, in any
+            // argument — including elementTypes, which the gate slots exclude.
+            var predictedBare = PropertiesWhere(argument =>
+                argument.Identifier.Contains(identifier, StringComparison.Ordinal));
+
+            var actualBare = ModifierGateSource.Hazard.Bare(identifier);
+
+            if (!actualBare.SetEquals(predictedBare))
+            {
+                problems.Add(
+                    $"Hazard.Bare('{identifier}') selected [{Join(actualBare)}] but the argument list " +
+                    $"predicts [{Join(predictedBare)}]");
+            }
+        }
+
+        Assert.True(
+            problems.Count == 0,
+            "A hazard matcher no longer selects what ModifierTable's argument list predicts, so the " +
+            "non-vacuity floors in " +
+            nameof(Substring_Matching_Accepts_A_Wider_Gate_Where_Boundary_Matching_Does_Not) +
+            " are not measuring the hazard they claim to. Either a matcher is broken, or the table's " +
+            "formatting changed so the naive needle ('slot: Name', exactly one space) no longer " +
+            "reflects how the gates are written:\n  " + string.Join("\n  ", problems));
+
+        // Negative control: an identifier that appears nowhere must select nothing in all three
+        // matchers. Without this, a matcher that returns everything could still agree above if the
+        // prediction were equally broken.
+        const string Absent = "NoSuchGateIdentifier1062";
+        Assert.Empty(ModifierGateSource.Hazard.Bare(Absent));
+        foreach (var slot in ModifierGateSource.SlotNames)
+        {
+            Assert.Empty(ModifierGateSource.Hazard.SlotPrefixed(slot, Absent));
+            Assert.Empty(ModifierGateSource.MatchAnchored(slot, Absent));
+        }
+    }
+
+    /// <summary>Properties with at least one entry argument satisfying <paramref name="predicate"/>.</summary>
+    private static ISet<string> PropertiesWhere(Func<ModifierGateArgument, bool> predicate) =>
+        new HashSet<string>(
+            ModifierGateSource.EntryArguments
+                .Where(entry => entry.Value.Any(predicate))
+                .Select(entry => entry.Key),
+            StringComparer.Ordinal);
+
     private static string TypedMemberName(string slot) =>
         slot == ModifierGateSource.ControlGate ? nameof(ModifierInfo.ControlGate) : nameof(ModifierInfo.PoolResetGate);
 
@@ -282,14 +370,14 @@ public class ModifierGateIdentifierTests
             : info.PoolResetGate;
 
     /// <summary>Properties whose typed gate in <paramref name="slot"/> is exactly these types.</summary>
-    private static ISet<string> PropertiesCarrying(string slot, string[] types) =>
+    private static ISet<string> PropertiesCarrying(string slot, IReadOnlyList<string> types) =>
         new HashSet<string>(
             ModifierTable.Properties
                 .Where(entry => TypedGate(entry.Key, slot) is { } gate && SameSet(gate, types))
                 .Select(entry => entry.Key),
             StringComparer.Ordinal);
 
-    private static bool SameSet(string[] left, string[] right) =>
+    private static bool SameSet(IEnumerable<string> left, IEnumerable<string> right) =>
         new HashSet<string>(left, StringComparer.Ordinal).SetEquals(right);
 
     private static string Join(IEnumerable<string> values) =>

--- a/tests/Reactor.Tests/AnalyzerTests/ModifierGateIdentifierTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/ModifierGateIdentifierTests.cs
@@ -104,14 +104,13 @@ public class ModifierGateIdentifierTests
         // The other direction: a gate the typed table carries but the reader did not see.
         foreach (var property in ModifierTable.Properties.Keys)
         {
-            var typedSlots = ModifierGateSource.SlotNames
-                .Where(slotName => TypedGate(property, slotName) is not null);
+            var unreadSlots = ModifierGateSource.SlotNames
+                .Where(slotName => TypedGate(property, slotName) is not null)
+                .Where(slotName => !slots.Any(
+                    slot => slot.Property == property && slot.Slot == slotName));
 
-            foreach (var slotName in typedSlots)
+            foreach (var slotName in unreadSlots)
             {
-                if (slots.Any(slot => slot.Property == property && slot.Slot == slotName))
-                    continue;
-
                 problems.Add(
                     $"{property}: the typed ModifierInfo.{TypedMemberName(slotName)} is set, but the " +
                     $"reader found no '{slotName}:' argument for it — the entry is probably written " +

--- a/tests/Reactor.Tests/AnalyzerTests/ModifierGateProseParityTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/ModifierGateProseParityTests.cs
@@ -53,13 +53,14 @@ public class ModifierGateProseParityTests
 
         var relativeSkillPath = SkillPath.Replace('/', Path.DirectorySeparatorChar);
 
-        // Path.Combine silently discards repoRoot if the second argument is rooted, which would
-        // make this fact read some other machine's file — or nothing — instead of failing.
+        // Path.Join, not Path.Combine: Combine silently discards repoRoot if the second argument is
+        // rooted, which would make this fact read some unrelated file instead of failing. Join has
+        // no such behavior. The assertion keeps the intent explicit either way.
         Assert.False(
             Path.IsPathRooted(relativeSkillPath),
-            $"SkillPath must stay repo-relative; '{relativeSkillPath}' is rooted and would discard the repo root.");
+            $"SkillPath must stay repo-relative; '{relativeSkillPath}' is rooted.");
 
-        var file = Path.Combine(repoRoot!, relativeSkillPath);
+        var file = Path.Join(repoRoot!, relativeSkillPath);
         Assert.True(File.Exists(file), $"{SkillPath} not found at {file}");
 
         var text = File.ReadAllText(file);
@@ -76,12 +77,11 @@ public class ModifierGateProseParityTests
         var stated = new Dictionary<string, ISet<string>>(StringComparer.Ordinal);
         var arrows = clause.Groups["body"].Value
             .Split(';')
-            .Select(segment => segment.Split('→'));
+            .Select(segment => segment.Split('→'))
+            .Where(arrow => arrow.Length == 2);
 
         foreach (var arrow in arrows)
         {
-            if (arrow.Length != 2)
-                continue;
 
             var types = new HashSet<string>(
                 arrow[1].Split('/').Select(t => t.Trim()).Where(t => t.Length > 0),

--- a/tests/Reactor.Tests/AnalyzerTests/ModifierGateProseParityTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/ModifierGateProseParityTests.cs
@@ -1,0 +1,144 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Microsoft.UI.Reactor.Analyzers;
+using Microsoft.UI.Reactor.Cli.Pack;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests.AnalyzerTests;
+
+/// <summary>
+/// Pins the <c>REACTOR_MOD_003</c> gate list in the shipped
+/// <c>reactor-build-and-check</c> skill to <see cref="ModifierTable"/>. Issue #1062.
+/// </summary>
+/// <remarks>
+/// <para>
+/// That row states the receiver gates in prose — "<c>Background</c> → Panel/Control/Border", and
+/// four more. It is shipped to end users as agent guidance, and until this fact existed nothing
+/// tied it to the table it describes, so widening a gate in <c>ModifierTable.cs</c> left the skill
+/// quietly wrong. This is the concrete text consumer issue #1062 was filed about.
+/// </para>
+/// <para>
+/// Note what this fact does <b>not</b> need: the gate group identifiers. The prose names receiver
+/// <em>types</em>, so the comparison is set-vs-set against the typed
+/// <see cref="ModifierInfo.ControlGate"/> — the rule the issue lands on, applied. A check phrased
+/// over gate <em>names</em> would have been the exposed one; see
+/// <see cref="ModifierGateIdentifierTests"/> for the matcher that makes name-based matching safe
+/// when an artifact leaves no alternative.
+/// </para>
+/// </remarks>
+public class ModifierGateProseParityTests
+{
+    private const string SkillPath = "plugins/reactor/skills/reactor-build-and-check/SKILL.md";
+
+    /// <summary>Prose spelling → the type name <see cref="ModifierTable"/> uses.</summary>
+    private static readonly Dictionary<string, string> ProseTypeNames = new(StringComparer.Ordinal)
+    {
+        ["Panel"] = "Panel",
+        ["Control"] = "Control",
+        ["Border"] = "Border",
+        ["Grid"] = "Grid",
+        ["StackPanel"] = "StackPanel",
+        ["RelativePanel"] = "RelativePanel",
+        ["TextBlock"] = "TextBlock",
+    };
+
+    [Fact]
+    public void Skill_Prose_Gate_List_Matches_The_Table()
+    {
+        var repoRoot = RepoRootFinder.FindRepoRoot();
+        Assert.NotNull(repoRoot);
+
+        var file = Path.Combine(repoRoot!, SkillPath.Replace('/', Path.DirectorySeparatorChar));
+        Assert.True(File.Exists(file), $"{SkillPath} not found at {file}");
+
+        var text = File.ReadAllText(file);
+
+        // The clause runs from "Gates:" to the end of that sentence.
+        var clause = Regex.Match(text, @"Gates:\s*(?<body>[^.|]+)");
+        Assert.True(
+            clause.Success,
+            $"No 'Gates: …' clause found in {SkillPath}. The REACTOR_MOD_003 row used to state the " +
+            "receiver gates in prose; if that was intentionally removed, delete this fact with it — " +
+            "do not leave a parity gate that silently measures nothing.");
+
+        // "Background → Panel/Control/Border; Foreground and fonts → Control/TextBlock; …"
+        var stated = new Dictionary<string, ISet<string>>(StringComparer.Ordinal);
+        foreach (var segment in clause.Groups["body"].Value.Split(';'))
+        {
+            var arrow = segment.Split('→');
+            if (arrow.Length != 2)
+                continue;
+
+            var types = new HashSet<string>(
+                arrow[1].Split('/').Select(t => t.Trim()).Where(t => t.Length > 0),
+                StringComparer.Ordinal);
+
+            // Backticked property names on the left: `BorderBrush`/`BorderThickness`, and prose
+            // like "Foreground and fonts" which the font properties are resolved from below.
+            foreach (Match property in Regex.Matches(arrow[0], @"`(?<name>\w+)`"))
+                stated[property.Groups["name"].Value] = types;
+
+            if (arrow[0].Contains("fonts", StringComparison.OrdinalIgnoreCase))
+            {
+                foreach (var font in new[] { "FontFamily", "FontSize", "FontWeight" })
+                    stated[font] = types;
+            }
+        }
+
+        // Floor: the five gate statements in that row cover 9 properties once fonts are expanded.
+        // A parser that silently stopped matching reads the same as a table with no gates.
+        Assert.True(
+            stated.Count >= 9,
+            $"Only {stated.Count} gate statements were parsed out of the {SkillPath} " +
+            "REACTOR_MOD_003 row; expected at least 9. The parser has probably stopped matching the " +
+            "prose shape — fix it rather than lowering this floor.");
+
+        var problems = new List<string>();
+
+        foreach (var (property, prose) in stated.OrderBy(p => p.Key, StringComparer.Ordinal))
+        {
+            var unknown = prose.Where(t => !ProseTypeNames.ContainsKey(t)).ToList();
+            if (unknown.Count > 0)
+            {
+                problems.Add(
+                    $"{property}: the skill names receiver type(s) [{string.Join("|", unknown)}] that " +
+                    "this fact does not know how to map to ModifierTable's spelling");
+                continue;
+            }
+
+            if (!ModifierTable.Properties.TryGetValue(property, out var info))
+            {
+                problems.Add($"{property}: stated in the skill but absent from ModifierTable.Properties");
+                continue;
+            }
+
+            if (info.ControlGate is not { } gate)
+            {
+                problems.Add(
+                    $"{property}: the skill states a gate but ModifierInfo.ControlGate is null, so " +
+                    "ApplyModifiers writes it unconditionally");
+                continue;
+            }
+
+            var expected = new HashSet<string>(prose.Select(t => ProseTypeNames[t]), StringComparer.Ordinal);
+            if (!expected.SetEquals(gate))
+            {
+                problems.Add(
+                    $"{property}: the skill says [{Join(expected)}] but ModifierTable's controlGate is " +
+                    $"[{Join(gate)}]");
+            }
+        }
+
+        Assert.True(
+            problems.Count == 0,
+            $"The REACTOR_MOD_003 gate prose in {SkillPath} has drifted from ModifierTable. That row " +
+            "ships to end users as agent guidance, so a stale gate there is advice to write code the " +
+            "analyzer will reject:\n  " + string.Join("\n  ", problems));
+    }
+
+    private static string Join(IEnumerable<string> values) =>
+        string.Join("|", values.OrderBy(value => value, StringComparer.Ordinal));
+}

--- a/tests/Reactor.Tests/AnalyzerTests/ModifierGateProseParityTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/ModifierGateProseParityTests.cs
@@ -51,7 +51,15 @@ public class ModifierGateProseParityTests
         var repoRoot = RepoRootFinder.FindRepoRoot();
         Assert.NotNull(repoRoot);
 
-        var file = Path.Combine(repoRoot!, SkillPath.Replace('/', Path.DirectorySeparatorChar));
+        var relativeSkillPath = SkillPath.Replace('/', Path.DirectorySeparatorChar);
+
+        // Path.Combine silently discards repoRoot if the second argument is rooted, which would
+        // make this fact read some other machine's file — or nothing — instead of failing.
+        Assert.False(
+            Path.IsPathRooted(relativeSkillPath),
+            $"SkillPath must stay repo-relative; '{relativeSkillPath}' is rooted and would discard the repo root.");
+
+        var file = Path.Combine(repoRoot!, relativeSkillPath);
         Assert.True(File.Exists(file), $"{SkillPath} not found at {file}");
 
         var text = File.ReadAllText(file);
@@ -66,9 +74,12 @@ public class ModifierGateProseParityTests
 
         // "Background → Panel/Control/Border; Foreground and fonts → Control/TextBlock; …"
         var stated = new Dictionary<string, ISet<string>>(StringComparer.Ordinal);
-        foreach (var segment in clause.Groups["body"].Value.Split(';'))
+        var arrows = clause.Groups["body"].Value
+            .Split(';')
+            .Select(segment => segment.Split('→'));
+
+        foreach (var arrow in arrows)
         {
-            var arrow = segment.Split('→');
             if (arrow.Length != 2)
                 continue;
 

--- a/tests/Reactor.Tests/AnalyzerTests/ModifierGateSource.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/ModifierGateSource.cs
@@ -121,7 +121,9 @@ internal static class ModifierGateSource
         Assert.True(
             slot == ControlGate || slot == PoolResetGate || slot == AnySlot,
             $"Unknown gate slot '{slot}'. MatchAnchored accepts ControlGate, PoolResetGate, or " +
-            "AnySlot; anything else is spliced into the regex verbatim and would match nothing.");
+            "AnySlot; anything else is spliced into the pattern verbatim, so — depending on whether " +
+            "it carries regex metacharacters — it matches either nothing or some unintended text. " +
+            "Either way the result would not be the slot you asked about.");
 
         var pattern = AnchoredPattern(slot, identifier);
         return Select(text => Regex.IsMatch(text, pattern));

--- a/tests/Reactor.Tests/AnalyzerTests/ModifierGateSource.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/ModifierGateSource.cs
@@ -190,10 +190,12 @@ internal static class ModifierGateSource
                 continue;
             }
 
-            foreach (var variable in field.Declaration.Variables)
+            var initialized = field.Declaration.Variables
+                .Where(variable => variable.Initializer?.Value is InitializerExpressionSyntax);
+
+            foreach (var variable in initialized)
             {
-                if (variable.Initializer?.Value is not InitializerExpressionSyntax initializer)
-                    continue;
+                var initializer = (InitializerExpressionSyntax)variable.Initializer!.Value;
 
                 var types = initializer.Expressions
                     .OfType<LiteralExpressionSyntax>()
@@ -239,18 +241,19 @@ internal static class ModifierGateSource
 
             var referenced = new List<ModifierGateArgument>();
 
-            foreach (var argument in info.ArgumentList.Arguments)
-            {
-                // Only identifier-valued arguments matter: a group referenced by name is what a
-                // text matcher can see. Inline `new[] { "..." }` element lists have no identifier.
-                if (argument.Expression is not IdentifierNameSyntax identifier)
-                    continue;
+            // Only identifier-valued arguments matter: a group referenced by name is what a text
+            // matcher can see. Inline `new[] { "..." }` element lists have no identifier.
+            var namedGroups = info.ArgumentList.Arguments
+                .Where(argument => argument.Expression is IdentifierNameSyntax);
 
+            foreach (var argument in namedGroups)
+            {
+                var identifier = ((IdentifierNameSyntax)argument.Expression).Identifier.Text;
                 var slot = argument.NameColon?.Name.Identifier.Text;
-                referenced.Add(new ModifierGateArgument(slot, identifier.Identifier.Text));
+                referenced.Add(new ModifierGateArgument(slot, identifier));
 
                 if (slot is ControlGate or PoolResetGate)
-                    slots.Add(new ModifierGateSlot(property, slot, identifier.Identifier.Text));
+                    slots.Add(new ModifierGateSlot(property, slot, identifier));
             }
 
             arguments[property] = referenced;

--- a/tests/Reactor.Tests/AnalyzerTests/ModifierGateSource.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/ModifierGateSource.cs
@@ -17,6 +17,14 @@ namespace Microsoft.UI.Reactor.Tests.AnalyzerTests;
 internal readonly record struct ModifierGateSlot(string Property, string Slot, string Identifier);
 
 /// <summary>
+/// One identifier-valued argument of a <c>ModifierTable.Properties</c> entry — the argument name
+/// (<c>null</c> when positional) and the group identifier it references. Unlike
+/// <see cref="ModifierGateSlot"/> this includes non-gate arguments such as <c>elementTypes</c>,
+/// because a slot-blind text matcher sees those too.
+/// </summary>
+internal readonly record struct ModifierGateArgument(string? Slot, string Identifier);
+
+/// <summary>
 /// Reads gate facts out of <c>src/Reactor.Analyzers/ModifierTable.cs</c> <em>as text</em>, and
 /// supplies the one matcher that is safe to do it with.
 /// </summary>
@@ -33,9 +41,18 @@ internal readonly record struct ModifierGateSlot(string Property, string Slot, s
 /// <b>Prefer the typed property.</b> <see cref="ModifierInfo.ControlGate"/> is the authority and
 /// comparing its <em>contents</em> is immune to the naming structure — that is what
 /// <see cref="ModifierTableIntegrityTests"/> does, and why those 20 facts were never exposed.
-/// Reach for this reader only when the artifact really is text (a <c>mur check</c> rule, a docs or
-/// prose-parity gate, a review script), and then match with
+/// Reach for this reader only when the artifact really is text, and then match with
 /// <see cref="AnchoredPattern(string, string)"/>, never a bare <c>Contains</c>.
+/// </para>
+/// <para>
+/// <b>This is a test-only reference implementation, not a shared utility.</b> It lives in
+/// <c>tests/Reactor.Tests</c>, depends on xUnit assertions, and is <c>internal</c> — production
+/// code cannot call it. <c>mur check</c> rules live in <c>src/Reactor.Cli/Check/Rules/</c> and
+/// <c>src/Reactor.Analyzers</c> targets <c>netstandard2.0</c> and cannot reference the CLI, so a
+/// rule that needs this matching must <b>copy the pattern and add a parity test</b> — the same
+/// convention the repo already uses for analyzer/CLI shared logic. What is reusable here is the
+/// <em>shape</em> of <see cref="AnchoredPattern(string, string)"/>, verified by
+/// <see cref="ModifierGateIdentifierTests"/>.
 /// </para>
 /// <para>
 /// Roslyn supplies the entry boundaries rather than a line scan: an entry's extent is a brace-depth
@@ -59,22 +76,39 @@ internal static class ModifierGateSource
 
     /// <summary>
     /// Every <c>private static readonly string[] NAME = { … }</c> group in the table, mapped to the
-    /// type names it declares. Includes groups used only as <c>elementTypes</c>.
+    /// type names it declares. Includes groups used only as <c>elementTypes</c>. The lists are
+    /// read-only views: the model is a process-wide cache, so handing out the live arrays would let
+    /// one fact corrupt every later one.
     /// </summary>
-    public static IReadOnlyDictionary<string, string[]> DeclaredGroups => Model.Value.Groups;
+    public static IReadOnlyDictionary<string, IReadOnlyList<string>> DeclaredGroups => Model.Value.Groups;
 
     /// <summary>Every gate argument in the table, read off the syntax tree.</summary>
     public static IReadOnlyList<ModifierGateSlot> GateSlots => Model.Value.Slots;
 
+    /// <summary>
+    /// Every identifier-valued argument in each entry, keyed by property — including
+    /// <c>elementTypes</c>, which the gate slots deliberately exclude. This is the syntax-model
+    /// prediction <see cref="ModifierGateIdentifierTests"/> measures <see cref="Hazard"/> against,
+    /// so that a hazard matcher which has stopped discriminating cannot pass for the right reason.
+    /// </summary>
+    public static IReadOnlyDictionary<string, IReadOnlyList<ModifierGateArgument>> EntryArguments =>
+        Model.Value.Arguments;
+
     /// <summary>Property name → the exact source text of that entry in <c>Properties</c>.</summary>
-    public static IReadOnlyDictionary<string, string> EntryText => Model.Value.Entries;
+    /// <remarks>
+    /// Deliberately private. Raw entry text plus a hand-rolled <c>Contains</c> is exactly the
+    /// defect this type exists to prevent, so the raw text is not offered as a public surface —
+    /// go through <see cref="MatchAnchored"/>.
+    /// </remarks>
+    private static IReadOnlyDictionary<string, string> EntryText => Model.Value.Entries;
 
     /// <summary>
     /// The safe matcher: the gate identifier bounded by the delimiters the C# syntax already
     /// guarantees, so a superset name cannot satisfy a subset's pattern.
     /// </summary>
     /// <param name="slot">
-    /// <see cref="ControlGate"/>, <see cref="PoolResetGate"/>, or <see cref="AnySlot"/>.
+    /// <see cref="ControlGate"/>, <see cref="PoolResetGate"/>, or <see cref="AnySlot"/>. Spliced
+    /// into the pattern unescaped, because <see cref="AnySlot"/> is itself a regex alternation.
     /// </param>
     public static string AnchoredPattern(string slot, string identifier) =>
         slot + @":\s*" + Regex.Escape(identifier) + @"\s*[,)]";
@@ -82,29 +116,42 @@ internal static class ModifierGateSource
     /// <summary>Properties whose entry carries <paramref name="identifier"/> in that slot.</summary>
     public static ISet<string> MatchAnchored(string slot, string identifier)
     {
+        // AnchoredPattern splices `slot` in unescaped so AnySlot can be an alternation, which means
+        // an unrecognized slot yields a silently wrong answer rather than an error. Fail loudly.
+        Assert.True(
+            slot == ControlGate || slot == PoolResetGate || slot == AnySlot,
+            $"Unknown gate slot '{slot}'. MatchAnchored accepts ControlGate, PoolResetGate, or " +
+            "AnySlot; anything else is spliced into the regex verbatim and would match nothing.");
+
         var pattern = AnchoredPattern(slot, identifier);
         return Select(text => Regex.IsMatch(text, pattern));
     }
 
     /// <summary>
-    /// The charitable naive matcher — slot-aware, but with no closing delimiter. Used only to
-    /// demonstrate the hazard in <see cref="ModifierGateIdentifierTests"/>; never to assert a fact
-    /// about the table.
+    /// The unsafe matchers, kept only so <see cref="ModifierGateIdentifierTests"/> can demonstrate
+    /// the hazard differentially. Never assert a fact about the table with these — that is the bug.
     /// </summary>
-    public static ISet<string> MatchNaive(string slot, string identifier)
+    public static class Hazard
     {
-        Assert.Contains(slot, SlotNames);
-        var needle = slot + ": " + identifier;
-        return Select(text => text.Contains(needle, StringComparison.Ordinal));
-    }
+        /// <summary>
+        /// The charitable naive matcher — slot-aware, but with no closing delimiter, so it accepts
+        /// every gate name that <em>starts with</em> the identifier.
+        /// </summary>
+        public static ISet<string> SlotPrefixed(string slot, string identifier)
+        {
+            Assert.Contains(slot, SlotNames);
+            var needle = slot + ": " + identifier;
+            return Select(text => text.Contains(needle, StringComparison.Ordinal));
+        }
 
-    /// <summary>
-    /// The bare <c>Contains</c> the issue reports on — slot-blind, so it also accepts a name that
-    /// merely <em>contains</em> the identifier without starting with it
-    /// (<c>PanelControlBorder</c> ⊃ <c>ControlBorder</c>).
-    /// </summary>
-    public static ISet<string> MatchNaiveBare(string identifier) =>
-        Select(text => text.Contains(identifier, StringComparison.Ordinal));
+        /// <summary>
+        /// The bare <c>Contains</c> the issue reports on — slot-blind, so it also accepts a name
+        /// that merely <em>contains</em> the identifier without starting with it
+        /// (<c>PanelControlBorder</c> ⊃ <c>ControlBorder</c>).
+        /// </summary>
+        public static ISet<string> Bare(string identifier) =>
+            Select(text => text.Contains(identifier, StringComparison.Ordinal));
+    }
 
     private static ISet<string> Select(Func<string, bool> predicate) =>
         new HashSet<string>(
@@ -112,9 +159,10 @@ internal static class ModifierGateSource
             StringComparer.Ordinal);
 
     private sealed record TableModel(
-        IReadOnlyDictionary<string, string[]> Groups,
+        IReadOnlyDictionary<string, IReadOnlyList<string>> Groups,
         IReadOnlyList<ModifierGateSlot> Slots,
-        IReadOnlyDictionary<string, string> Entries);
+        IReadOnlyDictionary<string, string> Entries,
+        IReadOnlyDictionary<string, IReadOnlyList<ModifierGateArgument>> Arguments);
 
     private static TableModel Load()
     {
@@ -131,7 +179,7 @@ internal static class ModifierGateSource
 
         Assert.True(table is not null, $"No 'ModifierTable' class declaration found in {file}");
 
-        var groups = new Dictionary<string, string[]>(StringComparer.Ordinal);
+        var groups = new Dictionary<string, IReadOnlyList<string>>(StringComparer.Ordinal);
         foreach (var field in table!.Members.OfType<FieldDeclarationSyntax>())
         {
             if (field.Declaration.Type is not ArrayTypeSyntax { ElementType: PredefinedTypeSyntax element }
@@ -151,7 +199,7 @@ internal static class ModifierGateSource
                     .ToArray();
 
                 if (types.Length > 0)
-                    groups[variable.Identifier.Text] = types;
+                    groups[variable.Identifier.Text] = Array.AsReadOnly(types);
             }
         }
 
@@ -170,6 +218,7 @@ internal static class ModifierGateSource
 
         var entries = new Dictionary<string, string>(StringComparer.Ordinal);
         var slots = new List<ModifierGateSlot>();
+        var arguments = new Dictionary<string, IReadOnlyList<ModifierGateArgument>>(StringComparer.Ordinal);
 
         foreach (var entry in entriesSyntax.Expressions.OfType<InitializerExpressionSyntax>())
         {
@@ -181,21 +230,30 @@ internal static class ModifierGateSource
 
             var property = key.Token.ValueText;
             entries[property] = entry.ToString();
+            arguments[property] = Array.Empty<ModifierGateArgument>();
 
             if (entry.Expressions[1] is not ObjectCreationExpressionSyntax { ArgumentList: not null } info)
                 continue;
 
+            var referenced = new List<ModifierGateArgument>();
+
             foreach (var argument in info.ArgumentList.Arguments)
             {
-                var slot = argument.NameColon?.Name.Identifier.Text;
-                if (slot is not (ControlGate or PoolResetGate))
+                // Only identifier-valued arguments matter: a group referenced by name is what a
+                // text matcher can see. Inline `new[] { "..." }` element lists have no identifier.
+                if (argument.Expression is not IdentifierNameSyntax identifier)
                     continue;
 
-                if (argument.Expression is IdentifierNameSyntax identifier)
+                var slot = argument.NameColon?.Name.Identifier.Text;
+                referenced.Add(new ModifierGateArgument(slot, identifier.Identifier.Text));
+
+                if (slot is ControlGate or PoolResetGate)
                     slots.Add(new ModifierGateSlot(property, slot, identifier.Identifier.Text));
             }
+
+            arguments[property] = referenced;
         }
 
-        return new TableModel(groups, slots, entries);
+        return new TableModel(groups, slots, entries, arguments);
     }
 }

--- a/tests/Reactor.Tests/AnalyzerTests/ModifierGateSource.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/ModifierGateSource.cs
@@ -134,14 +134,16 @@ internal static class ModifierGateSource
     public static class Hazard
     {
         /// <summary>
-        /// The charitable naive matcher — slot-aware, but with no closing delimiter, so it accepts
-        /// every gate name that <em>starts with</em> the identifier.
+        /// The charitable naive matcher — slot-aware and whitespace-tolerant, but with no closing
+        /// delimiter, so it accepts every gate name that <em>starts with</em> the identifier. The
+        /// missing delimiter is the hazard; tolerating whitespace keeps it from also being brittle
+        /// to a benign reformat of the table.
         /// </summary>
         public static ISet<string> SlotPrefixed(string slot, string identifier)
         {
             Assert.Contains(slot, SlotNames);
-            var needle = slot + ": " + identifier;
-            return Select(text => text.Contains(needle, StringComparison.Ordinal));
+            var needle = slot + @":\s*" + Regex.Escape(identifier);
+            return Select(text => Regex.IsMatch(text, needle));
         }
 
         /// <summary>

--- a/tests/Reactor.Tests/AnalyzerTests/ModifierGateSource.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/ModifierGateSource.cs
@@ -70,7 +70,8 @@ internal static class ModifierGateSource
     public const string AnySlot = "(?:" + ControlGate + "|" + PoolResetGate + ")";
 
     /// <summary>The two real slot names, for tests that sweep both.</summary>
-    public static IReadOnlyList<string> SlotNames { get; } = new[] { ControlGate, PoolResetGate };
+    public static IReadOnlyList<string> SlotNames { get; } =
+        Array.AsReadOnly(new[] { ControlGate, PoolResetGate });
 
     private static readonly Lazy<TableModel> Model = new(Load);
 
@@ -90,6 +91,7 @@ internal static class ModifierGateSource
     /// <c>elementTypes</c>, which the gate slots deliberately exclude. This is the syntax-model
     /// prediction <see cref="ModifierGateIdentifierTests"/> measures <see cref="Hazard"/> against,
     /// so that a hazard matcher which has stopped discriminating cannot pass for the right reason.
+    /// Read-only views, for the same cache-integrity reason as <see cref="DeclaredGroups"/>.
     /// </summary>
     public static IReadOnlyDictionary<string, IReadOnlyList<ModifierGateArgument>> EntryArguments =>
         Model.Value.Arguments;
@@ -258,9 +260,9 @@ internal static class ModifierGateSource
                     slots.Add(new ModifierGateSlot(property, slot, identifier));
             }
 
-            arguments[property] = referenced;
+            arguments[property] = referenced.AsReadOnly();
         }
 
-        return new TableModel(groups, slots, entries, arguments);
+        return new TableModel(groups, slots.AsReadOnly(), entries, arguments);
     }
 }

--- a/tests/Reactor.Tests/AnalyzerTests/ModifierGateSource.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/ModifierGateSource.cs
@@ -1,0 +1,201 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.UI.Reactor.Cli.Pack;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests.AnalyzerTests;
+
+/// <summary>
+/// One <c>controlGate:</c> / <c>poolResetGate:</c> argument exactly as written in
+/// <c>ModifierTable.Properties</c> — the ground truth a text matcher is measured against.
+/// </summary>
+internal readonly record struct ModifierGateSlot(string Property, string Slot, string Identifier);
+
+/// <summary>
+/// Reads gate facts out of <c>src/Reactor.Analyzers/ModifierTable.cs</c> <em>as text</em>, and
+/// supplies the one matcher that is safe to do it with.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The gate groups are named by concatenating their receiver list, so a gate that is a superset of
+/// another <b>necessarily</b> has a name that is a superset string —
+/// <c>ControlBorder</c> ⊏ <c>ControlBorderGridStack</c> ⊏ <c>ControlBorderGridStackRelative</c> ⊏
+/// <c>…RelativeText</c>. Any check that asserts "modifier X has gate Y" by substring therefore
+/// passes when X carries a different, <em>wider</em> gate: a silent false PASS on precisely the
+/// assertion meant to catch a mis-widened gate. Issue #1062.
+/// </para>
+/// <para>
+/// <b>Prefer the typed property.</b> <see cref="ModifierInfo.ControlGate"/> is the authority and
+/// comparing its <em>contents</em> is immune to the naming structure — that is what
+/// <see cref="ModifierTableIntegrityTests"/> does, and why those 20 facts were never exposed.
+/// Reach for this reader only when the artifact really is text (a <c>mur check</c> rule, a docs or
+/// prose-parity gate, a review script), and then match with
+/// <see cref="AnchoredPattern(string, string)"/>, never a bare <c>Contains</c>.
+/// </para>
+/// <para>
+/// Roslyn supplies the entry boundaries rather than a line scan: an entry's extent is a brace-depth
+/// question, and guessing at it textually would make the reader fail on reformatting instead of on
+/// real drift. The <em>matching decision</em> stays textual on purpose — being a text matcher is the
+/// thing under test.
+/// </para>
+/// </remarks>
+internal static class ModifierGateSource
+{
+    public const string ControlGate = "controlGate";
+    public const string PoolResetGate = "poolResetGate";
+
+    /// <summary>Matches either gate slot, as the fix suggested on issue #1062 is written.</summary>
+    public const string AnySlot = "(?:" + ControlGate + "|" + PoolResetGate + ")";
+
+    /// <summary>The two real slot names, for tests that sweep both.</summary>
+    public static IReadOnlyList<string> SlotNames { get; } = new[] { ControlGate, PoolResetGate };
+
+    private static readonly Lazy<TableModel> Model = new(Load);
+
+    /// <summary>
+    /// Every <c>private static readonly string[] NAME = { … }</c> group in the table, mapped to the
+    /// type names it declares. Includes groups used only as <c>elementTypes</c>.
+    /// </summary>
+    public static IReadOnlyDictionary<string, string[]> DeclaredGroups => Model.Value.Groups;
+
+    /// <summary>Every gate argument in the table, read off the syntax tree.</summary>
+    public static IReadOnlyList<ModifierGateSlot> GateSlots => Model.Value.Slots;
+
+    /// <summary>Property name → the exact source text of that entry in <c>Properties</c>.</summary>
+    public static IReadOnlyDictionary<string, string> EntryText => Model.Value.Entries;
+
+    /// <summary>
+    /// The safe matcher: the gate identifier bounded by the delimiters the C# syntax already
+    /// guarantees, so a superset name cannot satisfy a subset's pattern.
+    /// </summary>
+    /// <param name="slot">
+    /// <see cref="ControlGate"/>, <see cref="PoolResetGate"/>, or <see cref="AnySlot"/>.
+    /// </param>
+    public static string AnchoredPattern(string slot, string identifier) =>
+        slot + @":\s*" + Regex.Escape(identifier) + @"\s*[,)]";
+
+    /// <summary>Properties whose entry carries <paramref name="identifier"/> in that slot.</summary>
+    public static ISet<string> MatchAnchored(string slot, string identifier)
+    {
+        var pattern = AnchoredPattern(slot, identifier);
+        return Select(text => Regex.IsMatch(text, pattern));
+    }
+
+    /// <summary>
+    /// The charitable naive matcher — slot-aware, but with no closing delimiter. Used only to
+    /// demonstrate the hazard in <see cref="ModifierGateIdentifierTests"/>; never to assert a fact
+    /// about the table.
+    /// </summary>
+    public static ISet<string> MatchNaive(string slot, string identifier)
+    {
+        Assert.Contains(slot, SlotNames);
+        var needle = slot + ": " + identifier;
+        return Select(text => text.Contains(needle, StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// The bare <c>Contains</c> the issue reports on — slot-blind, so it also accepts a name that
+    /// merely <em>contains</em> the identifier without starting with it
+    /// (<c>PanelControlBorder</c> ⊃ <c>ControlBorder</c>).
+    /// </summary>
+    public static ISet<string> MatchNaiveBare(string identifier) =>
+        Select(text => text.Contains(identifier, StringComparison.Ordinal));
+
+    private static ISet<string> Select(Func<string, bool> predicate) =>
+        new HashSet<string>(
+            EntryText.Where(entry => predicate(entry.Value)).Select(entry => entry.Key),
+            StringComparer.Ordinal);
+
+    private sealed record TableModel(
+        IReadOnlyDictionary<string, string[]> Groups,
+        IReadOnlyList<ModifierGateSlot> Slots,
+        IReadOnlyDictionary<string, string> Entries);
+
+    private static TableModel Load()
+    {
+        var repoRoot = RepoRootFinder.FindRepoRoot();
+        Assert.NotNull(repoRoot);
+        var file = Path.Join(repoRoot!, "src", "Reactor.Analyzers", "ModifierTable.cs");
+        Assert.True(File.Exists(file), $"ModifierTable.cs not found at {file}");
+
+        var table = CSharpSyntaxTree.ParseText(File.ReadAllText(file))
+            .GetRoot()
+            .DescendantNodes()
+            .OfType<ClassDeclarationSyntax>()
+            .FirstOrDefault(c => c.Identifier.Text == "ModifierTable");
+
+        Assert.True(table is not null, $"No 'ModifierTable' class declaration found in {file}");
+
+        var groups = new Dictionary<string, string[]>(StringComparer.Ordinal);
+        foreach (var field in table!.Members.OfType<FieldDeclarationSyntax>())
+        {
+            if (field.Declaration.Type is not ArrayTypeSyntax { ElementType: PredefinedTypeSyntax element }
+                || element.Keyword.Text != "string")
+            {
+                continue;
+            }
+
+            foreach (var variable in field.Declaration.Variables)
+            {
+                if (variable.Initializer?.Value is not InitializerExpressionSyntax initializer)
+                    continue;
+
+                var types = initializer.Expressions
+                    .OfType<LiteralExpressionSyntax>()
+                    .Select(literal => literal.Token.ValueText)
+                    .ToArray();
+
+                if (types.Length > 0)
+                    groups[variable.Identifier.Text] = types;
+            }
+        }
+
+        var properties = table.Members
+            .OfType<FieldDeclarationSyntax>()
+            .SelectMany(field => field.Declaration.Variables)
+            .FirstOrDefault(variable => variable.Identifier.Text == "Properties");
+
+        Assert.True(properties is not null, "No 'Properties' field found on ModifierTable");
+        Assert.True(
+            properties!.Initializer?.Value is ObjectCreationExpressionSyntax { Initializer: not null },
+            "ModifierTable.Properties is no longer a collection-initialized dictionary; the entry " +
+            "reader needs updating.");
+
+        var entriesSyntax = ((ObjectCreationExpressionSyntax)properties.Initializer!.Value).Initializer!;
+
+        var entries = new Dictionary<string, string>(StringComparer.Ordinal);
+        var slots = new List<ModifierGateSlot>();
+
+        foreach (var entry in entriesSyntax.Expressions.OfType<InitializerExpressionSyntax>())
+        {
+            if (entry.Expressions.Count != 2
+                || entry.Expressions[0] is not LiteralExpressionSyntax key)
+            {
+                continue;
+            }
+
+            var property = key.Token.ValueText;
+            entries[property] = entry.ToString();
+
+            if (entry.Expressions[1] is not ObjectCreationExpressionSyntax { ArgumentList: not null } info)
+                continue;
+
+            foreach (var argument in info.ArgumentList.Arguments)
+            {
+                var slot = argument.NameColon?.Name.Identifier.Text;
+                if (slot is not (ControlGate or PoolResetGate))
+                    continue;
+
+                if (argument.Expression is IdentifierNameSyntax identifier)
+                    slots.Add(new ModifierGateSlot(property, slot, identifier.Identifier.Text));
+            }
+        }
+
+        return new TableModel(groups, slots, entries);
+    }
+}


### PR DESCRIPTION
Fixes #1062.

## The hazard

The gate groups in `src/Reactor.Analyzers/ModifierTable.cs` are named by concatenating their receiver list, so **set inclusion is string inclusion**:

```
ControlBorder ⊏ ControlBorderGridStack ⊏ ControlBorderGridStackRelative ⊏ …RelativeText
```

8 strict prefix pairs today, plus `PanelControlBorder`, which *contains* `ControlBorder` without starting with it — the case a prefix-only fix misses.

So any check asserting "modifier X has gate Y" by substring passes when X carries a different, **wider** gate: a silent false PASS on precisely the assertion meant to catch a mis-widened gate.

## Severity is preventive — measured, not assumed

Every shipped consumer is immune: `ModifierTableIntegrityTests` reads the typed `ModifierInfo.ControlGate` / `PoolResetGate` and compares type **sets**, and a repo-wide grep finds no gate identifier used outside `ModifierTable.cs`. The exposed party is the *next* text consumer.

Per maintainer direction the cumulative names stay (the file documents them as deliberate). Instead this hardens the text path and codifies the rule.

## What changed

**One vetted matcher.** `ModifierGateSource` uses Roslyn for entry *boundaries* — an entry's extent is a brace-depth question, so guessing textually would fail on reformatting instead of on real drift — while the matching *decision* stays textual on purpose, because being a text matcher is the thing under test. The safe form is `SLOT:\s*NAME\s*[,)]`.

**Four facts** in `ModifierGateIdentifierTests`:
| | |
|---|---|
| A | Reader positive control, pinned bidirectionally to the typed table |
| B | Anchored matching selects *exactly* the properties the typed gate names |
| C | Differential oracle: substring matching false-accepts a wider gate where anchored matching does not |
| D | The hazard matchers themselves select exactly what the syntax model predicts |

**A real consumer.** `ModifierGateProseParityTests` pins the `REACTOR_MOD_003` gate list in the **shipped** `reactor-build-and-check` skill to the table. It compares receiver type *sets*, not gate names — the issue's own rule, applied.

**The rule, where the next author reads it:** at the group declarations in `ModifierTable.cs` and in `.github/skills/analyzer-dym/SKILL.md`. `ModifierTable.cs` receives comment text only; no analyzer behaviour changes.

## Why the facts aren't vacuous

Each was mutation-checked, per the repo's own standard that an assertion must fail when its target is broken:

- Relaxing `AnchoredPattern` to a bare substring → **B and C redden**, A stays green (it doesn't depend on the matcher).
- Forcing both hazard matchers to `Select(_ => true)` → **D reddens**. This is why D exists: C's floors only assert a false accept *at* the expected sites, so a matcher that stopped discriminating satisfied them while proving nothing. A broken instrument is trusted by default.
- Dropping `Panel` from the skill's `Background` gate prose → parity test fails with `the skill says [Border|Control] but ModifierTable's controlGate is [Border|Control|Panel]`.

Worth stating explicitly: widening a real gate in `ModifierTable.cs` leaves these facts green, and that is correct by design — they guard the *matcher*, so both sides move together. The pre-existing `ModifierTableIntegrityTests.Every_ControlGate_Matches_The_Types_ApplyModifiers_Writes_To` is the semantic guard, and it does redden. Verified independently.

## Verification

- Full `Reactor.Tests`: **13294 passed, 0 failed**, 64 skipped.
- Release builds of `Reactor.Analyzers` and `Reactor.Tests` clean (`TreatWarningsAsErrors` is Release-only).
- Every mutation reverted and hash-verified byte-identical.

## Review already applied

The repo's `pr-review` skill ran over the first commit (7 dimensions + a cross-model check). Commit 2 addresses the confirmed findings: the vacuous floors above, making the raw-text surface private and nesting the hazard matchers, read-only cached data, slot validation, and correcting docs that implied a `mur check` rule could call a helper that is `internal` to the test assembly.

Two findings were rejected with evidence: a reported "fails as a suite, passes individually" was a concurrent reviewer's in-flight file mutation (`FindRepoRoot` resolves from `AppContext.BaseDirectory`, not the CWD; clean rebuild + 3 same-process runs, 3/3 each), and a proposal to validate `slot` against `SlotNames` would have broken the deliberately-raw `AnySlot` alternation.