### PR TITLE
Make the selftest harness click stimulus fail loudly (#1063)

### DIFF
--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/CommandingCoverageFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/CommandingCoverageFixtures.cs
@@ -645,8 +645,10 @@ internal static class CommandingCoverageFixtures
             var btn = H.FindControl<Button>(b => b.Name == "bareDisBtn");
             H.Check("BareInitDis_Mounted", btn is not null);
             H.Check("BareInitDis_Disabled", btn is not null && !btn.IsEnabled);
-            H.ClickButton("Save"); // ClickButton is gated on IsEnabled — disabled button won't invoke
-            H.Check("BareInitDis_NotInvokedWhileDisabled", count == 0);
+            // ClickButtonIfEnabled still throws if "Save" isn't there, so a false result
+            // means "found it, and it refused the click" — not "I typo'd the label".
+            H.Check("BareInitDis_NotInvokedWhileDisabled",
+                !H.ClickButtonIfEnabled("Save") && count == 0);
         }
     }
 

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/CommandingCoverageFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/CommandingCoverageFixtures.cs
@@ -645,10 +645,11 @@ internal static class CommandingCoverageFixtures
             var btn = H.FindControl<Button>(b => b.Name == "bareDisBtn");
             H.Check("BareInitDis_Mounted", btn is not null);
             H.Check("BareInitDis_Disabled", btn is not null && !btn.IsEnabled);
-            // ClickButtonIfEnabled still throws if "Save" isn't there, so a false result
-            // means "found it, and it refused the click" — not "I typo'd the label".
-            H.Check("BareInitDis_NotInvokedWhileDisabled",
-                !H.ClickButtonIfEnabled("Save") && count == 0);
+            // Throws if "Save" is absent OR unexpectedly enabled, so simply reaching the
+            // Check below already establishes the button is there and refusing clicks —
+            // leaving the Check to prove the one thing left: the handler never ran.
+            H.RequireButtonDisabled("Save");
+            H.Check("BareInitDis_NotInvokedWhileDisabled", count == 0);
         }
     }
 

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ContentDialogLiveContentFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ContentDialogLiveContentFixtures.cs
@@ -204,7 +204,8 @@ public static class ContentDialogLiveContentFixtures
                     ContentDialogProbe.FindText(dialog, "dialog-count:0") is null);
 
                 // A second update proves the path stays live, not just first-flush.
