### PR TITLE
Group version-locked Roslyn NuGet packages into one Dependabot PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,6 +30,40 @@ updates:
       - "dependencies"
       - "nuget"
     open-pull-requests-limit: 10
+    # Grouping is deliberately limited to package sets that NuGet itself forces
+    # to move together (exact-pin `[x, x]` dependencies or floors that advance
+    # every release). Families that merely share a prefix are left ungrouped, so
+    # an unrelated bump still gets its own reviewable PR.
+    groups:
+      # Roslyn ships Microsoft.CodeAnalysis.* as one version-locked set:
+      # Microsoft.CodeAnalysis.CSharp.Workspaces 5.6.0 exact-pins
+      # Microsoft.CodeAnalysis.CSharp [5.6.0, 5.6.0] and
+      # Microsoft.CodeAnalysis.Common [5.6.0, 5.6.0], and each Roslyn release
+      # raises its floor on Microsoft.CodeAnalysis.Analyzers (5.9.0 requires
+      # >= 5.9.0-1.26328.17). Updating them one package per PR breaks restore
+      # with NU1608 "Detected package version outside of dependency constraint",
+      # which is an error here because Release treats warnings as errors. This
+      # has already happened twice: #814 merged with CSharp.Workspaces stranded
+      # a version behind, and #1113 repeated it. Group them so a Roslyn bump
+      # always moves the whole set in a single PR.
+      roslyn:
+        patterns:
+          - "Microsoft.CodeAnalysis*"
+        # The analyzer/code-fix test harness ships from dotnet/roslyn-sdk on an
+        # independent 1.1.x line, so it must not be dragged into a 5.x bump.
+        exclude-patterns:
+          - "Microsoft.CodeAnalysis*Testing"
+
+      # The roslyn-sdk test harness is its own version-locked set, one line down:
+      # Microsoft.CodeAnalysis.CSharp.CodeFix.Testing 1.1.4 exact-pins
+      # Microsoft.CodeAnalysis.CodeFix.Testing [1.1.4, 1.1.4], which in turn
+      # exact-pins Microsoft.CodeAnalysis.Analyzer.Testing [1.1.4, 1.1.4] — the
+      # same package Microsoft.CodeAnalysis.CSharp.Analyzer.Testing 1.1.4 pins.
+      # Bumping one without the other reproduces the NU1608 above on the 1.1.x
+      # line, so they get their own group rather than joining `roslyn`.
+      roslyn-testing:
+        patterns:
+          - "Microsoft.CodeAnalysis*Testing"
     ignore:
       # Windows App SDK and Win2D are pinned via Directory.Build.props
       # (WindowsAppSDKVersion / WindowsAppSDKWinUIVersion / Win2DVersion) and bumped


### PR DESCRIPTION
## Problem

Dependabot proposes NuGet version updates **one package per PR**. `Directory.Packages.props` contains package families that NuGet forces to move in lockstep, so a per-package bump strands the rest of the family and breaks restore.

The current failure is **#1113** (`deps: Bump Microsoft.CodeAnalysis.Analyzers and Microsoft.CodeAnalysis.CSharp`), which takes two of the three Roslyn packages to 5.9.0 and leaves `Microsoft.CodeAnalysis.CSharp.Workspaces` at 5.6.0. Restore then fails ([run 32526662087](https://github.com/microsoft/microsoft-ui-reactor/actions/runs/32526662087)):

```
src\Reactor.Analyzers\Reactor.Analyzers.csproj : error NU1608: Warning As Error:
Detected package version outside of dependency constraint:
Microsoft.CodeAnalysis.CSharp.Workspaces 5.6.0 requires
Microsoft.CodeAnalysis.Common (= 5.6.0) but version
Microsoft.CodeAnalysis.Common 5.9.0 was resolved.
```

Four checks are red on #1113: AOT Selftests, AOT Trim Proof, Docs build, Fuzz smoke.

> [!NOTE]
> **#1113 is superseded by #1098**, which already takes all three Roslyn packages to 5.9.0 together. This PR does not unblock #1113 — it prevents the *next* recurrence.

And there will be a next one, because **this has already happened twice**. #814 has the identical title and merged with `CSharp.Workspaces` stranded at 5.3.0 while the other two moved to 5.6.0; it stayed mismatched until #850 healed it by hand. The mismatch only became *fatal* once #850 made `TreatWarningsAsErrors` apply on Release, promoting NU1608 from warning to error.

## Root cause

`.github/dependabot.yml` has a `nuget` entry with `ignore:` rules but **no `groups:`** block, so nothing keeps a version-locked family in a single PR.

## Fix

