### PR TITLE
Report a fully-skipped selftest fixture as SKIPPED, not PASSED

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,23 @@ Conventions for contributors:
 
 ### Fixed
 
+- **A fully-skipped selftest fixture is no longer reported as PASSED (issue #1061).**
+  `Harness.Skip` emits `ok <name> # SKIP <reason>`, and `SelfTestBatch.ParseTap` treated any
+  `ok ` line as proof the fixture had asserted something — satisfying the very flag that exists
+  to catch a fixture that asserted nothing. A fixture whose *only* TAP output was a skip
+  therefore reported green, indistinguishable from one that ran and passed. Selftests now carry
+  a genuine third verdict on both sides of the TAP boundary: the Host counts checks and skips,
+  paints a fully-skipped fixture amber, and emits `# Skipped fixture:` plus a
+  `# Total skipped fixtures: N` trailer (after `# Total failures:`, so the #978/#988 abort
+  discriminator is unchanged) for raw-TAP consumers such as the NativeAOT job; the MSTest
+  wrapper parses the `# SKIP` directive and reports such fixtures as **Skipped**
+  (`Assert.Inconclusive`) with their reasons, publishing the full skipped-check inventory —
+  including partial skips — to the job summary. Simply not setting the flag would have been
+  wrong: it turns `CenterOnCurrent_UsesCursorMonitor` and `CornerStyle_Apply` red on exactly the
+  non-interactive and Windows 10 machines their skips were added to accommodate. No fixture
+  changed; those two change *verdict* (PASSED → SKIPPED) on the affected machines, which is the
+  evidence the fix landed in the right layer.
+
 ### Security
 
 ## [0.1.0-preview.13] — 2026-08-04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,10 @@ Conventions for contributors:
   wrong: it turns `CenterOnCurrent_UsesCursorMonitor` and `CornerStyle_Apply` red on exactly the
   non-interactive and Windows 10 machines their skips were added to accommodate. No fixture
   changed; those two change *verdict* (PASSED → SKIPPED) on the affected machines, which is the
-  evidence the fix landed in the right layer.
+  evidence the fix landed in the right layer. A dedicated fixture,
+  `SelfTestVerdict_OnlySkips_PositiveControl`, asserts nothing on purpose so the SKIPPED verdict
+  has an end-to-end positive control on every run — the Host half of the mechanism lives in a
+  project no test can reference, so a fabricated TAP stream cannot reach it.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,9 +42,10 @@ Conventions for contributors:
   to catch a fixture that asserted nothing. A fixture whose *only* TAP output was a skip
   therefore reported green, indistinguishable from one that ran and passed. Selftests now carry
   a genuine third verdict on both sides of the TAP boundary: the Host counts checks and skips,
-  paints a fully-skipped fixture amber, and emits `# Skipped fixture:` plus a
-  `# Total skipped fixtures: N` trailer (after `# Total failures:`, so the #978/#988 abort
-  discriminator is unchanged) for raw-TAP consumers such as the NativeAOT job; the MSTest
+  paints a fully-skipped fixture amber, and emits `# Fully skipped fixture:` plus a
+  `# Total skipped fixtures: N` trailer and a `# Skipped fixture list:` roll-up (all after
+  `# Total failures:`, so the #978/#988 abort discriminator is unchanged) for raw-TAP consumers
+  such as the NativeAOT job; the MSTest
   wrapper parses the `# SKIP` directive and reports such fixtures as **Skipped**
   (`Assert.Inconclusive`) with their reasons, publishing the full skipped-check inventory —
   including partial skips — to the job summary. Simply not setting the flag would have been

--- a/TESTING.md
+++ b/TESTING.md
@@ -159,11 +159,17 @@ A selftest fixture has **three** outcomes, not two. `H.Check(name, cond)` assert
 | ≥1 `H.Check`, none failed | green | **Passed** |
 | any failed check | red | **Failed** |
 | ≥1 `H.Skip` and **zero** checks | amber | **Skipped** (`Assert.Inconclusive`) |
-| nothing at all | red | **Failed** — "fixture emitted no TAP checks" |
+| nothing at all | red | **Failed** — the Host emits `not ok <n> <fixture> - fixture ran to completion without emitting a single check or skip` |
 
 A fixture that both checks and skips stays **Passed**; its skipped check names and reasons are
 still listed in the run's skip report so a fixture cannot quietly erode to skipping everything
 it used to assert.
+
+The last row is enforced on **both** sides on purpose. The wrapper has always failed a silent
+fixture, but the Host used to paint it green and emit no `not ok` line at all — so the two
+disagreed, and the raw-TAP consumers had only the Host to go on. Since the AOT job greps
+`^not ok `, a fixture that asserted nothing was invisible precisely where nothing was left to
+correct it.
 
 Until [#1061](https://github.com/microsoft/microsoft-ui-reactor/issues/1061) the third row
 collapsed into the first: `ParseTap` treated any `ok ` line as evidence that the fixture had

--- a/TESTING.md
+++ b/TESTING.md
@@ -182,15 +182,32 @@ if (!ok) { H.Skip("Thing_Behaves", "probe unavailable on this desktop"); return;
 H.Check("Thing_Behaves", value == expected);
 ```
 
-Reach for a bare `H.Skip` only when the *probe itself* is what's unavailable — a locked desktop,
-an OS version without the API. If you find yourself skipping to silence a flake, fix the flake:
-a Skipped fixture establishes nothing about the code either way, which is the point of making it
-visible rather than green.
+Three reasons to skip are legitimate, and they are **not** interchangeable when you read a result:
+
+| reason | example | what a Skipped result means |
+|---|---|---|
+| Undeterminable precondition | `GetCursorPos` on a non-interactive desktop; DWM corners on Windows 10 | this machine cannot answer the question |
+| Coverage owned by another tier | `EventStateSplit_RawHatch_HandledChildParentStillFires` — live KeyDown, asserted by E2E | covered, just not here |
+| A tracked product gap | `"issue #942 - decorator retags the target"` | the product **is** broken; the skip is a referenced deferral |
+
+Because the third row exists, **never read a skip as evidence the product works** — only that this
+run did not establish otherwise. That is exactly why reporting one as PASSED was worth fixing, and
+why SKIPPED is not just a politer green. Always put an issue number in the reason when there is
+one; the reason string is all a reader of the skip report gets. And if you are reaching for a skip
+to silence a flake, fix the flake instead — a skip makes the flake invisible rather than absent.
 
 For raw-TAP consumers (the AOT job pipes `--self-test` straight to a `.tap` artifact and greps
 `^not ok `), the Host emits a `# Total skipped fixtures: N` trailer — placed *after*
 `# Total failures:` so the abort discriminator below is unaffected — followed by
-`# Skipped fixtures: <names>` when non-zero.
+`# Skipped fixture list: <names>` when non-zero. Each fully-skipped fixture also gets its own
+`# Fully skipped fixture: <name> - N check(s) skipped, 0 assertions ran` line as it happens. The
+three prefixes are deliberately distinct so a grep for one does not match the others.
+
+One fixture, `SelfTestVerdict_OnlySkips_PositiveControl`, is **expected** to be Skipped on every
+run. It asserts nothing on purpose: it is the positive control that proves the SKIPPED verdict
+still works end to end, since the Host half of the mechanism lives in a project no test can
+reference. Its amber is the healthy result — don't "fix" it, and don't copy it as a template.
+`SkippedFixtures_AreReported` fails if it ever stops being reported as fully skipped.
 
 ### Selftest waiting patterns — `Render` vs `WaitFor` vs `WaitForIdleAsync`
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -149,6 +149,49 @@ rule, because its user has no reason to doubt the answer. Two probes with comple
 spots don't compose into coverage unless you run both, and if you're running both the
 whole-tree grep is cheaper than remembering why.
 
+### Skipping a check — `H.Skip` and the three-state verdict
+
+A selftest fixture has **three** outcomes, not two. `H.Check(name, cond)` asserts;
+`H.Skip(name, reason)` says *"I could not assert this here"* and emits `ok <name> # SKIP <reason>`.
+
+| what the fixture emitted | Host title-bar | `dotnet test` verdict |
+|---|---|---|
+| ≥1 `H.Check`, none failed | green | **Passed** |
+| any failed check | red | **Failed** |
+| ≥1 `H.Skip` and **zero** checks | amber | **Skipped** (`Assert.Inconclusive`) |
+| nothing at all | red | **Failed** — "fixture emitted no TAP checks" |
+
+A fixture that both checks and skips stays **Passed**; its skipped check names and reasons are
+still listed in the run's skip report so a fixture cannot quietly erode to skipping everything
+it used to assert.
+
+Until [#1061](https://github.com/microsoft/microsoft-ui-reactor/issues/1061) the third row
+collapsed into the first: `ParseTap` treated any `ok ` line as evidence that the fixture had
+asserted something, so a fully-skipped fixture was reported **PASSED** — the `# SKIP` directive
+satisfied the very flag that exists to catch a fixture asserting nothing. Two anti-vacuity
+mechanisms cancelled each other out.
+
+**Prefer asserting the precondition, then skipping.** The strongest shape keeps a real check on
+the environment probe itself, so the fixture still proves *something* and only the part that
+genuinely cannot run is skipped (`NativeDockingA11yFixture.cs`):
+
+```csharp
+var ok = TryGetSomething(out var value);
+H.Check("Probe_Succeeded", ok);          // a real assertion, runs everywhere
+if (!ok) { H.Skip("Thing_Behaves", "probe unavailable on this desktop"); return; }
+H.Check("Thing_Behaves", value == expected);
+```
+
+Reach for a bare `H.Skip` only when the *probe itself* is what's unavailable — a locked desktop,
+an OS version without the API. If you find yourself skipping to silence a flake, fix the flake:
+a Skipped fixture establishes nothing about the code either way, which is the point of making it
+visible rather than green.
+
+For raw-TAP consumers (the AOT job pipes `--self-test` straight to a `.tap` artifact and greps
+`^not ok `), the Host emits a `# Total skipped fixtures: N` trailer — placed *after*
+`# Total failures:` so the abort discriminator below is unaffected — followed by
+`# Skipped fixtures: <names>` when non-zero.
+
 ### Selftest waiting patterns — `Render` vs `WaitFor` vs `WaitForIdleAsync`
 
 Selftests run against a real WinUI dispatcher: most user-visible work (template realization, layout, content-presenter materialization, control intrinsic `Loaded` handlers) lands on *later* dispatcher waves, not synchronously with the mount call. Always wait on a concrete idle signal — never `Task.Delay(<n>)` — and pick the right primitive for the host you're driving:
@@ -281,8 +324,12 @@ before theorising:**
   returns **ACCESS_DENIED (err 5)** and never writes its `out` param, so the cursor monitor
   cannot be determined at all — a **100% deterministic** condition, not a flake. Confirmed by
   direct P/Invoke probe on two separate machines. Both fixtures now `H.Skip` here rather than
-  assert, so the expected symptom on such a machine is a **skip, not a red**; a red means this
-  is not your mechanism. Note `System.Windows.Forms.Cursor.Position` **hides** the condition —
+  assert, so the expected symptom on such a machine is a **reported Skipped result, not a red**
+  — and, since [#1061](https://github.com/microsoft/microsoft-ui-reactor/issues/1061), not a
+  silent green either: a fixture whose only TAP output is a skip is now surfaced as MSTest
+  Skipped with its reason, so "this machine cannot test it" is distinguishable from "this
+  machine tested it and it worked". A red means this is not your mechanism. Note
+  `System.Windows.Forms.Cursor.Position` **hides** the condition —
   it surfaces the uninitialised `(0,0)` instead of the failure, so probe `GetCursorPos(out p)`
   directly (`False` / `LastError=5`) rather than through it.
 - **Interactive multi-monitor box.** A TOCTOU: `GetCursorPos` is sampled *before*
@@ -316,7 +363,7 @@ dotnet publish tests/Reactor.AppTests.Host `
 ./artifacts/aot-host/Reactor.AppTests.Host.exe --self-test
 ```
 
-Output is the same TAP stream as a normal selftest run. The runner detects AOT at startup (`RuntimeFeature.IsDynamicCodeSupported == false`) and emits `# SKIP crashes/hangs under NativeAOT` lines for known-bad fixtures.
+Output is the same TAP stream as a normal selftest run. The runner detects AOT at startup (`RuntimeFeature.IsDynamicCodeSupported == false`) and emits `# SKIP crashes/hangs under NativeAOT` lines for known-bad fixtures. Those roll into the `# Total skipped fixtures: N` trailer alongside `# Total failures: N`, so a raw `.tap` artifact tells you how much of the suite actually ran — grepping `^not ok ` alone cannot, because a skipped fixture produces no `not ok` line.
 
 **3. Filtering known-bad fixtures.** The skip list lives in `DefaultAotSkipPatterns` in `tests/Reactor.AppTests.Host/SelfTest/SelfTestRunner.cs`. Entries are either an exact fixture name or a prefix-wildcard ending in `*` — by convention these match a fixture family, e.g. `MyFamily_*`. When you discover a new AOT crasher, you have two choices:
 

--- a/docs/_pipeline/templates/testing.md.dt
+++ b/docs/_pipeline/templates/testing.md.dt
@@ -179,6 +179,15 @@ when the WinUI control's measured size affects the component's
 behavior, or when an automation peer's role depends on the
 materialized XAML control class.
 
+A fixture asserts with `H.Check(name, condition)`. When the machine
+genuinely cannot run a check — a locked desktop, an OS version without
+the API — use `H.Skip(name, reason)` instead of quietly returning. A
+fixture that skipped every check and asserted nothing is reported as
+**Skipped**, not Passed, so "this machine could not test it" stays
+distinguishable from "this machine tested it and it worked". Prefer
+asserting the environment probe itself and skipping only the part that
+depends on it, so the fixture still proves something everywhere.
+
 ## Tips
 
 **Don't drive the unit fixture from `Task.Delay`.** If an effect

--- a/docs/_pipeline/templates/testing.md.dt
+++ b/docs/_pipeline/templates/testing.md.dt
@@ -186,7 +186,10 @@ fixture that skipped every check and asserted nothing is reported as
 **Skipped**, not Passed, so "this machine could not test it" stays
 distinguishable from "this machine tested it and it worked". Prefer
 asserting the environment probe itself and skipping only the part that
-depends on it, so the fixture still proves something everywhere.
+depends on it, so the fixture still proves something everywhere. Put an
+issue number in the reason when the skip marks a real product gap: a
+skip is never evidence the product works, only that this run did not
+establish otherwise.
 
 ## Tips
 

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -209,7 +209,10 @@ fixture that skipped every check and asserted nothing is reported as
 **Skipped**, not Passed, so "this machine could not test it" stays
 distinguishable from "this machine tested it and it worked". Prefer
 asserting the environment probe itself and skipping only the part that
-depends on it, so the fixture still proves something everywhere.
+depends on it, so the fixture still proves something everywhere. Put an
+issue number in the reason when the skip marks a real product gap: a
+skip is never evidence the product works, only that this run did not
+establish otherwise.
 
 ## Tips
 

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -202,6 +202,15 @@ when the WinUI control's measured size affects the component's
 behavior, or when an automation peer's role depends on the
 materialized XAML control class.
 
+A fixture asserts with `H.Check(name, condition)`. When the machine
+genuinely cannot run a check — a locked desktop, an OS version without
+the API — use `H.Skip(name, reason)` instead of quietly returning. A
+fixture that skipped every check and asserted nothing is reported as
+**Skipped**, not Passed, so "this machine could not test it" stays
+distinguishable from "this machine tested it and it worked". Prefer
+asserting the environment probe itself and skipping only the part that
+depends on it, so the fixture still proves something everywhere.
+
 ## Tips
 
 **Don't drive the unit fixture from `Task.Delay`.** If an effect

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/SkipVerdictPositiveControlFixture.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/SkipVerdictPositiveControlFixture.cs
@@ -1,0 +1,49 @@
+using System.Threading.Tasks;
+
+namespace Microsoft.UI.Reactor.AppTests.Host.SelfTest.Fixtures;
+
+/// <summary>
+/// Positive control for the three-state fixture verdict (issue #1061).
+///
+/// <para><b>Why this exists.</b> A fixture whose only TAP output is <c>H.Skip</c> used to be
+/// reported <b>PASSED</b>: <c>Harness.Skip</c> emits a line beginning <c>ok </c>, and the parser
+/// set its "did you assert anything?" flag for any such line — so the one signal meaning *I did
+/// not assert* satisfied the one guard meaning *did you assert*. The fix added a real SKIPPED
+/// verdict, spanning the Host (which decides a fixture asserted nothing) and the MSTest wrapper
+/// (which reports it). The Host half is not reachable from any test project: both
+/// <c>Reactor.SelfTests</c> and <c>Reactor.AppTests</c> reference this Host with
+/// <c>ReferenceOutputAssembly=false</c>, so nothing can call <c>SelfTestRunner</c> directly. The
+/// only way to exercise it is to be a fixture — this one.</para>
+///
+/// <para><b>What it proves, every run.</b> That the whole path still works end to end: the Host
+/// notices zero assertions, paints the segment amber, writes
+/// <c>&#35; Fully skipped fixture:</c> and counts it into <c>&#35; Total skipped fixtures:</c>;
+/// and the wrapper parses the directive and reports SKIPPED rather than green. Its verdict is
+/// asserted by <c>SelfTestBatch.SkippedFixtures_AreReported</c>, so if any link breaks — the Host
+/// stops classifying, the <c>&#35; SKIP</c> literal drifts across the duplicated boundary, the
+/// parser regresses — that test fails and names this fixture.</para>
+///
+/// <para><b>It is a control, so its behaviour is fixed on purpose.</b> It must skip
+/// unconditionally and assert nothing: a control that can pass proves nothing on the runs where
+/// it passes. This is the one fixture in the suite whose amber is the healthy result. Do not
+/// "fix" it by giving it a check, and do not copy it as a template for a real fixture — see
+/// <c>Harness.Skip</c> for the shape a real fixture should use (assert the precondition, then
+/// skip only the leg that cannot be observed).</para>
+/// </summary>
+internal class SkipVerdictPositiveControl(Harness h) : SelfTestFixtureBase(h)
+{
+    /// <summary>
+    /// The fixture name, shared with <c>SelfTestBatch</c> by convention only — the two projects
+    /// do not share an assembly, so this literal is duplicated there. Drift is caught rather than
+    /// prevented: the wrapper's assertion fails naming this fixture when it stops appearing.
+    /// </summary>
+    public const string FixtureName = "SelfTestVerdict_OnlySkips_PositiveControl";
+
+    public override Task RunAsync()
+    {
+        H.Skip("SelfTestVerdict_OnlySkips",
+            "positive control for issue #1061 - this fixture asserts nothing on purpose, so that " +
+            "the SKIPPED verdict is proven to still work on every run");
+        return Task.CompletedTask;
+    }
+}

--- a/tests/Reactor.AppTests.Host/SelfTest/Harness.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Harness.cs
@@ -203,10 +203,8 @@ internal sealed class Harness
     }
 
     /// <summary>
-    /// Emits a TAP "skipped" line for a known-failing or deferred check
-    /// without counting it as a pass OR a failure. Use for documented
-    /// gaps that have a tracking item — the assertion is explicit in
-    /// the log instead of being silently dropped.
+    /// Emits a TAP "skipped" line for a check this run cannot make, without counting it as a pass
+    /// OR a failure. The assertion stays explicit in the log instead of being silently dropped.
     ///
     /// <para><b>A skip is not an assertion, and the reporting layer now says so.</b> The
     /// directive below is a TAP payload, and <c>SelfTestBatch</c> used to discard it: any line
@@ -215,9 +213,29 @@ internal sealed class Harness
     /// was a skip reported <b>PASSED</b>, indistinguishable from one that ran and passed
     /// (issue #1061). It is now reported <b>SKIPPED</b>: amber in the title bar, counted in the
     /// Host's <c># Total skipped fixtures:</c> trailer, and surfaced as an MSTest skip rather than
-    /// a green tick. It is deliberately still not a failure — the fixtures that skip do so because
-    /// a precondition is <i>undeterminable</i>, not because the product is broken, and failing
-    /// them would recreate the regression the skip was introduced to fix.</para>
+    /// a green tick.</para>
+    ///
+    /// <para><b>Three legitimate reasons to skip</b>, all in use today, and the reason a skip is
+    /// reported rather than failed differs for each:
+    /// <list type="bullet">
+    ///   <item><description><i>Undeterminable precondition.</i> The machine cannot answer the
+    ///     question — <c>GetCursorPos</c> on a non-interactive desktop, DWM corner attributes on
+    ///     Windows 10, focus on a headless harness. Failing these would redden the suite on
+    ///     exactly the machines the skip was introduced to accommodate.</description></item>
+    ///   <item><description><i>Coverage owned by another tier.</i> Live input cannot be
+    ///     synthesized in-process, so the leg is asserted by the E2E suite instead — e.g.
+    ///     <c>EventStateSplit_RawHatch_HandledChildParentStillFires</c>. The behaviour <i>is</i>
+    ///     covered; not here.</description></item>
+    ///   <item><description><i>A tracked product gap.</i> A real defect with an issue number, e.g.
+    ///     <c>"issue #942 - decorator retags the target"</c>. Here the product genuinely is broken
+    ///     — the skip is a deliberate, referenced deferral, not a claim of health.</description>
+    ///   </item>
+    /// </list>
+    /// Because the third case exists, <b>a skipped fixture must never be read as evidence the
+    /// product works</b> — only that this run did not establish otherwise. That is precisely why
+    /// reporting it as PASSED was a bug worth fixing, and why SKIPPED is not simply a nicer green.
+    /// Put the reason in <paramref name="reason"/>, with an issue number when there is one; it is
+    /// the only thing a reader of the skip report gets.</para>
     ///
     /// <para><b>Prefer an observable precondition over a bare skip.</b> When the precondition
     /// <i>can</i> be asserted, assert it first and skip only the leg that genuinely cannot be

--- a/tests/Reactor.AppTests.Host/SelfTest/Harness.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Harness.cs
@@ -16,6 +16,8 @@ internal sealed class Harness
 {
     private readonly Window _window;
     private int _failures;
+    private int _checks;
+    private int _skips;
 
     // Persistent title bar with visual test-result segments
     private TextBlock? _subtitleText;
@@ -31,6 +33,17 @@ internal sealed class Harness
     public Window Window => _window;
     public int Failures => _failures;
     public void RecordFailure() => _failures++;
+
+    /// <summary>
+    /// Assertions attempted, passing or failing. Snapshotted around each fixture by
+    /// <see cref="SelfTestRunner"/> so a fixture that emitted <i>only</i> skips can be told apart
+    /// from one that actually asserted something (issue #1061). Counts the throwing overloads too:
+    /// an exception is an assertion attempt, not an absence of one.
+    /// </summary>
+    public int Checks => _checks;
+
+    /// <summary>Skip directives emitted — see <see cref="Skip"/>.</summary>
+    public int Skips => _skips;
 
     // -- TitleBar setup ---------------------------------------------------
 
@@ -179,6 +192,7 @@ internal sealed class Harness
 
     public void Check(string name, bool result)
     {
+        _checks++;
         if (result)
             Console.WriteLine($"ok {name}");
         else
@@ -193,9 +207,27 @@ internal sealed class Harness
     /// without counting it as a pass OR a failure. Use for documented
     /// gaps that have a tracking item — the assertion is explicit in
     /// the log instead of being silently dropped.
+    ///
+    /// <para><b>A skip is not an assertion, and the reporting layer now says so.</b> The
+    /// directive below is a TAP payload, and <c>SelfTestBatch</c> used to discard it: any line
+    /// starting <c>ok </c> satisfied the parser's <c>sawChecksForCurrent</c> guard — the flag whose
+    /// whole purpose is to catch a fixture that asserted nothing. So a fixture whose only output
+    /// was a skip reported <b>PASSED</b>, indistinguishable from one that ran and passed
+    /// (issue #1061). It is now reported <b>SKIPPED</b>: amber in the title bar, counted in the
+    /// Host's <c># Total skipped fixtures:</c> trailer, and surfaced as an MSTest skip rather than
+    /// a green tick. It is deliberately still not a failure — the fixtures that skip do so because
+    /// a precondition is <i>undeterminable</i>, not because the product is broken, and failing
+    /// them would recreate the regression the skip was introduced to fix.</para>
+    ///
+    /// <para><b>Prefer an observable precondition over a bare skip.</b> When the precondition
+    /// <i>can</i> be asserted, assert it first and skip only the leg that genuinely cannot be
+    /// observed — see <c>NativeDockingA11yFixture.cs</c>, which does
+    /// <c>H.Check(focusStartsOutside)</c> before its <c>H.Skip</c> + <c>return</c>. That shape
+    /// keeps a real red available for the case where the harness itself broke.</para>
     /// </summary>
     public void Skip(string name, string reason)
     {
+        _skips++;
         Console.WriteLine($"ok {name} # SKIP {reason}");
     }
 
@@ -204,6 +236,7 @@ internal sealed class Harness
         try { Check(name, test()); }
         catch (Exception ex)
         {
+            _checks++;
             Console.WriteLine($"not ok {name} - {ex.GetType().Name}: {ex.Message}");
             _failures++;
         }
@@ -214,6 +247,7 @@ internal sealed class Harness
         try { Check(name, await test()); }
         catch (Exception ex)
         {
+            _checks++;
             Console.WriteLine($"not ok {name} - {ex.GetType().Name}: {ex.Message}");
             _failures++;
         }

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -1700,6 +1700,10 @@ internal static class SelfTestFixtureRegistry
         "CmdBarFlyout_UnmountDetachesFlyout",
         "CmdBarFlyout_KeyedReorderKeepsSiblingFlyouts",
         "CmdBarFlyout_TargetKeepsItsOwnCallbacks",
+
+        // Positive control for the three-state verdict (issue #1061). Asserts nothing on purpose;
+        // its SKIPPED result is what SelfTestBatch.SkippedFixtures_AreReported checks for.
+        SkipVerdictPositiveControl.FixtureName,
     ];
 
     public static SelfTestFixtureBase? Create(string name, Harness harness) => name switch
@@ -3327,6 +3331,8 @@ internal static class SelfTestFixtureRegistry
         "CmdBarFlyout_UnmountDetachesFlyout" => new CommandBarFlyoutWiringFixtures.UnmountDetachesFlyout(harness),
         "CmdBarFlyout_KeyedReorderKeepsSiblingFlyouts" => new CommandBarFlyoutWiringFixtures.KeyedReorderKeepsSiblingFlyouts(harness),
         "CmdBarFlyout_TargetKeepsItsOwnCallbacks" => new CommandBarFlyoutWiringFixtures.TargetKeepsItsOwnCallbacks(harness),
+
+        SkipVerdictPositiveControl.FixtureName => new SkipVerdictPositiveControl(harness),
 
         _ => null,
     };

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestRunner.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestRunner.cs
@@ -415,8 +415,8 @@ internal static class SelfTestRunner
                         {
                             int skipped = harness.Skips - skipsBefore;
                             Console.WriteLine(
-                                $"# Skipped fixture: {fixtureName} - {skipped} check(s) skipped, " +
-                                $"0 assertions ran");
+                                $"# Fully skipped fixture: {fixtureName} - {skipped} check(s) " +
+                                $"skipped, 0 assertions ran");
                             skippedFixtures.Add(fixtureName);
                             harness.MarkFixtureSkipped(testIndex - 1);
                         }
@@ -445,7 +445,7 @@ internal static class SelfTestRunner
                     // the answer to "`# Total failures: 0` — but did anything actually assert?".
                     Console.WriteLine($"# Total skipped fixtures: {skippedFixtures.Count}");
                     if (skippedFixtures.Count > 0)
-                        Console.WriteLine($"# Skipped fixtures: {string.Join(", ", skippedFixtures)}");
+                        Console.WriteLine($"# Skipped fixture list: {string.Join(", ", skippedFixtures)}");
                     Console.WriteLine(SuiteElapsedMarker +
                         Stopwatch.GetElapsedTime(suiteStart).TotalSeconds
                             .ToString("F1", global::System.Globalization.CultureInfo.InvariantCulture));

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestRunner.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestRunner.cs
@@ -283,6 +283,15 @@ internal static class SelfTestRunner
                     int testIndex = 0;
                     bool isAot = !RuntimeFeature.IsDynamicCodeSupported;
                     var aotSkipPatterns = GetAotSkipPatterns();
+
+                    // Fixtures that finished having run ZERO assertions. Two ways in: skipped
+                    // wholesale by the AOT pattern list, or ran to completion emitting nothing but
+                    // H.Skip directives. Both are reported PASSED by a consumer that only counts
+                    // failures, which is issue #1061 — so the count goes in the trailer next to
+                    // "# Total failures:", where a raw-TAP reader (the AOT CI job pipes straight to
+                    // a .tap artifact and never goes through SelfTestBatch) can see it.
+                    var skippedFixtures = new List<string>();
+
                     foreach (var fixtureName in fixtures)
                     {
                         testIndex++;
@@ -298,6 +307,7 @@ internal static class SelfTestRunner
                         if (isAot && SkipAotPatterns && MatchesAnyPattern(fixtureName, aotSkipPatterns))
                         {
                             Console.WriteLine($"ok {testIndex} {fixtureName} # SKIP crashes/hangs under NativeAOT");
+                            skippedFixtures.Add(fixtureName);
                             harness.MarkFixtureSkipped(testIndex - 1);
                             // Clear progress so the hang watchdog doesn't trip
                             // while we yield between skips.
@@ -320,6 +330,8 @@ internal static class SelfTestRunner
                             new FixtureProgress(fixtureName, fixtureStart, HangTimeout));
 
                         int failuresBefore = harness.Failures;
+                        int checksBefore = harness.Checks;
+                        int skipsBefore = harness.Skips;
                         bool crashed = false;
                         try
                         {
@@ -389,8 +401,29 @@ internal static class SelfTestRunner
                         // its dispatcher-bound timeout fired) so the watchdog
                         // doesn't blame this fixture for an inter-fixture gap.
                         Volatile.Write(ref _currentFixture, null);
-                        harness.MarkFixtureResult(testIndex - 1,
-                            !crashed && harness.Failures == failuresBefore);
+
+                        // Three outcomes, not two (issue #1061). A fixture that ran to completion
+                        // having emitted only H.Skip directives asserted NOTHING, yet it produces
+                        // no `not ok` and so is indistinguishable from a real pass to anything that
+                        // counts failures. Paint it amber and name it, so the healthy and the
+                        // fully-degraded case are not the same green square.
+                        bool failed = crashed || harness.Failures != failuresBefore;
+                        bool assertedNothing = harness.Checks == checksBefore;
+                        bool onlySkipped = !failed && assertedNothing && harness.Skips > skipsBefore;
+
+                        if (onlySkipped)
+                        {
+                            int skipped = harness.Skips - skipsBefore;
+                            Console.WriteLine(
+                                $"# Skipped fixture: {fixtureName} - {skipped} check(s) skipped, " +
+                                $"0 assertions ran");
+                            skippedFixtures.Add(fixtureName);
+                            harness.MarkFixtureSkipped(testIndex - 1);
+                        }
+                        else
+                        {
+                            harness.MarkFixtureResult(testIndex - 1, !failed);
+                        }
 
                         // Per-fixture wall clock, as a TAP comment. Comments are
                         // inert to every consumer (SelfTestBatch.ParseTap keys only
@@ -404,6 +437,15 @@ internal static class SelfTestRunner
                     }
 
                     Console.WriteLine($"# Total failures: {harness.Failures}");
+
+                    // Deliberately AFTER the failures trailer: `# Total failures:` is the
+                    // documented discriminator for "the Host reached the end of its run"
+                    // (TESTING.md), and SelfTestBatch keys `sawTotalFailures` on it, so nothing may
+                    // come between it and the end of a healthy run's fixture output. This line is
+                    // the answer to "`# Total failures: 0` — but did anything actually assert?".
+                    Console.WriteLine($"# Total skipped fixtures: {skippedFixtures.Count}");
+                    if (skippedFixtures.Count > 0)
+                        Console.WriteLine($"# Skipped fixtures: {string.Join(", ", skippedFixtures)}");
                     Console.WriteLine(SuiteElapsedMarker +
                         Stopwatch.GetElapsedTime(suiteStart).TotalSeconds
                             .ToString("F1", global::System.Globalization.CultureInfo.InvariantCulture));

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestRunner.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestRunner.cs
@@ -409,7 +409,29 @@ internal static class SelfTestRunner
                         // fully-degraded case are not the same green square.
                         bool failed = crashed || harness.Failures != failuresBefore;
                         bool assertedNothing = harness.Checks == checksBefore;
-                        bool onlySkipped = !failed && assertedNothing && harness.Skips > skipsBefore;
+                        bool skippedSomething = harness.Skips > skipsBefore;
+                        bool onlySkipped = !failed && assertedNothing && skippedSomething;
+
+                        // Nothing at all — no check, no skip, no crash. Same defect as above with
+                        // the one mitigating detail removed: a skip at least states a reason, so
+                        // it is reported rather than failed. Silence states nothing, so there is
+                        // no verdict to be generous about, and the wrapper has always called this
+                        // a failure ("fixture emitted no TAP checks"). The Host called it a PASS,
+                        // which meant the two disagreed and the raw-TAP consumers believed the
+                        // Host: the AOT job greps `^not ok `, and a silent fixture emitted no such
+                        // line, so it was invisible exactly where there is no wrapper to correct
+                        // it. Emit the failure here so both sides — and the title bar — agree.
+                        if (!failed && assertedNothing && !skippedSomething)
+                        {
+                            // Deliberately no `_CRASH`/`_TIMEOUT`-style suffix: the wrapper strips
+                            // only those two, so any other decoration would attribute this to a
+                            // fixture name that does not exist instead of to this one.
+                            Console.WriteLine(
+                                $"not ok {testIndex} {fixtureName} - fixture ran to completion " +
+                                $"without emitting a single check or skip");
+                            harness.RecordFailure();
+                            failed = true;
+                        }
 
                         if (onlySkipped)
                         {

--- a/tests/Reactor.SelfTests/SelfTestBatch.cs
+++ b/tests/Reactor.SelfTests/SelfTestBatch.cs
@@ -760,10 +760,13 @@ public class SelfTestBatch
         $"so this run establishes nothing about it either way.\n" +
         $"  {string.Join("\n  ", skipped)}\n" +
         $"This is reported as skipped rather than passed because a `# SKIP` directive is a fixture " +
-        $"saying it could not observe its precondition (issue #1061). It is deliberately NOT a " +
-        $"failure: the preconditions involved — a non-interactive desktop where GetCursorPos " +
-        $"returns ACCESS_DENIED, or a Windows 10 box where the DWM corner attribute is not " +
-        $"round-trippable — are undeterminable, not broken. If you need coverage here, give the " +
+        $"saying it did not make its assertion (issue #1061). It is deliberately NOT a failure, " +
+        $"because a skip is usually a question this machine cannot answer — a non-interactive " +
+        $"desktop where GetCursorPos returns ACCESS_DENIED, a Windows 10 box where the DWM corner " +
+        $"attribute is not round-trippable — and failing those would redden the suite on exactly " +
+        $"the machines the skips accommodate. Read the reasons above before concluding anything: " +
+        $"some skips instead defer to the E2E tier, and some mark a tracked product gap with an " +
+        $"issue number, where the product really is broken. If you need coverage here, give the " +
         $"fixture an observable precondition to assert before it skips (see " +
         $"NativeDockingA11yFixture), rather than turning the skip into a red.";
 
@@ -773,27 +776,41 @@ public class SelfTestBatch
     /// that way; the Host emits upper case today, and a parser that only accepts what the current
     /// emitter happens to produce is one rename away from silently reporting every skip as a pass
     /// again.
+    ///
+    /// <para><b>Every</b> <c>#</c> is a directive candidate, not just the first. Check names embed
+    /// a tracking number by convention — <c>ContentDialogLive_Rerender_TextAdvanced_#1069</c>,
+    /// <c>..._#948</c>, <c>..._#246</c> — so on those lines the first <c>#</c> belongs to the
+    /// <i>name</i>. Anchoring on it leaves <c>1069 # SKIP …</c> as the candidate directive, which
+    /// fails the match and drops the line into the ordinary-pass arm: issue #1061 restored in full,
+    /// and precisely for the checks most likely to carry an issue number, because those are the
+    /// ones already known to be problematic. The scan makes the name's own hashes inert.</para>
     /// </summary>
     internal static bool TryParseSkipDirective(string afterOk, out string name, out string reason)
     {
         name = "";
         reason = "";
 
-        var hash = afterOk.IndexOf('#');
-        if (hash < 0) return false;
+        for (var hash = afterOk.IndexOf('#'); hash >= 0; hash = afterOk.IndexOf('#', hash + 1))
+        {
+            var directive = afterOk[(hash + 1)..].TrimStart();
+            if (!directive.StartsWith("SKIP", StringComparison.OrdinalIgnoreCase)) continue;
 
-        var directive = afterOk[(hash + 1)..].TrimStart();
-        if (!directive.StartsWith("SKIP", StringComparison.OrdinalIgnoreCase)) return false;
+            // Guard against a name that merely starts with "skip..." — the directive is the bare
+            // word. `continue` rather than `return false`: a later hash may still be the real
+            // directive, e.g. `Foo_#SKIPPABLE # SKIP reason`.
+            var afterWord = directive[4..];
+            if (afterWord.Length > 0 && !char.IsWhiteSpace(afterWord[0]) && afterWord[0] != ':')
+                continue;
 
-        // Guard against a name that merely starts with "skip..." — the directive is the bare word.
-        var afterWord = directive[4..];
-        if (afterWord.Length > 0 && !char.IsWhiteSpace(afterWord[0]) && afterWord[0] != ':')
-            return false;
+            name = afterOk[..hash].Trim();
+            if (name.Length == 0) continue;
 
-        name = afterOk[..hash].Trim();
-        reason = afterWord.TrimStart(' ', ':', '\t');
-        if (reason.Length == 0) reason = "(no reason given)";
-        return name.Length > 0;
+            reason = afterWord.TrimStart(' ', ':', '\t');
+            if (reason.Length == 0) reason = "(no reason given)";
+            return true;
+        }
+
+        return false;
     }
 
     /// <summary>
@@ -1118,12 +1135,17 @@ public class SelfTestBatch
     /// Publishes the run's skip inventory, and reports a fixture that established nothing as a
     /// skip rather than letting it pass unremarked.
     ///
-    /// <para>Deliberately <c>Inconclusive</c> and not <c>Fail</c>. The fixtures that reach here do
-    /// so because a precondition is <i>undeterminable</i> on this machine — <c>GetCursorPos</c>
-    /// returning <c>ACCESS_DENIED</c> on a non-interactive desktop, or a Windows 10 box where the
-    /// DWM corner attribute is not round-trippable. Failing them would make the suite red on
-    /// exactly the machines those skips were introduced to accommodate, which is the regression
-    /// the skips fixed.</para>
+    /// <para>Deliberately <c>Inconclusive</c> and not <c>Fail</c>, because most skips mark a
+    /// question this machine cannot answer — <c>GetCursorPos</c> returning <c>ACCESS_DENIED</c> on
+    /// a non-interactive desktop, or a Windows 10 box where the DWM corner attribute is not
+    /// round-trippable. Failing those would make the suite red on exactly the machines the skips
+    /// were introduced to accommodate, which is the regression the skips fixed.</para>
+    ///
+    /// <para>But <b>not every skip is benign</b>: some mark a tracked product gap (see
+    /// <c>Harness.Skip</c> — e.g. <c>"issue #942 - decorator retags the target"</c>), where the
+    /// product really is broken and the skip is a referenced deferral. That is why the reasons are
+    /// reproduced verbatim below rather than summarised into a count: a reader has to be able to
+    /// tell the two apart, and only the reason string can tell them.</para>
     /// </summary>
     [TestMethod]
     public void SkippedFixtures_AreReported()
@@ -1147,15 +1169,87 @@ public class SelfTestBatch
         foreach (var entry in report.Inventory.FullySkippedFixtures)
             Console.WriteLine($"  fully skipped: {entry}");
 
-        if (report.Inventory.FullySkippedFixtures.Count > 0)
+        // Same reasoning as the delivery check in SuiteDuration_WithinBudget, and the same failure
+        // mode: under `dotnet test` the Inconclusive message below never reaches the log, because
+        // the testhost's stdout is not forwarded. The step summary is therefore the ONLY channel
+        // that renders this inventory, so a dead channel leaves the skip report silently
+        // undelivered while everything else stays green — the suite passes, the report is composed,
+        // and nobody learns which fixtures asserted nothing.
+        var summaryPath = Environment.GetEnvironmentVariable(StepSummaryEnvVar);
+        if (Environment.GetEnvironmentVariable("GITHUB_ACTIONS") == "true")
+        {
+            Assert.IsFalse(string.IsNullOrWhiteSpace(summaryPath),
+                $"{StepSummaryEnvVar} is unset on a GitHub Actions runner, so the skip inventory " +
+                $"had nowhere to go and the delivery check below silently skipped. Without this " +
+                $"the check cannot come out the other way, and a check that cannot fail is the " +
+                $"instrument bug issue #1061 was.");
+        }
+
+        if (!string.IsNullOrWhiteSpace(summaryPath))
+        {
+            Assert.IsTrue(report.Delivered,
+                $"The skip inventory could not be written to {StepSummaryEnvVar} " +
+                $"('{summaryPath}'). This is a fault in the reporting channel, not in the suite: " +
+                $"the run itself is fine, but the only surface that names the skipped fixtures is " +
+                $"now silent.");
+        }
+
+        // The positive control. Everything else in this file feeds ParseTap a fabricated string,
+        // which proves the parser but not the Host: the decision "this fixture asserted nothing"
+        // is made in SelfTestRunner, in a project no test can reference
+        // (ReferenceOutputAssembly=false), so a fabricated stream cannot reach it. This fixture
+        // exists to be fully skipped, so its presence here is the one end-to-end proof that the
+        // Host still classifies, the `# SKIP` literal still matches across the duplicated
+        // boundary, and the wrapper still reports SKIPPED instead of green.
+        //
+        // It fails rather than warns because the regression it guards is silent by construction:
+        // if the chain breaks, this fixture goes GREEN, the suite stays green, and issue #1061 is
+        // back with nothing to show for it. Without this assertion the whole skip pipeline could
+        // rot while every test above it stayed passing — a check that cannot come out the other
+        // way, which is the exact instrument bug this work is about.
+        var controlSeen = report.Inventory.FullySkippedFixtures
+            .Any(e => e.Contains(SkipVerdictControlFixture, StringComparison.Ordinal));
+
+        Assert.IsTrue(controlSeen,
+            $"The positive control '{SkipVerdictControlFixture}' was not reported as a fully " +
+            $"skipped fixture. It asserts nothing on purpose, so it must land here on every run. " +
+            $"Something in the chain is broken, and the failure is silent everywhere else:\n" +
+            $"  (a) The fixture was deleted, renamed, or given a real H.Check — restore it; its " +
+            $"amber IS the healthy result (see SkipVerdictPositiveControlFixture.cs).\n" +
+            $"  (b) SelfTestRunner stopped classifying a zero-assertion fixture as skipped, so " +
+            $"fully-skipped fixtures are reported PASSED again — that is issue #1061 exactly.\n" +
+            $"  (c) The '# SKIP' literal drifted between Harness.Skip and TryParseSkipDirective. " +
+            $"The Host is referenced with ReferenceOutputAssembly=false, so it is duplicated, not " +
+            $"shared, and nothing but this assertion compares the two.\n" +
+            $"Fixtures reported fully skipped this run: " +
+            $"{(report.Inventory.FullySkippedFixtures.Count == 0 ? "(none)" : string.Join(", ", report.Inventory.FullySkippedFixtures))}");
+
+        // Report only the *unexpected* skips. The control is always here, so folding it in would
+        // make this permanently Inconclusive and drown the signal it exists to protect.
+        var unexpected = report.Inventory.FullySkippedFixtures
+            .Where(e => !e.Contains(SkipVerdictControlFixture, StringComparison.Ordinal))
+            .ToArray();
+
+        if (unexpected.Length > 0)
         {
             Assert.Inconclusive(
                 $"{report.Inventory.Text}\n" +
-                $"Fully skipped:\n  {string.Join("\n  ", report.Inventory.FullySkippedFixtures)}\n" +
-                $"Each of those is reported Skipped individually too. They are NOT failures — see " +
-                $"the per-fixture message for why the precondition could not be observed.");
+                $"Fully skipped (excluding the '{SkipVerdictControlFixture}' control):\n  " +
+                $"{string.Join("\n  ", unexpected)}\n" +
+                $"Each of those is reported Skipped individually too. They are NOT automatically " +
+                $"failures — but they are not passes either: read the per-fixture reason, because " +
+                $"a skip can mean an undeterminable precondition, coverage owned by the E2E tier, " +
+                $"or a tracked product gap where the product really is broken.");
         }
     }
+
+    /// <summary>
+    /// Name of the fixture that exists purely to be fully skipped, so the SKIPPED verdict has an
+    /// end-to-end positive control. Duplicated from
+    /// <c>SkipVerdictPositiveControl.FixtureName</c> in the Host, which cannot be referenced from
+    /// here; <see cref="SkippedFixtures_AreReported"/> is what catches the two drifting apart.
+    /// </summary>
+    internal const string SkipVerdictControlFixture = "SelfTestVerdict_OnlySkips_PositiveControl";
 
     /// <summary>
     /// The one assertion that observes the <b>real</b> Host's real skip output, and the only thing
@@ -1170,12 +1264,11 @@ public class SelfTestBatch
     /// green suite. The same reasoning, and the same shape, as the
     /// <c>'# Suite elapsed: '</c> guard in <see cref="SuiteDuration_WithinBudget"/>.</para>
     ///
-    /// <para>Non-vacuous today because <c>Spec047EventStateSplitFixtures</c> skips
-    /// <b>unconditionally</b> (<c>EventStateSplit_RawHatch_HandledChildParentStillFires</c>: live
-    /// KeyDown cannot be synthesized headlessly), so every run of the full suite emits at least one
-    /// directive regardless of the machine. If that ever stops being true the failure message says
-    /// so and says what to do about it — the guard has no value once the suite has no skips to
-    /// observe.</para>
+    /// <para>Non-vacuous by design, not by luck: <c>SelfTestVerdict_OnlySkips_PositiveControl</c>
+    /// exists to be fully skipped, so every full run emits at least one directive regardless of
+    /// the machine. It previously leaned on <c>Spec047EventStateSplitFixtures</c> skipping
+    /// unconditionally, which was true but incidental — that fixture's skip could be closed at any
+    /// time by work that had no idea this guard depended on it.</para>
     /// </summary>
     [TestMethod]
     public void SkipDirectives_SurviveIntoTheReport()
@@ -1197,17 +1290,16 @@ public class SelfTestBatch
         var inventory = BuildSkipInventory(_byFixture);
 
         Assert.IsTrue(inventory.TotalSkippedChecks > 0,
-            "The Host completed its run but the parser saw ZERO '# SKIP' directives. Two " +
-            "explanations, and they need different fixes:\n" +
+            "The Host completed its run but the parser saw ZERO '# SKIP' directives. That should " +
+            "be impossible: " + SkipVerdictControlFixture + " exists to emit one on every run. " +
+            "Two explanations, and they need different fixes:\n" +
             "  (a) DRIFT — Harness.Skip stopped emitting 'ok <name> # SKIP <reason>', or " +
             "SelfTestBatch.TryParseSkipDirective stopped recognising it. Every fully-skipped " +
             "fixture is now silently reported PASSED again, which is issue #1061 exactly. Check " +
             "the literal on BOTH sides: the Host is referenced with ReferenceOutputAssembly=false, " +
             "so it is duplicated, not shared.\n" +
-            "  (b) The suite genuinely has no H.Skip sites left. That is a fine state to be in — " +
-            "and it makes this guard worthless, so delete it rather than adding a fixture to keep " +
-            "it fed. It was non-vacuous when written because " +
-            "Spec047EventStateSplitFixtures skips unconditionally.");
+            "  (b) The positive-control fixture was deleted or de-registered. Restore it rather " +
+            "than deleting this guard — it is the only thing keeping the check falsifiable.");
     }
 
     /// <summary>

--- a/tests/Reactor.SelfTests/SelfTestBatch.cs
+++ b/tests/Reactor.SelfTests/SelfTestBatch.cs
@@ -676,7 +676,7 @@ public class SelfTestBatch
         foreach (var raw in stdout.Split('\n', StringSplitOptions.RemoveEmptyEntries))
         {
             var line = raw.Trim();
-            if (line.StartsWith("# Running: "))
+            if (line.StartsWith("# Running: ", StringComparison.Ordinal))
             {
                 Flush();
                 current = line["# Running: ".Length..].Trim();
@@ -689,7 +689,7 @@ public class SelfTestBatch
             {
                 sawTotalFailures = true;
             }
-            else if (line.StartsWith("ok "))
+            else if (line.StartsWith("ok ", StringComparison.Ordinal))
             {
                 var rest = line[3..].Trim();
                 if (TryParseSkipDirective(rest, out var skipName, out var skipReason))
@@ -724,7 +724,7 @@ public class SelfTestBatch
                     sawChecksForCurrent = true;
                 }
             }
-            else if (line.StartsWith("not ok "))
+            else if (line.StartsWith("not ok ", StringComparison.Ordinal))
             {
                 var rest = line[7..].Trim();
                 if (TryParseRunnerLevelFailure(rest, out var fixtureName, out var detail))

--- a/tests/Reactor.SelfTests/SelfTestBatch.cs
+++ b/tests/Reactor.SelfTests/SelfTestBatch.cs
@@ -702,10 +702,16 @@ public class SelfTestBatch
                         // Fixture-level skip (the AOT pattern list). It arrives with no
                         // `# Running:` marker, so attributing it to `current` would credit an
                         // unrelated, already-finished fixture with a skip it never emitted.
+                        //
+                        // The entry is labelled rather than named, because there is no check name
+                        // to give: the fixture never ran, so no `H.Skip` was reached and the TAP
+                        // name here is the FIXTURE's. Reusing it would render as
+                        // "`X` — X — <reason>" in the inventory, which both repeats the fixture
+                        // and asserts a check called X was skipped. No such check exists.
                         byFixture[skippedFixture] = new FixtureOutcome(
                             FixtureStatus.Skipped,
                             $"Fixture '{skippedFixture}' was skipped by the runner before it ran: {skipReason}",
-                            [$"{skippedFixture} — {skipReason}"]);
+                            [$"{RunnerLevelSkipLabel} — {skipReason}"]);
                     }
                     else
                     {
@@ -769,6 +775,13 @@ public class SelfTestBatch
         $"issue number, where the product really is broken. If you need coverage here, give the " +
         $"fixture an observable precondition to assert before it skips (see " +
         $"NativeDockingA11yFixture), rather than turning the skip into a red.";
+
+    /// <summary>
+    /// Stands in for the check name on a runner-level skip, where the fixture never ran and so
+    /// reached no <c>H.Skip</c> call. Reusing the fixture name there would render as
+    /// <c>`X` — X — reason</c> and claim a check named <c>X</c> was skipped.
+    /// </summary>
+    internal const string RunnerLevelSkipLabel = "(whole fixture)";
 
     /// <summary>
     /// Splits a TAP <c>SKIP</c> directive off the payload of an <c>ok </c> line, returning the

--- a/tests/Reactor.SelfTests/SelfTestBatch.cs
+++ b/tests/Reactor.SelfTests/SelfTestBatch.cs
@@ -107,8 +107,8 @@ public class SelfTestBatch
     internal static int EffectiveTimeoutSeconds => SelfTestTimeoutMs / 1000;
 
     // Per-fixture aggregated outcome, populated by ClassInitialize.
-    // Key = fixture name; Value = (passed, joined failure reasons).
-    private static readonly ConcurrentDictionary<string, (bool Passed, string Detail)> _byFixture = new();
+    // Key = fixture name; Value = the three-state verdict plus its detail.
+    private static readonly ConcurrentDictionary<string, FixtureOutcome> _byFixture = new();
     private static string _fullOutput = "";
     private static bool _initialized;
     private static string? _initError;
@@ -147,7 +147,7 @@ public class SelfTestBatch
 
         _hostElapsedSeconds = ExtractSuiteElapsedSeconds(stdout);
 
-        var tap = ParseTap(stdout);
+        var tap = ParseTap(stdout, _byFixture);
 
         // Off-dispatcher watchdog in the Host emits a structured signal on
         // dispatcher-starvation hangs. Parse it from stdout *and* stderr (the
@@ -185,6 +185,49 @@ public class SelfTestBatch
     internal sealed record AbortOutcome(string Fixture, string Detail, string AbortReason);
 
     /// <summary>
+    /// What a fixture's TAP output actually established. Three states, not two, because
+    /// <c>Harness.Skip</c> emits a line beginning <c>ok </c> and the parser used to let that
+    /// satisfy its own "did you assert anything?" guard — so a fixture whose <i>only</i> output
+    /// was a skip reported PASSED, with zero <c>not ok</c> lines and a <c># Total failures: 0</c>
+    /// trailer (issue #1061).
+    ///
+    /// <para><b>Why a third state rather than just not counting the skip.</b> Treating a skip line
+    /// as "no checks" makes <c>passed</c> false, which turns
+    /// <c>CenterOnCurrent_UsesCursorMonitor</c> and <c>CornerStyle_Apply</c> red on exactly the
+    /// machines their skip was introduced to accommodate — a non-interactive desktop where
+    /// <c>GetCursorPos</c> cannot answer, and Windows 10 where the DWM corner attribute is not
+    /// round-trippable. Those are undeterminable preconditions, not product defects. The verdict
+    /// has to carry "could not tell" as its own value; anything else re-creates one of the two
+    /// bugs.</para>
+    /// </summary>
+    internal enum FixtureStatus
+    {
+        /// <summary>At least one real assertion ran, and none failed.</summary>
+        Passed,
+
+        /// <summary>An assertion failed, the fixture crashed/timed out, or it emitted nothing at all.</summary>
+        Failed,
+
+        /// <summary>The fixture ran no assertions at all; everything it owns was skipped.</summary>
+        Skipped,
+    }
+
+    /// <summary>
+    /// A fixture's verdict, the text explaining it, and the checks it skipped.
+    ///
+    /// <para><paramref name="SkippedChecks"/> is carried for <b>passing</b> fixtures too, not just
+    /// fully-skipped ones: a fixture that asserted 26 of its 27 checks and skipped the 27th is
+    /// legitimately green, but the skipped leg is still information the TAP stream carried and the
+    /// consumer used to discard. It is reported rather than acted on.</para>
+    /// </summary>
+    internal sealed record FixtureOutcome(
+        FixtureStatus Status, string Detail, IReadOnlyList<string> SkippedChecks)
+    {
+        internal FixtureOutcome(FixtureStatus status, string detail)
+            : this(status, detail, Array.Empty<string>()) { }
+    }
+
+    /// <summary>
     /// What the runner does with a classified abort: the reason to stamp on every unexecuted
     /// fixture, an initialization error when a timeout could not be attributed at all, and whether
     /// the early-abort scan still runs.
@@ -210,11 +253,11 @@ public class SelfTestBatch
         bool timedOut,
         int budgetMs,
         string fullOutput,
-        IDictionary<string, (bool Passed, string Detail)> byFixture)
+        IDictionary<string, FixtureOutcome> byFixture)
     {
         if (outcome is not null)
         {
-            byFixture[outcome.Fixture] = (false, outcome.Detail);
+            byFixture[outcome.Fixture] = new FixtureOutcome(FixtureStatus.Failed, outcome.Detail);
             return new RunDisposition(outcome.AbortReason, null, RunEarlyAbortCheck: !timedOut);
         }
 
@@ -570,21 +613,33 @@ public class SelfTestBatch
         return "..." + s[^maxChars..];
     }
 
-    private sealed record TapParseResult(string? LastRunningFixture, bool SawTotalFailures);
+    internal sealed record TapParseResult(string? LastRunningFixture, bool SawTotalFailures);
 
-    private static TapParseResult ParseTap(string stdout)
+    /// <summary>
+    /// Folds the Host's TAP stream into a per-fixture verdict.
+    ///
+    /// <para>Takes <paramref name="byFixture"/> as a parameter rather than reading the static
+    /// field, for the same reason <see cref="ApplyAbortOutcome"/> does: it makes the <i>wiring</i>
+    /// testable, not just the classification. A parser that is correct in isolation says nothing
+    /// about whether production still routes through it, and issue #1061 was precisely a case of
+    /// the stream carrying a distinction the consumer discarded.</para>
+    /// </summary>
+    internal static TapParseResult ParseTap(string stdout, IDictionary<string, FixtureOutcome> byFixture)
     {
-        // Two TAP emitter sources:
+        // Three TAP emitter shapes:
         //   Harness check:   "ok <checkName>"  /  "not ok <checkName> - <reason>"
+        //   Harness skip:    "ok <checkName> # SKIP <reason>"
         //   SelfTestRunner:  "# Running: <fixtureName>"
+        //                    "ok <index> <fixtureName> # SKIP <reason>"              (AOT skip list)
         //                    "not ok <index> <fixtureName> - fixture not found"     (before any marker)
         //                    "not ok <index> <fixtureName>_CRASH - <type>: <msg>"   (after marker if RunAsync threw)
         //
-        // Runner-level "not ok" lines start with a numeric test index; check-level lines do not.
-        // Runner-level failures attribute to their own fixture name regardless of `current`.
+        // Runner-level lines start with a numeric test index; check-level lines do not.
+        // Runner-level results attribute to their own fixture name regardless of `current`.
 
         string? current = null;
         var failuresForCurrent = new List<string>();
+        var skipsForCurrent = new List<string>();
         var sawChecksForCurrent = false;
         string? lastRunningFixture = null;
         var sawTotalFailures = false;
@@ -592,14 +647,30 @@ public class SelfTestBatch
         void Flush()
         {
             if (current is null) return;
-            if (_byFixture.TryGetValue(current, out var existing) && !existing.Passed && failuresForCurrent.Count == 0)
+            if (byFixture.TryGetValue(current, out var existing)
+                && existing.Status == FixtureStatus.Failed
+                && failuresForCurrent.Count == 0)
                 return;
 
-            var passed = failuresForCurrent.Count == 0 && sawChecksForCurrent;
-            var detail = failuresForCurrent.Count == 0
-                ? (sawChecksForCurrent ? "" : "fixture emitted no TAP checks")
-                : string.Join("\n", failuresForCurrent);
-            _byFixture[current] = (passed, detail);
+            var skipped = skipsForCurrent.ToArray();
+
+            // Order matters, and each arm is a distinct claim about what the run established:
+            //   a failure          -> the product (or the fixture) is broken
+            //   a real assertion   -> the product was exercised and held
+            //   only skips         -> nothing was established; say so instead of showing green
+            //   nothing at all     -> the fixture is broken; this stays a FAILURE, because a
+            //                         silent fixture has no documented reason where a skip does
+            var outcome = failuresForCurrent.Count > 0
+                ? new FixtureOutcome(
+                    FixtureStatus.Failed, string.Join("\n", failuresForCurrent), skipped)
+                : sawChecksForCurrent
+                    ? new FixtureOutcome(FixtureStatus.Passed, "", skipped)
+                    : skipped.Length > 0
+                        ? new FixtureOutcome(
+                            FixtureStatus.Skipped, DescribeFullySkipped(current, skipped), skipped)
+                        : new FixtureOutcome(FixtureStatus.Failed, "fixture emitted no TAP checks");
+
+            byFixture[current] = outcome;
         }
 
         foreach (var raw in stdout.Split('\n', StringSplitOptions.RemoveEmptyEntries))
@@ -611,6 +682,7 @@ public class SelfTestBatch
                 current = line["# Running: ".Length..].Trim();
                 lastRunningFixture = current;
                 failuresForCurrent = new List<string>();
+                skipsForCurrent = new List<string>();
                 sawChecksForCurrent = false;
             }
             else if (line.StartsWith("# Total failures:", StringComparison.Ordinal))
@@ -619,8 +691,32 @@ public class SelfTestBatch
             }
             else if (line.StartsWith("ok "))
             {
-                // Harness-level pass; ignore payload, just note that current saw checks.
-                sawChecksForCurrent = true;
+                var rest = line[3..].Trim();
+                if (TryParseSkipDirective(rest, out var skipName, out var skipReason))
+                {
+                    // A skip is NOT a check. Letting it set sawChecksForCurrent is the whole of
+                    // issue #1061: the flag exists to catch a fixture that asserted nothing, and a
+                    // skip is a fixture saying exactly that.
+                    if (TryParseRunnerLevelName(skipName, out var skippedFixture))
+                    {
+                        // Fixture-level skip (the AOT pattern list). It arrives with no
+                        // `# Running:` marker, so attributing it to `current` would credit an
+                        // unrelated, already-finished fixture with a skip it never emitted.
+                        byFixture[skippedFixture] = new FixtureOutcome(
+                            FixtureStatus.Skipped,
+                            $"Fixture '{skippedFixture}' was skipped by the runner before it ran: {skipReason}",
+                            [$"{skippedFixture} — {skipReason}"]);
+                    }
+                    else
+                    {
+                        skipsForCurrent.Add($"{skipName} — {skipReason}");
+                    }
+                }
+                else
+                {
+                    // Harness-level pass; ignore payload, just note that current saw checks.
+                    sawChecksForCurrent = true;
+                }
             }
             else if (line.StartsWith("not ok "))
             {
@@ -636,7 +732,7 @@ public class SelfTestBatch
                     {
                         // Runner-level failure — attribute directly to the fixture name,
                         // overriding any in-progress `current` bucket.
-                        _byFixture[fixtureName] = (false, detail);
+                        byFixture[fixtureName] = new FixtureOutcome(FixtureStatus.Failed, detail);
                     }
                 }
                 else