-                await ContentDialogProbe.WaitAndClick(dialog, "Bump");
+                var clickedAgain = await ContentDialogProbe.WaitAndClick(dialog, "Bump");
+                H.Check("ContentDialogLive_Rerender_SecondClickLanded", clickedAgain);
                 await Harness.WaitFor(() => ContentDialogProbe.FindText(dialog, "dialog-count:2") is not null);
                 H.Check("ContentDialogLive_Rerender_SecondUpdate_#1069",
                     ContentDialogProbe.FindText(dialog, "dialog-count:2") is not null);

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/HarnessGuardFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/HarnessGuardFixtures.cs
@@ -1,0 +1,137 @@
+using Microsoft.UI.Reactor.Core;
+using WinUI = Microsoft.UI.Xaml.Controls;
+using static Microsoft.UI.Reactor.Factories;
+
+namespace Microsoft.UI.Reactor.AppTests.Host.SelfTest.Fixtures;
+
+/// <summary>
+/// Issue #1063 — the harness's own click stimulus must fail loudly.
+///
+/// <para><c>ClickButton</c> used to have no <c>else</c>, no throw and no return value, so a
+/// missing, renamed or disabled button was byte-identical to a landed click at all ~700
+/// call sites. A fixture is a stimulus followed by an assertion; when the stimulus silently
+/// no-ops the assertion measures the UNSTIMULATED state, and every "X was left alone" /
+/// "X was restored" / "X is still within tolerance" check passes on that state.</para>
+///
+/// <para>This fixture is the guard's own guard. Every check here fails if the throw is
+/// removed from <see cref="Harness.ClickButton"/> / <see cref="Harness.ToggleCheckBox"/>:
+/// the "threw" checks flip to false directly, and the two behavioural checks
+/// (<c>ClickButtonIfEnabled</c> returning true/false) fail because the fail-open bodies
+/// return <c>void</c> and cannot compile a caller that reads a result.</para>
+/// </summary>
+internal static class HarnessGuardFixtures
+{
+    private const string MissingLabel = "HarnessGuard_NoSuchButton";
+
+    /// <summary>Runs <paramref name="act"/> and returns the message of the
+    /// InvalidOperationException it threw, or null if it did not throw one.</summary>
+    private static string? MessageIfThrows(Action act)
+    {
+        try { act(); return null; }
+        catch (InvalidOperationException ex) { return ex.Message; }
+    }
+
+    internal class ClickButtonFailsLoudly(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            await MissingButtonThrows();
+            await DisabledButtonThrows();
+            await IfEnabledReportsInsteadOfThrowing();
+            await ToggleCheckBoxThrowsWhenMissing();
+        }
+
+        // A label that is nowhere in the tree must abort the fixture, and the message must
+        // carry enough to fix it without a debugger: the bad label AND what was there.
+        private async Task MissingButtonThrows()
+        {
+            using var host = H.CreateHost();
+            host.Mount(_ => VStack(
+                Button("HarnessGuard_Present", () => { }),
+                TextBlock("HarnessGuard_Missing_Mounted")));
+            await Harness.Render();
+
+            H.Check("HarnessGuard_Missing_TreeReady", H.FindButton("HarnessGuard_Present") is not null);
+
+            var message = MessageIfThrows(() => H.ClickButton(MissingLabel));
+            H.Check("HarnessGuard_Missing_Throws", message is not null);
+            H.Check("HarnessGuard_Missing_MessageNamesLabel",
+                message?.Contains(MissingLabel, StringComparison.Ordinal) == true);
+            // The "here is what I did find" suffix is what turns the crash line into a fix.
+            H.Check("HarnessGuard_Missing_MessageListsCandidates",
+                message?.Contains("HarnessGuard_Present", StringComparison.Ordinal) == true);
+
+            // Same rule for the opt-in variant: a wrong label is always a broken fixture, so
+            // `false` keeps meaning "disabled" rather than "disabled, or I typo'd it".
+            H.Check("HarnessGuard_Missing_IfEnabledThrowsToo",
+                MessageIfThrows(() => H.ClickButtonIfEnabled(MissingLabel)) is not null);
+        }
+
+        // The disabled case is the one that used to look most like success: the button is
+        // right there, the call returns normally, and nothing was invoked.
+        private async Task DisabledButtonThrows()
+        {
+            int clicks = 0;
+            using var host = H.CreateHost();
+            host.Mount(_ => VStack(
+                Button("HarnessGuard_Disabled", () => clicks++).IsEnabled(false)));
+            await Harness.Render();
+
+            var btn = H.FindButton("HarnessGuard_Disabled");
+            H.Check("HarnessGuard_Disabled_Mounted", btn is not null && !btn.IsEnabled);
+
+            var message = MessageIfThrows(() => H.ClickButton("HarnessGuard_Disabled"));
+            H.Check("HarnessGuard_Disabled_Throws", message is not null);
+            H.Check("HarnessGuard_Disabled_MessageSaysDisabled",
+                message?.Contains("disabled", StringComparison.OrdinalIgnoreCase) == true);
+            // And the click genuinely did not land — the throw replaced a no-op, it did not
+            // paper over a delivered click.
+            H.Check("HarnessGuard_Disabled_HandlerNotRun", clicks == 0);
+        }
+
+        // ClickButtonIfEnabled is the escape hatch for fixtures that mean to prove a disabled
+        // button ignores clicks. It must distinguish the two outcomes by return value.
+        private async Task IfEnabledReportsInsteadOfThrowing()
+        {
+            int enabledClicks = 0, disabledClicks = 0;
+            using var host = H.CreateHost();
+            host.Mount(_ => VStack(
+                Button("HarnessGuard_Live", () => enabledClicks++),
+                Button("HarnessGuard_Inert", () => disabledClicks++).IsEnabled(false)));
+            await Harness.Render();
+
+            H.Check("HarnessGuard_IfEnabled_FalseOnDisabled",
+                !H.ClickButtonIfEnabled("HarnessGuard_Inert"));
+            H.Check("HarnessGuard_IfEnabled_DisabledHandlerNotRun", disabledClicks == 0);
+
+            H.Check("HarnessGuard_IfEnabled_TrueOnEnabled",
+                H.ClickButtonIfEnabled("HarnessGuard_Live"));
+            await Harness.Render();
+            // A `true` that did not actually invoke anything would be the same lie in a new
+            // shape, so pin the side effect too.
+            H.Check("HarnessGuard_IfEnabled_EnabledHandlerRan", enabledClicks == 1);
+        }
+
+        // ToggleCheckBox had the same fail-open shape (silent when the CheckBox is absent).
+        private async Task ToggleCheckBoxThrowsWhenMissing()
+        {
+            using var host = H.CreateHost();
+            host.Mount(_ => VStack(
+                CheckBox(Optional<bool?>.Unset, _ => { }, "HarnessGuard_Box")));
+            await Harness.Render();
+
+            var cb = H.FindControl<WinUI.CheckBox>(c => c.Content as string == "HarnessGuard_Box");
+            H.Check("HarnessGuard_Toggle_Mounted", cb is not null && cb.IsChecked != true);
+
+            var message = MessageIfThrows(() => H.ToggleCheckBox("HarnessGuard_NoSuchBox"));
+            H.Check("HarnessGuard_Toggle_ThrowsWhenMissing", message is not null);
+            H.Check("HarnessGuard_Toggle_MessageNamesLabel",
+                message?.Contains("HarnessGuard_NoSuchBox", StringComparison.Ordinal) == true);
+
+            // The present CheckBox still toggles — the guard did not break the happy path.
+            H.ToggleCheckBox("HarnessGuard_Box");
+            await Harness.Render();
+            H.Check("HarnessGuard_Toggle_PresentStillToggles", cb?.IsChecked == true);
+        }
+    }
+}

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/HarnessGuardFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/HarnessGuardFixtures.cs
@@ -14,10 +14,8 @@ namespace Microsoft.UI.Reactor.AppTests.Host.SelfTest.Fixtures;
 /// "X was restored" / "X is still within tolerance" check passes on that state.</para>
 ///
 /// <para>This fixture is the guard's own guard. Every check here fails if the throw is
