### PR TITLE
fix(aot): make legacy text-node TreeView render under NativeAOT

### DIFF
--- a/src/Reactor/Core/Element.cs
+++ b/src/Reactor/Core/Element.cs
@@ -2550,7 +2550,18 @@ public record PivotItemData(string Header, Element Content);
 
 public record BreadcrumbBarItemData(string Label, object? Tag = null);
 
-public record TreeViewNodeData(string Content, TreeViewNodeData[]? Children = null)
+// The legacy node-mode TreeView renders node text through a classic {Binding}
+// (Reconciler.TreeViewTextItemTemplate resolves "Content.Content"). That path
+// goes through CsWinRT's ICustomPropertyProvider, which is reflection-based and
+// gets trimmed under NativeAOT — the TextBlock then silently renders empty, with
+// no build-time warning. This attribute makes the CsWinRT source generator emit
+// strongly-typed binding metadata for this type so the hop survives trimming.
+//
+// Scoped to just "Content": that is the only member the template binds, and the
+// parameterless overload would also emit an accessor for the [Obsolete]
+// ContentElement, which fails the warnings-as-errors Release build (CS0618).
+[WinRT.GeneratedBindableCustomProperty(["Content"], [])]
+public partial record TreeViewNodeData(string Content, TreeViewNodeData[]? Children = null)
 {
     public bool IsExpanded { get; init; }
 

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/TextTreeBindingAotFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/TextTreeBindingAotFixtures.cs
@@ -21,9 +21,16 @@ namespace Microsoft.UI.Reactor.AppTests.Host.SelfTest.Fixtures;
 /// This exists because the managed property hop is resolved by string through
 /// CsWinRT's <c>ICustomPropertyProvider</c>, which is reflection-based: under
 /// NativeAOT it is trimmed away and the TextBlock silently renders empty, with
-/// no build-time warning. The assertions are deliberately non-vacuous — they
-/// search the live visual tree for the bound strings, so they fail if that
-/// resolution regresses.
+/// no build-time warning.
+///
+/// <para>The assertions use <b>exact</b> text matching, not a substring probe.
+/// <c>TreeViewNodeData</c> is a positional record, so its synthesized
+/// <c>ToString()</c> embeds <c>Content = BindingRootZulu</c>. If the template
+/// selection ever regressed to <c>SharedContentControlTemplate</c>, that bare
+/// <c>ContentControl</c> would render the record's <c>ToString()</c> into an
+/// implicit TextBlock — which <i>contains</i> the expected substring. A
+/// <c>Contains</c> probe would go green there while the text-template binding
+/// path was dead; an equality probe cannot.</para>
 /// </summary>
 internal static class TextTreeBindingAotFixtures
 {
@@ -34,23 +41,43 @@ internal static class TextTreeBindingAotFixtures
             static TreeViewNodeData Expanded(TreeViewNodeData n) => n with { IsExpanded = true };
 
             var host = H.CreateHost();
-            host.Mount(_ =>
-                TreeView(
-                    Expanded(TreeNode("BindingRootZulu",
-                        TreeNode("BindingChildYankee"))),
-                    TreeNode("BindingSiblingXray")
-                ).Height(300));
+            host.Mount(ctx =>
+            {
+                var (phase, set) = ctx.UseState(0);
+                string tag = phase == 0 ? "Zulu" : "Quebec";
+                return VStack(
+                    Button("Rebind", () => set(1)),
+                    TreeView(
+                        Expanded(TreeNode($"BindingRoot{tag}",
+                            TreeNode($"BindingChild{tag}"))),
+                        TreeNode($"BindingSibling{tag}")
+                    ).Height(300));
+            });
 
             await Harness.Render();
 
             H.Check("TXB_RootTextResolved",
-                await Harness.WaitFor(() => H.FindTextContaining("BindingRootZulu") is not null));
+                await Harness.WaitFor(() => H.FindText("BindingRootZulu") is not null));
             H.Check("TXB_ChildTextResolved",
-                await Harness.WaitFor(() => H.FindTextContaining("BindingChildYankee") is not null));
+                await Harness.WaitFor(() => H.FindText("BindingChildZulu") is not null));
             H.Check("TXB_SiblingTextResolved",
-                await Harness.WaitFor(() => H.FindTextContaining("BindingSiblingXray") is not null));
+                await Harness.WaitFor(() => H.FindText("BindingSiblingZulu") is not null));
+
+            // Update arm: TreeChildren.Bind(isMount: false) clears RootNodes and
+            // rebuilds every TreeViewNode, so the binding has to resolve again on
+            // freshly-created nodes — a different code path from mount.
+            H.ClickButton("Rebind");
+            await Harness.Render();
+
+            H.Check("TXB_RootTextResolvedAfterUpdate",
+                await Harness.WaitFor(() => H.FindText("BindingRootQuebec") is not null));
+            H.Check("TXB_ChildTextResolvedAfterUpdate",
+                await Harness.WaitFor(() => H.FindText("BindingChildQuebec") is not null));
+            // Guards node duplication specifically: if the update arm re-added
+            // nodes without clearing RootNodes, the two checks above would still
+            // find their text, so only the absence of the old text catches it.
+            H.Check("TXB_StaleNodeTextCleared",
+                await Harness.WaitFor(() => H.FindText("BindingRootZulu") is null));
         }
     }
 }