@@ -651,6 +747,73 @@ public class SelfTestBatch
         }
         Flush();
         return new TapParseResult(lastRunningFixture, sawTotalFailures);
+    }
+
+    /// <summary>
+    /// The message a fully-skipped fixture reports. Written for someone reading a Skipped result
+    /// with no other context: it has to say that the fixture is <i>not</i> known-good, and that the
+    /// skip is a deliberate design choice rather than an oversight, or the next reader will either
+    /// trust it as a pass or "fix" it into a failure.
+    /// </summary>
+    private static string DescribeFullySkipped(string fixture, IReadOnlyList<string> skipped) =>
+        $"Fixture '{fixture}' ran NO assertions — all {skipped.Count} of its checks were skipped, " +
+        $"so this run establishes nothing about it either way.\n" +
+        $"  {string.Join("\n  ", skipped)}\n" +
+        $"This is reported as skipped rather than passed because a `# SKIP` directive is a fixture " +
+        $"saying it could not observe its precondition (issue #1061). It is deliberately NOT a " +
+        $"failure: the preconditions involved — a non-interactive desktop where GetCursorPos " +
+        $"returns ACCESS_DENIED, or a Windows 10 box where the DWM corner attribute is not " +
+        $"round-trippable — are undeterminable, not broken. If you need coverage here, give the " +
+        $"fixture an observable precondition to assert before it skips (see " +
+        $"NativeDockingA11yFixture), rather than turning the skip into a red.";
+
+    /// <summary>
+    /// Splits a TAP <c>SKIP</c> directive off the payload of an <c>ok </c> line, returning the
+    /// name and the reason. The directive is matched case-insensitively because TAP 14 specifies it
+    /// that way; the Host emits upper case today, and a parser that only accepts what the current
+    /// emitter happens to produce is one rename away from silently reporting every skip as a pass
+    /// again.
+    /// </summary>
+    internal static bool TryParseSkipDirective(string afterOk, out string name, out string reason)
+    {
+        name = "";
+        reason = "";
+
+        var hash = afterOk.IndexOf('#');
+        if (hash < 0) return false;
+
+        var directive = afterOk[(hash + 1)..].TrimStart();
+        if (!directive.StartsWith("SKIP", StringComparison.OrdinalIgnoreCase)) return false;
+
+        // Guard against a name that merely starts with "skip..." — the directive is the bare word.
+        var afterWord = directive[4..];
+        if (afterWord.Length > 0 && !char.IsWhiteSpace(afterWord[0]) && afterWord[0] != ':')
+            return false;
+
+        name = afterOk[..hash].Trim();
+        reason = afterWord.TrimStart(' ', ':', '\t');
+        if (reason.Length == 0) reason = "(no reason given)";
+        return name.Length > 0;
+    }
+
+    /// <summary>
+    /// Recognises the runner's <c>&lt;index&gt; &lt;fixtureName&gt;</c> head and returns the
+    /// fixture name. Same numeric-index discriminator <see cref="TryParseRunnerLevelFailure"/>
+    /// uses: <c>Harness</c> check names are C# identifiers, so a leading all-digits token can only
+    /// have come from the runner.
+    /// </summary>
+    internal static bool TryParseRunnerLevelName(string head, out string fixtureName)
+    {
+        fixtureName = "";
+        var firstSpace = head.IndexOf(' ');
+        if (firstSpace <= 0) return false;
+        if (!head[..firstSpace].All(char.IsDigit)) return false;
+
+        var name = head[(firstSpace + 1)..].Trim();
+        if (name.Length == 0) return false;
+
+        fixtureName = StripRunnerFailureSuffix(name);
+        return true;
     }
 
     private static bool TryParseRunnerLevelFailure(string rest, out string fixtureName, out string detail)