-/// removed from <see cref="Harness.ClickButton"/> / <see cref="Harness.ToggleCheckBox"/>:
-/// the "threw" checks flip to false directly, and the two behavioural checks
-/// (<c>ClickButtonIfEnabled</c> returning true/false) fail because the fail-open bodies
-/// return <c>void</c> and cannot compile a caller that reads a result.</para>
+/// removed from <see cref="Harness.ClickButton"/> / <see cref="Harness.ToggleCheckBox"/> /
+/// <see cref="Harness.RequireButtonDisabled"/>.</para>
 /// </summary>
 internal static class HarnessGuardFixtures
 {
@@ -37,8 +35,9 @@ internal static class HarnessGuardFixtures
         {
             await MissingButtonThrows();
             await DisabledButtonThrows();
-            await IfEnabledReportsInsteadOfThrowing();
+            await RequireButtonDisabledAssertsBothWays();
             await ToggleCheckBoxThrowsWhenMissing();
+            await LabelsAreFlattenedForTap();
         }
 
         // A label that is nowhere in the tree must abort the fixture, and the message must
@@ -61,10 +60,10 @@ internal static class HarnessGuardFixtures
             H.Check("HarnessGuard_Missing_MessageListsCandidates",
                 message?.Contains("HarnessGuard_Present", StringComparison.Ordinal) == true);
 
-            // Same rule for the opt-in variant: a wrong label is always a broken fixture, so
-            // `false` keeps meaning "disabled" rather than "disabled, or I typo'd it".
-            H.Check("HarnessGuard_Missing_IfEnabledThrowsToo",
-                MessageIfThrows(() => H.ClickButtonIfEnabled(MissingLabel)) is not null);
+            // Same rule for the assertion variant: a wrong label is always a broken fixture,
+            // and must never be mistaken for "the button was disabled, as expected".
+            H.Check("HarnessGuard_Missing_RequireDisabledThrowsToo",
+                MessageIfThrows(() => H.RequireButtonDisabled(MissingLabel)) is not null);
         }
 
         // The disabled case is the one that used to look most like success: the button is
@@ -89,9 +88,9 @@ internal static class HarnessGuardFixtures
             H.Check("HarnessGuard_Disabled_HandlerNotRun", clicks == 0);
         }
 