-
-

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/TextTreeBindingAotFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/TextTreeBindingAotFixtures.cs
@@ -1,0 +1,56 @@
+using Microsoft.UI.Reactor;
+using Microsoft.UI.Reactor.Core;
+using Microsoft.UI.Reactor.AppTests.Host.SelfTest;
+using static Microsoft.UI.Reactor.Factories;
+
+namespace Microsoft.UI.Reactor.AppTests.Host.SelfTest.Fixtures;
+
+/// <summary>
+/// Isolates the <b>legacy text-node</b> TreeView path — the only place Reactor
+/// renders item content through a classic <c>{Binding}</c> rather than setting
+/// it imperatively. <c>Reconciler.TreeViewTextItemTemplate</c> resolves
+/// <c>Content.Content</c>, hopping <c>TreeViewNode.Content</c> (a native WinRT
+/// property) → <c>TreeViewNodeData.Content</c> (a <b>managed</b> record property).
+///
+/// Nodes here carry no <c>ContentElement</c>, so <c>HasAnyContentElement</c> is
+/// false and the tree uses the text template rather than the
+/// <c>SharedContentControlTemplate</c> shell — the distinction that makes the
+/// existing TTV_* fixtures (which all pass a <c>viewBuilder</c>) unable to cover
+/// this path.
+///
+/// This exists because the managed property hop is resolved by string through
+/// CsWinRT's <c>ICustomPropertyProvider</c>, which is reflection-based: under
+/// NativeAOT it is trimmed away and the TextBlock silently renders empty, with
+/// no build-time warning. The assertions are deliberately non-vacuous — they
+/// search the live visual tree for the bound strings, so they fail if that
+/// resolution regresses.
+/// </summary>
+internal static class TextTreeBindingAotFixtures
+{
+    internal class TextTree_NodeTextRendersUnderAot(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            static TreeViewNodeData Expanded(TreeViewNodeData n) => n with { IsExpanded = true };
+
+            var host = H.CreateHost();
+            host.Mount(_ =>
+                TreeView(
+                    Expanded(TreeNode("BindingRootZulu",
+                        TreeNode("BindingChildYankee"))),
+                    TreeNode("BindingSiblingXray")
+                ).Height(300));
+
+            await Harness.Render();
+
+            H.Check("TXB_RootTextResolved",
+                await Harness.WaitFor(() => H.FindTextContaining("BindingRootZulu") is not null));
+            H.Check("TXB_ChildTextResolved",
+                await Harness.WaitFor(() => H.FindTextContaining("BindingChildYankee") is not null));
+            H.Check("TXB_SiblingTextResolved",
+                await Harness.WaitFor(() => H.FindTextContaining("BindingSiblingXray") is not null));
+        }
+    }
+}
+
+

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -3345,4 +3345,3 @@ internal static class SelfTestFixtureRegistry
         _ => null,
     };
 }
-

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -168,6 +168,9 @@ internal static class SelfTestFixtureRegistry
         "TTV_ControlPropsMountAndUpdate",
         "TTV_EmptyThenPopulate",
         "TTV_DeepNestingRenders",
+        // Legacy text-node TreeView — the only Reactor item template that
+        // renders through a classic {Binding} (see TextTreeBindingAotFixtures).
+        "TXB_TextTreeNodeTextRendersUnderAot",
         "TTV_TwoIndependentTrees",
         // ItemsView reconciler arm — mount / update / layout-kind / selection.
         "ItemsView_Mount",
@@ -1877,6 +1880,7 @@ internal static class SelfTestFixtureRegistry
         "TTV_ControlPropsMountAndUpdate" => new TemplatedTreeViewFixtures.ControlPropsMountAndUpdate(harness),
         "TTV_EmptyThenPopulate" => new TemplatedTreeViewFixtures.EmptyThenPopulate(harness),
         "TTV_DeepNestingRenders" => new TemplatedTreeViewFixtures.DeepNestingRenders(harness),
+        "TXB_TextTreeNodeTextRendersUnderAot" => new TextTreeBindingAotFixtures.TextTree_NodeTextRendersUnderAot(harness),
         "TTV_TwoIndependentTrees" => new TemplatedTreeViewFixtures.TwoIndependentTrees(harness),
         "ItemsView_Mount" => new ItemsViewFixtures.ItemsView_BasicMount(harness),
         "ItemsView_Layout_UniformGrid" => new ItemsViewFixtures.ItemsView_LayoutKind_AppliesUniformGrid(harness),
@@ -3341,3 +3345,4 @@ internal static class SelfTestFixtureRegistry
         _ => null,
     };
 }