Add two `groups` to the `nuget` ecosystem entry. Grouping is limited to sets with a *demonstrated* constraint, verified by reading the shipped `.nuspec` files:

| Group | Packages | Constraint (from nuspec) |
|---|---|---|
| `roslyn` | `Microsoft.CodeAnalysis.CSharp`, `.CSharp.Workspaces`, `.Analyzers` | `CSharp.Workspaces 5.6.0` exact-pins `CodeAnalysis.CSharp [5.6.0, 5.6.0]`, `CodeAnalysis.Common [5.6.0, 5.6.0]`, `Workspaces.Common [5.6.0, 5.6.0]` |
| `roslyn-testing` | `.CSharp.Analyzer.Testing`, `.CSharp.CodeFix.Testing` | `CSharp.CodeFix.Testing 1.1.4` exact-pins `CodeFix.Testing [1.1.4, 1.1.4]`, which exact-pins `Analyzer.Testing [1.1.4, 1.1.4]` — the same package `CSharp.Analyzer.Testing 1.1.4` pins |

Two groups rather than one, because they are independent version lines: Roslyn's 5.x versus the dotnet/roslyn-sdk harness's 1.1.x. `exclude-patterns` keeps the 1.1.x harness out of a 5.x bump so the two never land in one mixed PR.

**`Microsoft.CodeAnalysis.Analyzers` is included on evidence, not by prefix.** It has no dependencies of its own, but the Roslyn compiler packages raise their floor on it each release — `Microsoft.CodeAnalysis.CSharp 5.6.0` requires `Analyzers >= 5.3.0`, while `5.9.0` requires `>= 5.9.0-1.26328.17`. Since `Analyzers` is a direct `PackageReference` in `Reactor.Localization.Generator`, leaving it behind a compiler bump is a downgrade, not a silent transitive lift.

## Families considered and deliberately *not* grouped

- **`Microsoft.VisualStudio.*`** — `Microsoft.VisualStudio.SDK 17.14.40265` declares *minimum* bounds on `Shell.15.0`, `Utilities`, `Interop` etc., not exact pins, so a split bump self-heals rather than failing restore. The family also spans at least six independent version lines in `Directory.Packages.props` (17.7.x, 17.11.x, 17.13.x, 17.14.x, 18.6.x, 18.7.x), so a blanket `Microsoft.VisualStudio*` group would merge unrelated lines into one unreviewable PR.
- **`System.*` runtime packages** — minimum bounds, no exact pins. Empirically fine as individual PRs: `System.Text.Json` (#1095) and `System.Formats.Asn1` (#1094) each merged green on their own in the last weekly bump.

Grouping these would be speculative, so they keep today's per-package behaviour.

## Validation

There is no local Dependabot runner, so **Dependabot itself was not executed** — the grouping takes effect server-side on the next scheduled run. What I did verify:

- **Reproduced the failure** rather than assuming it: `gh pr checks 1113` shows the four red checks, and the NU1608 lines above are quoted from the Docs build job log (96910065273).
- **Constraints read from the shipped nuspecs** in the local NuGet cache (nuget.org is TLS-blocked from this machine), not inferred from version numbers.
- **Schema checked** against the [`groups` reference](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#groups--): `groups` → `<name>` → `patterns` / `exclude-patterns`, identifier must start and end with a letter.
- **Pattern semantics checked against the implementation**, not guessed — dependabot-core's `WildcardMatcher.match?` lowercases both sides, `Regexp.quote`s literal segments (so `.` stays literal) and expands `*` to `.*` anchored `^…$`; `DependencyGroup#contains?` evaluates `exclude-patterns` *before* `patterns`, so exclusion is order-independent.
- **Simulated group assignment offline** by porting those two functions and running them over all 54 `PackageVersion` entries. Exactly the 5 intended packages are grouped and the other 49 stay ungrouped. The harness carries positive controls proving the matcher can return `false`, and mutation-testing it (removing `exclude-patterns`) correctly turns it red — so the green result is not vacuous.
- **Untouched sections asserted byte-identical** to `origin/main` via parsed-YAML comparison: the `github-actions` and `npm` entries, all five `ignore:` rules, and every other key of the `nuget` entry. The only added key is `groups`. None of the ignored names (`Microsoft.WindowsAppSDK*`, `Microsoft.Graphics.Win2D`, `MessagePack`) match either group pattern, so no ignored package is silently re-enabled.

No build or test run was performed: the change is a single YAML file that ships no code and is not consumed by the build.

## Scope

Config only — **no package versions change in `Directory.Packages.props`**. Diff is 34 insertions, 0 deletions, in `.github/dependabot.yml`.