-        // ClickButtonIfEnabled is the escape hatch for fixtures that mean to prove a disabled
-        // button ignores clicks. It must distinguish the two outcomes by return value.
-        private async Task IfEnabledReportsInsteadOfThrowing()
+        // RequireButtonDisabled is the sanctioned way to prove a disabled button ignores
+        // clicks. It must be loud in BOTH directions and must not click anything itself.
+        private async Task RequireButtonDisabledAssertsBothWays()
         {
             int enabledClicks = 0, disabledClicks = 0;
             using var host = H.CreateHost();
@@ -100,16 +99,25 @@ internal static class HarnessGuardFixtures
                 Button("HarnessGuard_Inert", () => disabledClicks++).IsEnabled(false)));
             await Harness.Render();
 
-            H.Check("HarnessGuard_IfEnabled_FalseOnDisabled",
-                !H.ClickButtonIfEnabled("HarnessGuard_Inert"));
-            H.Check("HarnessGuard_IfEnabled_DisabledHandlerNotRun", disabledClicks == 0);
+            // Expected case: present and disabled — passes quietly.
+            H.Check("HarnessGuard_RequireDisabled_PassesOnDisabled",
+                MessageIfThrows(() => H.RequireButtonDisabled("HarnessGuard_Inert")) is null);
+            H.Check("HarnessGuard_RequireDisabled_DisabledHandlerNotRun", disabledClicks == 0);
 
-            H.Check("HarnessGuard_IfEnabled_TrueOnEnabled",
-                H.ClickButtonIfEnabled("HarnessGuard_Live"));
+            // The direction a bool-returning variant could not enforce: a button the fixture
+            // believed was disabled is actually live, so the next "nothing happened" assertion
+            // would have been measuring the wrong thing. That must be loud, not a dropped flag.
+            H.Check("HarnessGuard_RequireDisabled_ThrowsOnEnabled",
+                MessageIfThrows(() => H.RequireButtonDisabled("HarnessGuard_Live")) is not null);
             await Harness.Render();
-            // A `true` that did not actually invoke anything would be the same lie in a new
-            // shape, so pin the side effect too.
-            H.Check("HarnessGuard_IfEnabled_EnabledHandlerRan", enabledClicks == 1);
+            // It asserts; it must never deliver a click as a side effect.
+            H.Check("HarnessGuard_RequireDisabled_DidNotClickEnabled", enabledClicks == 0);
+
+            // Control: the enabled button really is clickable, so the check above failed for
+            // the stated reason (it is enabled) rather than because nothing works here.
+            H.ClickButton("HarnessGuard_Live");
+            await Harness.Render();
+            H.Check("HarnessGuard_RequireDisabled_EnabledStillClickable", enabledClicks == 1);
         }
 
         // ToggleCheckBox had the same fail-open shape (silent when the CheckBox is absent).
@@ -132,6 +140,26 @@ internal static class HarnessGuardFixtures
             H.ToggleCheckBox("HarnessGuard_Box");
             await Harness.Render();
             H.Check("HarnessGuard_Toggle_PresentStillToggles", cb?.IsChecked == true);
+        }
+
+        // The message ends up inside a single-line TAP record
+        // (`not ok <n> <fixture>_CRASH - <msg>`, SelfTestRunner.cs), and SelfTestBatch.ParseTap
+        // reads that stream line by line. A raw newline inside a control label would therefore
+        // split one failure into two records, and the tail could be re-read as a forged `ok` or
+        // `# Total failures:` line — turning a diagnostic into a corrupted run report.
+        private async Task LabelsAreFlattenedForTap()
+        {
+            using var host = H.CreateHost();
+            host.Mount(_ => VStack(Button("HarnessGuard_Two\nLines", () => { })));
+            await Harness.Render();
+
+            var message = MessageIfThrows(() => H.ClickButton(MissingLabel));
+            H.Check("HarnessGuard_Tap_Throws", message is not null);
+            H.Check("HarnessGuard_Tap_NoRawNewlineInMessage",
+                message is not null && !message.Contains('\n') && !message.Contains('\r'));
+            // Escaped rather than dropped, so the label is still identifiable in the report.
+            H.Check("HarnessGuard_Tap_NewlineEscapedNotDropped",
+                message?.Contains("HarnessGuard_Two\\nLines", StringComparison.Ordinal) == true);
         }
     }
 }