+

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestRunner.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestRunner.cs
@@ -147,9 +147,8 @@ internal static class SelfTestRunner
     // debugging workflow.
     private static readonly string[] DefaultAotSkipPatterns =
     {
-        // -- Reactor framework, control-collection assertions still under
+        // -- Reactor framework, control-collection assertion still under
         // investigation (no native crash; assertion fails inside the fixture). --
-        "ControlUpdate_Collections",
         "CoreCov2_UseObservableTreeHook",
 
         // -- Devtools / MCP server. The other 25 Devtools fixtures run under AOT;
@@ -678,3 +677,4 @@ internal static class SelfTestRunner
         }
     }
 }
+

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestRunner.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestRunner.cs
@@ -116,10 +116,10 @@ internal static class SelfTestRunner
     // tests/Reactor.AppTests.Host/probe-aot-skips.ps1 against the AOT-published
     // Host. As of WindowsAppSDK#6394 workaround (see Reactor.AppTests.Host.csproj
     // _CopyWinUIResourcesForAot target), all NATIVE_CRASH skips are gone. What is
-    // left is the buckets below: two control-collection assertions still under
-    // investigation, the two Devtools fixtures whose reflection targets the
-    // trimmer removes, PropertyGrid auto-discovery, the Issue142
-    // XAML-metadata-provider edge cases, and hot-reload state migration.
+    // left is the buckets below: the UseObservableTree property walk, the two
+    // Devtools fixtures whose reflection targets the trimmer removes,
+    // PropertyGrid auto-discovery, the Issue142 XAML-metadata-provider edge
+    // cases, and hot-reload state migration.
     //
     // Reflection on its own does NOT make a fixture AOT-hostile, so don't use it
     // as the sorting rule. The 25 Devtools fixtures that run here mostly depend on
@@ -147,8 +147,12 @@ internal static class SelfTestRunner
     // debugging workflow.
     private static readonly string[] DefaultAotSkipPatterns =
     {
-        // -- Reactor framework, control-collection assertion still under
-        // investigation (no native crash; assertion fails inside the fixture). --
+        // -- UseObservableTree subscribes to nested INotifyPropertyChanged by
+        // walking the model graph with Type.GetProperties (see
+        // ObservableTreeTracker.CreateInpcCandidateProperties). The fixture's
+        // POCO model is not rooted for PublicProperties under AOT, so the walk
+        // finds no nested INPC source and the deep-mutation assertion fails
+        // (no native crash; the assertion fails inside the fixture). --
         "CoreCov2_UseObservableTreeHook",
 
         // -- Devtools / MCP server. The other 25 Devtools fixtures run under AOT;
@@ -677,4 +681,3 @@ internal static class SelfTestRunner
         }
     }
 }
-


### PR DESCRIPTION
## The bug

The legacy node-mode TreeView renders node text through a classic `{Binding}` — `Reconciler.TreeViewTextItemTemplate` resolves `Content.Content`, hopping `TreeViewNode.Content` (native WinRT) → `TreeViewNodeData.Content` (a **managed** record property).

That managed hop goes through CsWinRT's `ICustomPropertyProvider`, which is reflection-based. NativeAOT trims it and **the TextBlock silently renders empty** — with **no build-time warning**, because the reflection happens across the WinRT ABI where the IL trim analyzers can't see it. The publish reports zero IL2xxx/IL3xxx.

## The fix

Annotate `TreeViewNodeData` with `[WinRT.GeneratedBindableCustomProperty]` so the CsWinRT generator emits strongly-typed binding metadata (explicit interface implementation + static lambdas — **no public API surface added**, `api.txt` unchanged).

Scoped to `"Content"` deliberately: it's the only member the template binds, and the unscoped overload also emits an accessor for the `[Obsolete]` `ContentElement`, which **fails the warnings-as-errors Release build** with `CS0618`.

## This was not theoretical

`ControlUpdate_Collections` mounts a text-mode TreeView and asserts its node text renders. It has been sitting in `DefaultAotSkipPatterns` as an unexplained *"control-collection assertion still under investigation"*.

**It was this bug all along.** The skip is removed, so that fixture now guards the fix.

## New coverage

Every existing `TTV_*` fixture passes a `viewBuilder`, which routes to the `SharedContentControlTemplate` shell and never exercises the binding template — so this path had **no direct coverage**. The new fixture isolates it, and its assertions search the live visual tree for the bound strings, so they fail if the resolution regresses.

## Verification

| | JIT | NativeAOT |
|---|---|---|
| Before | pass | **fail** (`CollUpdate_TVPresent`, 3/3 reproducible) |
| After | pass | **pass** |

Full selftest suite: **1446 planned, 0 failures** under both JIT and NativeAOT. Release build of `src/Reactor`: 0 warnings, 0 errors.

## Note

There is a follow-up direction where the template uses a strongly-typed `DataContextChanged` handler instead of a `{Binding}` — reflection-free outright rather than reflection-made-trimmable. That needs WinUI's code-based `DataTemplate` API ([microsoft-ui-xaml#11260](https://github.com/microsoft/microsoft-ui-xaml/pull/11260)) to construct the template from code, so it can't land until that ships. This PR fixes the scenario on today's WinAppSDK.