@@ -713,9 +876,13 @@ public class SelfTestBatch
         var attributed = tap.LastRunningFixture;
         if (attributed is not null)
         {
-            if (!_byFixture.TryGetValue(attributed, out var existing) || existing.Passed)
+            // Overwrite anything that is not already a Failed verdict. A Skipped fixture reached
+            // here means the run died right after a fixture that established nothing — the silent
+            // death is the more important fact and must not be masked by the skip.
+            if (!_byFixture.TryGetValue(attributed, out var existing)
+                || existing.Status != FixtureStatus.Failed)
             {
-                _byFixture[attributed] = (false, DescribeSilentDeath(
+                _byFixture[attributed] = new FixtureOutcome(FixtureStatus.Failed, DescribeSilentDeath(
                     attributed, exitCode, tap.SawTotalFailures, ElapsedSeconds,
                     SelfTestTimeoutMs, Tail(_fullOutput, 4000)));
             }
@@ -840,8 +1007,207 @@ public class SelfTestBatch
             Assert.Fail($"Fixture '{name}' was not reported by the Host. Full output:\n{_fullOutput}");
         }
 
-        if (!result.Passed)
+        // Reported as an MSTest skip, not a pass. `Assert.Inconclusive` is the only verdict that
+        // is visible without being red: `dotnet test` prints `Skipped <FixtureName>` and the run
+        // stays green, so a machine that legitimately cannot observe the precondition does not
+        // manufacture a failure — while a reader can no longer mistake it for a fixture that ran.
+        if (result.Status == FixtureStatus.Skipped)
+            Assert.Inconclusive(result.Detail);
+
+        if (result.Status == FixtureStatus.Failed)
             Assert.Fail(result.Detail);
+    }
+
+    /// <summary>
+    /// What the run's skip directives added up to: how many fixtures established nothing, how many
+    /// were merely missing a leg, and the inventory behind both numbers.
+    /// </summary>
+    internal sealed record SkipInventory(
+        IReadOnlyList<string> FullySkippedFixtures,
+        IReadOnlyList<string> PartiallySkippedFixtures,
+        int TotalSkippedChecks,
+        string Text);
+
+    /// <summary>Entries listed in full before the report elides the tail.</summary>
+    private const int MaxListedSkips = 25;
+
+    /// <summary>
+    /// Folds the per-fixture verdicts into the run-level skip inventory.
+    ///
+    /// <para>Both halves are reported, and they mean different things. A <b>fully</b> skipped
+    /// fixture ran no assertions at all, so the run establishes nothing about it — that is issue
+    /// #1061's subject and it changes the fixture's verdict. A <b>partially</b> skipped fixture is
+    /// legitimately green; listing it changes no verdict, but the skipped leg is a real gap the
+    /// TAP stream carried and the consumer used to throw away, and a gap nobody can see is a gap
+    /// nobody closes.</para>
+    /// </summary>
+    internal static SkipInventory BuildSkipInventory(IReadOnlyDictionary<string, FixtureOutcome> byFixture)
+    {
+        var fully = new List<string>();
+        var partial = new List<string>();
+        var totalChecks = 0;
+
+        foreach (var (fixture, outcome) in byFixture.OrderBy(kv => kv.Key, StringComparer.Ordinal))
+        {
+            if (outcome.SkippedChecks.Count == 0) continue;
+            totalChecks += outcome.SkippedChecks.Count;
+
+            var entry = $"`{fixture}` — {string.Join("; ", outcome.SkippedChecks)}";
+            if (outcome.Status == FixtureStatus.Skipped) fully.Add(entry);
+            else partial.Add(entry);
+        }
+
+        var text = fully.Count == 0 && partial.Count == 0
+            ? "No checks were skipped in this run."
+            : $"{fully.Count} fixture(s) ran NO assertions (every check they own was skipped); " +
+              $"{partial.Count} more skipped at least one check. " +
+              $"{totalChecks} skipped check(s) in total.";
+
+        return new SkipInventory(fully, partial, totalChecks, text);
+    }
+
+    /// <summary>The skip inventory's markdown, and whether it landed on the job summary.</summary>
+    internal sealed record SkipReport(SkipInventory Inventory, string Markdown, bool Delivered);
+
+    /// <summary>
+    /// Builds the job-summary block for the run's skips and delivers it.
+    ///
+    /// <para>Composition and delivery live together for the same reason
+    /// <see cref="PublishSuiteDuration"/> does: delivery is the load-bearing half. An
+    /// <c>Assert.Inconclusive</c> message never reaches the Actions log — the tests run in a child
+    /// <c>testhost</c> whose stdout the runner does not forward, so all CI shows is the bare line
+    /// <c>Skipped &lt;FixtureName&gt;</c> with no reason attached. The job summary is plain file
+    /// I/O performed by this process, so it is the only channel that actually renders the
+    /// <i>why</i>.</para>
+    /// </summary>
+    internal static SkipReport PublishSkipReport(
+        IReadOnlyDictionary<string, FixtureOutcome> byFixture, string? summaryPath)
+    {
+        var inventory = BuildSkipInventory(byFixture);
+
+        var icon = inventory.FullySkippedFixtures.Count > 0 ? "⚠️" : "ℹ️";
+        var body = new System.Text.StringBuilder()
+            .Append($"### {icon} Selftest skipped checks\n\n")
+            .Append(inventory.Text)
+            .Append("\n\n");
+
+        AppendList(body, "Fully skipped — these establish nothing either way",
+            inventory.FullySkippedFixtures);
+        AppendList(body, "Partially skipped — passed on their remaining checks",
+            inventory.PartiallySkippedFixtures);
+
+        body.Append("<sub>A `# SKIP` directive is a fixture reporting that it could not observe " +
+                    "its precondition. Background: issue #1061.</sub>");
+
+        var markdown = body.ToString();
+        return new SkipReport(inventory, markdown, TryAppendSummary(summaryPath, markdown));
+
+        static void AppendList(System.Text.StringBuilder sb, string heading, IReadOnlyList<string> entries)
+        {
+            if (entries.Count == 0) return;
+            sb.Append($"**{heading}:**\n\n");
+            foreach (var entry in entries.Take(MaxListedSkips))
+                sb.Append($"- {entry}\n");
+            if (entries.Count > MaxListedSkips)
+                sb.Append($"- …and {entries.Count - MaxListedSkips} more\n");
+            sb.Append('\n');
+        }
+    }
+
+    /// <summary>
+    /// Publishes the run's skip inventory, and reports a fixture that established nothing as a
+    /// skip rather than letting it pass unremarked.
+    ///
+    /// <para>Deliberately <c>Inconclusive</c> and not <c>Fail</c>. The fixtures that reach here do
+    /// so because a precondition is <i>undeterminable</i> on this machine — <c>GetCursorPos</c>
+    /// returning <c>ACCESS_DENIED</c> on a non-interactive desktop, or a Windows 10 box where the
+    /// DWM corner attribute is not round-trippable. Failing them would make the suite red on
+    /// exactly the machines those skips were introduced to accommodate, which is the regression
+    /// the skips fixed.</para>
+    /// </summary>
+    [TestMethod]
+    public void SkippedFixtures_AreReported()
+    {
+        Assert.IsTrue(_initialized, "Self-test batch did not run.");
+        if (_initError is not null)
+            Assert.Fail(_initError);
+
+        if (_timedOut || _abortedReason is not null)
+        {
+            Assert.Inconclusive(
+                $"{_abortedReason ?? "The suite was killed by its process budget"}; the skip " +
+                $"inventory is not meaningful for a run that did not complete, because every " +
+                $"fixture downstream of the abort is missing rather than skipped.");
+        }
+
+        var report = PublishSkipReport(_byFixture, Environment.GetEnvironmentVariable(StepSummaryEnvVar));
+
+        // Kept for local vstest/IDE runs, where testhost stdout does show up.
+        Console.WriteLine(report.Inventory.Text);
+        foreach (var entry in report.Inventory.FullySkippedFixtures)
+            Console.WriteLine($"  fully skipped: {entry}");
+
+        if (report.Inventory.FullySkippedFixtures.Count > 0)
+        {
+            Assert.Inconclusive(
+                $"{report.Inventory.Text}\n" +
+                $"Fully skipped:\n  {string.Join("\n  ", report.Inventory.FullySkippedFixtures)}\n" +
+                $"Each of those is reported Skipped individually too. They are NOT failures — see " +
+                $"the per-fixture message for why the precondition could not be observed.");
+        }
+    }
+
+    /// <summary>
+    /// The one assertion that observes the <b>real</b> Host's real skip output, and the only thing
+    /// that can catch the two projects drifting apart.
+    ///
+    /// <para>Every other test of the skip pipeline feeds <see cref="ParseTap"/> a fabricated
+    /// string, so if <c>Harness.Skip</c> stopped emitting the <c># SKIP</c> directive — or the
+    /// literal changed on one side only, which it can, because the Host is referenced with
+    /// <c>ReferenceOutputAssembly=false</c> and the token is duplicated rather than shared — every
+    /// one of those tests would stay green while the wrapper quietly went back to reporting
+    /// fully-skipped fixtures as PASSED. That is issue #1061 restored in full, with a completely
+    /// green suite. The same reasoning, and the same shape, as the
+    /// <c>'# Suite elapsed: '</c> guard in <see cref="SuiteDuration_WithinBudget"/>.</para>
+    ///
+    /// <para>Non-vacuous today because <c>Spec047EventStateSplitFixtures</c> skips
+    /// <b>unconditionally</b> (<c>EventStateSplit_RawHatch_HandledChildParentStillFires</c>: live
+    /// KeyDown cannot be synthesized headlessly), so every run of the full suite emits at least one
+    /// directive regardless of the machine. If that ever stops being true the failure message says
+    /// so and says what to do about it — the guard has no value once the suite has no skips to
+    /// observe.</para>
+    /// </summary>
+    [TestMethod]
+    public void SkipDirectives_SurviveIntoTheReport()
+    {
+        Assert.IsTrue(_initialized, "Self-test batch did not run.");
+        if (_initError is not null)
+            Assert.Fail(_initError);
+
+        // An aborted run is truncated by definition, so "no skips seen" would mean "the run
+        // stopped before reaching one" rather than "the channel is broken". Reporting it would
+        // manufacture a second failure on top of the abort, blaming the wrong thing.
+        if (_timedOut || _abortedReason is not null)
+        {
+            Assert.Inconclusive(
+                $"{_abortedReason ?? "The suite was killed by its process budget"}; a truncated " +
+                $"run cannot establish whether skip directives still reach the parser.");
+        }
+
+        var inventory = BuildSkipInventory(_byFixture);
+
+        Assert.IsTrue(inventory.TotalSkippedChecks > 0,
+            "The Host completed its run but the parser saw ZERO '# SKIP' directives. Two " +
+            "explanations, and they need different fixes:\n" +
+            "  (a) DRIFT — Harness.Skip stopped emitting 'ok <name> # SKIP <reason>', or " +
+            "SelfTestBatch.TryParseSkipDirective stopped recognising it. Every fully-skipped " +
+            "fixture is now silently reported PASSED again, which is issue #1061 exactly. Check " +
+            "the literal on BOTH sides: the Host is referenced with ReferenceOutputAssembly=false, " +
+            "so it is duplicated, not shared.\n" +
+            "  (b) The suite genuinely has no H.Skip sites left. That is a fine state to be in — " +
+            "and it makes this guard worthless, so delete it rather than adding a fixture to keep " +
+            "it fed. It was non-vacuous when written because " +
+            "Spec047EventStateSplitFixtures skips unconditionally.");
     }
 
     /// <summary>

--- a/tests/Reactor.SelfTests/SelfTestBatch.cs
+++ b/tests/Reactor.SelfTests/SelfTestBatch.cs
@@ -1103,7 +1103,7 @@ public class SelfTestBatch
         var inventory = BuildSkipInventory(byFixture);
 
         var icon = inventory.FullySkippedFixtures.Count > 0 ? "⚠️" : "ℹ️";
-        var body = new System.Text.StringBuilder()
+        var body = new global::System.Text.StringBuilder()
             .Append($"### {icon} Selftest skipped checks\n\n")
             .Append(inventory.Text)
             .Append("\n\n");
@@ -1119,7 +1119,7 @@ public class SelfTestBatch
         var markdown = body.ToString();
         return new SkipReport(inventory, markdown, TryAppendSummary(summaryPath, markdown));
 
-        static void AppendList(System.Text.StringBuilder sb, string heading, IReadOnlyList<string> entries)
+        static void AppendList(global::System.Text.StringBuilder sb, string heading, IReadOnlyList<string> entries)
         {
             if (entries.Count == 0) return;
             sb.Append($"**{heading}:**\n\n");

--- a/tests/Reactor.SelfTests/SelfTestBatch.cs
+++ b/tests/Reactor.SelfTests/SelfTestBatch.cs
@@ -1066,10 +1066,12 @@ public class SelfTestBatch
     ///
     /// <para>Both halves are reported, and they mean different things. A <b>fully</b> skipped
     /// fixture ran no assertions at all, so the run establishes nothing about it — that is issue
-    /// #1061's subject and it changes the fixture's verdict. A <b>partially</b> skipped fixture is
-    /// legitimately green; listing it changes no verdict, but the skipped leg is a real gap the
-    /// TAP stream carried and the consumer used to throw away, and a gap nobody can see is a gap
-    /// nobody closes.</para>
+    /// #1061's subject and it changes the fixture's verdict. The other bucket is everything else
+    /// that skipped at least one check: usually a passing fixture, but a <b>failed</b> one can
+    /// land here too, because a fixture that skips and then crashes keeps its skip. So this half
+    /// deliberately makes no claim about the verdict — listing it changes no verdict either way,
+    /// but the skipped leg is a real gap the TAP stream carried and the consumer used to throw
+    /// away, and a gap nobody can see is a gap nobody closes.</para>
     /// </summary>
     internal static SkipInventory BuildSkipInventory(IReadOnlyDictionary<string, FixtureOutcome> byFixture)
     {
@@ -1123,7 +1125,7 @@ public class SelfTestBatch
 
         AppendList(body, "Fully skipped — these establish nothing either way",
             inventory.FullySkippedFixtures);
-        AppendList(body, "Partially skipped — passed on their remaining checks",
+        AppendList(body, "Partially skipped — these also ran real checks; see each fixture's own verdict",
             inventory.PartiallySkippedFixtures);
 
         body.Append("<sub>A `# SKIP` directive is a fixture reporting that it could not observe " +

--- a/tests/Reactor.SelfTests/SkipReportingTests.cs
+++ b/tests/Reactor.SelfTests/SkipReportingTests.cs
@@ -199,11 +199,10 @@ public class SkipReportingTests
 
         var map = Parse($"# Running: F\nnot ok 7 F - {Detail}\n");
 
-        Assert.IsTrue(map.ContainsKey("F"),
+        Assert.IsTrue(map.TryGetValue("F", out var outcome),
             "The failure must land on 'F', not on a phantom name parsed out of the line.");
 
-        var outcome = map["F"];
-        Assert.AreEqual(SelfTestBatch.FixtureStatus.Failed, outcome.Status);
+        Assert.AreEqual(SelfTestBatch.FixtureStatus.Failed, outcome!.Status);
         Assert.IsTrue(outcome.Detail.Contains(Detail, StringComparison.Ordinal),
             $"The reported detail must say why. Got: {outcome.Detail}");
         Assert.AreEqual(1, map.Count,

--- a/tests/Reactor.SelfTests/SkipReportingTests.cs
+++ b/tests/Reactor.SelfTests/SkipReportingTests.cs
@@ -185,6 +185,32 @@ public class SkipReportingTests
     // ------------------------------------------------------------------ directive parsing
 
     /// <summary>
+    /// The Host emits a bare-named runner-level <c>not ok</c> when a fixture completes without a
+    /// single check or skip, so this asserts the wrapper attributes it to that fixture rather than
+    /// inventing a phantom entry. It matters because only <c>_CRASH</c> and <c>_TIMEOUT</c> are
+    /// stripped from runner-level names: any other decoration on the Host's line would land the
+    /// failure on a fixture name that does not exist, and the real fixture would be reported
+    /// against a message that never mentions why.
+    /// </summary>
+    [TestMethod]
+    public void RunnerLevelNoChecksFailure_IsAttributedToTheSilentFixture()
+    {
+        const string Detail = "fixture ran to completion without emitting a single check or skip";
+
+        var map = Parse($"# Running: F\nnot ok 7 F - {Detail}\n");
+
+        Assert.IsTrue(map.ContainsKey("F"),
+            "The failure must land on 'F', not on a phantom name parsed out of the line.");
+
+        var outcome = map["F"];
+        Assert.AreEqual(SelfTestBatch.FixtureStatus.Failed, outcome.Status);
+        Assert.IsTrue(outcome.Detail.Contains(Detail, StringComparison.Ordinal),
+            $"The reported detail must say why. Got: {outcome.Detail}");
+        Assert.AreEqual(1, map.Count,
+            $"Exactly one fixture should be recorded. Got: {string.Join(", ", map.Keys)}");
+    }
+
+    /// <summary>
     /// TAP 14 specifies directives case-insensitively. The Host emits upper case today, and a
     /// parser that accepts only what the current emitter happens to produce is one rename away from
     /// silently reporting every skip as a pass again.

--- a/tests/Reactor.SelfTests/SkipReportingTests.cs
+++ b/tests/Reactor.SelfTests/SkipReportingTests.cs
@@ -1,0 +1,393 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.UI.Reactor.SelfTests;
+
+/// <summary>
+/// Headless guards for the three-state fixture verdict added for issue #1061. Everything exercised
+/// here is pure, so this class does not launch the Host and does not trigger
+/// <see cref="SelfTestBatch"/>'s <c>[ClassInitialize]</c> — it runs in milliseconds under
+/// <c>--filter "ClassName~SkipReportingTests"</c>.
+///
+/// <para><b>What these tests are actually defending.</b> <c>Harness.Skip</c> emits a TAP line
+/// beginning <c>ok </c>. The parser branched on that prefix and set <c>sawChecksForCurrent</c> —
+/// the flag that exists <i>specifically</i> to catch a fixture which asserted nothing. So a fixture
+/// that skipped every check it owned reported <b>PASSED</b>, with zero <c>not ok</c> lines and a
+/// <c># Total failures: 0</c> trailer: two anti-vacuity mechanisms cancelling each other out.</para>
+///
+/// <para><b>And what they are defending against the fix.</b> The obvious repair — don't set the
+/// flag for a skip line — makes the verdict <c>Failed</c>, which reddens
+/// <c>CenterOnCurrent_UsesCursorMonitor</c> and <c>CornerStyle_Apply</c> on exactly the machines
+/// their skips were introduced to accommodate. Both directions are pinned below, so neither bug
+/// can be reintroduced while the other stays fixed.</para>
+/// </summary>
+[TestClass]
+public class SkipReportingTests
+{
+    private const string Skipped = "SkippedFixture";
+    private const string Reason = "GetCursorPos unavailable (non-interactive desktop)";
+
+    private static Dictionary<string, SelfTestBatch.FixtureOutcome> Parse(string tap)
+    {
+        var map = new Dictionary<string, SelfTestBatch.FixtureOutcome>();
+        SelfTestBatch.ParseTap(tap, map);
+        return map;
+    }
+
+    private static SelfTestBatch.FixtureOutcome Outcome(string tap, string fixture)
+    {
+        var map = Parse(tap);
+        Assert.IsTrue(map.TryGetValue(fixture, out var outcome),
+            $"Fixture '{fixture}' produced no verdict at all. Reported: " +
+            $"[{string.Join(", ", map.Keys)}]");
+        return outcome!;
+    }
+
+    // ------------------------------------------------------------------ the acceptance test
+
+    /// <summary>
+    /// Issue #1061's acceptance test, stated as it is stated in the issue: <i>a fixture emitting
+    /// only skip lines must not be indistinguishable from one that ran and passed.</i>
+    ///
+    /// <para>Deliberately written as a <b>differential</b> oracle over the same fixture name and
+    /// the same surrounding stream, so the only difference between the two arms is the
+    /// <c># SKIP</c> directive itself. A parser that hard-codes a verdict, or that keys on
+    /// anything other than the directive, fails here — a bare
+    /// <c>AreEqual(Skipped, …)</c> would also pass against a stub that returns <c>Skipped</c> for
+    /// everything.</para>
+    /// </summary>
+    [TestMethod]
+    public void FixtureWhoseOnlyOutputIsASkip_IsNotReportedAsPassed()
+    {
+        var skipArm = Outcome(
+            $"# Running: {Skipped}\nok {Skipped}_Check # SKIP {Reason}\n# Total failures: 0\n",
+            Skipped);
+
+        var checkArm = Outcome(
+            $"# Running: {Skipped}\nok {Skipped}_Check\n# Total failures: 0\n",
+            Skipped);
+
+        Assert.AreEqual(SelfTestBatch.FixtureStatus.Passed, checkArm.Status,
+            "Control arm: a real assertion must still pass, or the comparison below is between " +
+            "two broken states rather than a healthy and a degraded one.");
+
+        Assert.AreNotEqual(checkArm.Status, skipArm.Status,
+            "A fixture that skipped its only check reports the SAME verdict as one that asserted " +
+            "and passed. That is issue #1061: the TAP stream carries the distinction and the " +
+            "consumer discards it.");
+
+        Assert.AreEqual(SelfTestBatch.FixtureStatus.Skipped, skipArm.Status);
+    }
+
+    /// <summary>
+    /// The other half of the pin, and the reason a third state was needed at all. Reporting the
+    /// skip as a failure would turn the two windowing fixtures red on the non-interactive desktops
+    /// their skip exists for — re-creating the regression the skip fixed, in the opposite
+    /// direction.
+    /// </summary>
+    [TestMethod]
+    public void FixtureWhoseOnlyOutputIsASkip_IsNotReportedAsFailed()
+    {
+        var outcome = Outcome(
+            $"# Running: {Skipped}\nok {Skipped}_Check # SKIP {Reason}\n", Skipped);
+
+        Assert.AreNotEqual(SelfTestBatch.FixtureStatus.Failed, outcome.Status,
+            "An undeterminable precondition is not a product defect. Failing here makes the suite " +
+            "red on exactly the machines the skip was introduced to accommodate.");
+    }
+
+    /// <summary>
+    /// The reason has to survive into the verdict, because the verdict is all a reader gets: an
+    /// MSTest skip with no explanation is only marginally better than a green tick with none.
+    /// </summary>
+    [TestMethod]
+    public void SkipReason_ReachesTheReportedDetail()
+    {
+        var outcome = Outcome(
+            $"# Running: {Skipped}\nok {Skipped}_Check # SKIP {Reason}\n", Skipped);
+
+        Assert.IsTrue(outcome.Detail.Contains(Reason, StringComparison.Ordinal),
+            $"The '# SKIP' payload is the whole point — it says WHY nothing was established.\n" +
+            outcome.Detail);
+        CollectionAssert.AreEqual(
+            new[] { $"{Skipped}_Check — {Reason}" }, outcome.SkippedChecks.ToArray());
+    }
+
+    // ------------------------------------------------------------------ the other verdicts
+
+    [TestMethod]
+    public void FixtureWithARealAssertion_Passes()
+    {
+        var outcome = Outcome("# Running: F\nok F_Check\n", "F");
+
+        Assert.AreEqual(SelfTestBatch.FixtureStatus.Passed, outcome.Status);
+        Assert.AreEqual(0, outcome.SkippedChecks.Count);
+    }
+
+    /// <summary>
+    /// A partially-skipped fixture is legitimately green — it asserted something, and what it
+    /// asserted held. The skipped leg is still reported, because a gap nobody can see is a gap
+    /// nobody closes, but it must not change the verdict.
+    /// </summary>
+    [TestMethod]
+    public void FixtureWithBothAnAssertionAndASkip_PassesButKeepsTheSkip()
+    {
+        var outcome = Outcome(
+            "# Running: F\nok F_Real\nok F_Deferred # SKIP covered by the E2E tier\nok F_Other\n", "F");
+
+        Assert.AreEqual(SelfTestBatch.FixtureStatus.Passed, outcome.Status,
+            "Skipping one leg of a fixture that asserted two others is not a degraded run.");
+        CollectionAssert.AreEqual(
+            new[] { "F_Deferred — covered by the E2E tier" }, outcome.SkippedChecks.ToArray());
+    }
+
+    [TestMethod]
+    public void FixtureWithAFailure_Fails()
+    {
+        var outcome = Outcome(
+            "# Running: F\nok F_Real\nnot ok F_Broken - assertion failed\n", "F");
+
+        Assert.AreEqual(SelfTestBatch.FixtureStatus.Failed, outcome.Status);
+        Assert.IsTrue(outcome.Detail.Contains("F_Broken", StringComparison.Ordinal), outcome.Detail);
+    }
+
+    /// <summary>
+    /// A failure outranks a skip. A fixture that skipped one leg and failed another established
+    /// something, and what it established is bad — the skip must not soften that to "could not
+    /// tell".
+    /// </summary>
+    [TestMethod]
+    public void FixtureThatBothSkippedAndFailed_Fails()
+    {
+        var outcome = Outcome(
+            "# Running: F\nok F_Deferred # SKIP not observable here\nnot ok F_Broken - assertion failed\n",
+            "F");
+
+        Assert.AreEqual(SelfTestBatch.FixtureStatus.Failed, outcome.Status);
+    }
+
+    /// <summary>
+    /// The pre-existing guard this change must not weaken. A fixture that emitted nothing at all is
+    /// still a <b>failure</b>: unlike a skip it carries no documented reason, so there is nothing
+    /// to distinguish "deliberately deferred" from "the fixture is broken". Widening the verdict
+    /// for skips is only safe if the silent case keeps reddening.
+    /// </summary>
+    [TestMethod]
+    public void FixtureThatEmittedNothingAtAll_StillFails()
+    {
+        var outcome = Outcome("# Running: F\n# Total failures: 0\n", "F");
+
+        Assert.AreEqual(SelfTestBatch.FixtureStatus.Failed, outcome.Status,
+            "'Emitted no TAP checks' is the older sibling of this bug and must stay red. A skip " +
+            "says why nothing was established; silence does not.");
+        Assert.IsTrue(outcome.Detail.Contains("no TAP checks", StringComparison.Ordinal), outcome.Detail);
+    }
+
+    // ------------------------------------------------------------------ directive parsing
+
+    /// <summary>
+    /// TAP 14 specifies directives case-insensitively. The Host emits upper case today, and a
+    /// parser that accepts only what the current emitter happens to produce is one rename away from
+    /// silently reporting every skip as a pass again.
+    /// </summary>
+    [TestMethod]
+    public void SkipDirective_IsMatchedCaseInsensitively()
+    {
+        foreach (var directive in new[] { "# SKIP", "# skip", "# Skip" })
+        {
+            var outcome = Outcome($"# Running: F\nok F_Check {directive} reason text\n", "F");
+            Assert.AreEqual(SelfTestBatch.FixtureStatus.Skipped, outcome.Status,
+                $"Directive '{directive}' was not recognised.");
+        }
+    }
+
+    /// <summary>
+    /// The directive is the bare word <c>SKIP</c>, so a comment that merely begins with those
+    /// letters is not one. Without this, a check whose trailing comment happened to start
+    /// "skipping…" would silently stop counting as an assertion — the same class of bug in reverse.
+    /// </summary>
+    [TestMethod]
+    public void CommentThatMerelyStartsWithSkip_IsNotADirective()
+    {
+        Assert.IsFalse(
+            SelfTestBatch.TryParseSkipDirective("F_Check # SKIPPABLE later", out _, out _),
+            "'SKIPPABLE' is a comment, not a SKIP directive.");
+
+        var outcome = Outcome("# Running: F\nok F_Check # SKIPPABLE later\n", "F");
+        Assert.AreEqual(SelfTestBatch.FixtureStatus.Passed, outcome.Status);
+    }
+
+    [TestMethod]
+    public void SkipWithNoReason_StillParsesAndSaysSo()
+    {
+        Assert.IsTrue(SelfTestBatch.TryParseSkipDirective("F_Check # SKIP", out var name, out var reason));
+        Assert.AreEqual("F_Check", name);
+        Assert.AreEqual("(no reason given)", reason);
+    }
+
+    [TestMethod]
+    public void OrdinaryOkLine_IsNotASkip()
+    {
+        Assert.IsFalse(SelfTestBatch.TryParseSkipDirective("F_Check", out _, out _));
+    }
+
+    // ------------------------------------------------------------------ runner-level skips
+
+    /// <summary>
+    /// The runner's AOT skip list emits <c>ok &lt;index&gt; &lt;fixture&gt; # SKIP …</c> with
+    /// <b>no</b> <c># Running:</c> marker, so `current` is still the previous, already-finished
+    /// fixture. Crediting that fixture with a skip it never emitted would misattribute the reason
+    /// text and — worse — could turn a genuinely silent fixture into a plausible-looking skip.
+    /// </summary>
+    [TestMethod]
+    public void RunnerLevelSkip_IsAttributedToItsOwnFixture_NotThePrecedingOne()
+    {
+        var map = Parse(
+            "# Running: Earlier\nok Earlier_Check\n" +
+            "ok 42 AotHostile # SKIP crashes/hangs under NativeAOT\n" +
+            "# Total failures: 0\n");
+
+        Assert.IsTrue(map.TryGetValue("AotHostile", out var skipped),
+            "A fixture the runner skipped before it ran is otherwise reported as 'not reported by " +
+            "the Host', which is a hard failure for a deliberate skip.");
+        Assert.AreEqual(SelfTestBatch.FixtureStatus.Skipped, skipped!.Status);
+        Assert.IsTrue(skipped.Detail.Contains("NativeAOT", StringComparison.Ordinal), skipped.Detail);
+
+        Assert.AreEqual(SelfTestBatch.FixtureStatus.Passed, map["Earlier"].Status);
+        Assert.AreEqual(0, map["Earlier"].SkippedChecks.Count,
+            "The preceding fixture emitted no skip of its own, so it must not be credited with one.");
+    }
+
+    /// <summary>
+    /// The discriminator is the leading all-digits index, matching
+    /// <c>TryParseRunnerLevelFailure</c>. Harness check names are C# identifiers, so this cannot
+    /// collide with one — but a check-level skip must still land on the running fixture.
+    /// </summary>
+    [TestMethod]
+    public void CheckLevelSkip_LandsOnTheRunningFixture()
+    {
+        var map = Parse($"# Running: {Skipped}\nok {Skipped}_Check # SKIP {Reason}\n");
+
+        Assert.AreEqual(1, map.Count,
+            $"A check-level skip must not invent a fixture. Reported: [{string.Join(", ", map.Keys)}]");
+        Assert.AreEqual(SelfTestBatch.FixtureStatus.Skipped, map[Skipped].Status);
+    }
+
+    // ------------------------------------------------------------------ run-level inventory
+
+    [TestMethod]
+    public void SkipInventory_SeparatesFullyFromPartiallySkipped()
+    {
+        var inventory = SelfTestBatch.BuildSkipInventory(Parse(
+            "# Running: FullySkipped\nok FullySkipped_Only # SKIP cannot observe\n" +
+            "# Running: PartlySkipped\nok PartlySkipped_Real\nok PartlySkipped_Leg # SKIP deferred\n" +
+            "# Running: Clean\nok Clean_Real\n"));
+
+        CollectionAssert.AreEqual(
+            new[] { "`FullySkipped` — FullySkipped_Only — cannot observe" },
+            inventory.FullySkippedFixtures.ToArray());
+        CollectionAssert.AreEqual(
+            new[] { "`PartlySkipped` — PartlySkipped_Leg — deferred" },
+            inventory.PartiallySkippedFixtures.ToArray());
+        Assert.AreEqual(2, inventory.TotalSkippedChecks);
+        Assert.IsFalse(inventory.Text.Contains("Clean", StringComparison.Ordinal),
+            "A fixture with no skips has nothing to report.");
+    }
+
+    /// <summary>
+    /// The counter that <c>SkipDirectives_SurviveIntoTheReport</c> gates on. If it could not reach
+    /// zero, that guard would be a tautology; if it could not exceed zero, the guard would be
+    /// permanently red. Both directions are pinned here so the guard is known to be an instrument
+    /// that can come out either way.
+    /// </summary>
+    [TestMethod]
+    public void SkipInventory_CountsZeroForARunWithNoSkips()
+    {
+        var inventory = SelfTestBatch.BuildSkipInventory(Parse("# Running: F\nok F_Check\n"));
+
+        Assert.AreEqual(0, inventory.TotalSkippedChecks);
+        Assert.AreEqual(0, inventory.FullySkippedFixtures.Count);
+        Assert.AreEqual(0, inventory.PartiallySkippedFixtures.Count);
+        Assert.IsTrue(inventory.Text.Contains("No checks were skipped", StringComparison.Ordinal),
+            inventory.Text);
+    }
+
+    /// <summary>
+    /// The report has to name the fixtures and their reasons, not just count them. A summary that
+    /// says "2 fixtures skipped" without saying which is the same silence in a shorter costume.
+    /// </summary>
+    [TestMethod]
+    public void SkipReport_NamesTheFixturesAndTheirReasons()
+    {
+        var report = SelfTestBatch.PublishSkipReport(Parse(
+            $"# Running: {Skipped}\nok {Skipped}_Check # SKIP {Reason}\n"), summaryPath: null);
+
+        Assert.IsTrue(report.Markdown.Contains(Skipped, StringComparison.Ordinal), report.Markdown);
+        Assert.IsTrue(report.Markdown.Contains(Reason, StringComparison.Ordinal), report.Markdown);
+        Assert.IsFalse(report.Delivered,
+            "There is no summary file on this path, so nothing can have been delivered.");
+    }
+
+    /// <summary>
+    /// Delivery is the load-bearing half — an <c>Assert.Inconclusive</c> message never reaches the
+    /// Actions log, so the job summary is the only channel that renders the reasons. Composing a
+    /// report nobody receives would look identical to working.
+    /// </summary>
+    [TestMethod]
+    public void SkipReport_LandsOnTheJobSummaryWhenThereIsOne()
+    {
+        var path = global::System.IO.Path.Combine(
+            global::System.IO.Path.GetTempPath(), $"reactor-skip-summary-{Guid.NewGuid():N}.md");
+        try
+        {
+            var report = SelfTestBatch.PublishSkipReport(Parse(
+                $"# Running: {Skipped}\nok {Skipped}_Check # SKIP {Reason}\n"), path);
+
+            Assert.IsTrue(report.Delivered);
+            var written = global::System.IO.File.ReadAllText(path);
+            Assert.IsTrue(written.Contains(Skipped, StringComparison.Ordinal), written);
+            Assert.IsTrue(written.Contains(Reason, StringComparison.Ordinal), written);
+        }
+        finally
+        {
+            if (global::System.IO.File.Exists(path)) global::System.IO.File.Delete(path);
+        }
+    }
+
+    // ------------------------------------------------------------------ regression guards
+
+    /// <summary>
+    /// A recorded runner-level failure must survive the flush that follows it. This is pre-existing
+    /// behaviour rather than new, but the flush was rewritten around a three-state verdict, and the
+    /// failure mode — a crash downgraded to a pass — is silent.
+    /// </summary>
+    [TestMethod]
+    public void RunnerLevelFailure_IsNotOverwrittenByTheFlush()
+    {
+        var outcome = Outcome("# Running: F\nnot ok 7 F_CRASH - InvalidOperationException: boom\n", "F");
+
+        Assert.AreEqual(SelfTestBatch.FixtureStatus.Failed, outcome.Status);
+        Assert.IsTrue(outcome.Detail.Contains("boom", StringComparison.Ordinal), outcome.Detail);
+    }
+
+    /// <summary>
+    /// The trailer detector must be indifferent to everything added around it: <c>ParseTap</c>'s
+    /// <c>SawTotalFailures</c> is the documented discriminator between a suite-budget kill (#988)
+    /// and a Host that died mid-run (#978), and the new <c># Total skipped fixtures:</c> line sits
+    /// directly beside it.
+    /// </summary>
+    [TestMethod]
+    public void TotalFailuresTrailer_IsStillDetectedAlongsideTheSkipTrailer()
+    {
+        var withTrailer = SelfTestBatch.ParseTap(
+            "# Running: F\nok F_Check\n# Total failures: 0\n# Total skipped fixtures: 0\n",
+            new Dictionary<string, SelfTestBatch.FixtureOutcome>());
+        Assert.IsTrue(withTrailer.SawTotalFailures);
+
+        var truncated = SelfTestBatch.ParseTap(
+            "# Running: F\nok F_Check\n",
+            new Dictionary<string, SelfTestBatch.FixtureOutcome>());
+        Assert.IsFalse(truncated.SawTotalFailures,
+            "Non-vacuity: the detector must be able to come out false, or the assertion above " +
+            "proves nothing.");
+    }
+}

--- a/tests/Reactor.SelfTests/SkipReportingTests.cs
+++ b/tests/Reactor.SelfTests/SkipReportingTests.cs
@@ -210,6 +210,41 @@ public class SkipReportingTests
     }
 
     /// <summary>
+    /// A fixture that skips and then crashes must keep its skip in the inventory. The crash
+    /// arrives as a runner-level <c>not ok &lt;n&gt; &lt;fixture&gt;_CRASH</c>, and <c>Flush</c> has
+    /// an early return for a fixture already stamped Failed — so the question is whether the crash
+    /// lands in <c>failuresForCurrent</c> (early return skipped, skips preserved) or stamps the map
+    /// directly (early return taken, skips silently dropped). It is the former, because
+    /// <c>StripRunnerFailureSuffix</c> removes <c>_CRASH</c> and the name then matches the running
+    /// fixture — but that is a two-step inference across two functions, so it is pinned here
+    /// rather than left to be re-derived. Losing the skip would undercount the inventory in the
+    /// one case where a reader most wants both facts: what it gave up on, and what then broke.
+    /// </summary>
+    [TestMethod]
+    public void FixtureThatSkippedThenCrashed_IsFailedButKeepsItsSkip()
+    {
+        var map = Parse(
+            "# Running: F\n" +
+            "ok F_Deferred # SKIP live input not synthesizable headlessly\n" +
+            "not ok 9 F_CRASH - InvalidOperationException: boom\n");
+
+        Assert.IsTrue(map.TryGetValue("F", out var outcome),
+            "The _CRASH suffix must be stripped so the failure lands on 'F'.");
+        Assert.AreEqual(SelfTestBatch.FixtureStatus.Failed, outcome!.Status,
+            "A crash outranks a skip: the fixture is broken, not merely unproven.");
+        Assert.AreEqual(1, outcome.SkippedChecks.Count,
+            $"The skip must survive the crash. Got: {string.Join("; ", outcome.SkippedChecks)}");
+        Assert.IsTrue(outcome.SkippedChecks[0].Contains("F_Deferred", StringComparison.Ordinal),
+            $"The skipped check name must survive. Got: {outcome.SkippedChecks[0]}");
+
+        var inventory = SelfTestBatch.BuildSkipInventory(map);
+        Assert.AreEqual(1, inventory.TotalSkippedChecks,
+            "A crashed fixture's skip still counts toward the run's skip total.");
+        Assert.AreEqual(0, inventory.FullySkippedFixtures.Count,
+            "It is Failed, not Skipped, so it must not appear as a fully-skipped fixture.");
+    }
+
+    /// <summary>
     /// TAP 14 specifies directives case-insensitively. The Host emits upper case today, and a
     /// parser that accepts only what the current emitter happens to produce is one rename away from
     /// silently reporting every skip as a pass again.

--- a/tests/Reactor.SelfTests/SkipReportingTests.cs
+++ b/tests/Reactor.SelfTests/SkipReportingTests.cs
@@ -242,6 +242,16 @@ public class SkipReportingTests
             "A crashed fixture's skip still counts toward the run's skip total.");
         Assert.AreEqual(0, inventory.FullySkippedFixtures.Count,
             "It is Failed, not Skipped, so it must not appear as a fully-skipped fixture.");
+
+        // It therefore lands in the OTHER bucket, which is why that bucket's job-summary heading
+        // must not claim its members passed — this fixture did not.
+        Assert.AreEqual(1, inventory.PartiallySkippedFixtures.Count,
+            "A failed fixture that skipped something still belongs in the partial bucket.");
+
+        var report = SelfTestBatch.PublishSkipReport(map, summaryPath: null);
+        Assert.IsFalse(report.Markdown.Contains("passed on their remaining checks", StringComparison.Ordinal),
+            "The partial-skip heading must not assert that its members passed: a fixture that " +
+            "skipped and then crashed is listed there and did not pass.\n" + report.Markdown);
     }
 
     /// <summary>

--- a/tests/Reactor.SelfTests/SkipReportingTests.cs
+++ b/tests/Reactor.SelfTests/SkipReportingTests.cs
@@ -349,6 +349,42 @@ public class SkipReportingTests
     }
 
     /// <summary>
+    /// A runner-level skip has no check name to record: the fixture never ran, so no
+    /// <c>H.Skip</c> was reached and the name on the TAP line is the FIXTURE's. Recording it as
+    /// the check name renders as <c>`AotHostile` — AotHostile — reason</c> in the job summary,
+    /// which repeats the fixture and asserts a check by that name was skipped. There is no such
+    /// check, and the inventory is the only place a reader learns what a run did not establish.
+    /// </summary>
+    [TestMethod]
+    public void RunnerLevelSkip_IsLabelled_NotNamedAfterItsFixture()
+    {
+        var map = Parse("ok 42 AotHostile # SKIP crashes/hangs under NativeAOT\n");
+        var entry = Assert.ContainsSingle(map["AotHostile"].SkippedChecks);
+
+        Assert.IsFalse(entry.Contains("AotHostile", StringComparison.Ordinal),
+            $"The fixture name must not be repeated as the check name. Got: {entry}");
+        Assert.IsTrue(entry.StartsWith(SelfTestBatch.RunnerLevelSkipLabel, StringComparison.Ordinal),
+            $"Expected the '{SelfTestBatch.RunnerLevelSkipLabel}' label. Got: {entry}");
+        Assert.IsTrue(entry.Contains("NativeAOT", StringComparison.Ordinal),
+            $"The reason must survive. Got: {entry}");
+
+        // The rendered inventory line is what a reader actually sees, so assert on that too —
+        // the label above is only correct if it composes into a truthful entry.
+        var rendered = SelfTestBatch.BuildSkipInventory(map).FullySkippedFixtures.Single();
+        Assert.AreEqual(1, CountOccurrences(rendered, "AotHostile"),
+            $"The fixture name should appear exactly once in the rendered entry. Got: {rendered}");
+    }
+
+    private static int CountOccurrences(string haystack, string needle)
+    {
+        var count = 0;
+        for (var i = haystack.IndexOf(needle, StringComparison.Ordinal); i >= 0;
+             i = haystack.IndexOf(needle, i + needle.Length, StringComparison.Ordinal))
+            count++;
+        return count;
+    }
+
+    /// <summary>
     /// The discriminator is the leading all-digits index, matching
     /// <c>TryParseRunnerLevelFailure</c>. Harness check names are C# identifiers, so this cannot
     /// collide with one — but a check-level skip must still land on the running fixture.

--- a/tests/Reactor.SelfTests/SkipReportingTests.cs
+++ b/tests/Reactor.SelfTests/SkipReportingTests.cs
@@ -224,6 +224,71 @@ public class SkipReportingTests
         Assert.AreEqual("(no reason given)", reason);
     }
 
+    /// <summary>
+    /// A check name that embeds a tracking number — the repo spells these
+    /// <c>ContentDialogLive_Rerender_TextAdvanced_#1069</c>, <c>..._#948</c>, <c>..._#246</c> —
+    /// puts a <c>#</c> in the name itself. A parser anchored on the FIRST <c>#</c> reads the
+    /// directive as <c>1069 # SKIP …</c>, fails to match, and files the line as an ordinary pass:
+    /// issue #1061 restored, for exactly the checks whose names say they are already known to be
+    /// trouble.
+    ///
+    /// <para>Differential, so it cannot pass vacuously: the same fixture, the same skip, the same
+    /// wrapping — only the check NAME differs between the two arms. A parser that ignores names
+    /// makes both arms Skipped and this test cannot fail; a parser that anchors on the first hash
+    /// splits them, which is the defect.</para>
+    /// </summary>
+    [TestMethod]
+    public void SkippedCheckWhoseNameEmbedsAnIssueNumber_IsStillASkip()
+    {
+        const string Reason = "decorator retags the target";
+
+        var plain = Outcome($"# Running: F\nok F_Check # SKIP {Reason}\n", "F");
+        var hashed = Outcome($"# Running: F\nok F_Check_#1069 # SKIP {Reason}\n", "F");
+
+        Assert.AreEqual(SelfTestBatch.FixtureStatus.Skipped, plain.Status,
+            "Control arm: a skip with an ordinary check name must be Skipped.");
+        Assert.AreEqual(plain.Status, hashed.Status,
+            "A '#' in the CHECK NAME must not change the verdict. Anchoring on the first '#' " +
+            "makes this Passed — a fixture that asserted nothing reported green, which is #1061.");
+
+        Assert.IsTrue(SelfTestBatch.TryParseSkipDirective($"F_Check_#1069 # SKIP {Reason}",
+            out var name, out var parsedReason));
+        Assert.AreEqual("F_Check_#1069", name, "The name must keep its own hash.");
+        Assert.AreEqual(Reason, parsedReason, "The reason must not absorb the name's hash.");
+    }
+
+    /// <summary>
+    /// The scan must not stop at a hash whose word merely starts with "skip": a later hash can
+    /// still carry the real directive. This is the interaction between the multi-hash scan and the
+    /// bare-word guard, which a single-hash parser never had to resolve.
+    /// </summary>
+    [TestMethod]
+    public void NameContainingSkippableWord_DoesNotSwallowTheRealDirective()
+    {
+        Assert.IsTrue(
+            SelfTestBatch.TryParseSkipDirective("F_#SKIPPABLE # SKIP the real reason",
+                out var name, out var reason),
+            "A 'SKIPPABLE' token in the name must not consume the scan.");
+        Assert.AreEqual("F_#SKIPPABLE", name);
+        Assert.AreEqual("the real reason", reason);
+    }
+
+    /// <summary>
+    /// The other direction of the same change: a PASSING check whose name embeds a tracking number
+    /// must not be mistaken for a skip. Without this, widening the scan could turn every
+    /// <c>#</c>-bearing pass into a phantom skip and mark healthy fixtures Skipped.
+    /// </summary>
+    [TestMethod]
+    public void PassingCheckWhoseNameEmbedsAnIssueNumber_IsStillAPass()
+    {
+        Assert.IsFalse(
+            SelfTestBatch.TryParseSkipDirective("F_Check_#1069", out _, out _),
+            "A bare name with a tracking number carries no directive.");
+
+        var outcome = Outcome("# Running: F\nok F_Check_#1069\n", "F");
+        Assert.AreEqual(SelfTestBatch.FixtureStatus.Passed, outcome.Status);
+    }
+
     [TestMethod]
     public void OrdinaryOkLine_IsNotASkip()
     {

--- a/tests/Reactor.SelfTests/SkipReportingTests.cs
+++ b/tests/Reactor.SelfTests/SkipReportingTests.cs
@@ -240,10 +240,10 @@ public class SkipReportingTests
     [TestMethod]
     public void SkippedCheckWhoseNameEmbedsAnIssueNumber_IsStillASkip()
     {
-        const string Reason = "decorator retags the target";
+        const string GapReason = "decorator retags the target";
 
-        var plain = Outcome($"# Running: F\nok F_Check # SKIP {Reason}\n", "F");
-        var hashed = Outcome($"# Running: F\nok F_Check_#1069 # SKIP {Reason}\n", "F");
+        var plain = Outcome($"# Running: F\nok F_Check # SKIP {GapReason}\n", "F");
+        var hashed = Outcome($"# Running: F\nok F_Check_#1069 # SKIP {GapReason}\n", "F");
 
         Assert.AreEqual(SelfTestBatch.FixtureStatus.Skipped, plain.Status,
             "Control arm: a skip with an ordinary check name must be Skipped.");
@@ -251,10 +251,10 @@ public class SkipReportingTests
             "A '#' in the CHECK NAME must not change the verdict. Anchoring on the first '#' " +
             "makes this Passed — a fixture that asserted nothing reported green, which is #1061.");
 
-        Assert.IsTrue(SelfTestBatch.TryParseSkipDirective($"F_Check_#1069 # SKIP {Reason}",
+        Assert.IsTrue(SelfTestBatch.TryParseSkipDirective($"F_Check_#1069 # SKIP {GapReason}",
             out var name, out var parsedReason));
         Assert.AreEqual("F_Check_#1069", name, "The name must keep its own hash.");
-        Assert.AreEqual(Reason, parsedReason, "The reason must not absorb the name's hash.");
+        Assert.AreEqual(GapReason, parsedReason, "The reason must not absorb the name's hash.");
     }
 
     /// <summary>
@@ -400,7 +400,7 @@ public class SkipReportingTests
     [TestMethod]
     public void SkipReport_LandsOnTheJobSummaryWhenThereIsOne()
     {
-        var path = global::System.IO.Path.Combine(
+        var path = global::System.IO.Path.Join(
             global::System.IO.Path.GetTempPath(), $"reactor-skip-summary-{Guid.NewGuid():N}.md");
         try
         {

--- a/tests/Reactor.SelfTests/SuiteBudgetDiagnosticsTests.cs
+++ b/tests/Reactor.SelfTests/SuiteBudgetDiagnosticsTests.cs
@@ -625,7 +625,7 @@ public class SuiteBudgetDiagnosticsTests
     [TestMethod]
     public void ApplyAbortOutcome_BudgetKill_StampsTheVictimAndSuppressesTheEarlyAbortScan()
     {
-        var map = new Dictionary<string, (bool Passed, string Detail)>();
+        var map = new Dictionary<string, SelfTestBatch.FixtureOutcome>();
 
         var outcome = SelfTestBatch.ClassifyAbort(
             timedOut: true, hangFixture: null, lastRunningFixture: "VictimFixture",
@@ -637,7 +637,9 @@ public class SuiteBudgetDiagnosticsTests
         Assert.IsTrue(map.TryGetValue("VictimFixture", out var victim),
             "The attribution has to land in the map the Fixture test method reads, or the run " +
             "reports every fixture as simply 'not reported'.");
-        Assert.IsFalse(victim.Passed);
+        Assert.AreEqual(SelfTestBatch.FixtureStatus.Failed, victim.Status,
+            "A budget kill stamps a FAILURE. The three-state outcome added for issue #1061 must " +
+            "not have quietly turned an abort attribution into a skip, which reads as benign.");
         Assert.IsTrue(victim.Detail.Contains("NOT PROVEN", StringComparison.Ordinal),
             victim.Detail);
 
@@ -651,7 +653,7 @@ public class SuiteBudgetDiagnosticsTests
     [TestMethod]
     public void ApplyAbortOutcome_TimeoutWithNothingToBlame_FallsThroughToAnInitError()
     {
-        var map = new Dictionary<string, (bool Passed, string Detail)>();
+        var map = new Dictionary<string, SelfTestBatch.FixtureOutcome>();
 
         var outcome = SelfTestBatch.ClassifyAbort(
             timedOut: true, hangFixture: null, lastRunningFixture: null,
@@ -675,7 +677,7 @@ public class SuiteBudgetDiagnosticsTests
     [TestMethod]
     public void ApplyAbortOutcome_CleanRun_TouchesNothingAndLetsTheEarlyAbortScanRun()
     {
-        var map = new Dictionary<string, (bool Passed, string Detail)>();
+        var map = new Dictionary<string, SelfTestBatch.FixtureOutcome>();
 
         var disposition = SelfTestBatch.ApplyAbortOutcome(
             outcome: null, timedOut: false, budgetMs: 900_000, fullOutput: "OUT", byFixture: map);
@@ -691,7 +693,7 @@ public class SuiteBudgetDiagnosticsTests
     [TestMethod]
     public void ApplyAbortOutcome_HangThatKilledItself_StillAllowsTheEarlyAbortScan()
     {
-        var map = new Dictionary<string, (bool Passed, string Detail)>();
+        var map = new Dictionary<string, SelfTestBatch.FixtureOutcome>();
 
         var outcome = SelfTestBatch.ClassifyAbort(
             timedOut: false, hangFixture: "HangingFixture", lastRunningFixture: null,
@@ -703,7 +705,8 @@ public class SuiteBudgetDiagnosticsTests
         Assert.IsTrue(map.TryGetValue("HangingFixture", out var stamped),
             "A hang names its culprit causally, so that name must reach the map even though the " +
             "wrapper's own budget never fired.");
-        Assert.IsFalse(stamped.Passed);
+        Assert.AreEqual(SelfTestBatch.FixtureStatus.Failed, stamped.Status,
+            "A hang is a failure, not a skip.");
         Assert.IsTrue(stamped.Detail.Contains("HangingFixture", StringComparison.Ordinal),
             "Unlike a budget kill this attribution IS causal, so the detail has to name the " +
             "fixture rather than hedge about position.\n" + stamped.Detail);


### PR DESCRIPTION
Fixes #1061.

## The bug

`Harness.Skip(name, reason)` emits the TAP line `ok <name> # SKIP <reason>`. `SelfTestBatch.ParseTap` branched on `line.StartsWith("ok ")`, discarded the payload, and set `sawChecksForCurrent = true` — the flag whose entire purpose is to catch a fixture that asserted nothing.

So the one signal meaning *"I did not assert this"* satisfied the one guard meaning *"did you assert anything?"*. A fixture whose **only** TAP output was a skip reported **PASSED**, with zero `not ok` lines and `# Total failures: 0` — indistinguishable from a fixture that ran and passed. Two anti-vacuity mechanisms cancelled each other out.

## Why the one-line fix is wrong

Simply not setting the flag yields `passed = false`, which turns `CenterOnCurrent_UsesCursorMonitor` (non-interactive desktops, where `GetCursorPos` returns `ACCESS_DENIED`) and `CornerStyle_Apply` (Windows 10, DWM corner attribute not round-trippable) **red on exactly the machines their skips were introduced to accommodate** — recreating the regression the skips fixed. A genuine third verdict is required.

## The change

**Host** (`Reactor.AppTests.Host`) — `Harness` counts `Checks`/`Skips`; `SelfTestRunner` classifies each fixture three ways, paints a zero-assertion fixture amber, and emits `# Fully skipped fixture: <name>` plus a `# Total skipped fixtures: N` trailer. That trailer goes *after* `# Total failures:`, which is the documented #978-vs-#988 abort discriminator. This half exists because the NativeAOT CI job pipes `--self-test` straight to a `.tap` artifact and greps `^not ok ` — it never goes through the wrapper, so a skip was completely invisible to it.

**Wrapper** (`Reactor.SelfTests`) — three-state `FixtureOutcome`; `ParseTap` parses the `# SKIP` directive instead of discarding it; fully-skipped fixtures report `Assert.Inconclusive` (MSTest **Skipped**, run stays green); the skip inventory — including partial skips, whose fixtures stay PASSED — is published to `GITHUB_STEP_SUMMARY`, which is the only channel that renders, since an Inconclusive message never reaches the Actions log. Also fixes a pre-existing mis-attribution where a runner-level AOT skip was credited to the *previous* fixture.

No fixture was rewritten. `CenterOnCurrent_UsesCursorMonitor` and `CornerStyle_Apply` change *verdict* (PASSED → SKIPPED) on the affected machines without a line of fixture code changing, which is the evidence the fix landed in the right layer.

## Guarding against silent regression

The failure mode here is a **green suite**, so ordinary tests can't catch its return:

- `SelfTestVerdict_OnlySkips_PositiveControl` is a fixture that asserts nothing on purpose. `SkippedFixtures_AreReported` fails if it is ever *not* reported as fully skipped. This is the only end-to-end proof the Host still classifies and that the `# SKIP` literal still matches across the boundary — the Host is referenced with `ReferenceOutputAssembly=false`, so no test project can call its code and no fabricated TAP stream can reach it. **`dotnet test` therefore reports 1 skipped, permanently and by design: its amber is the passing state.**
- `SkipDirectives_SurviveIntoTheReport` hard-fails if the parser sees zero directives.
- Step-summary delivery is asserted, including that the env var is set on a runner, so the check cannot pass by silently skipping.

## Verification

- **1529/1529 green**, exit 0 (1528 passed + the control skipped). Release build clean.
- **Mutation-checked**: restoring the unconditional `sawChecksForCurrent` reddens the acceptance test — a differential oracle where the same fixture must come out Passed from one stream and Skipped from another — plus 4 siblings. Giving the positive control a real `H.Check` reddens its guard.
- End-to-end probe confirmed the real Host emits `# Total skipped fixtures: 1` and the real wrapper reports `Skipped Fixture ("...")`.
- Confirmed safe against CI's "Fail on skipped input-injection E2Es" gate: it reads `app-tests.trx` from the E2E job only and filters on input-injection messages, so the selftest job's Inconclusive results aren't caught.

## Review

The second commit addresses findings from a multi-dimensional review (8 dimensions, plus a cross-check on a different model family). The notable one: `TryParseSkipDirective` originally anchored on the *first* `#`, but this repo names checks `..._#1069`, `..._#948`, `..._#246` — so on those lines the first hash belongs to the name, the candidate directive became `1069 # SKIP …`, and the skip was filed as an ordinary pass. That silently re-introduced this very bug for exactly the checks whose names say they're already known trouble. It now scans every `#`.