--- a/tests/Reactor.AppTests.Host/SelfTest/Harness.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Harness.cs
@@ -423,7 +423,7 @@ internal sealed class Harness
                 $"{nameof(ToggleCheckBox)}(\"{OneLine(label)}\"): no CheckBox with that Content is in the " +
                 $"visual tree. {DescribeContent<CheckBox>("CheckBox")}");
 
-        cb.IsChecked = cb.IsChecked != true;
+        cb.IsChecked = cb.IsChecked is not true;
     }
 
     private Button RequireButton(string caller, string label)

--- a/tests/Reactor.AppTests.Host/SelfTest/Harness.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Harness.cs
@@ -373,7 +373,7 @@ internal sealed class Harness
     /// to "silently did nothing" at the call site (issue #1063).</para>
     ///
     /// <para>To assert that a disabled button ignores clicks, use
-    /// <see cref="ClickButtonIfEnabled"/> — it still throws when the label is wrong, so the
+    /// <see cref="RequireButtonDisabled"/> — it too throws when the label is wrong, so the
     /// assertion cannot pass for the wrong reason.</para>
     /// </summary>
     /// <exception cref="InvalidOperationException">No such button, or the button is disabled.</exception>
@@ -382,28 +382,33 @@ internal sealed class Harness
         var btn = RequireButton(nameof(ClickButton), label);
         if (!btn.IsEnabled)
             throw new InvalidOperationException(
-                $"{nameof(ClickButton)}(\"{label}\"): the Button is disabled, so the click was NOT " +
+                $"{nameof(ClickButton)}(\"{OneLine(label)}\"): the Button is disabled, so the click was NOT " +
                 $"delivered. If the fixture means to prove that a disabled button ignores clicks, " +
-                $"call {nameof(ClickButtonIfEnabled)} and assert it returns false.");
+                $"call {nameof(RequireButtonDisabled)} instead.");
 
         InvokeButton(btn);
     }
 
     /// <summary>
-    /// Invokes the button only if it is enabled, and reports which happened: true when the
-    /// click was delivered, false when the button was found but disabled.
+    /// Asserts that the button carrying <paramref name="label"/> is present but disabled —
+    /// and therefore that no click can land on it. Deliberately does NOT click.
     ///
-    /// <para>Still throws when no button carries <paramref name="label"/> — that is always a
-    /// broken fixture, and it keeps a <c>false</c> result meaning "the button is disabled"
-    /// rather than the ambiguous "disabled, or I typo'd the label".</para>
+    /// <para>This is the sanctioned way to prove "a disabled button ignores clicks". It
+    /// throws in BOTH failure directions: a wrong label and an unexpectedly ENABLED button
+    /// are each a broken fixture. That is why it returns <c>void</c> rather than a
+    /// <c>bool</c> — a returned flag can be dropped at the call site, and a silently
+    /// ignorable signal is precisely the defect this guard exists to prevent (issue #1063).
+    /// Reintroducing one here would rebuild the bug inside its own fix.</para>
     /// </summary>
-    /// <exception cref="InvalidOperationException">No button carries <paramref name="label"/>.</exception>
-    public bool ClickButtonIfEnabled(string label)
+    /// <exception cref="InvalidOperationException">No such button, or the button is enabled.</exception>
+    public void RequireButtonDisabled(string label)
     {
-        var btn = RequireButton(nameof(ClickButtonIfEnabled), label);
-        if (!btn.IsEnabled) return false;
-        InvokeButton(btn);
-        return true;
+        var btn = RequireButton(nameof(RequireButtonDisabled), label);
+        if (btn.IsEnabled)
+            throw new InvalidOperationException(
+                $"{nameof(RequireButtonDisabled)}(\"{OneLine(label)}\"): the Button is ENABLED, but the " +
+                $"fixture expected it to be disabled. A real click would land here, so whatever the " +
+                $"fixture asserts next about nothing having happened would be measuring the wrong thing.");
     }
 
     /// <summary>
@@ -415,7 +420,7 @@ internal sealed class Harness
     {
         var cb = FindControl<CheckBox>(c => c.Content is string s && s == label)
             ?? throw new InvalidOperationException(
-                $"{nameof(ToggleCheckBox)}(\"{label}\"): no CheckBox with that Content is in the " +
+                $"{nameof(ToggleCheckBox)}(\"{OneLine(label)}\"): no CheckBox with that Content is in the " +
                 $"visual tree. {DescribeContent<CheckBox>("CheckBox")}");
 
         cb.IsChecked = cb.IsChecked != true;
@@ -424,7 +429,7 @@ internal sealed class Harness
     private Button RequireButton(string caller, string label)
         => FindButton(label)
            ?? throw new InvalidOperationException(
-               $"{caller}(\"{label}\"): no Button with that Content is in the visual tree. " +
+               $"{caller}(\"{OneLine(label)}\"): no Button with that Content is in the visual tree. " +
                DescribeContent<Button>("Button"));
 
     private static void InvokeButton(Button btn)
@@ -445,12 +450,24 @@ internal sealed class Harness
         if (all.Count == 0) return $"No {kind} is mounted at all.";
 
         var labels = all
-            .Select(c => c.Content is string s ? $"\"{s}\"" : $"<{c.Content?.GetType().Name ?? "null"}>")
+            .Select(c => c.Content is string s ? $"\"{OneLine(s)}\"" : $"<{c.Content?.GetType().Name ?? "null"}>")
             .Take(20)
             .ToList();
-        var more = all.Count > labels.Count ? $", … (+{all.Count - labels.Count} more)" : "";
+        var more = all.Count > labels.Count ? $", \u2026 (+{all.Count - labels.Count} more)" : "";
         return $"{all.Count} {kind}(s) present: {string.Join(", ", labels)}{more}.";
     }
+
+    /// <summary>
+    /// Escapes the characters that would break the single-line TAP record this text ends up
+    /// in. A throw from here surfaces as <c>not ok &lt;n&gt; &lt;fixture&gt;_CRASH - &lt;msg&gt;</c>
+    /// (SelfTestRunner.cs), and SelfTestBatch.ParseTap reads that stream line by line — so a
+    /// raw newline inside a control label would split one failure into two records and the
+    /// tail could be re-read as a forged <c>ok</c> / <c># Total failures:</c> line.
+    /// </summary>
+    private static string OneLine(string s)
+        => s.Replace("\r", "\\r", StringComparison.Ordinal)
+            .Replace("\n", "\\n", StringComparison.Ordinal)
+            .Replace("\t", "\\t", StringComparison.Ordinal);
 
     // -- Tree walking ----------------------------------------------------
 

--- a/tests/Reactor.AppTests.Host/SelfTest/Harness.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Harness.cs
@@ -362,23 +362,94 @@ internal sealed class Harness
 
     // -- Interaction helpers ----------------------------------------------
 
+    /// <summary>
+    /// Invokes the <see cref="Button"/> whose Content equals <paramref name="label"/>.
+    ///
+    /// <para>Throws when the button is missing OR disabled. A fixture is a stimulus followed
+    /// by an assertion, so a stimulus that silently does not land leaves the assertion
+    /// measuring the UNSTIMULATED state — and every assertion of the form "X was left
+    /// alone" / "X was restored" / "X is still within tolerance" passes on that state. The
+    /// fixture then goes green having exercised nothing, and "clicked it" is byte-identical
+    /// to "silently did nothing" at the call site (issue #1063).</para>
+    ///
+    /// <para>To assert that a disabled button ignores clicks, use
+    /// <see cref="ClickButtonIfEnabled"/> — it still throws when the label is wrong, so the
+    /// assertion cannot pass for the wrong reason.</para>
+    /// </summary>
+    /// <exception cref="InvalidOperationException">No such button, or the button is disabled.</exception>
     public void ClickButton(string label)
     {
-        var btn = FindButton(label);
-        if (btn is not null && btn.IsEnabled)
-        {
-            var peer = new Microsoft.UI.Xaml.Automation.Peers.ButtonAutomationPeer(btn);
-            var invokeProvider = (Microsoft.UI.Xaml.Automation.Provider.IInvokeProvider)
-                peer.GetPattern(Microsoft.UI.Xaml.Automation.Peers.PatternInterface.Invoke);
-            invokeProvider.Invoke();
-        }
+        var btn = RequireButton(nameof(ClickButton), label);
+        if (!btn.IsEnabled)
+            throw new InvalidOperationException(
+                $"{nameof(ClickButton)}(\"{label}\"): the Button is disabled, so the click was NOT " +
+                $"delivered. If the fixture means to prove that a disabled button ignores clicks, " +
+                $"call {nameof(ClickButtonIfEnabled)} and assert it returns false.");
+
+        InvokeButton(btn);
     }
 
+    /// <summary>
+    /// Invokes the button only if it is enabled, and reports which happened: true when the
+    /// click was delivered, false when the button was found but disabled.
+    ///
+    /// <para>Still throws when no button carries <paramref name="label"/> — that is always a
+    /// broken fixture, and it keeps a <c>false</c> result meaning "the button is disabled"
+    /// rather than the ambiguous "disabled, or I typo'd the label".</para>
+    /// </summary>
+    /// <exception cref="InvalidOperationException">No button carries <paramref name="label"/>.</exception>
+    public bool ClickButtonIfEnabled(string label)
+    {
+        var btn = RequireButton(nameof(ClickButtonIfEnabled), label);
+        if (!btn.IsEnabled) return false;
+        InvokeButton(btn);
+        return true;
+    }
+
+    /// <summary>
+    /// Flips the <see cref="CheckBox"/> whose Content equals <paramref name="label"/>.
+    /// Throws when there is no such CheckBox, for the reasons in <see cref="ClickButton"/>.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">No CheckBox carries <paramref name="label"/>.</exception>
     public void ToggleCheckBox(string label)
     {
-        var cb = FindControl<CheckBox>(c => c.Content is string s && s == label);
-        if (cb is not null)
-            cb.IsChecked = cb.IsChecked != true;
+        var cb = FindControl<CheckBox>(c => c.Content is string s && s == label)
+            ?? throw new InvalidOperationException(
+                $"{nameof(ToggleCheckBox)}(\"{label}\"): no CheckBox with that Content is in the " +
+                $"visual tree. {DescribeContent<CheckBox>("CheckBox")}");
+
+        cb.IsChecked = cb.IsChecked != true;
+    }
+
+    private Button RequireButton(string caller, string label)
+        => FindButton(label)
+           ?? throw new InvalidOperationException(
+               $"{caller}(\"{label}\"): no Button with that Content is in the visual tree. " +
+               DescribeContent<Button>("Button"));
+
+    private static void InvokeButton(Button btn)
+    {
+        var peer = new Microsoft.UI.Xaml.Automation.Peers.ButtonAutomationPeer(btn);
+        var invokeProvider = (Microsoft.UI.Xaml.Automation.Provider.IInvokeProvider)
+            peer.GetPattern(Microsoft.UI.Xaml.Automation.Peers.PatternInterface.Invoke);
+        invokeProvider.Invoke();
+    }
+
+    /// <summary>
+    /// "3 Button(s) present: "Save", "Cancel", "Reset"." — turns a crash line into a fix
+    /// without a debugger attach, the way <c>UiElementResolver.FindByName</c> does for E2E.
+    /// </summary>
+    private string DescribeContent<T>(string kind) where T : ContentControl
+    {
+        var all = FindAllControls<T>(_ => true);
+        if (all.Count == 0) return $"No {kind} is mounted at all.";
+
+        var labels = all
+            .Select(c => c.Content is string s ? $"\"{s}\"" : $"<{c.Content?.GetType().Name ?? "null"}>")
+            .Take(20)
+            .ToList();
+        var more = all.Count > labels.Count ? $", … (+{all.Count - labels.Count} more)" : "";
+        return $"{all.Count} {kind}(s) present: {string.Join(", ", labels)}{more}.";
     }
 
     // -- Tree walking ----------------------------------------------------

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -1700,10 +1700,14 @@ internal static class SelfTestFixtureRegistry
         "CmdBarFlyout_UnmountDetachesFlyout",
         "CmdBarFlyout_KeyedReorderKeepsSiblingFlyouts",
         "CmdBarFlyout_TargetKeepsItsOwnCallbacks",
+
+        // The harness's own click stimulus must fail loudly (HarnessGuardFixtures, #1063).
+        "HarnessGuard_ClickButtonFailsLoudly",
     ];
 
     public static SelfTestFixtureBase? Create(string name, Harness harness) => name switch
     {
+        "HarnessGuard_ClickButtonFailsLoudly" => new HarnessGuardFixtures.ClickButtonFailsLoudly(harness),
         "ErrorBoundary_CatchesRenderError" => new ErrorBoundaryFixtures.CatchesRenderError(harness),
         "ErrorBoundary_Recovery" => new ErrorBoundaryFixtures.Recovery(harness),
         "Reconciler_MountText" => new ReconcilerFixtures.MountText(harness),


### PR DESCRIPTION
Fixes #1063.

## The defect

`Harness.ClickButton` — the selftest click stimulus, used at ~700 call sites — had no `else`, no throw, and no return value:

```csharp
var btn = FindButton(label);
if (btn is not null && btn.IsEnabled) { ...ButtonAutomationPeer Invoke... }
```

So "the click landed" and "nothing happened" were **byte-identical at every call site**. A fixture is a stimulus followed by an assertion; when the stimulus silently no-ops, the assertion measures the *unstimulated* state — and every assertion of the form "X was left alone" / "X was restored" / "X is still within tolerance" passes on that state. The fixture then goes green having exercised nothing. `ToggleCheckBox` had the same shape.

## The change

| Helper | Missing label | Disabled |
|---|---|---|
| `ClickButton` | throws | throws |
| `RequireButtonDisabled` (new) | throws | passes (asserts; never clicks) |
| `ToggleCheckBox` | throws | — |

`RequireButtonDisabled` is the sanctioned way to prove "a disabled button ignores clicks". It is deliberately **void**: it throws on a wrong label *and* on an unexpectedly **enabled** button. That second direction is the one that matters — a button the fixture believed was inert being live means the following "nothing happened" assertion was measuring the wrong thing.

It returns void rather than `bool` on purpose. `.editorconfig` sets `csharp_style_unused_value_expression_statement_preference = discard_variable:silent`, and neither CA1806 nor `EnableNETAnalyzers` is on, so a returned flag could be dropped at a call site with no warning — reintroducing the exact defect this PR removes.

Diagnostic messages name the bad label and enumerate what *was* found, modelled on the already-fail-closed E2E `UiElementResolver.FindByName`, so a crash line is fixable without attaching a debugger:

```
ClickButton("Sve"): no Button with that Content is in the visual tree.
3 Button(s) present: "Save", "Cancel", "Reset".
```

Labels are flattened through `OneLine` first. `SelfTestRunner.cs:384` writes `ex.Message` straight into `not ok <n> <fixture>_CRASH - <msg>`, and `SelfTestBatch.ParseTap` is line-oriented — a raw newline in a control label would split one failure into two records and let the tail be re-read as a forged `ok` or `# Total failures:` line. No fixture mounts a multi-line label today, so this is hardening against a latent trap.

No runner change was needed: `SelfTestRunner` already turns a fixture throw into a `_CRASH` TAP line that `SelfTestBatch` attributes to the right MSTest case.

## Call-site impact

Exactly one existing site relied on the silent disabled-skip (`CommandingCoverageFixtures`, `BareInitDis_NotInvokedWhileDisabled`). It now uses `RequireButtonDisabled` and is strictly stronger: the label is verified to exist, and a wrongly-enabled button is a hard error rather than a soft check failure. One discarded `WaitAndClick` return in `ContentDialogLiveContentFixtures` is now captured into a check — same fail-open family, and its 10 sibling call sites already did this.

## Evidence

- **The guard fixture is non-vacuous.** Restoring the fail-open bodies reddens exactly the 9 guard-targeting checks; the setup/control checks stay green. Neutering the enabled-direction throw reddens exactly `RequireDisabled_ThrowsOnEnabled`; a passthrough `OneLine` reddens exactly the two `Tap_` checks while their control stays green.
- **Zero fallout is a measurement, not an absence.** Full suite: **6664 ok, 0 not ok**, 7 pre-existing SKIPs. `HarnessGuard_Missing_Throws`, `HarnessGuard_Disabled_Throws`, `HarnessGuard_RequireDisabled_ThrowsOnEnabled` and `HarnessGuard_Tap_NoRawNewlineInMessage` all pass *inside that same run* — an in-run positive control that can only hold if the throws were live across all 1444 fixtures.
- Release build clean under `TreatWarningsAsErrors`, verified by planting a `CS0219` in the new file and watching Release fail before removing it.

## Known follow-ups (deliberately out of scope)

- Ambiguous labels still resolve first-match silently.
- 152 of 376 `WaitFor` call sites discard their `bool` — same silent-failure family, but pre-existing and corpus-wide.
- ~120 `if (x is null) return;` early-returns across the fixture corpus abandon a fixture with no TAP line.
- A `Visibility.Collapsed` button remains invocable via its peer, so it is still a fake stimulus.