### PR TITLE
Gate the shipped agent kit against modifier drift

### DIFF
--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitDocCorpus.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitDocCorpus.cs
@@ -89,6 +89,15 @@ internal static class AgentKitDocCorpus
     /// text rather than a list (<c>Md4cCommonMarkSpecTest.Example_0288</c>), so the marker is
     /// validated against its own container below instead of being taken from the line alone.
     /// </para>
+    /// <para>
+    /// One blockquote run then at most one list marker is the deliberate boundary. CommonMark
+    /// nests containers arbitrarily, so <c>- &gt; ```csharp</c> is a legal opener this does not
+    /// match. <see cref="CSharpFenceProbe"/> does not match it either, which is what makes the miss
+    /// safe rather than silent in the dangerous direction: the two agree, so the completeness fact
+    /// still means what it says, and the cost is an unscanned block rather than a finding on prose.
+    /// The shipped corpus contains no such opener — measured, with the single-container forms as
+    /// positive controls — so parsing containers recursively would guard nothing today.
+    /// </para>
     /// </remarks>
     private static readonly Regex FenceOpen = new(
         @"^(?<indent>[ \t]*)((?<marker>[-*+]|\d+[.)])(?<pad>[ \t]+))?(?<fence>`{3,}|~{3,})[ ]*(?<info>[^`\r\n]*)$",

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitDocCorpus.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitDocCorpus.cs
@@ -103,11 +103,51 @@ internal static class AgentKitDocCorpus
     /// </remarks>
     private static readonly Regex BlockquotePrefix = new(@"^(?:[ \t]*(?:>[ \t]?)+)", RegexOptions.Compiled);
 
-    /// <summary>Splits a line into its blockquote container prefix and the content inside it.</summary>
-    internal static (int PrefixLength, string Content) StripBlockquote(string line)
+    /// <summary>A single blockquote level: optional indent, a <c>&gt;</c>, and optional space.</summary>
+    private static readonly Regex BlockquoteLevel = new(@"^[ \t]*>[ \t]?", RegexOptions.Compiled);
+
+    /// <summary>
+    /// Splits a line into its blockquote container prefix and the content inside it, removing at
+    /// most <paramref name="maxDepth"/> levels.
+    /// </summary>
+    /// <remarks>
+    /// The depth bound is what keeps a nested quote from closing an outer fence. Stripping every
+    /// level reduced <c>&gt; &gt; ```</c> — a legitimate nested-blockquote line inside a
+    /// <c>&gt; ```csharp</c> block — to a bare <c>```</c>, which closed the block early and left
+    /// the rest of the sample unscanned. The differential probe computes its covered lines from the
+    /// same scan, so the truncation would have stayed green.
+    /// </remarks>
+    internal static (int PrefixLength, string Content) StripBlockquote(string line, int maxDepth = int.MaxValue)
     {
-        var match = BlockquotePrefix.Match(line);
-        return match.Success && match.Length > 0 ? (match.Length, line[match.Length..]) : (0, line);
+        var offset = 0;
+
+        for (var level = 0; level < maxDepth; level++)
+        {
+            var match = BlockquoteLevel.Match(line[offset..]);
+            if (!match.Success || match.Length == 0)
+                break;
+
+            offset += match.Length;
+        }
+
+        return (offset, line[offset..]);
+    }
+
+    /// <summary>Number of blockquote levels a line opens with.</summary>
+    private static int BlockquoteDepth(string line)
+    {
+        var offset = 0;
+        var depth = 0;
+
+        while (true)
+        {
+            var match = BlockquoteLevel.Match(line[offset..]);
+            if (!match.Success || match.Length == 0)
+                return depth;
+
+            offset += match.Length;
+            depth++;
+        }
     }
 
     /// <summary>
@@ -274,7 +314,7 @@ internal static class AgentKitDocCorpus
     /// <param name="BodyStartLine">1-based first line of the body.</param>
     /// <param name="BodyEndLine">1-based last line of the body; less than
     /// <paramref name="BodyStartLine"/> for an empty block.</param>
-    internal readonly record struct FenceRegion(int OpenLine, int BodyStartLine, int BodyEndLine, string Language, int Indent, int BlockquotePrefix);
+    internal readonly record struct FenceRegion(int OpenLine, int BodyStartLine, int BodyEndLine, string Language, int Indent, int BlockquoteDepth);
 
     /// <summary>
     /// Every fenced block in a markdown document, in source order, whatever its language.
@@ -293,7 +333,8 @@ internal static class AgentKitDocCorpus
 
         for (var i = 0; i < lines.Length; i++)
         {
-            var (prefix, content) = StripBlockquote(lines[i]);
+            var depth = BlockquoteDepth(lines[i]);
+            var content = StripBlockquote(lines[i]).Content;
 
             var open = FenceOpen.Match(content);
             if (!open.Success)
@@ -316,7 +357,7 @@ internal static class AgentKitDocCorpus
             // Find the close first, so a non-C# fence still advances past its own body instead
             // of letting the body's contents be re-read as markdown.
             var close = i + 1;
-            while (close < lines.Length && !IsClosingFence(lines[close], fenceChar, fenceLength, container))
+            while (close < lines.Length && !IsClosingFence(lines[close], fenceChar, fenceLength, container, depth))
                 close++;
 
             regions.Add(new FenceRegion(
@@ -325,7 +366,7 @@ internal static class AgentKitDocCorpus
                 BodyEndLine: close,          // 1-based last body line; == i+1 when empty.
                 Language: open.Groups["info"].Value.Trim().Split(' ', ',')[0],
                 Indent: indent,
-                BlockquotePrefix: prefix));
+                BlockquoteDepth: depth));
 
             i = close;
         }
@@ -393,7 +434,7 @@ internal static class AgentKitDocCorpus
                 string.Join(
                     "\n",
                     lines[(region.BodyStartLine - 1)..(region.BodyEndLine - 1 + 1)]
-                        .Select(line => StripIndent(StripBlockquote(line).Content, region.Indent)))))
+                        .Select(line => StripIndent(StripBlockquote(line, region.BlockquoteDepth).Content, region.Indent)))))
             .ToList();
     }
 
@@ -424,9 +465,9 @@ internal static class AgentKitDocCorpus
     /// demonstrating Markdown — truncate the block, so the rest of that sample was never scanned.
     /// The differential probe trusts <see cref="Fences"/> for block structure, so it cannot see it.
     /// </remarks>
-    private static bool IsClosingFence(string rawLine, char fenceChar, int openLength, int containerIndent)
+    private static bool IsClosingFence(string rawLine, char fenceChar, int openLength, int containerIndent, int blockquoteDepth)
     {
-        var line = StripBlockquote(rawLine).Content;
+        var line = StripBlockquote(rawLine, blockquoteDepth).Content;
         var text = line.TrimStart(' ', '\t');
 
         if (line.Length - text.Length - containerIndent > 3)

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitDocCorpus.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitDocCorpus.cs
@@ -10,10 +10,16 @@ using Microsoft.UI.Reactor.Cli.Pack;
 namespace Microsoft.UI.Reactor.Tests.AnalyzerTests;
 
 /// <summary>
-/// One <c>&lt;None&gt;</c> item from <c>src/Reactor/Reactor.csproj</c> that packs into
+/// One glob from a <c>&lt;None&gt;</c> item in <c>src/Reactor/Reactor.csproj</c> that packs into
 /// <c>agentkit/</c>, resolved to the files it actually matches on disk.
 /// </summary>
-internal sealed record AgentKitPackEntry(string Include, string PackagePath, IReadOnlyList<string> Files);
+/// <remarks>
+/// One entry per <em>pattern</em>, not per item. An item's <c>Include</c> may carry several
+/// semicolon-separated globs — <c>skills\recipes\*.md;skills\recipes\*.cs</c> is packed that way —
+/// and aggregating them would let a dead glob hide behind a live sibling: the item still matches
+/// files, so an emptiness check on it stays false while half its content has stopped shipping.
+/// </remarks>
+internal sealed record AgentKitPackEntry(string Pattern, string PackagePath, IReadOnlyList<string> Files);
 
 /// <summary>
 /// One unit of C# taken from a shipped agent-kit document: a fenced block from a
@@ -106,12 +112,21 @@ internal static class AgentKitDocCorpus
     /// be tested against project XML directly rather than only through the working tree.
     /// </summary>
     internal static IReadOnlyList<string> AgentKitPackagePaths(string projectXml) =>
+        AgentKitItems(projectXml).Select(item => item.Path).ToList();
+
+    /// <summary>
+    /// The raw <c>Include</c> of every agentkit item, before it is split on <c>;</c>.
+    /// </summary>
+    internal static IReadOnlyList<string> AgentKitIncludes(string projectXml) =>
+        AgentKitItems(projectXml).Select(item => item.Include).ToList();
+
+    private static IEnumerable<(string Path, string Include)> AgentKitItems(string projectXml) =>
         XDocument.Parse(projectXml)
             .Descendants()
             .Where(e => e.Name.LocalName == "None")
             .Select(e => (Path: (string?)e.Attribute("PackagePath"), Include: (string?)e.Attribute("Include")))
             .Where(item => item.Path is not null && item.Include is not null && IsAgentKitPath(item.Path))
-            .Select(item => item.Path!)
+            .Select(item => (item.Path!, item.Include!))
             .ToList();
 
     /// <summary>
@@ -154,18 +169,24 @@ internal static class AgentKitDocCorpus
             if (!IsAgentKitPath(packagePath))
                 continue;
 
-            var files = new List<string>();
-
+            // One entry per pattern. Aggregating an item's globs would let a dead one hide behind a
+            // live sibling: `skills\recipes\*.md;skills\recipes\*.cs` still matches files if only
+            // the .cs half survives, so an item-level emptiness check would stay false while half
+            // the recipes stopped shipping.
             foreach (var pattern in include.Split(';', StringSplitOptions.RemoveEmptyEntries))
             {
-                foreach (var file in Expand(projectDirectory, pattern.Trim()))
-                    files.Add(file);
-            }
+                var trimmed = pattern.Trim();
+                if (trimmed.Length == 0)
+                    continue;
 
-            entries.Add(new AgentKitPackEntry(
-                include,
-                packagePath,
-                files.Distinct(StringComparer.OrdinalIgnoreCase).OrderBy(f => f, StringComparer.Ordinal).ToList()));
+                entries.Add(new AgentKitPackEntry(
+                    trimmed,
+                    packagePath,
+                    Expand(projectDirectory, trimmed)
+                        .Distinct(StringComparer.OrdinalIgnoreCase)
+                        .OrderBy(f => f, StringComparer.Ordinal)
+                        .ToList()));
+            }
         }
 
         return entries;

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitDocCorpus.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitDocCorpus.cs
@@ -88,7 +88,7 @@ internal static class AgentKitDocCorpus
     /// </para>
     /// </remarks>
     private static readonly Regex FenceOpen = new(
-        @"^(?<indent>[ \t]*)(?<fence>`{3,}|~{3,})[ ]*(?<info>[^`\r\n]*)$",
+        @"^(?<indent>[ \t]*)(?<marker>([-*+]|\d+[.)])[ \t]+)?(?<fence>`{3,}|~{3,})[ ]*(?<info>[^`\r\n]*)$",
         RegexOptions.Compiled);
 
     /// <summary>
@@ -162,7 +162,7 @@ internal static class AgentKitDocCorpus
     /// independently.
     /// </remarks>
     internal static readonly Regex CSharpFenceProbe = new(
-        @"^(?:[ \t]*(?:>[ \t]?)+)?[ \t]*(`{3,}|~{3,})[ ]*(csharp|cs|c\#)([ \t,][^\r\n]*)?$",
+        @"^(?:[ \t]*(?:>[ \t]?)+)?[ \t]*(?:([-*+]|\d+[.)])[ \t]+)?(`{3,}|~{3,})[ ]*(csharp|cs|c\#)([ \t,][^\r\n]*)?$",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
     /// <summary>
@@ -342,13 +342,15 @@ internal static class AgentKitDocCorpus
 
             var indent = open.Groups["indent"].Value.Length;
 
-            // CommonMark measures a fence's indent against its *container*: at most three spaces
-            // past the content column. Beyond that it is an indented code block, where a fence is
-            // literal text — and honouring one swallowed everything to the next close, including a
-            // genuine ```csharp opener below it, which then shipped uninspected. The differential
-            // probe cannot catch that, since it derives its exclusions from this same scan.
-            var container = ContainerIndent(lines, i);
-            if (indent - container > 3)
+            // A fence may open as the content of a list item on the marker's own line
+            // (`- ```csharp`). The marker establishes the content column, so measure — and strip —
+            // against that rather than the line's leading whitespace.
+            var inlineMarker = open.Groups["marker"];
+            var container = inlineMarker.Success
+                ? indent + inlineMarker.Length
+                : ContainerIndent(lines, i);
+
+            if (!inlineMarker.Success && indent - container > 3)
                 continue;
 
             var fenceChar = open.Groups["fence"].Value[0];
@@ -390,7 +392,9 @@ internal static class AgentKitDocCorpus
                 // whole run as the language, so the body never reached the gate — and the probe
                 // accepted only spaces too, so the completeness fact stayed green over it.
                 Language: open.Groups["info"].Value.Trim().Split(' ', '\t', ',')[0],
-                Indent: indent,
+                // Body lines have the opening fence's own offset removed. For an inline marker that
+                // offset includes the marker; otherwise it is just the leading whitespace.
+                Indent: inlineMarker.Success ? container : indent,
                 BlockquoteDepth: depth));
 
             // On container exit the terminating line belongs to whatever follows, so leave it for

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitDocCorpus.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitDocCorpus.cs
@@ -92,6 +92,25 @@ internal static class AgentKitDocCorpus
         RegexOptions.Compiled);
 
     /// <summary>
+    /// A blockquote container prefix: any run of <c>&gt;</c> markers with optional spacing.
+    /// </summary>
+    /// <remarks>
+    /// Fences are legal inside a blockquote, and the prefix is container syntax rather than
+    /// content. Matching only whitespace before the delimiter skipped <c>&gt; ```csharp</c>
+    /// entirely — and <see cref="CSharpFenceProbe"/> shared the restriction, so the differential
+    /// oracle stayed green while the block went uninspected. The corpus has four blockquoted
+    /// fences today, all untagged shell, so this closes the gap before a C# one appears.
+    /// </remarks>
+    private static readonly Regex BlockquotePrefix = new(@"^(?:[ \t]*(?:>[ \t]?)+)", RegexOptions.Compiled);
+
+    /// <summary>Splits a line into its blockquote container prefix and the content inside it.</summary>
+    private static (int PrefixLength, string Content) StripBlockquote(string line)
+    {
+        var match = BlockquotePrefix.Match(line);
+        return match.Success && match.Length > 0 ? (match.Length, line[match.Length..]) : (0, line);
+    }
+
+    /// <summary>
     /// An opening C# fence, found with no regard for indentation or for surrounding block
     /// structure — the independent probe
     /// <c>AgentKitDocGateInstrumentTests.Every_CSharp_Fence_In_The_Corpus_Is_Extracted</c> measures
@@ -103,7 +122,7 @@ internal static class AgentKitDocCorpus
     /// independently.
     /// </remarks>
     internal static readonly Regex CSharpFenceProbe = new(
-        @"^[ \t]*(`{3,}|~{3,})[ ]*(csharp|cs|c\#)[ ]*$",
+        @"^(?:[ \t]*(?:>[ \t]?)+)?[ \t]*(`{3,}|~{3,})[ ]*(csharp|cs|c\#)[ ]*$",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
     /// <summary>
@@ -255,7 +274,7 @@ internal static class AgentKitDocCorpus
     /// <param name="BodyStartLine">1-based first line of the body.</param>
     /// <param name="BodyEndLine">1-based last line of the body; less than
     /// <paramref name="BodyStartLine"/> for an empty block.</param>
-    internal readonly record struct FenceRegion(int OpenLine, int BodyStartLine, int BodyEndLine, string Language, int Indent);
+    internal readonly record struct FenceRegion(int OpenLine, int BodyStartLine, int BodyEndLine, string Language, int Indent, int BlockquotePrefix);
 
     /// <summary>
     /// Every fenced block in a markdown document, in source order, whatever its language.
@@ -274,7 +293,9 @@ internal static class AgentKitDocCorpus
 
         for (var i = 0; i < lines.Length; i++)
         {
-            var open = FenceOpen.Match(lines[i]);
+            var (prefix, content) = StripBlockquote(lines[i]);
+
+            var open = FenceOpen.Match(content);
             if (!open.Success)
                 continue;
 
@@ -303,7 +324,8 @@ internal static class AgentKitDocCorpus
                 BodyStartLine: i + 2,
                 BodyEndLine: close,          // 1-based last body line; == i+1 when empty.
                 Language: open.Groups["info"].Value.Trim().Split(' ', ',')[0],
-                Indent: open.Groups["indent"].Value.Length));
+                Indent: indent,
+                BlockquotePrefix: prefix));
 
             i = close;
         }
@@ -330,7 +352,7 @@ internal static class AgentKitDocCorpus
     {
         for (var i = index - 1; i >= 0; i--)
         {
-            var line = lines[i];
+            var line = StripBlockquote(lines[i]).Content;
             if (line.Trim().Length == 0)
                 continue;   // a blank line does not end a list item's content.
 
@@ -371,7 +393,7 @@ internal static class AgentKitDocCorpus
                 string.Join(
                     "\n",
                     lines[(region.BodyStartLine - 1)..(region.BodyEndLine - 1 + 1)]
-                        .Select(line => StripIndent(line, region.Indent)))))
+                        .Select(line => StripIndent(StripBlockquote(line).Content, region.Indent)))))
             .ToList();
     }
 
@@ -402,8 +424,9 @@ internal static class AgentKitDocCorpus
     /// demonstrating Markdown — truncate the block, so the rest of that sample was never scanned.
     /// The differential probe trusts <see cref="Fences"/> for block structure, so it cannot see it.
     /// </remarks>
-    private static bool IsClosingFence(string line, char fenceChar, int openLength, int containerIndent)
+    private static bool IsClosingFence(string rawLine, char fenceChar, int openLength, int containerIndent)
     {
+        var line = StripBlockquote(rawLine).Content;
         var text = line.TrimStart(' ', '\t');
 
         if (line.Length - text.Length - containerIndent > 3)

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitDocCorpus.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitDocCorpus.cs
@@ -280,12 +280,13 @@ internal static class AgentKitDocCorpus
 
             var indent = open.Groups["indent"].Value.Length;
 
-            // A run of four or more spaces outside a list is an *indented code block*, so a fence
-            // written there is literal text, not an opener. Honouring it swallowed everything up to
-            // the next close — including a genuine top-level ```csharp opener, which would then
-            // never be extracted. The differential probe cannot catch that, since it derives its
-            // exclusions from this same scan.
-            if (indent >= 4 && !IsInsideListItem(lines, i))
+            // CommonMark measures a fence's indent against its *container*: at most three spaces
+            // past the content column. Beyond that it is an indented code block, where a fence is
+            // literal text — and honouring one swallowed everything to the next close, including a
+            // genuine ```csharp opener below it, which then shipped uninspected. The differential
+            // probe cannot catch that, since it derives its exclusions from this same scan.
+            var container = ContainerIndent(lines, i);
+            if (indent - container > 3)
                 continue;
 
             var fenceChar = open.Groups["fence"].Value[0];
@@ -294,7 +295,7 @@ internal static class AgentKitDocCorpus
             // Find the close first, so a non-C# fence still advances past its own body instead
             // of letting the body's contents be re-read as markdown.
             var close = i + 1;
-            while (close < lines.Length && !IsClosingFence(lines[close], fenceChar, fenceLength))
+            while (close < lines.Length && !IsClosingFence(lines[close], fenceChar, fenceLength, container))
                 close++;
 
             regions.Add(new FenceRegion(
@@ -314,17 +315,18 @@ internal static class AgentKitDocCorpus
     private static readonly Regex ListItemMarker = new(@"^(?<indent>[ \t]*)([-*+]|\d+[.)])\s", RegexOptions.Compiled);
 
     /// <summary>
-    /// True when the deeply-indented line at <paramref name="index"/> is the content of a list item
-    /// rather than an indented code block.
+    /// The content column of the innermost list item containing <paramref name="index"/>, or
+    /// <c>0</c> at top level — the indentation a fence there is measured against.
     /// </summary>
     /// <remarks>
-    /// CommonMark measures a fence's indent relative to its container, so a fence inside a list item
-    /// legitimately sits at four or more absolute spaces — but the identical indentation outside a
-    /// list is a code block, where a fence is literal text. Distinguishing them is what lets the
-    /// corpus include the two real blocks under items 10 and 11 of
-    /// <c>skills/design-docs/typography-and-colors.md</c> without also honouring a quoted fence.
+    /// CommonMark measures a fence's indent relative to its container, not absolutely. A fence
+    /// inside <c>10. </c> legitimately sits at four spaces because that is the item's content
+    /// column; the identical four spaces under <c>- </c> (content column 2) is two past the column
+    /// and still fine, while six would be four past it and therefore literal indented code. Testing
+    /// absolute indentation alone got both ends wrong: it dropped real blocks at top level and
+    /// accepted literal ones inside shallow list items.
     /// </remarks>
-    private static bool IsInsideListItem(string[] lines, int index)
+    private static int ContainerIndent(string[] lines, int index)
     {
         for (var i = index - 1; i >= 0; i--)
         {
@@ -334,15 +336,15 @@ internal static class AgentKitDocCorpus
 
             var marker = ListItemMarker.Match(line);
             if (marker.Success)
-                return true;
+                return marker.Length;   // through the marker and its trailing whitespace.
 
             // Any other line at lower indentation closes the container.
             var indent = line.Length - line.TrimStart(' ', '\t').Length;
             if (indent < 4)
-                return false;
+                return 0;
         }
 
-        return false;
+        return 0;
     }
 
     /// <summary>
@@ -390,9 +392,23 @@ internal static class AgentKitDocCorpus
         return line[strip..];
     }
 
-    private static bool IsClosingFence(string line, char fenceChar, int openLength)
+    /// <summary>
+    /// True when the line closes a fence opened with <paramref name="openLength"/> run of
+    /// <paramref name="fenceChar"/> inside a container at <paramref name="containerIndent"/>.
+    /// </summary>
+    /// <remarks>
+    /// The indentation bound matters as much as the run length. Accepting any indentation let an
+    /// indented <c>```</c> — literal text inside a C# sample, for instance in a raw string
+    /// demonstrating Markdown — truncate the block, so the rest of that sample was never scanned.
+    /// The differential probe trusts <see cref="Fences"/> for block structure, so it cannot see it.
+    /// </remarks>
+    private static bool IsClosingFence(string line, char fenceChar, int openLength, int containerIndent)
     {
         var text = line.TrimStart(' ', '\t');
+
+        if (line.Length - text.Length - containerIndent > 3)
+            return false;
+
         var run = 0;
         while (run < text.Length && text[run] == fenceChar)
             run++;

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitDocCorpus.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitDocCorpus.cs
@@ -379,7 +379,27 @@ internal static class AgentKitDocCorpus
     }
 
     /// <summary>A markdown list item marker: <c>- </c>, <c>* </c>, <c>+ </c> or <c>10. </c>.</summary>
-    private static readonly Regex ListItemMarker = new(@"^(?<indent>[ \t]*)([-*+]|\d+[.)])\s", RegexOptions.Compiled);
+    private static readonly Regex ListItemMarker = new(
+        @"^(?<indent>[ \t]*)(?<marker>[-*+]|\d+[.)])(?<pad>[ \t]+)",
+        RegexOptions.Compiled);
+
+    /// <summary>
+    /// The content column a list item establishes, per CommonMark's padding rule.
+    /// </summary>
+    /// <remarks>
+    /// One to four spaces after the marker put the content at the marker's end plus that padding —
+    /// so <c>-    item</c> has content column 5, not 2. Five or more means the item's content
+    /// starts one space after the marker and the rest is indented code within it. Consuming a
+    /// single whitespace character reported column 2 for that item and rejected a fence three
+    /// spaces past its real content column as though it were literal.
+    /// </remarks>
+    private static int ContentColumn(Match marker)
+    {
+        var beforePad = marker.Groups["indent"].Length + marker.Groups["marker"].Length;
+        var padding = marker.Groups["pad"].Length;
+
+        return beforePad + (padding <= 4 ? padding : 1);
+    }
 
     /// <summary>
     /// The content column of the innermost list item containing <paramref name="index"/>, or
@@ -403,7 +423,7 @@ internal static class AgentKitDocCorpus
 
             var marker = ListItemMarker.Match(line);
             if (marker.Success)
-                return marker.Length;   // through the marker and its trailing whitespace.
+                return ContentColumn(marker);
 
             // Only an unindented line closes the container. Comparing against a hard-coded 4 was
             // wrong because content columns are marker-dependent: in `- item` / `  explanation`,

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitDocCorpus.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitDocCorpus.cs
@@ -357,8 +357,29 @@ internal static class AgentKitDocCorpus
             // Find the close first, so a non-C# fence still advances past its own body instead
             // of letting the body's contents be re-read as markdown.
             var close = i + 1;
-            while (close < lines.Length && !IsClosingFence(lines[close], fenceChar, fenceLength, container, depth))
+            var containerExited = false;
+
+            while (close < lines.Length)
+            {
+                // A blockquoted fence also ends when its container does. Stripping *up to* the
+                // opening depth without requiring that depth to still be present let an unclosed
+                // `> ```text` swallow a following top-level ```csharp block, which then shipped
+                // unscanned — and the completeness fact derives its covered set from this same
+                // scan, so it could not have seen it. Blank lines do not end it; they are routinely
+                // written without the marker.
+                if (depth > 0
+                    && lines[close].Trim().Length > 0
+                    && BlockquoteDepth(lines[close]) < depth)
+                {
+                    containerExited = true;
+                    break;
+                }
+
+                if (IsClosingFence(lines[close], fenceChar, fenceLength, container, depth))
+                    break;
+
                 close++;
+            }
 
             regions.Add(new FenceRegion(
                 OpenLine: i + 1,
@@ -372,7 +393,9 @@ internal static class AgentKitDocCorpus
                 Indent: indent,
                 BlockquoteDepth: depth));
 
-            i = close;
+            // On container exit the terminating line belongs to whatever follows, so leave it for
+            // the outer loop to reconsider rather than consuming it as a closing fence.
+            i = containerExited ? close - 1 : close;
         }
 
         return regions;

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitDocCorpus.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitDocCorpus.cs
@@ -401,9 +401,13 @@ internal static class AgentKitDocCorpus
             if (marker.Success)
                 return marker.Length;   // through the marker and its trailing whitespace.
 
-            // Any other line at lower indentation closes the container.
+            // Only an unindented line closes the container. Comparing against a hard-coded 4 was
+            // wrong because content columns are marker-dependent: in `- item` / `  explanation`,
+            // the continuation sits at 2, so the old test read it as closing the list and measured
+            // a following fence against column 0 — rejecting a fence that is three spaces past the
+            // bullet's content column and therefore valid.
             var indent = line.Length - line.TrimStart(' ', '\t').Length;
-            if (indent < 4)
+            if (indent == 0)
                 return 0;
         }
 

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitDocCorpus.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitDocCorpus.cs
@@ -81,10 +81,13 @@ internal static class AgentKitDocCorpus
     /// rather than trusting a floor.
     /// </para>
     /// <para>
-    /// Accepting arbitrary indentation slightly over-reads: four-space text outside any list is an
-    /// indented code block, so a literal <c>```csharp</c> there is content, not a fence. That
-    /// direction is the safe one — it inspects an extra snippet rather than skipping a real one —
-    /// and the corpus contains no such construct today.
+    /// Accepting arbitrary indentation before a bare fence slightly over-reads: four-space text
+    /// outside any list is an indented code block, so a literal <c>```csharp</c> there is content,
+    /// not a fence. That direction is the safe one — it inspects an extra snippet rather than
+    /// skipping a real one — and the corpus contains no such construct today. A leading <em>list
+    /// marker</em> is different: it is container syntax, and four columns of indent make it literal
+    /// text rather than a list (<c>Md4cCommonMarkSpecTest.Example_0288</c>), so the marker is
+    /// validated against its own container below instead of being taken from the line alone.
     /// </para>
     /// </remarks>
     private static readonly Regex FenceOpen = new(
@@ -94,17 +97,19 @@ internal static class AgentKitDocCorpus
     /// <summary>
     /// A blockquote container prefix: any run of <c>&gt;</c> markers with optional spacing.
     /// </summary>
+    /// <summary>
+    /// A single blockquote level: up to three columns of indent, a <c>&gt;</c>, and optional space.
+    /// </summary>
     /// <remarks>
-    /// Fences are legal inside a blockquote, and the prefix is container syntax rather than
-    /// content. Matching only whitespace before the delimiter skipped <c>&gt; ```csharp</c>
-    /// entirely — and <see cref="CSharpFenceProbe"/> shared the restriction, so the differential
-    /// oracle stayed green while the block went uninspected. The corpus has four blockquoted
-    /// fences today, all untagged shell, so this closes the gap before a C# one appears.
+    /// Four columns is an indented code block, not a container: the repository's own CommonMark
+    /// conformance fixture pins <c>    &gt; # Foo</c> as literal <c>&gt; # Foo</c> text
+    /// (<c>Md4cCommonMarkSpecTest.Example_0230</c>). Accepting any leading whitespace stripped that
+    /// prefix and scanned the literal as a real fence, so a gated modifier quoted inside one would
+    /// have failed the gate on text that is not a sample. <see cref="CSharpFenceProbe"/> shares the
+    /// limit, or it would corroborate the same misclassification. Zero instances in the corpus
+    /// today, measured; this closes the hole before one lands.
     /// </remarks>
-    private static readonly Regex BlockquotePrefix = new(@"^(?:[ \t]*(?:>[ \t]?)+)", RegexOptions.Compiled);
-
-    /// <summary>A single blockquote level: optional indent, a <c>&gt;</c>, and optional space.</summary>
-    private static readonly Regex BlockquoteLevel = new(@"^[ \t]*>[ \t]?", RegexOptions.Compiled);
+    private static readonly Regex BlockquoteLevel = new(@"^[ ]{0,3}>[ \t]?", RegexOptions.Compiled);
 
     /// <summary>
     /// Splits a line into its blockquote container prefix and the content inside it, removing at
@@ -159,12 +164,14 @@ internal static class AgentKitDocCorpus
     /// <remarks>
     /// Deliberately a different mechanism from <see cref="FenceOpen"/> rather than a second call to
     /// it: two derivations of the same number only corroborate each other when they can fail
-    /// independently. The one structural rule it does share is the marker's padding limit — five or
-    /// more spaces after a list marker make the rest indented code rather than a fence, and a probe
-    /// that accepted those would report literal text as an unscanned sample.
+    /// independently. The structural rules it does share are the container limits: a list marker
+    /// carries at most four columns of padding and sits at most three columns past its container,
+    /// and a blockquote prefix likewise — beyond those a line is indented code rather than a
+    /// container. A probe that accepted what the scanner rejects would report literal text as an
+    /// unscanned sample and fail the completeness fact on prose.
     /// </remarks>
     internal static readonly Regex CSharpFenceProbe = new(
-        @"^(?:[ \t]*(?:>[ \t]?)+)?[ \t]*(?:([-*+]|\d+[.)])[ \t]{1,4})?(`{3,}|~{3,})[ ]*(csharp|cs|c\#)([ \t,][^\r\n]*)?$",
+        @"^(?:[ ]{0,3}(?:>[ \t]?)+)?(?:[ ]{0,3}([-*+]|\d+[.)])[ \t]{1,4}|[ \t]*)(`{3,}|~{3,})[ ]*(csharp|cs|c\#)([ \t,][^\r\n]*)?$",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
     /// <summary>
@@ -352,6 +359,14 @@ internal static class AgentKitDocCorpus
             // text, not a fence. Treating all the padding as list padding scanned it as a sample
             // and could fail the gate on prose.
             var inlineMarker = open.Groups["marker"];
+
+            // A marker four columns past its own container is indented code, not list syntax, so
+            // `    - ```csharp` at top level is literal text. Deriving the content column from the
+            // line alone read it as a list item and scanned the literal as a sample, which can fail
+            // the gate on quoted prose. Validate the marker against its container first.
+            if (inlineMarker.Success && indent - ContainerIndent(lines, i) > 3)
+                continue;
+
             var container = inlineMarker.Success
                 ? ContentColumn(open)
                 : ContainerIndent(lines, i);

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitDocCorpus.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitDocCorpus.cs
@@ -233,6 +233,57 @@ internal static class AgentKitDocCorpus
     }
 
     /// <summary>
+    /// One fenced block found in a markdown document, C# or not.
+    /// </summary>
+    /// <param name="BodyStartLine">1-based first line of the body.</param>
+    /// <param name="BodyEndLine">1-based last line of the body; less than
+    /// <paramref name="BodyStartLine"/> for an empty block.</param>
+    internal readonly record struct FenceRegion(int OpenLine, int BodyStartLine, int BodyEndLine, string Language, int Indent);
+
+    /// <summary>
+    /// Every fenced block in a markdown document, in source order, whatever its language.
+    /// </summary>
+    /// <remarks>
+    /// The single fence scanner. <see cref="ExtractFences"/> filters this to C#, and the
+    /// independent-probe fact uses the full list to know which lines are inside <em>some</em>
+    /// block — a <c>```csharp</c> quoted as literal text inside a <c>```text</c> block is content,
+    /// not a block the extractor skipped. Deriving both from one scan is what keeps them from
+    /// disagreeing about where blocks begin and end.
+    /// </remarks>
+    internal static IReadOnlyList<FenceRegion> Fences(string markdown)
+    {
+        var lines = markdown.Replace("\r\n", "\n").Split('\n');
+        var regions = new List<FenceRegion>();
+
+        for (var i = 0; i < lines.Length; i++)
+        {
+            var open = FenceOpen.Match(lines[i]);
+            if (!open.Success)
+                continue;
+
+            var fenceChar = open.Groups["fence"].Value[0];
+            var fenceLength = open.Groups["fence"].Value.Length;
+
+            // Find the close first, so a non-C# fence still advances past its own body instead
+            // of letting the body's contents be re-read as markdown.
+            var close = i + 1;
+            while (close < lines.Length && !IsClosingFence(lines[close], fenceChar, fenceLength))
+                close++;
+
+            regions.Add(new FenceRegion(
+                OpenLine: i + 1,
+                BodyStartLine: i + 2,
+                BodyEndLine: close,          // 1-based last body line; == i+1 when empty.
+                Language: open.Groups["info"].Value.Trim().Split(' ', ',')[0],
+                Indent: open.Groups["indent"].Value.Length));
+
+            i = close;
+        }
+
+        return regions;
+    }
+
+    /// <summary>
     /// Pulls the C# fenced blocks out of one markdown document.
     /// </summary>
     /// <remarks>
@@ -246,37 +297,18 @@ internal static class AgentKitDocCorpus
     internal static IReadOnlyList<AgentKitSnippet> ExtractFences(string path, string markdown)
     {
         var lines = markdown.Replace("\r\n", "\n").Split('\n');
-        var snippets = new List<AgentKitSnippet>();
 
-        for (var i = 0; i < lines.Length; i++)
-        {
-            var open = FenceOpen.Match(lines[i]);
-            if (!open.Success)
-                continue;
-
-            var fenceChar = open.Groups["fence"].Value[0];
-            var fenceLength = open.Groups["fence"].Value.Length;
-            var indent = open.Groups["indent"].Value.Length;
-            var language = open.Groups["info"].Value.Trim().Split(' ', ',')[0];
-
-            // Find the close first, so a non-C# fence still advances past its own body instead
-            // of letting the body's contents be re-read as markdown.
-            var close = i + 1;
-            while (close < lines.Length && !IsClosingFence(lines[close], fenceChar, fenceLength))
-                close++;
-
-            if (CSharpFenceLanguages.Contains(language, StringComparer.OrdinalIgnoreCase) && close > i + 1)
-            {
-                snippets.Add(new AgentKitSnippet(
-                    path,
-                    i + 2,  // 1-based, and the body starts on the line after the fence.
-                    string.Join("\n", lines[(i + 1)..close].Select(line => StripIndent(line, indent)))));
-            }
-
-            i = close;
-        }
-
-        return snippets;
+        return Fences(markdown)
+            .Where(region => CSharpFenceLanguages.Contains(region.Language, StringComparer.OrdinalIgnoreCase)
+                             && region.BodyEndLine >= region.BodyStartLine)
+            .Select(region => new AgentKitSnippet(
+                path,
+                region.BodyStartLine,
+                string.Join(
+                    "\n",
+                    lines[(region.BodyStartLine - 1)..(region.BodyEndLine - 1 + 1)]
+                        .Select(line => StripIndent(line, region.Indent)))))
+            .ToList();
     }
 
     /// <summary>
@@ -349,7 +381,7 @@ internal static class AgentKitDocCorpus
 /// </summary>
 /// <remarks>
 /// <para>
-/// Reading 63 documents and parsing 374 snippets is not free, and every fact over the agent kit
+/// Reading 63 documents and parsing 376 snippets is not free, and every fact over the agent kit
 /// wants the same answer. Recomputing it per fact ran the scan three times concurrently — xUnit
 /// runs test classes in parallel — and the resulting CPU spike intermittently blew the wall-clock
 /// budget in <c>CompilationLoaderTests.Cold_load_under_500ms_warm_under_50ms_for_minimal_project</c>,

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitDocCorpus.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitDocCorpus.cs
@@ -101,6 +101,33 @@ internal static class AgentKitDocCorpus
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
     /// <summary>
+    /// The <c>PackagePath</c> of every <c>&lt;None&gt;</c> item in a project that ships under
+    /// <c>agentkit/</c> — the selection predicate <see cref="PackEntries"/> uses, exposed so it can
+    /// be tested against project XML directly rather than only through the working tree.
+    /// </summary>
+    internal static IReadOnlyList<string> AgentKitPackagePaths(string projectXml) =>
+        XDocument.Parse(projectXml)
+            .Descendants()
+            .Where(e => e.Name.LocalName == "None")
+            .Select(e => (Path: (string?)e.Attribute("PackagePath"), Include: (string?)e.Attribute("Include")))
+            .Where(item => item.Path is not null && item.Include is not null && IsAgentKitPath(item.Path))
+            .Select(item => item.Path!)
+            .ToList();
+
+    /// <summary>
+    /// True when an item's <c>PackagePath</c> puts it under <c>agentkit/</c>.
+    /// </summary>
+    /// <remarks>
+    /// NuGet accepts either separator, and this very project uses backslashes elsewhere
+    /// (<c>Reactor.csproj</c> packs <c>lib\$(TargetFramework)\Reactor\Hosting\</c>). An agentkit
+    /// item written that way would ship and simply never enter this corpus — and because the entry
+    /// is dropped whole, the unmatched-glob guard could not see the gap either. Normalising is what
+    /// keeps "packed" and "inspected" the same set.
+    /// </remarks>
+    private static bool IsAgentKitPath(string packagePath) =>
+        packagePath.Replace('\\', '/').StartsWith(AgentKitPrefix, StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
     /// Every <c>&lt;None&gt;</c> item packed under <c>agentkit/</c>, in declaration order, with
     /// its glob expanded against the working tree.
     /// </summary>
@@ -121,8 +148,10 @@ internal static class AgentKitDocCorpus
             var packagePath = (string?)none.Attribute("PackagePath");
             var include = (string?)none.Attribute("Include");
 
-            if (packagePath is null || include is null
-                || !packagePath.StartsWith(AgentKitPrefix, StringComparison.Ordinal))
+            if (packagePath is null || include is null)
+                continue;
+
+            if (!IsAgentKitPath(packagePath))
                 continue;
 
             var files = new List<string>();

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitDocCorpus.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitDocCorpus.cs
@@ -104,7 +104,7 @@ internal static class AgentKitDocCorpus
     private static readonly Regex BlockquotePrefix = new(@"^(?:[ \t]*(?:>[ \t]?)+)", RegexOptions.Compiled);
 
     /// <summary>Splits a line into its blockquote container prefix and the content inside it.</summary>
-    private static (int PrefixLength, string Content) StripBlockquote(string line)
+    internal static (int PrefixLength, string Content) StripBlockquote(string line)
     {
         var match = BlockquotePrefix.Match(line);
         return match.Success && match.Length > 0 ? (match.Length, line[match.Length..]) : (0, line);

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitDocCorpus.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitDocCorpus.cs
@@ -58,13 +58,47 @@ internal static class AgentKitDocCorpus
     private static readonly string[] CSharpFenceLanguages = { "csharp", "cs", "c#" };
 
     /// <summary>
-    /// Opening fence: at least three backticks or tildes, then an optional info string. The
-    /// closing fence must use the same character and be at least as long, per CommonMark, which
-    /// is what keeps a nested <c>```</c> inside a longer fence from ending the block early.
+    /// Opening fence: any leading whitespace, then at least three backticks or tildes, then an
+    /// optional info string. The closing fence must use the same character and be at least as
+    /// long, per CommonMark, which is what keeps a nested <c>```</c> inside a longer fence from
+    /// ending the block early.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>Indentation is not capped at 3.</b> CommonMark measures a fence's indent relative to its
+    /// <em>container</em>, so a fence inside a numbered list item legitimately sits at four or more
+    /// absolute spaces — <c>skills/design-docs/typography-and-colors.md</c> has two such blocks
+    /// under list items 10 and 11. Capping at 3 silently dropped them from the corpus, and the
+    /// aggregate snippet floor stayed green because the other 370-odd blocks more than covered it:
+    /// a gate that inspects less than it claims, which is the failure mode issue #1121 exists to
+    /// prevent. <c>Every_CSharp_Fence_In_The_Corpus_Is_Extracted</c> now measures this directly
+    /// rather than trusting a floor.
+    /// </para>
+    /// <para>
+    /// Accepting arbitrary indentation slightly over-reads: four-space text outside any list is an
+    /// indented code block, so a literal <c>```csharp</c> there is content, not a fence. That
+    /// direction is the safe one — it inspects an extra snippet rather than skipping a real one —
+    /// and the corpus contains no such construct today.
+    /// </para>
+    /// </remarks>
     private static readonly Regex FenceOpen = new(
-        @"^(?<indent>[ ]{0,3})(?<fence>`{3,}|~{3,})[ ]*(?<info>[^`\r\n]*)$",
+        @"^(?<indent>[ \t]*)(?<fence>`{3,}|~{3,})[ ]*(?<info>[^`\r\n]*)$",
         RegexOptions.Compiled);
+
+    /// <summary>
+    /// An opening C# fence, found with no regard for indentation or for surrounding block
+    /// structure — the independent probe
+    /// <c>AgentKitDocGateInstrumentTests.Every_CSharp_Fence_In_The_Corpus_Is_Extracted</c> measures
+    /// <see cref="ExtractFences"/> against.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately a different mechanism from <see cref="FenceOpen"/> rather than a second call to
+    /// it: two derivations of the same number only corroborate each other when they can fail
+    /// independently.
+    /// </remarks>
+    internal static readonly Regex CSharpFenceProbe = new(
+        @"^[ \t]*(`{3,}|~{3,})[ ]*(csharp|cs|c\#)[ ]*$",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
     /// <summary>
     /// Every <c>&lt;None&gt;</c> item packed under <c>agentkit/</c>, in declaration order, with
@@ -155,8 +189,9 @@ internal static class AgentKitDocCorpus
     /// Hand-rolled rather than routed through the repo's markdown parser: this needs the
     /// <em>source line number</em> of each fence so a finding can be reported at
     /// <c>path:line</c>, and it must run on documents that are not otherwise parsed at build
-    /// time. The rules implemented are the two that matter for fence extraction — same fence
-    /// character, closing run at least as long as the opening run.
+    /// time. The rules implemented are the three that matter for fence extraction — same fence
+    /// character, closing run at least as long as the opening run, and the opening fence's
+    /// indentation stripped from the body.
     /// </remarks>
     internal static IReadOnlyList<AgentKitSnippet> ExtractFences(string path, string markdown)
     {
@@ -171,6 +206,7 @@ internal static class AgentKitDocCorpus
 
             var fenceChar = open.Groups["fence"].Value[0];
             var fenceLength = open.Groups["fence"].Value.Length;
+            var indent = open.Groups["indent"].Value.Length;
             var language = open.Groups["info"].Value.Trim().Split(' ', ',')[0];
 
             // Find the close first, so a non-C# fence still advances past its own body instead
@@ -184,7 +220,7 @@ internal static class AgentKitDocCorpus
                 snippets.Add(new AgentKitSnippet(
                     path,
                     i + 2,  // 1-based, and the body starts on the line after the fence.
-                    string.Join("\n", lines[(i + 1)..close])));
+                    string.Join("\n", lines[(i + 1)..close].Select(line => StripIndent(line, indent)))));
             }
 
             i = close;
@@ -193,9 +229,26 @@ internal static class AgentKitDocCorpus
         return snippets;
     }
 
+    /// <summary>
+    /// Removes up to <paramref name="indent"/> leading whitespace characters, which is how
+    /// CommonMark un-nests a fenced block from its list container.
+    /// </summary>
+    /// <remarks>
+    /// C# is whitespace-insensitive, so this changes no verdict — it exists so a reported snippet
+    /// reads the way the document's author wrote it rather than carrying its list indentation.
+    /// </remarks>
+    private static string StripIndent(string line, int indent)
+    {
+        var strip = 0;
+        while (strip < indent && strip < line.Length && (line[strip] == ' ' || line[strip] == '\t'))
+            strip++;
+
+        return line[strip..];
+    }
+
     private static bool IsClosingFence(string line, char fenceChar, int openLength)
     {
-        var text = line.TrimStart(' ');
+        var text = line.TrimStart(' ', '\t');
         var run = 0;
         while (run < text.Length && text[run] == fenceChar)
             run++;

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitDocCorpus.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitDocCorpus.cs
@@ -1,0 +1,287 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Xml.Linq;
+using Microsoft.UI.Reactor.Cli.Pack;
+
+namespace Microsoft.UI.Reactor.Tests.AnalyzerTests;
+
+/// <summary>
+/// One <c>&lt;None&gt;</c> item from <c>src/Reactor/Reactor.csproj</c> that packs into
+/// <c>agentkit/</c>, resolved to the files it actually matches on disk.
+/// </summary>
+internal sealed record AgentKitPackEntry(string Include, string PackagePath, IReadOnlyList<string> Files);
+
+/// <summary>
+/// One unit of C# taken from a shipped agent-kit document: a fenced block from a
+/// <c>.md</c>, or the whole text of a packed <c>.cs</c>.
+/// </summary>
+/// <param name="Path">Repo-relative path, forward-slashed, so failures name the file a
+/// reader can open.</param>
+/// <param name="StartLine">1-based line in <paramref name="Path"/> that
+/// <paramref name="Text"/> starts on, so a syntax offset can be turned back into a real
+/// line number.</param>
+internal sealed record AgentKitSnippet(string Path, int StartLine, string Text);
+
+/// <summary>
+/// The set of documents <c>Microsoft.UI.Reactor.nupkg</c> ships to consumers under
+/// <c>agentkit/</c>, and the C# they contain.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Derived, never hardcoded.</b> The corpus is read out of the <c>&lt;None&gt;</c> items in
+/// <c>src/Reactor/Reactor.csproj</c> whose <c>PackagePath</c> starts with <c>agentkit/</c>.
+/// That is the same list the pack target consumes, so a skill folder added to the package is
+/// covered by every fact built on this type the moment it is packed — which is the whole point
+/// of issue #1121, whose complaint is that the <em>next</em> divergence would land unnoticed.
+/// A hand-maintained path list would reproduce the defect one level up.
+/// </para>
+/// <para>
+/// Only file reads happen here; nothing is compiled and no WinUI type is touched, so this is
+/// safe in the headless <c>Reactor.Tests</c> host.
+/// </para>
+/// </remarks>
+internal static class AgentKitDocCorpus
+{
+    /// <summary>The package path prefix that marks an item as shipped agent guidance.</summary>
+    private const string AgentKitPrefix = "agentkit/";
+
+    /// <summary>
+    /// Fence languages that mean "this is Reactor C#". Markdown in this repo uses
+    /// <c>```csharp</c> almost exclusively; <c>cs</c> is accepted because it is the other
+    /// spelling a contributor reaches for and silently skipping it would shrink the corpus
+    /// without saying so.
+    /// </summary>
+    private static readonly string[] CSharpFenceLanguages = { "csharp", "cs", "c#" };
+
+    /// <summary>
+    /// Opening fence: at least three backticks or tildes, then an optional info string. The
+    /// closing fence must use the same character and be at least as long, per CommonMark, which
+    /// is what keeps a nested <c>```</c> inside a longer fence from ending the block early.
+    /// </summary>
+    private static readonly Regex FenceOpen = new(
+        @"^(?<indent>[ ]{0,3})(?<fence>`{3,}|~{3,})[ ]*(?<info>[^`\r\n]*)$",
+        RegexOptions.Compiled);
+
+    /// <summary>
+    /// Every <c>&lt;None&gt;</c> item packed under <c>agentkit/</c>, in declaration order, with
+    /// its glob expanded against the working tree.
+    /// </summary>
+    /// <remarks>
+    /// Entries whose glob matches nothing are returned with an empty <see cref="AgentKitPackEntry.Files"/>
+    /// rather than dropped: a folder that was renamed without updating the csproj stops shipping
+    /// silently, and a caller that never sees the entry cannot report it.
+    /// </remarks>
+    public static IReadOnlyList<AgentKitPackEntry> PackEntries(string repoRoot)
+    {
+        var projectDirectory = Path.Combine(repoRoot, "src", "Reactor");
+        var project = XDocument.Load(Path.Combine(projectDirectory, "Reactor.csproj"));
+
+        var entries = new List<AgentKitPackEntry>();
+
+        foreach (var none in project.Descendants().Where(e => e.Name.LocalName == "None"))
+        {
+            var packagePath = (string?)none.Attribute("PackagePath");
+            var include = (string?)none.Attribute("Include");
+
+            if (packagePath is null || include is null
+                || !packagePath.StartsWith(AgentKitPrefix, StringComparison.Ordinal))
+                continue;
+
+            var files = new List<string>();
+
+            foreach (var pattern in include.Split(';', StringSplitOptions.RemoveEmptyEntries))
+            {
+                foreach (var file in Expand(projectDirectory, pattern.Trim()))
+                    files.Add(file);
+            }
+
+            entries.Add(new AgentKitPackEntry(
+                include,
+                packagePath,
+                files.Distinct(StringComparer.OrdinalIgnoreCase).OrderBy(f => f, StringComparer.Ordinal).ToList()));
+        }
+
+        return entries;
+    }
+
+    /// <summary>
+    /// Every packed agent-kit file, repo-relative and forward-slashed.
+    /// </summary>
+    public static IReadOnlyList<string> Documents(string repoRoot) =>
+        PackEntries(repoRoot)
+            .SelectMany(entry => entry.Files)
+            .Select(file => Relative(repoRoot, file))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(path => path, StringComparer.Ordinal)
+            .ToList();
+
+    /// <summary>
+    /// Every unit of C# in the packed corpus: fenced blocks from <c>.md</c>, whole files from
+    /// packed <c>.cs</c>.
+    /// </summary>
+    /// <remarks>
+    /// Non-C# packed artifacts (<c>plugin.json</c>, <c>reactor.api.txt</c>) contribute nothing
+    /// and are simply absent from the result — they carry no samples to be wrong about.
+    /// </remarks>
+    public static IReadOnlyList<AgentKitSnippet> Snippets(string repoRoot)
+    {
+        var snippets = new List<AgentKitSnippet>();
+
+        foreach (var file in PackEntries(repoRoot).SelectMany(entry => entry.Files).Distinct(StringComparer.OrdinalIgnoreCase))
+        {
+            var extension = Path.GetExtension(file);
+            var relative = Relative(repoRoot, file);
+
+            if (extension.Equals(".md", StringComparison.OrdinalIgnoreCase))
+                snippets.AddRange(ExtractFences(relative, File.ReadAllText(file)));
+            else if (extension.Equals(".cs", StringComparison.OrdinalIgnoreCase))
+                snippets.Add(new AgentKitSnippet(relative, 1, File.ReadAllText(file)));
+        }
+
+        return snippets
+            .OrderBy(s => s.Path, StringComparer.Ordinal)
+            .ThenBy(s => s.StartLine)
+            .ToList();
+    }
+
+    /// <summary>
+    /// Pulls the C# fenced blocks out of one markdown document.
+    /// </summary>
+    /// <remarks>
+    /// Hand-rolled rather than routed through the repo's markdown parser: this needs the
+    /// <em>source line number</em> of each fence so a finding can be reported at
+    /// <c>path:line</c>, and it must run on documents that are not otherwise parsed at build
+    /// time. The rules implemented are the two that matter for fence extraction — same fence
+    /// character, closing run at least as long as the opening run.
+    /// </remarks>
+    internal static IReadOnlyList<AgentKitSnippet> ExtractFences(string path, string markdown)
+    {
+        var lines = markdown.Replace("\r\n", "\n").Split('\n');
+        var snippets = new List<AgentKitSnippet>();
+
+        for (var i = 0; i < lines.Length; i++)
+        {
+            var open = FenceOpen.Match(lines[i]);
+            if (!open.Success)
+                continue;
+
+            var fenceChar = open.Groups["fence"].Value[0];
+            var fenceLength = open.Groups["fence"].Value.Length;
+            var language = open.Groups["info"].Value.Trim().Split(' ', ',')[0];
+
+            // Find the close first, so a non-C# fence still advances past its own body instead
+            // of letting the body's contents be re-read as markdown.
+            var close = i + 1;
+            while (close < lines.Length && !IsClosingFence(lines[close], fenceChar, fenceLength))
+                close++;
+
+            if (CSharpFenceLanguages.Contains(language, StringComparer.OrdinalIgnoreCase) && close > i + 1)
+            {
+                snippets.Add(new AgentKitSnippet(
+                    path,
+                    i + 2,  // 1-based, and the body starts on the line after the fence.
+                    string.Join("\n", lines[(i + 1)..close])));
+            }
+
+            i = close;
+        }
+
+        return snippets;
+    }
+
+    private static bool IsClosingFence(string line, char fenceChar, int openLength)
+    {
+        var text = line.TrimStart(' ');
+        var run = 0;
+        while (run < text.Length && text[run] == fenceChar)
+            run++;
+
+        return run >= openLength && text[run..].Trim().Length == 0;
+    }
+
+    /// <summary>
+    /// Expands one MSBuild <c>Include</c> pattern relative to <c>src/Reactor</c>. The agent-kit
+    /// items use only <c>dir\*.ext</c> and <c>dir\*</c> — no <c>**</c> — so this handles a
+    /// literal path and a single-directory glob and deliberately nothing else: a pattern shape
+    /// this does not understand returns nothing, and the "every glob matches a file" fact then
+    /// fails loudly instead of quietly shrinking the corpus.
+    /// </summary>
+    private static IEnumerable<string> Expand(string projectDirectory, string pattern)
+    {
+        var normalized = pattern.Replace('\\', Path.DirectorySeparatorChar).Replace('/', Path.DirectorySeparatorChar);
+        var full = Path.GetFullPath(Path.Combine(projectDirectory, normalized));
+
+        var fileName = Path.GetFileName(full);
+        var directory = Path.GetDirectoryName(full);
+
+        if (directory is null || !Directory.Exists(directory))
+            return Array.Empty<string>();
+
+        if (!fileName.Contains('*') && !fileName.Contains('?'))
+            return File.Exists(full) ? new[] { full } : Array.Empty<string>();
+
+        return Directory.EnumerateFiles(directory, fileName, SearchOption.TopDirectoryOnly);
+    }
+
+    private static string Relative(string repoRoot, string file) =>
+        Path.GetRelativePath(repoRoot, file).Replace('\\', '/');
+
+    /// <summary>Locates the repository root, failing with a usable message rather than a null deref.</summary>
+    public static string RepoRoot()
+    {
+        var root = RepoRootFinder.FindRepoRoot();
+        if (root is null)
+            throw new InvalidOperationException("Could not locate the repository root from " + AppContext.BaseDirectory);
+
+        return root;
+    }
+}
+
+/// <summary>
+/// The corpus and its scan, computed once per test process.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Reading 63 documents and parsing 374 snippets is not free, and every fact over the agent kit
+/// wants the same answer. Recomputing it per fact ran the scan three times concurrently — xUnit
+/// runs test classes in parallel — and the resulting CPU spike intermittently blew the wall-clock
+/// budget in <c>CompilationLoaderTests.Cold_load_under_500ms_warm_under_50ms_for_minimal_project</c>,
+/// a test with nothing to do with any of this. Sharing one lazy scan removes the spike at its
+/// source rather than widening someone else's budget to absorb it.
+/// </para>
+/// <para>
+/// Caching is sound because nothing in the suite writes to the shipped documents; the corpus is
+/// fixed for the life of the process.
+/// </para>
+/// </remarks>
+internal static class AgentKitCorpus
+{
+    private static readonly Lazy<string> LazyRepoRoot =
+        new(AgentKitDocCorpus.RepoRoot, LazyThreadSafetyMode.ExecutionAndPublication);
+
+    private static readonly Lazy<IReadOnlyList<AgentKitPackEntry>> LazyPackEntries =
+        new(() => AgentKitDocCorpus.PackEntries(RepoRoot), LazyThreadSafetyMode.ExecutionAndPublication);
+
+    private static readonly Lazy<IReadOnlyList<string>> LazyDocuments =
+        new(() => AgentKitDocCorpus.Documents(RepoRoot), LazyThreadSafetyMode.ExecutionAndPublication);
+
+    private static readonly Lazy<IReadOnlyList<AgentKitSnippet>> LazySnippets =
+        new(() => AgentKitDocCorpus.Snippets(RepoRoot), LazyThreadSafetyMode.ExecutionAndPublication);
+
+    private static readonly Lazy<AgentKitScan> LazyScan =
+        new(() => AgentKitSnippetWalker.Scan(Snippets), LazyThreadSafetyMode.ExecutionAndPublication);
+
+    public static string RepoRoot => LazyRepoRoot.Value;
+
+    public static IReadOnlyList<AgentKitPackEntry> PackEntries => LazyPackEntries.Value;
+
+    public static IReadOnlyList<string> Documents => LazyDocuments.Value;
+
+    public static IReadOnlyList<AgentKitSnippet> Snippets => LazySnippets.Value;
+
+    public static AgentKitScan Scan => LazyScan.Value;
+}

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitDocCorpus.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitDocCorpus.cs
@@ -134,7 +134,7 @@ internal static class AgentKitDocCorpus
     }
 
     /// <summary>Number of blockquote levels a line opens with.</summary>
-    private static int BlockquoteDepth(string line)
+    internal static int BlockquoteDepth(string line)
     {
         var offset = 0;
         var depth = 0;

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitDocCorpus.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitDocCorpus.cs
@@ -88,7 +88,7 @@ internal static class AgentKitDocCorpus
     /// </para>
     /// </remarks>
     private static readonly Regex FenceOpen = new(
-        @"^(?<indent>[ \t]*)(?<marker>([-*+]|\d+[.)])[ \t]+)?(?<fence>`{3,}|~{3,})[ ]*(?<info>[^`\r\n]*)$",
+        @"^(?<indent>[ \t]*)((?<marker>[-*+]|\d+[.)])(?<pad>[ \t]+))?(?<fence>`{3,}|~{3,})[ ]*(?<info>[^`\r\n]*)$",
         RegexOptions.Compiled);
 
     /// <summary>
@@ -159,10 +159,12 @@ internal static class AgentKitDocCorpus
     /// <remarks>
     /// Deliberately a different mechanism from <see cref="FenceOpen"/> rather than a second call to
     /// it: two derivations of the same number only corroborate each other when they can fail
-    /// independently.
+    /// independently. The one structural rule it does share is the marker's padding limit — five or
+    /// more spaces after a list marker make the rest indented code rather than a fence, and a probe
+    /// that accepted those would report literal text as an unscanned sample.
     /// </remarks>
     internal static readonly Regex CSharpFenceProbe = new(
-        @"^(?:[ \t]*(?:>[ \t]?)+)?[ \t]*(?:([-*+]|\d+[.)])[ \t]+)?(`{3,}|~{3,})[ ]*(csharp|cs|c\#)([ \t,][^\r\n]*)?$",
+        @"^(?:[ \t]*(?:>[ \t]?)+)?[ \t]*(?:([-*+]|\d+[.)])[ \t]{1,4})?(`{3,}|~{3,})[ ]*(csharp|cs|c\#)([ \t,][^\r\n]*)?$",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
     /// <summary>
@@ -344,13 +346,24 @@ internal static class AgentKitDocCorpus
 
             // A fence may open as the content of a list item on the marker's own line
             // (`- ```csharp`). The marker establishes the content column, so measure — and strip —
-            // against that rather than the line's leading whitespace.
+            // against that rather than the line's leading whitespace. The column follows the same
+            // padding rule as an ordinary item: five or more spaces after the marker put content
+            // one space along and make the rest indented code, so `-     ```csharp` is literal
+            // text, not a fence. Treating all the padding as list padding scanned it as a sample
+            // and could fail the gate on prose.
             var inlineMarker = open.Groups["marker"];
             var container = inlineMarker.Success
-                ? indent + inlineMarker.Length
+                ? ContentColumn(open)
                 : ContainerIndent(lines, i);
 
-            if (!inlineMarker.Success && indent - container > 3)
+            // Where the fence characters actually start. Equal to the line's indentation unless a
+            // marker precedes them, and what the three-column limit and body de-indentation are
+            // both measured with.
+            var fenceColumn = inlineMarker.Success
+                ? indent + inlineMarker.Length + open.Groups["pad"].Length
+                : indent;
+
+            if (fenceColumn - container > 3)
                 continue;
 
             var fenceChar = open.Groups["fence"].Value[0];
@@ -392,7 +405,7 @@ internal static class AgentKitDocCorpus
                 // the nearest list above the line, which for a block that has already de-indented
                 // out of the list is a container it is not in; applying the rule there ended the
                 // region on its own first body line and emptied it.
-                if (container > 0 && indent >= container)
+                if (container > 0 && fenceColumn >= container)
                 {
                     var outside = StripBlockquote(lines[close], depth).Content;
                     if (outside.Trim().Length > 0 && LeadingWidth(outside) < container)
@@ -414,9 +427,10 @@ internal static class AgentKitDocCorpus
                 // whole run as the language, so the body never reached the gate — and the probe
                 // accepted only spaces too, so the completeness fact stayed green over it.
                 Language: open.Groups["info"].Value.Trim().Split(' ', '\t', ',')[0],
-                // Body lines have the opening fence's own offset removed. For an inline marker that
-                // offset includes the marker; otherwise it is just the leading whitespace.
-                Indent: inlineMarker.Success ? container : indent,
+                // Body lines have the opening fence's own offset removed, which for a fence opened
+                // on a list marker's line is the column the fence characters start at, not the
+                // line's leading whitespace.
+                Indent: fenceColumn,
                 BlockquoteDepth: depth));
 
             // On container exit the terminating line belongs to whatever follows, so leave it for

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitDocCorpus.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitDocCorpus.cs
@@ -171,7 +171,7 @@ internal static class AgentKitDocCorpus
     /// unscanned sample and fail the completeness fact on prose.
     /// </remarks>
     internal static readonly Regex CSharpFenceProbe = new(
-        @"^(?:[ ]{0,3}(?:>[ \t]?)+)?(?:[ ]{0,3}([-*+]|\d+[.)])[ \t]{1,4}|[ \t]*)(`{3,}|~{3,})[ ]*(csharp|cs|c\#)([ \t,][^\r\n]*)?$",
+        @"^(?:[ ]{0,3}(?:>[ \t]?)+)?(?:[ ]{0,3}([-*+]|\d+[.)])[ \t]{1,4}|[ ]*)(`{3,}|~{3,})[ ]*(csharp|cs|c\#)([ \t,][^\r\n]*)?$",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
     /// <summary>
@@ -349,7 +349,7 @@ internal static class AgentKitDocCorpus
             if (!open.Success)
                 continue;
 
-            var indent = open.Groups["indent"].Value.Length;
+            var indent = VisualWidth(open.Groups["indent"].Value);
 
             // A fence may open as the content of a list item on the marker's own line
             // (`- ```csharp`). The marker establishes the content column, so measure — and strip —
@@ -375,7 +375,7 @@ internal static class AgentKitDocCorpus
             // marker precedes them, and what the three-column limit and body de-indentation are
             // both measured with.
             var fenceColumn = inlineMarker.Success
-                ? indent + inlineMarker.Length + open.Groups["pad"].Length
+                ? indent + inlineMarker.Length + VisualWidth(open.Groups["pad"].Value)
                 : indent;
 
             if (fenceColumn - container > 3)
@@ -462,14 +462,30 @@ internal static class AgentKitDocCorpus
         RegexOptions.Compiled);
 
     /// <summary>
-    /// Width of a line's leading whitespace, counting a tab as one column.
+    /// Visual width of a run of leading whitespace, with tabs advancing to four-column tab stops.
     /// </summary>
     /// <remarks>
-    /// One column per character is what every other measurement here uses — the indent groups are
-    /// <c>[ \t]*</c> matched by length — so widths stay comparable across the scanner.
+    /// The block rules this scanner implements are stated in columns, and CommonMark advances a tab
+    /// to the next multiple of four (<c>Md4cFixtures/spec.txt</c>, "Tabs"). Counting one column per
+    /// character made a single leading tab measure 1, so a tab-indented <c>```csharp</c> at top
+    /// level read as a fence when it is really an indented code block — the gate could then fail on
+    /// quoted, code-like prose. Every indentation measurement here goes through this.
     /// </remarks>
+    private static int VisualWidth(string whitespace)
+    {
+        var column = 0;
+
+        foreach (var c in whitespace)
+            column = c == '\t' ? (column / 4 * 4) + 4 : column + 1;
+
+        return column;
+    }
+
+    /// <summary>
+    /// Width of a line's leading whitespace in columns.
+    /// </summary>
     private static int LeadingWidth(string line) =>
-        line.Length - line.TrimStart(' ', '\t').Length;
+        VisualWidth(line[..(line.Length - line.TrimStart(' ', '\t').Length)]);
 
     /// <summary>
     /// A line with any leading list marker removed, leaving the item's content.
@@ -499,8 +515,8 @@ internal static class AgentKitDocCorpus
     /// </remarks>
     private static int ContentColumn(Match marker)
     {
-        var beforePad = marker.Groups["indent"].Length + marker.Groups["marker"].Length;
-        var padding = marker.Groups["pad"].Length;
+        var beforePad = VisualWidth(marker.Groups["indent"].Value) + marker.Groups["marker"].Length;
+        var padding = VisualWidth(marker.Groups["pad"].Value);
 
         return beforePad + (padding <= 4 ? padding : 1);
     }

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitDocCorpus.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitDocCorpus.cs
@@ -375,7 +375,7 @@ internal static class AgentKitDocCorpus
             // marker precedes them, and what the three-column limit and body de-indentation are
             // both measured with.
             var fenceColumn = inlineMarker.Success
-                ? indent + inlineMarker.Length + VisualWidth(open.Groups["pad"].Value)
+                ? indent + inlineMarker.Length + VisualWidth(open.Groups["pad"].Value, indent + inlineMarker.Length)
                 : indent;
 
             if (fenceColumn - container > 3)
@@ -471,14 +471,20 @@ internal static class AgentKitDocCorpus
     /// level read as a fence when it is really an indented code block — the gate could then fail on
     /// quoted, code-like prose. Every indentation measurement here goes through this.
     /// </remarks>
-    private static int VisualWidth(string whitespace)
+    /// <remarks>
+    /// The width a tab contributes depends on where it starts, so a run measured mid-line must say
+    /// where: in <c>10.\t```csharp</c> the tab advances from column 3 to 4 and is worth one column,
+    /// not four. Measuring it from zero put the content column at 7 and read the block's own body
+    /// as having left the list.
+    /// </remarks>
+    private static int VisualWidth(string whitespace, int startColumn = 0)
     {
-        var column = 0;
+        var column = startColumn;
 
         foreach (var c in whitespace)
             column = c == '\t' ? (column / 4 * 4) + 4 : column + 1;
 
-        return column;
+        return column - startColumn;
     }
 
     /// <summary>
@@ -516,7 +522,7 @@ internal static class AgentKitDocCorpus
     private static int ContentColumn(Match marker)
     {
         var beforePad = VisualWidth(marker.Groups["indent"].Value) + marker.Groups["marker"].Length;
-        var padding = VisualWidth(marker.Groups["pad"].Value);
+        var padding = VisualWidth(marker.Groups["pad"].Value, beforePad);
 
         return beforePad + (padding <= 4 ? padding : 1);
     }

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitDocCorpus.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitDocCorpus.cs
@@ -612,13 +612,16 @@ internal static class AgentKitDocCorpus
     /// indented <c>```</c> — literal text inside a C# sample, for instance in a raw string
     /// demonstrating Markdown — truncate the block, so the rest of that sample was never scanned.
     /// The differential probe trusts <see cref="Fences"/> for block structure, so it cannot see it.
+    /// Measured in visual columns like every other indentation here: counting characters made a
+    /// leading tab worth 1, so a tab-indented <c>```</c> closed a top-level block three columns
+    /// early and everything after it in that sample went unscanned.
     /// </remarks>
     private static bool IsClosingFence(string rawLine, char fenceChar, int openLength, int containerIndent, int blockquoteDepth)
     {
         var line = StripBlockquote(rawLine, blockquoteDepth).Content;
         var text = line.TrimStart(' ', '\t');
 
-        if (line.Length - text.Length - containerIndent > 3)
+        if (VisualWidth(line[..(line.Length - text.Length)]) - containerIndent > 3)
             return false;
 
         var run = 0;

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitDocCorpus.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitDocCorpus.cs
@@ -124,10 +124,27 @@ internal static class AgentKitDocCorpus
         XDocument.Parse(projectXml)
             .Descendants()
             .Where(e => e.Name.LocalName == "None")
-            .Select(e => (Path: (string?)e.Attribute("PackagePath"), Include: (string?)e.Attribute("Include")))
-            .Where(item => item.Path is not null && item.Include is not null && IsAgentKitPath(item.Path))
+            .Select(e => (
+                Path: (string?)e.Attribute("PackagePath"),
+                Include: (string?)e.Attribute("Include"),
+                Pack: (string?)e.Attribute("Pack")))
+            .Where(item => item.Path is not null && item.Include is not null
+                           && IsPacked(item.Pack) && IsAgentKitPath(item.Path))
             .Select(item => (item.Path!, item.Include!))
             .ToList();
+
+    /// <summary>
+    /// True when an item is actually shipped, i.e. carries <c>Pack="true"</c>.
+    /// </summary>
+    /// <remarks>
+    /// A <c>&lt;None&gt;</c> item is not packed unless it opts in, so an <c>agentkit/</c>
+    /// <c>PackagePath</c> alone does not mean the file reaches a consumer. Without this,
+    /// <c>&lt;None Include="draft.md" Pack="false" PackagePath="agentkit/" /&gt;</c> would be
+    /// scanned and could fail the gate over a document nobody receives — breaking the one property
+    /// this corpus is built on, that it is the same list the pack target consumes.
+    /// </remarks>
+    private static bool IsPacked(string? pack) =>
+        pack is not null && pack.Trim().Equals("true", StringComparison.OrdinalIgnoreCase);
 
     /// <summary>
     /// True when an item's <c>PackagePath</c> puts it under <c>agentkit/</c>.
@@ -166,7 +183,7 @@ internal static class AgentKitDocCorpus
             if (packagePath is null || include is null)
                 continue;
 
-            if (!IsAgentKitPath(packagePath))
+            if (!IsPacked((string?)none.Attribute("Pack")) || !IsAgentKitPath(packagePath))
                 continue;
 
             // One entry per pattern. Aggregating an item's globs would let a dead one hide behind a
@@ -261,6 +278,16 @@ internal static class AgentKitDocCorpus
             if (!open.Success)
                 continue;
 
+            var indent = open.Groups["indent"].Value.Length;
+
+            // A run of four or more spaces outside a list is an *indented code block*, so a fence
+            // written there is literal text, not an opener. Honouring it swallowed everything up to
+            // the next close — including a genuine top-level ```csharp opener, which would then
+            // never be extracted. The differential probe cannot catch that, since it derives its
+            // exclusions from this same scan.
+            if (indent >= 4 && !IsInsideListItem(lines, i))
+                continue;
+
             var fenceChar = open.Groups["fence"].Value[0];
             var fenceLength = open.Groups["fence"].Value.Length;
 
@@ -281,6 +308,41 @@ internal static class AgentKitDocCorpus
         }
 
         return regions;
+    }
+
+    /// <summary>A markdown list item marker: <c>- </c>, <c>* </c>, <c>+ </c> or <c>10. </c>.</summary>
+    private static readonly Regex ListItemMarker = new(@"^(?<indent>[ \t]*)([-*+]|\d+[.)])\s", RegexOptions.Compiled);
+
+    /// <summary>
+    /// True when the deeply-indented line at <paramref name="index"/> is the content of a list item
+    /// rather than an indented code block.
+    /// </summary>
+    /// <remarks>
+    /// CommonMark measures a fence's indent relative to its container, so a fence inside a list item
+    /// legitimately sits at four or more absolute spaces — but the identical indentation outside a
+    /// list is a code block, where a fence is literal text. Distinguishing them is what lets the
+    /// corpus include the two real blocks under items 10 and 11 of
+    /// <c>skills/design-docs/typography-and-colors.md</c> without also honouring a quoted fence.
+    /// </remarks>
+    private static bool IsInsideListItem(string[] lines, int index)
+    {
+        for (var i = index - 1; i >= 0; i--)
+        {
+            var line = lines[i];
+            if (line.Trim().Length == 0)
+                continue;   // a blank line does not end a list item's content.
+
+            var marker = ListItemMarker.Match(line);
+            if (marker.Success)
+                return true;
+
+            // Any other line at lower indentation closes the container.
+            var indent = line.Length - line.TrimStart(' ', '\t').Length;
+            if (indent < 4)
+                return false;
+        }
+
+        return false;
     }
 
     /// <summary>

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitDocCorpus.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitDocCorpus.cs
@@ -162,7 +162,7 @@ internal static class AgentKitDocCorpus
     /// independently.
     /// </remarks>
     internal static readonly Regex CSharpFenceProbe = new(
-        @"^(?:[ \t]*(?:>[ \t]?)+)?[ \t]*(`{3,}|~{3,})[ ]*(csharp|cs|c\#)([ \t][^\r\n]*)?$",
+        @"^(?:[ \t]*(?:>[ \t]?)+)?[ \t]*(`{3,}|~{3,})[ ]*(csharp|cs|c\#)([ \t,][^\r\n]*)?$",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
     /// <summary>

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitDocCorpus.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitDocCorpus.cs
@@ -162,7 +162,7 @@ internal static class AgentKitDocCorpus
     /// independently.
     /// </remarks>
     internal static readonly Regex CSharpFenceProbe = new(
-        @"^(?:[ \t]*(?:>[ \t]?)+)?[ \t]*(`{3,}|~{3,})[ ]*(csharp|cs|c\#)[ ]*$",
+        @"^(?:[ \t]*(?:>[ \t]?)+)?[ \t]*(`{3,}|~{3,})[ ]*(csharp|cs|c\#)([ \t][^\r\n]*)?$",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
     /// <summary>
@@ -364,7 +364,11 @@ internal static class AgentKitDocCorpus
                 OpenLine: i + 1,
                 BodyStartLine: i + 2,
                 BodyEndLine: close,          // 1-based last body line; == i+1 when empty.
-                Language: open.Groups["info"].Value.Trim().Split(' ', ',')[0],
+                // Info strings separate the language from its attributes with any whitespace, not
+                // just a space: `csharp\tlinenos` is a C# block. Splitting on spaces alone read the
+                // whole run as the language, so the body never reached the gate — and the probe
+                // accepted only spaces too, so the completeness fact stayed green over it.
+                Language: open.Groups["info"].Value.Trim().Split(' ', '\t', ',')[0],
                 Indent: indent,
                 BlockquoteDepth: depth));
 

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitDocCorpus.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitDocCorpus.cs
@@ -380,6 +380,28 @@ internal static class AgentKitDocCorpus
                 if (IsClosingFence(lines[close], fenceChar, fenceLength, container, depth))
                     break;
 
+                // A fence inside a list item ends when that item does, for the same reason the
+                // blockquote rule above exists: an unclosed indented ```text under a bullet
+                // otherwise swallowed the next top-level ```csharp block, which then shipped
+                // unscanned — and the completeness fact derives its covered set from this same
+                // scan, so it could not have reported the gap. A non-blank line left of the item's
+                // content column has left the container. Checked after the close so a properly
+                // terminated block is never truncated by it.
+                //
+                // Only when the fence itself sits at or past that column. `ContainerIndent` reports
+                // the nearest list above the line, which for a block that has already de-indented
+                // out of the list is a container it is not in; applying the rule there ended the
+                // region on its own first body line and emptied it.
+                if (container > 0 && indent >= container)
+                {
+                    var outside = StripBlockquote(lines[close], depth).Content;
+                    if (outside.Trim().Length > 0 && LeadingWidth(outside) < container)
+                    {
+                        containerExited = true;
+                        break;
+                    }
+                }
+
                 close++;
             }
 
@@ -409,6 +431,32 @@ internal static class AgentKitDocCorpus
     private static readonly Regex ListItemMarker = new(
         @"^(?<indent>[ \t]*)(?<marker>[-*+]|\d+[.)])(?<pad>[ \t]+)",
         RegexOptions.Compiled);
+
+    /// <summary>
+    /// Width of a line's leading whitespace, counting a tab as one column.
+    /// </summary>
+    /// <remarks>
+    /// One column per character is what every other measurement here uses — the indent groups are
+    /// <c>[ \t]*</c> matched by length — so widths stay comparable across the scanner.
+    /// </remarks>
+    private static int LeadingWidth(string line) =>
+        line.Length - line.TrimStart(' ', '\t').Length;
+
+    /// <summary>
+    /// A line with any leading list marker removed, leaving the item's content.
+    /// </summary>
+    /// <remarks>
+    /// The fence scanner accepts a fence opening on the marker's own line (<c>- ```csharp</c>), so
+    /// anything else that has to recognise a fence must strip the marker the same way or the two
+    /// disagree about the same document — which, in the counterexample walk, read the opener as
+    /// code and failed a deliberately marked sample.
+    /// </remarks>
+    internal static string StripListMarker(string line)
+    {
+        var marker = ListItemMarker.Match(line);
+
+        return marker.Success ? line[marker.Length..] : line;
+    }
 
     /// <summary>
     /// The content column a list item establishes, per CommonMark's padding rule.

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateInstrumentTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateInstrumentTests.cs
@@ -867,6 +867,35 @@ public class AgentKitDocGateInstrumentTests
             "FlexColumn(children).FlexPadding(16)",
             Assert.Single(AgentKitDocCorpus.ExtractFences("fixture/maxpadded.md", MaxPaddedMarker)).Text);
         Assert.Matches(AgentKitDocCorpus.CSharpFenceProbe, "-    ```csharp");
+
+        // A container marker four columns past its own container is indented code, not container
+        // syntax — the repository's CommonMark fixtures pin `    > # Foo` (Example_0230) and
+        // `    1.  A paragraph` (Example_0288) as literal text. Scanning those as samples can fail
+        // the gate on quoted prose, and the probe has to agree or it corroborates the same
+        // misclassification and the completeness fact reddens on a document that is correct.
+        const string DeepMarker = """
+            Some prose.
+
+                - ```csharp
+                  FlexColumn(children).Padding(16)
+                  ```
+            """;
+
+        Assert.Empty(AgentKitDocCorpus.ExtractFences("fixture/deepmarker.md", DeepMarker));
+        Assert.DoesNotMatch(AgentKitDocCorpus.CSharpFenceProbe, "    - ```csharp");
+        Assert.DoesNotMatch(AgentKitDocCorpus.CSharpFenceProbe, "    > ```csharp");
+
+        const string DeepQuote = """
+                > ```csharp
+                > FlexColumn(children).Padding(16)
+                > ```
+            """;
+
+        Assert.Empty(AgentKitDocCorpus.ExtractFences("fixture/deepquote.md", DeepQuote));
+
+        // Positive control at three columns, where both are still container syntax.
+        Assert.Matches(AgentKitDocCorpus.CSharpFenceProbe, "   - ```csharp");
+        Assert.Matches(AgentKitDocCorpus.CSharpFenceProbe, "   > ```csharp");
     }
 
     /// <summary>

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateInstrumentTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateInstrumentTests.cs
@@ -626,16 +626,31 @@ public class AgentKitDocGateInstrumentTests
             ReactorSurface.Instance.Element("Semantics", 0));
 
         // ...and because SemanticElement declares no `Set` overload, the receiver is unresolvable,
-        // so the chain is skipped rather than attributed to the Border. That matches the analyzer,
-        // which is silent on receivers it cannot resolve the same way. The value of the stop is
-        // therefore *non*-attribution: without it the walk would judge a SemanticPanel against
-        // Border's gate.
+        // so the chain is skipped rather than attributed to the element that opened it. That
+        // matches the analyzer, which is silent on receivers it cannot resolve the same way. The
+        // value of the stop is therefore *non*-attribution: without it the walk would judge a
+        // SemanticPanel against the opening element's gate.
+        //
+        // The head has to be one that would produce a finding when misattributed, or the assertion
+        // proves nothing. A `Border` head cannot: Border is a legal `Padding` receiver, so deleting
+        // the stop leaves this silent for the wrong reason and the test passes either way. A
+        // FlexColumn mounts a FlexPanel, outside Padding's gate, so misattribution is visible.
         var scan = AgentKitSnippetWalker.Scan(new[]
         {
-            new AgentKitSnippet("fixture/semantics.md", 1, "Border(child).Semantics(role: \"button\").Padding(16)"),
+            new AgentKitSnippet("fixture/semantics.md", 1, "FlexColumn(children).Semantics(role: \"button\").Padding(16)"),
         });
 
         Assert.Empty(scan.Findings);
+
+        // Positive control: the same chain without the type-changing modifier does report, so the
+        // emptiness above is the stop working rather than the walker being unable to see the shape.
+        var withoutStop = AgentKitSnippetWalker.Scan(new[]
+        {
+            new AgentKitSnippet("fixture/semantics.md", 1, "FlexColumn(children).Padding(16)"),
+        });
+
+        Assert.NotEmpty(withoutStop.Findings);
+
         Assert.Null(ReactorSurface.Instance.MountedControl(ReactorSurface.Instance.Element("Semantics", 0)!));
     }
 
@@ -827,6 +842,31 @@ public class AgentKitDocGateInstrumentTests
             Assert.Single(AgentKitDocCorpus.ExtractFences("fixture/inline.md", InlineMarker)).Text);
 
         Assert.Matches(AgentKitDocCorpus.CSharpFenceProbe, "- ```csharp");
+
+        // Five or more spaces after the marker put the item's content one space along and make the
+        // rest indented code, so this is literal text rather than a fence. Treating all the padding
+        // as list padding scanned it as a sample, and the gate can fail on prose that way. The
+        // probe has to agree, or the completeness fact reports the same literal text as unscanned.
+        const string OverPaddedMarker = """
+            -     ```csharp
+                  FlexColumn(children).Padding(16)
+                  ```
+            """;
+
+        Assert.Empty(AgentKitDocCorpus.ExtractFences("fixture/overpadded.md", OverPaddedMarker));
+        Assert.DoesNotMatch(AgentKitDocCorpus.CSharpFenceProbe, "-     ```csharp");
+
+        // Four is still list padding, and both halves must still see it.
+        const string MaxPaddedMarker = """
+            -    ```csharp
+                 FlexColumn(children).FlexPadding(16)
+                 ```
+            """;
+
+        Assert.Equal(
+            "FlexColumn(children).FlexPadding(16)",
+            Assert.Single(AgentKitDocCorpus.ExtractFences("fixture/maxpadded.md", MaxPaddedMarker)).Text);
+        Assert.Matches(AgentKitDocCorpus.CSharpFenceProbe, "-    ```csharp");
     }
 
     /// <summary>

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateInstrumentTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateInstrumentTests.cs
@@ -427,6 +427,82 @@ public class AgentKitDocGateInstrumentTests
     }
 
     /// <summary>
+    /// A generic DSL factory must resolve like any other, so its chains are actually inspected.
+    /// </summary>
+    /// <remarks>
+    /// Two things kept them out: a generic factory returns an open constructed type
+    /// (<c>ListView&lt;T&gt;</c> gives <c>TemplatedListViewElement&lt;T&gt;</c>), and its call site
+    /// is <c>GenericNameSyntax</c> rather than <c>IdentifierNameSyntax</c>. A skipped chain neither
+    /// reports nor counts, so the blind spot was invisible to every floor — while
+    /// <c>ListView&lt;Todo&gt;(...)</c>, <c>ListView&lt;Item&gt;(...)</c> and
+    /// <c>ListView&lt;Order&gt;(...)</c> all appear in the shipped corpus.
+    /// </remarks>
+    [Theory]
+    [InlineData("ListView")]
+    [InlineData("GridView")]
+    [InlineData("LazyVStack")]
+    [InlineData("FlipView")]
+    public void Generic_Factories_Resolve_To_An_Element(string factory)
+    {
+        var element = ReactorSurface.Instance.Element(factory, typeArgumentCount: 1);
+
+        Assert.NotNull(element);
+        Assert.True(
+            typeof(Microsoft.UI.Reactor.Core.Element).IsAssignableFrom(element),
+            $"{factory}<T> resolved to {element}, which is not an Element.");
+
+        // Arity is what separates these from their non-generic namesakes; without it the two
+        // collide and the factory is discarded as ambiguous, which is how they were excluded.
+        Assert.NotEqual(element, ReactorSurface.Instance.Element(factory, typeArgumentCount: 0));
+    }
+
+    /// <summary>
+    /// A generic factory call site reaches the walker, rather than being dropped before it counts.
+    /// </summary>
+    [Fact]
+    public void A_Generic_Factory_Call_Site_Is_Walked()
+    {
+        var scan = AgentKitSnippetWalker.Scan(new[]
+        {
+            new AgentKitSnippet("fixture/generic.md", 1, "ListView<Todo>(items, (t, _) => Row(t)).Padding(16)"),
+        });
+
+        Assert.True(
+            scan.ResolvedChains >= 1,
+            "A `ListView<Todo>(...)` chain resolved nothing, so generic factories are still invisible " +
+            "to the gate and their samples ship uninspected.");
+    }
+
+    /// <summary>
+    /// A justification later in the chain still counts when the chain is parenthesised.
+    /// </summary>
+    /// <remarks>
+    /// The outward walk that collects chain modifiers has to treat the same nodes as transparent
+    /// that the downward walk does. While it did not,
+    /// <c>(Border(FlexColumn(children)).Padding(16)).Background(...)</c> was reported as a
+    /// workaround — the walk never reached the <c>Background</c> that justifies the Border — which
+    /// is a CI failure on valid documentation.
+    /// </remarks>
+    [Theory]
+    [InlineData("(Border(FlexColumn(children)).Padding(16)).Background(Theme.CardBackground)")]
+    [InlineData("(Border(FlexColumn(children)).Padding(16))!.Background(Theme.CardBackground)")]
+    public void A_Justification_Survives_Parentheses(string snippet)
+    {
+        var scan = AgentKitSnippetWalker.Scan(new[] { new AgentKitSnippet("fixture/parens.md", 1, snippet) });
+
+        Assert.Empty(scan.Of(AgentKitFindingKind.WrapperWorkaround));
+
+        // Positive control on the same shape: without the justification it must still report, or
+        // this would pass because parenthesising had disabled the rule outright.
+        var unjustified = AgentKitSnippetWalker.Scan(new[]
+        {
+            new AgentKitSnippet("fixture/parens.md", 1, "(Border(FlexColumn(children)).Padding(16)).Margin(8)"),
+        });
+
+        Assert.Single(unjustified.Of(AgentKitFindingKind.WrapperWorkaround));
+    }
+
+    /// <summary>
     /// Floors over the corpus and the reflection behind it. Each one turns a silent collapse — a
     /// glob that stopped matching, a factory map that resolved to nothing, a fence parser that
     /// stopped recognising ```` ```csharp ```` — into a failure.

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateInstrumentTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateInstrumentTests.cs
@@ -899,6 +899,35 @@ public class AgentKitDocGateInstrumentTests
     }
 
     /// <summary>
+    /// A nested blockquote inside a quoted fence does not close it.
+    /// </summary>
+    /// <remarks>
+    /// Stripping every <c>&gt;</c> level reduced <c>&gt; &gt; ```</c> to a bare <c>```</c>, which
+    /// closed the outer block early and left the rest of the sample unscanned. Only the opener's
+    /// depth is removed now. The differential probe computes its covered lines from the same scan,
+    /// so this truncation could not have been caught downstream.
+    /// </remarks>
+    [Fact]
+    public void A_Nested_Blockquote_Does_Not_Close_The_Outer_Fence()
+    {
+        const string Markdown = """
+            > ```csharp
+            > // the sample quotes a nested blockquote:
+            > > ```
+            > FlexColumn(children).Padding(16)
+            > ```
+            """;
+
+        var snippet = Assert.Single(AgentKitDocCorpus.ExtractFences("fixture/nested.md", Markdown));
+
+        // Truncating at the nested line would drop this, leaving the sample uninspected.
+        Assert.Contains("FlexColumn(children).Padding(16)", snippet.Text, StringComparison.Ordinal);
+
+        // One level is still stripped, so the nested quote survives as content rather than syntax.
+        Assert.Contains("> ```", snippet.Text, StringComparison.Ordinal);
+    }
+
+    /// <summary>
     /// Both facts require a marked counterexample to name its remedy.
     /// </summary>
     /// <remarks>

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateInstrumentTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateInstrumentTests.cs
@@ -491,13 +491,27 @@ public class AgentKitDocGateInstrumentTests
 
         var empty = entries
             .Where(entry => entry.Files.Count == 0)
-            .Select(entry => $"{entry.Include} → {entry.PackagePath}")
+            .Select(entry => $"{entry.Pattern} → {entry.PackagePath}")
             .ToList();
 
         Assert.True(
             empty.Count == 0,
-            "An agentkit/ pack item matches no file on disk, so the NuGet ships without it and this " +
+            "An agentkit/ pack glob matches no file on disk, so the NuGet ships without it and this " +
             "gate never inspects it:\n  " + string.Join("\n  ", empty));
+
+        // Granularity control. The guard above is per-glob, not per-item, and that difference is
+        // the whole point: an item's `*.md` half can go dead while its `*.cs` half still matches,
+        // and an item-level check stays green through it. Asserting no entry carries a `;` is what
+        // pins the split — comparing entry and item counts would not, because several agentkit
+        // items legitimately share one PackagePath.
+        Assert.DoesNotContain(entries, entry => entry.Pattern.Contains(';', StringComparison.Ordinal));
+
+        // ...and the assertion above is only meaningful while some item really does carry several
+        // globs. Today that is the recipes item, `skills\recipes\*.md;skills\recipes\*.cs`.
+        var repoRootPath = Path.Combine(AgentKitCorpus.RepoRoot, "src", "Reactor", "Reactor.csproj");
+        Assert.Contains(
+            AgentKitDocCorpus.AgentKitIncludes(File.ReadAllText(repoRootPath)),
+            include => include.Contains(';', StringComparison.Ordinal));
 
         var documents = AgentKitCorpus.Documents;
 

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateInstrumentTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateInstrumentTests.cs
@@ -145,6 +145,8 @@ public class AgentKitDocGateInstrumentTests
     [InlineData("Rectangle().Background(default(Microsoft.UI.Xaml.Media.Brush))")]
     [InlineData("Rectangle().Background(default(global::Microsoft.UI.Xaml.Media.Brush))")]
     [InlineData("Rectangle().Background(default(Brush?))")]
+    [InlineData("Rectangle().Background((Brush)default)")]
+    [InlineData("Rectangle().Background(((Brush)default)!)")]
     [InlineData("FlexColumn(children).Padding(null)")]
     public void Walker_Mirrors_The_Analyzers_Constant_Null_Gate(string snippet)
     {
@@ -786,6 +788,16 @@ public class AgentKitDocGateInstrumentTests
             Assert.Single(AgentKitDocCorpus.ExtractFences("fixture/tab.md", Tabbed)).Text);
 
         Assert.Matches(AgentKitDocCorpus.CSharpFenceProbe, "```csharp\tlinenos");
+
+        // The probe must accept every info-string syntax the extractor does, or the differential
+        // oracle is blind to exactly the blocks it is meant to police.
+        Assert.Matches(AgentKitDocCorpus.CSharpFenceProbe, "```csharp,linenos");
+
+        const string CommaInfo = "```csharp,linenos\nFlexColumn(children).FlexPadding(16)\n```";
+
+        Assert.Equal(
+            "FlexColumn(children).FlexPadding(16)",
+            Assert.Single(AgentKitDocCorpus.ExtractFences("fixture/comma.md", CommaInfo)).Text);
 
         // Marker padding sets the content column: `-    item` puts content at 5, so a fence eight
         // spaces in is three past it and valid. Consuming a single space read the column as 2 and

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateInstrumentTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateInstrumentTests.cs
@@ -819,6 +819,56 @@ public class AgentKitDocGateInstrumentTests
     }
 
     /// <summary>
+    /// A fence inside a blockquote is extracted, with the container prefix stripped.
+    /// </summary>
+    /// <remarks>
+    /// The opener previously allowed only whitespace before the delimiter, so <c>&gt; ```csharp</c>
+    /// was skipped — and <see cref="AgentKitDocCorpus.CSharpFenceProbe"/> shared the restriction,
+    /// so the differential oracle stayed green while the block shipped uninspected. The corpus has
+    /// four blockquoted fences today, all untagged shell, so this closes the gap before a C# one
+    /// appears rather than after.
+    /// </remarks>
+    [Fact]
+    public void A_Fence_Inside_A_Blockquote_Is_Extracted()
+    {
+        const string Markdown = """
+            > ### Note
+            >
+            > ```csharp
+            > FlexColumn(children).FlexPadding(16)
+            > ```
+            """;
+
+        var snippet = Assert.Single(AgentKitDocCorpus.ExtractFences("fixture/quote.md", Markdown));
+
+        // Line 3 opens the fence, so the body — and StartLine — is line 4.
+        Assert.Equal(4, snippet.StartLine);
+        Assert.Equal("FlexColumn(children).FlexPadding(16)", snippet.Text);
+
+        // The probe must see it too, or the differential oracle would stay blind to this shape even
+        // once the extractor handles it.
+        Assert.Matches(AgentKitDocCorpus.CSharpFenceProbe, "> ```csharp");
+    }
+
+    /// <summary>
+    /// Both facts require a marked counterexample to name its remedy.
+    /// </summary>
+    /// <remarks>
+    /// This is the condition that closes the #1119 gap, and on the wrapper fact nothing else can
+    /// cover for it: the wrapper is a legal receiver, so no other check objects to the sample at
+    /// all. Tested directly because the corpus currently produces zero wrapper findings, which
+    /// would leave the branch unexecuted and the guard vacuous.
+    /// </remarks>
+    [Theory]
+    [InlineData("Use .FlexPadding(16) instead.", "FlexPadding", true)]
+    [InlineData("Never wrap in a Border just for padding.", "FlexPadding", false)]
+    [InlineData("anything at all", null, true)]
+    public void A_Counterexample_Must_Name_Its_Remedy(string documentText, string? replacement, bool ok)
+    {
+        Assert.Equal(ok, AgentKitDocGateTests.NamesRemedy(documentText, replacement));
+    }
+
+    /// <summary>
     /// Floors over the corpus and the reflection behind it. Each one turns a silent collapse — a
     /// glob that stopped matching, a factory map that resolved to nothing, a fence parser that
     /// stopped recognising ```` ```csharp ```` — into a failure.

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateInstrumentTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateInstrumentTests.cs
@@ -120,6 +120,90 @@ public class AgentKitDocGateInstrumentTests
     }
 
     /// <summary>
+    /// A constant-null argument must not produce a finding, because
+    /// <c>NoOpModifierAnalyzer.HasConstantNullArgument</c> returns before reporting on exactly this
+    /// shape.
+    /// </summary>
+    /// <remarks>
+    /// A documentation gate that is stricter than the packaged analyzer produces findings a reader
+    /// cannot act on: the sample is correct, the analyzer agrees it is correct, and the only remedy
+    /// on offer is to delete the gate. This keeps the two aligned in the direction that matters.
+    /// </remarks>
+    [Theory]
+    [InlineData("Rectangle().Background((Brush)null)")]
+    [InlineData("Rectangle().Background(null)")]
+    [InlineData("Rectangle().Background(((Brush)null))")]
+    [InlineData("Rectangle().Background(default)")]
+    [InlineData("Rectangle().Background(default(Brush))")]
+    [InlineData("FlexColumn(children).Padding(null)")]
+    public void Walker_Mirrors_The_Analyzers_Constant_Null_Gate(string snippet)
+    {
+        var scan = AgentKitSnippetWalker.Scan(new[] { new AgentKitSnippet("fixture/null.md", 1, snippet) });
+
+        Assert.Empty(scan.Findings);
+
+        // The chain still had to resolve, or this would be passing because the walker could not
+        // read the line at all rather than because the null gate fired.
+        Assert.True(
+            scan.ResolvedChains >= 1,
+            $"'{snippet}' resolved no modifier chain, so this asserts nothing about the null gate.");
+    }
+
+    /// <summary>
+    /// A counterexample marker must come from a real comment, not from a string literal or a URL
+    /// that happens to contain one of the marker words.
+    /// </summary>
+    /// <remarks>
+    /// The exemption is the one place this gate deliberately declines to report, so anything that
+    /// widens it silently converts a real violation into a pass. A textual <c>IndexOf("//")</c>
+    /// cannot tell <c>// Wrong:</c> from <c>"https://example/avoid"</c>, and the second case is a
+    /// perfectly ordinary thing for a sample to contain.
+    /// </remarks>
+    [Theory]
+    // Genuine markers: exempt.
+    [InlineData("FlexColumn(children).Padding(16) // Wrong: no effect", true)]
+    [InlineData("FlexColumn(children).Padding(16) // ❌ dropped", true)]
+    [InlineData("FlexColumn(children).Padding(16) /* Wrong */", true)]
+    // A marker word inside a string is not a marker.
+    [InlineData("FlexColumn(TextBlock(\"https://example/avoid\")).Padding(16)", false)]
+    [InlineData("FlexColumn(TextBlock(\"never do this\")).Padding(16)", false)]
+    [InlineData("Button(\"Never\").Padding(16)", false)]
+    // A marker inside a string does not become one just because a real comment follows.
+    [InlineData("FlexColumn(TextBlock(\"https://x/avoid\")).Padding(16) // see docs", false)]
+    [InlineData("FlexColumn(children).Padding(16)", false)]
+    public void Counterexample_Markers_Come_Only_From_Comments(string line, bool expected)
+    {
+        Assert.Equal(expected, AgentKitDocGateTests.IsMarkedAt(new[] { line }, 1));
+    }
+
+    /// <summary>
+    /// A URL in the prose above a fence is a citation, not an instruction that the block below it
+    /// is wrong.
+    /// </summary>
+    [Fact]
+    public void Prose_Urls_Do_Not_Mark_The_Block_Below_As_A_Counterexample()
+    {
+        var withUrl = new[]
+        {
+            "- background reading: https://example.com/patterns/avoid",
+            "```csharp",
+            "FlexColumn(children).Padding(16)",
+        };
+
+        Assert.False(AgentKitDocGateTests.IsMarkedAt(withUrl, 3));
+
+        // Positive control: the same prose shape, marker in the words rather than the link.
+        var withMarker = new[]
+        {
+            "- Wrong, and it costs a build-check cycle:",
+            "```csharp",
+            "FlexColumn(children).Padding(16)",
+        };
+
+        Assert.True(AgentKitDocGateTests.IsMarkedAt(withMarker, 3));
+    }
+
+    /// <summary>
     /// Floors over the corpus and the reflection behind it. Each one turns a silent collapse — a
     /// glob that stopped matching, a factory map that resolved to nothing, a fence parser that
     /// stopped recognising ```` ```csharp ```` — into a failure.

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateInstrumentTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateInstrumentTests.cs
@@ -262,6 +262,113 @@ public class AgentKitDocGateInstrumentTests
     }
 
     /// <summary>
+    /// A counterexample marker must be a <em>label</em>, not any occurrence of one of those words.
+    /// </summary>
+    /// <remarks>
+    /// The exemption is the only place this gate declines to report, so anything that widens it
+    /// converts a real violation into a pass. <c>// avoid re-enumerating children</c> is an
+    /// ordinary explanatory comment, and treating it as a label would ship the broken sample
+    /// beneath it unnoticed.
+    /// </remarks>
+    [Theory]
+    // Labels, as this repo actually writes them.
+    [InlineData("// Wrong: no effect, and costs a build-check cycle", true)]
+    [InlineData("// ❌ WRONG — feeds the host's shape back", true)]
+    [InlineData("// Bad: skipping levels", true)]
+    [InlineData("/* Wrong */", true)]
+    [InlineData("Avoid this:", true)]
+    [InlineData("### ❌ The anti-pattern that breaks everything", true)]
+    [InlineData("- Wrong, and it costs a build-check cycle:", true)]
+    // Explanations that merely contain a marker word.
+    [InlineData("// avoid re-enumerating children", false)]
+    [InlineData("// Never hardcode hex on themed surfaces — reviewers reject it", false)]
+    [InlineData("// Good: proper hierarchy", false)]
+    [InlineData("- background reading: https://example.com/patterns/avoid", false)]
+    [InlineData("// Common modifiers", false)]
+    public void Counterexample_Labels_Are_Labels_Not_Incidental_Words(string text, bool expected)
+    {
+        Assert.Equal(expected, AgentKitDocGateTests.IsCounterexampleLabel(text));
+    }
+
+    /// <summary>
+    /// An ordinary markdown lead-in paragraph above a fence must be read as prose.
+    /// </summary>
+    /// <remarks>
+    /// A lead-in usually has no <c>#</c>, <c>&gt;</c> or <c>-</c> to recognise it by, so inferring
+    /// "prose" from a line's shape read <c>Avoid this:</c> as code and abandoned the walk — turning
+    /// a clearly labelled counterexample into a CI failure the author cannot satisfy without
+    /// deleting their own example.
+    /// </remarks>
+    [Fact]
+    public void A_Plain_Lead_In_Paragraph_Above_The_Fence_Is_Prose()
+    {
+        var leadIn = new[]
+        {
+            "Avoid this:",
+            "",
+            "```csharp",
+            "FlexColumn(children).Padding(16)",
+        };
+
+        Assert.True(AgentKitDocGateTests.IsMarkedAt(leadIn, 4));
+
+        // Negative control: the same shape with an ordinary sentence must NOT exempt, or the
+        // assertion above would be passing on "prose is reachable" rather than "the label matched".
+        var unlabelled = new[]
+        {
+            "Here is how spacing works:",
+            "",
+            "```csharp",
+            "FlexColumn(children).Padding(16)",
+        };
+
+        Assert.False(AgentKitDocGateTests.IsMarkedAt(unlabelled, 4));
+
+        // The walk must not cross into an earlier, unrelated block and borrow its label.
+        var previousBlock = new[]
+        {
+            "Wrong:",
+            "",
+            "```csharp",
+            "VStack(8, items).Padding(15)",
+            "```",
+            "",
+            "```csharp",
+            "FlexColumn(children).Padding(16)",
+        };
+
+        Assert.False(AgentKitDocGateTests.IsMarkedAt(previousBlock, 8));
+    }
+
+    /// <summary>
+    /// An unrelated modifier that merely ends in "Set" does not justify a wrapper.
+    /// </summary>
+    /// <remarks>
+    /// <c>.Set(...)</c> justifies one because its lambda is opaque to this walker. As a substring
+    /// that also swallowed <c>.PositionInSet(...)</c>, an accessibility modifier that can live on
+    /// the inner element — so a Border that is still only a padding workaround stopped being
+    /// reported.
+    /// </remarks>
+    [Fact]
+    public void Only_An_Exact_Set_Justifies_A_Wrapper()
+    {
+        var suppressed = AgentKitSnippetWalker.Scan(new[]
+        {
+            new AgentKitSnippet("fixture/set.md", 1, "Border(FlexColumn(children)).Padding(16).Set(b => b.Tag = x)"),
+        });
+
+        Assert.Empty(suppressed.Of(AgentKitFindingKind.WrapperWorkaround));
+
+        var reported = AgentKitSnippetWalker.Scan(new[]
+        {
+            new AgentKitSnippet("fixture/set.md", 1, "Border(FlexColumn(children)).Padding(16).PositionInSet(2, 5)"),
+        });
+
+        var finding = Assert.Single(reported.Of(AgentKitFindingKind.WrapperWorkaround));
+        Assert.Equal("FlexPadding", finding.Replacement);
+    }
+
+    /// <summary>
     /// Floors over the corpus and the reflection behind it. Each one turns a silent collapse — a
     /// glob that stopped matching, a factory map that resolved to nothing, a fence parser that
     /// stopped recognising ```` ```csharp ```` — into a failure.

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateInstrumentTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateInstrumentTests.cs
@@ -1302,6 +1302,46 @@ public class AgentKitDocGateInstrumentTests
 
         var inElse = Assert.Single(branches.Of(AgentKitFindingKind.DroppedModifier));
         Assert.Equal(4, inElse.Line);
+
+        // A silent arm must not reserve the de-duplication key for a later one. Here the same
+        // outer line resolves to a Border in the first arm — legal, no finding — and to a
+        // FlexColumn in the `#else`, where it is a real violation.
+        var masked = AgentKitSnippetWalker.Scan(new[]
+        {
+            new AgentKitSnippet(
+                "fixture/masked.md",
+                1,
+                "#if DEBUG\nvar a = Border(child).Padding(16);\n#else\nvar a = FlexColumn(children).Padding(16);\n#endif"),
+        });
+
+        Assert.Equal(4, Assert.Single(masked.Of(AgentKitFindingKind.DroppedModifier)).Line);
+
+        // Nesting keeps an outer arm's chain head together with an inner arm's body. The chain only
+        // resolves if both are present: the wrapper opens in the outer arm, its child is in the
+        // inner one, and the modifier follows the inner `#endif`. Numbering arms flat reset to the
+        // unconditional arm there, so no variant held all three.
+        var nested = AgentKitSnippetWalker.Scan(new[]
+        {
+            new AgentKitSnippet(
+                "fixture/nested.md",
+                1,
+                "#if OUTER\nvar a = Border(\n#if INNER\n    FlexColumn(children)\n#endif\n).Padding(16);\n#endif"),
+        });
+
+        Assert.Single(nested.Of(AgentKitFindingKind.WrapperWorkaround));
+
+        // An unconditional line is scanned by every variant, so it must still be reported once.
+        // Without de-duplication this snippet yields the same finding twice — once for the
+        // arm-free variant and once for the arm.
+        var shared = AgentKitSnippetWalker.Scan(new[]
+        {
+            new AgentKitSnippet(
+                "fixture/shared.md",
+                1,
+                "var a = FlexColumn(children).Padding(16);\n#if DEBUG\nvar b = 1;\n#endif"),
+        });
+
+        Assert.Equal(1, Assert.Single(shared.Of(AgentKitFindingKind.DroppedModifier)).Line);
     }
 
     /// <summary>

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateInstrumentTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateInstrumentTests.cs
@@ -450,10 +450,6 @@ public class AgentKitDocGateInstrumentTests
         Assert.True(
             typeof(Microsoft.UI.Reactor.Core.Element).IsAssignableFrom(element),
             $"{factory}<T> resolved to {element}, which is not an Element.");
-
-        // Arity is what separates these from their non-generic namesakes; without it the two
-        // collide and the factory is discarded as ambiguous, which is how they were excluded.
-        Assert.NotEqual(element, ReactorSurface.Instance.Element(factory, typeArgumentCount: 0));
     }
 
     /// <summary>
@@ -500,6 +496,66 @@ public class AgentKitDocGateInstrumentTests
         });
 
         Assert.Single(unjustified.Of(AgentKitFindingKind.WrapperWorkaround));
+    }
+
+    /// <summary>
+    /// A generic factory written without explicit type arguments still resolves.
+    /// </summary>
+    /// <remarks>
+    /// C# infers <c>T</c>, so <c>LazyVStack(items, (x, _) => Row(x))</c> reaches the walker as a
+    /// plain identifier with arity 0 while the surface map holds it at arity 1. Keying on the
+    /// written arity alone therefore reintroduced the same blind spot for the far more common call
+    /// shape — and, as ever, a skipped chain neither reports nor counts, so no floor would say so.
+    /// </remarks>
+    [Theory]
+    [InlineData("LazyVStack")]
+    [InlineData("LazyHStack")]
+    public void An_Inferred_Generic_Factory_Resolves_Without_Type_Arguments(string factory)
+    {
+        var written = ReactorSurface.Instance.Element(factory, typeArgumentCount: 0);
+        var explicitly = ReactorSurface.Instance.Element(factory, typeArgumentCount: 1);
+
+        Assert.NotNull(explicitly);
+        Assert.Equal(explicitly, written);
+    }
+
+    /// <summary>
+    /// The fallback stays conservative where the name is genuinely ambiguous.
+    /// </summary>
+    /// <remarks>
+    /// Several names are both. <c>ListView(...)</c> returns <c>ListViewElement</c> while
+    /// <c>ListView&lt;T&gt;(...)</c> returns <c>TemplatedListViewElement&lt;T&gt;</c>. The written
+    /// form is honoured exactly, and inference is never used to overrule an arity that really
+    /// exists — guessing there would attribute a chain to the wrong control, which is how a gate
+    /// starts reporting findings that are not true.
+    /// </remarks>
+    [Theory]
+    [InlineData("ListView")]
+    [InlineData("GridView")]
+    [InlineData("FlipView")]
+    [InlineData("TreeView")]
+    public void Inference_Never_Overrules_An_Arity_That_Exists(string factory)
+    {
+        var nonGeneric = ReactorSurface.Instance.Element(factory, typeArgumentCount: 0);
+        var generic = ReactorSurface.Instance.Element(factory, typeArgumentCount: 1);
+
+        Assert.NotNull(nonGeneric);
+        Assert.NotNull(generic);
+        Assert.NotEqual(nonGeneric, generic);
+    }
+
+    [Fact]
+    public void An_Inferred_Generic_Call_Site_Is_Walked()
+    {
+        var scan = AgentKitSnippetWalker.Scan(new[]
+        {
+            new AgentKitSnippet("fixture/inferred.md", 1, "LazyVStack(items, (x, _) => Row(x)).Padding(16)"),
+        });
+
+        Assert.True(
+            scan.ResolvedChains >= 1,
+            "A `LazyVStack(items, ...)` chain resolved nothing, so generic factories written without " +
+            "explicit type arguments — the common form — are still invisible to the gate.");
     }
 
     /// <summary>

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateInstrumentTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateInstrumentTests.cs
@@ -855,6 +855,50 @@ public class AgentKitDocGateInstrumentTests
     }
 
     /// <summary>
+    /// A counterexample label inside a blockquote marks the blockquoted sample below it.
+    /// </summary>
+    /// <remarks>
+    /// The extractor learned about blockquotes before the marker walk did, so the walk saw a raw
+    /// <c>&gt;</c> on <c>&gt; ```csharp</c>, failed its fence test and treated the opener as code —
+    /// meaning a deliberately marked counterexample failed CI. Two readers of the same document
+    /// disagreeing about its structure is its own defect class, so both sides strip the prefix now.
+    /// </remarks>
+    [Fact]
+    public void A_Blockquoted_Label_Marks_The_Blockquoted_Sample()
+    {
+        var marked = new[]
+        {
+            "> Avoid this:",
+            ">",
+            "> ```csharp",
+            "> FlexColumn(children).Padding(16)",
+        };
+
+        Assert.True(AgentKitDocGateTests.IsMarkedAt(marked, 4));
+
+        // Negative control: the same blockquoted shape with ordinary prose must not exempt.
+        var unmarked = new[]
+        {
+            "> Here is how spacing works:",
+            ">",
+            "> ```csharp",
+            "> FlexColumn(children).Padding(16)",
+        };
+
+        Assert.False(AgentKitDocGateTests.IsMarkedAt(unmarked, 4));
+
+        // And a blockquoted comment label works too.
+        var comment = new[]
+        {
+            "> ```csharp",
+            "> // Wrong: no effect",
+            "> FlexColumn(children).Padding(16)",
+        };
+
+        Assert.True(AgentKitDocGateTests.IsMarkedAt(comment, 3));
+    }
+
+    /// <summary>
     /// Both facts require a marked counterexample to name its remedy.
     /// </summary>
     /// <remarks>

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateInstrumentTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateInstrumentTests.cs
@@ -1058,6 +1058,65 @@ public class AgentKitDocGateInstrumentTests
     }
 
     /// <summary>
+    /// A lead-in above a fence opened on a list marker's own line still marks that sample.
+    /// </summary>
+    /// <remarks>
+    /// The extractor accepts <c>- ```csharp</c>, so the marker walk has to as well. Recognising a
+    /// fence only by a trimmed line starting with the delimiter read that opener as C# code and
+    /// abandoned the search, turning a deliberately labelled counterexample into a CI failure —
+    /// the two halves disagreeing about the same document.
+    /// </remarks>
+    [Fact]
+    [Trait("Category", "AgentKitDocGate")]
+    public void A_Label_Marks_A_Sample_In_An_Inline_List_Fence()
+    {
+        var marked = new[]
+        {
+            "Avoid this:",
+            "",
+            "- ```csharp",
+            "  FlexColumn(children).Padding(16)",
+        };
+
+        Assert.True(AgentKitDocGateTests.IsMarkedAt(marked, 4));
+
+        // Negative control: the same shape with ordinary prose must not exempt, so the assertion
+        // above is failing on the label rather than on the walk reaching further than it should.
+        var unmarked = new[]
+        {
+            "Here is the layout:",
+            "",
+            "- ```csharp",
+            "  FlexColumn(children).Padding(16)",
+        };
+
+        Assert.False(AgentKitDocGateTests.IsMarkedAt(unmarked, 4));
+    }
+
+    /// <summary>
+    /// The remedy must be named at identifier boundaries, not as a substring of a longer name.
+    /// </summary>
+    /// <remarks>
+    /// This is the clause that <em>permits</em> an otherwise-invalid snippet, so a loose match
+    /// exempts the sample it was meant to hold to account: a document mentioning only
+    /// <c>FillColor</c> counted as having named <c>Fill</c>.
+    /// </remarks>
+    [Fact]
+    [Trait("Category", "AgentKitDocGate")]
+    public void A_Remedy_Named_Only_Inside_A_Longer_Identifier_Does_Not_Count()
+    {
+        Assert.False(AgentKitDocGateTests.NamesRemedy("use the FillColorDefaultBrush resource", "Fill"));
+        Assert.False(AgentKitDocGateTests.NamesRemedy("see FlexPaddingThickness", "FlexPadding"));
+
+        // Positive controls: the bare name, and the name in the shapes documents actually use.
+        Assert.True(AgentKitDocGateTests.NamesRemedy("reach for Fill instead", "Fill"));
+        Assert.True(AgentKitDocGateTests.NamesRemedy("write `.FlexPadding(16)`", "FlexPadding"));
+
+        // No replacement to name is not a failure to name it.
+        Assert.True(AgentKitDocGateTests.NamesRemedy("anything", null));
+    }
+
+    /// <summary>
     /// A nested blockquote inside a quoted fence does not close it.
     /// </summary>
     /// <remarks>
@@ -1110,6 +1169,49 @@ public class AgentKitDocGateInstrumentTests
         var snippet = Assert.Single(AgentKitDocCorpus.ExtractFences("fixture/exit.md", Markdown));
 
         Assert.Equal("FlexColumn(children).FlexPadding(16)", snippet.Text);
+    }
+
+    /// <summary>
+    /// An unclosed fence inside a list item does not swallow the block that follows the list.
+    /// </summary>
+    /// <remarks>
+    /// The counterpart of the blockquote rule above. Ending a region only at a closing fence let an
+    /// unclosed indented <c>```text</c> under a bullet absorb the next top-level C# block, which
+    /// then shipped unscanned — and <c>Every_CSharp_Fence_In_The_Corpus_Is_Extracted</c> derives
+    /// its covered set from this same scan, so it could not have reported the gap either.
+    /// </remarks>
+    [Fact]
+    [Trait("Category", "AgentKitDocGate")]
+    public void An_Unclosed_Fence_In_A_List_Item_Does_Not_Swallow_What_Follows()
+    {
+        const string Markdown = """
+            - a bullet
+
+              ```text
+              an unclosed block inside the item
+
+            ```csharp
+            FlexColumn(children).FlexPadding(16)
+            ```
+            """;
+
+        var snippet = Assert.Single(AgentKitDocCorpus.ExtractFences("fixture/listexit.md", Markdown));
+
+        Assert.Equal("FlexColumn(children).FlexPadding(16)", snippet.Text);
+
+        // Negative control: a *closed* block in the same position must keep its body intact, so
+        // the rule above is ending unterminated regions rather than truncating every indented one.
+        const string Closed = """
+            - a bullet
+
+              ```csharp
+              FlexColumn(children).FlexPadding(16)
+              ```
+            """;
+
+        Assert.Equal(
+            "FlexColumn(children).FlexPadding(16)",
+            Assert.Single(AgentKitDocCorpus.ExtractFences("fixture/listclosed.md", Closed)).Text);
     }
 
     /// <summary>

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateInstrumentTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateInstrumentTests.cs
@@ -759,6 +759,21 @@ public class AgentKitDocGateInstrumentTests
         Assert.Equal(
             "Border(child).Padding(8)",
             Assert.Single(AgentKitDocCorpus.ExtractFences("fixture/shallow.md", ShallowItem)).Text);
+
+        // A continuation line between the marker and the fence must not be read as closing the
+        // list: `- ` has content column 2, so five spaces is three past it and still a fence.
+        const string Continuation = """
+            - item
+              explanation
+
+                 ```csharp
+                 FlexColumn(children).FlexPadding(16)
+                 ```
+            """;
+
+        Assert.Equal(
+            "FlexColumn(children).FlexPadding(16)",
+            Assert.Single(AgentKitDocCorpus.ExtractFences("fixture/continuation.md", Continuation)).Text);
     }
 
     /// <summary>

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateInstrumentTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateInstrumentTests.cs
@@ -112,6 +112,11 @@ public class AgentKitDocGateInstrumentTests
     [InlineData("FlexRow(items).FlexPadding(horizontal: 16, vertical: 8)")]
     [InlineData("VStack(8, FlexColumn(children), Button(\"Go\")).Padding(16)")]
     [InlineData("Border(FlexColumn(children)).Padding(16).Background(Theme.CardBackground)")]
+    // A load-bearing single-child wrapper. Deleting the ScrollViewer deletes scrolling, so this is
+    // correct code and the wrapper rule must not claim otherwise. (A Viewbox would not do as the
+    // example here: it mounts a Viewbox, which is outside Padding's gate, so the dropped-modifier
+    // rule fires on it for a different and entirely correct reason.)
+    [InlineData("ScrollViewer(FlexColumn(children)).Padding(16)")]
     public void Walker_Stays_Silent_On_Sound_Code(string snippet)
     {
         var scan = AgentKitSnippetWalker.Scan(new[] { new AgentKitSnippet("fixture/sound.md", 1, snippet) });
@@ -133,7 +138,6 @@ public class AgentKitDocGateInstrumentTests
     [InlineData("Rectangle().Background((Brush)null)")]
     [InlineData("Rectangle().Background(null)")]
     [InlineData("Rectangle().Background(((Brush)null))")]
-    [InlineData("Rectangle().Background(default)")]
     [InlineData("Rectangle().Background(default(Brush))")]
     [InlineData("FlexColumn(children).Padding(null)")]
     public void Walker_Mirrors_The_Analyzers_Constant_Null_Gate(string snippet)
@@ -147,6 +151,60 @@ public class AgentKitDocGateInstrumentTests
         Assert.True(
             scan.ResolvedChains >= 1,
             $"'{snippet}' resolved no modifier chain, so this asserts nothing about the null gate.");
+    }
+
+    /// <summary>
+    /// A <c>default</c> that resolves to a value type is <b>not</b> null, so it must not inherit the
+    /// constant-null exemption.
+    /// </summary>
+    /// <remarks>
+    /// <c>default</c> is target-typed: <c>.Background(default)</c> is <c>default(Brush)</c> and
+    /// null, while <c>.Padding(default(double))</c> is <c>0</c> — a real write that
+    /// <c>ApplyModifiers</c> really does drop on a Flex receiver, and which
+    /// <c>NoOpModifierAnalyzer</c> correctly reports. Treating every <c>default</c> as null would
+    /// hide that, which is a silent miss: the failure mode this gate is least able to detect in
+    /// itself, since the result is indistinguishable from clean documentation.
+    /// </remarks>
+    [Theory]
+    [InlineData("FlexColumn(children).Padding(default(double))")]
+    [InlineData("FlexColumn(children).Padding(default(Thickness))")]
+    [InlineData("FlexColumn(children).Padding(default)")]
+    public void Walker_Still_Reports_A_Value_Typed_Default(string snippet)
+    {
+        var scan = AgentKitSnippetWalker.Scan(new[] { new AgentKitSnippet("fixture/default.md", 1, snippet) });
+
+        var finding = Assert.Single(scan.Of(AgentKitFindingKind.DroppedModifier));
+        Assert.Equal("Padding", finding.Modifier);
+        Assert.Equal("FlexElement", finding.ElementName);
+    }
+
+    /// <summary>
+    /// The reference/value split behind that exemption is read off the real modifier signatures,
+    /// not guessed.
+    /// </summary>
+    [Fact]
+    public void Default_Is_Provably_Null_Only_For_Reference_Typed_Modifiers()
+    {
+        // Explicit type settles it, whichever way.
+        Assert.True(ReactorSurface.Instance.DefaultIsProvablyNull("Background", "Brush"));
+        Assert.False(ReactorSurface.Instance.DefaultIsProvablyNull("Padding", "double"));
+        Assert.False(ReactorSurface.Instance.DefaultIsProvablyNull("Padding", "Thickness"));
+
+        // Bare `default` must hold for every overload it could bind to. Background takes
+        // string/Brush/ThemeRef, and ThemeRef is a readonly record struct — so `.Background(default)`
+        // is not provably null (and is in fact ambiguous C#, which is why refusing costs nothing).
+        Assert.False(ReactorSurface.Instance.DefaultIsProvablyNull("Background"));
+        Assert.False(ReactorSurface.Instance.DefaultIsProvablyNull("Padding"));
+
+        // An unknown modifier or type must not exempt: unprovable is not the same as null.
+        Assert.False(ReactorSurface.Instance.DefaultIsProvablyNull("NoSuchModifierExists"));
+        Assert.False(ReactorSurface.Instance.DefaultIsProvablyNull("Background", "NoSuchType"));
+
+        // Guard the reading above: if ThemeRef ever stopped being a value type, the Background
+        // assertions would start passing for a reason unrelated to what they claim to test.
+        Assert.Contains(
+            ReactorSurface.Instance.SingleArgumentModifierTypes("Background"),
+            t => t.Name == "ThemeRef" && t.IsValueType);
     }
 
     /// <summary>

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateInstrumentTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateInstrumentTests.cs
@@ -287,6 +287,7 @@ public class AgentKitDocGateInstrumentTests
     [InlineData("- Wrong, and it costs a build-check cycle:", true)]
     // Explanations that merely contain a marker word.
     [InlineData("// avoid re-enumerating children", false)]
+    [InlineData("// Show ❌ when validation fails", false)]
     [InlineData("// Never hardcode hex on themed surfaces — reviewers reject it", false)]
     [InlineData("// Good: proper hierarchy", false)]
     [InlineData("- background reading: https://example.com/patterns/avoid", false)]
@@ -798,6 +799,9 @@ public class AgentKitDocGateInstrumentTests
     [InlineData("Border(FlexColumn(children)).Padding(16).WithKey(\"k\")", true)]
     // Inert: does nothing, so it cannot be what the wrapper is for.
     [InlineData("Border(FlexColumn(children)).Padding(16).Background((Brush)null)", true)]
+    // A null argument to an *ungated* modifier proves nothing: `.Stagger(delay, null)` still
+    // installs a stagger, and moving it inward changes which children animate.
+    [InlineData("Border(FlexColumn(children)).Padding(16).Stagger(delay, null)", false)]
     // Behaviour-bearing or opaque: the wrapper is load-bearing, so no finding.
     [InlineData("Border(FlexColumn(children)).Padding(16).OnTapped((s, e) => Handle(e))", false)]
     [InlineData("Border(FlexColumn(children)).Padding(16).WithFlyout(menu)", false)]

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateInstrumentTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateInstrumentTests.cs
@@ -926,6 +926,24 @@ public class AgentKitDocGateInstrumentTests
             Assert.Single(AgentKitDocCorpus.ExtractFences(
                 "fixture/tabclose.md",
                 TabbedInnerFence.Replace("<TAB>", "\t"))).Text.Replace("\r\n", "\n"));
+
+        // A tab after a list marker advances from the marker's column, not from zero: in
+        // `10.<TAB>```csharp` it moves column 3 to 4 and is worth one column, so the content column
+        // is 4. Measuring it from zero reported 7, and the closing bound is measured against that —
+        // a ``` eight columns in is literal text inside the block at 4 but reads as the close at 7,
+        // truncating the sample. The inner fence is what makes this observable.
+        const string TabPaddedMarker = """
+            10.<TAB>```csharp
+                FlexColumn(children).FlexPadding(16)
+                    ```
+                ```
+            """;
+
+        Assert.Equal(
+            "FlexColumn(children).FlexPadding(16)\n    ```",
+            Assert.Single(AgentKitDocCorpus.ExtractFences(
+                "fixture/tabmarker.md",
+                TabPaddedMarker.Replace("<TAB>", "\t"))).Text.Replace("\r\n", "\n"));
     }
 
     /// <summary>
@@ -1243,6 +1261,35 @@ public class AgentKitDocGateInstrumentTests
             ReactorSurface.Instance.DefaultIsProvablyNull("Background"),
             ReactorSurface.Instance.DefaultIsProvablyNull("Background", null, "notAParameter"));
     }
+    /// <summary>
+    /// A sample inside an inactive <c>#if</c> branch is still scanned.
+    /// </summary>
+    /// <remarks>
+    /// <c>ParseText</c> uses the default symbol set, so an inactive branch survives only as
+    /// DisabledTextTrivia and never reaches <c>DescendantNodes</c> — a violation written inside
+    /// <c>#if DEBUG</c> would have shipped unchecked, and the corpus already contains conditional
+    /// C# (<c>skills/devtools.md</c>).
+    /// </remarks>
+    [Fact]
+    [Trait("Category", "AgentKitDocGate")]
+    public void A_Sample_In_An_Inactive_Conditional_Branch_Is_Scanned()
+    {
+        var scan = AgentKitSnippetWalker.Scan(new[]
+        {
+            new AgentKitSnippet(
+                "fixture/conditional.md",
+                1,
+                "#if DEBUG\nFlexColumn(children).Padding(16)\n#endif"),
+        });
+
+        var finding = Assert.Single(scan.Of(AgentKitFindingKind.DroppedModifier));
+        Assert.Equal("FlexPadding", finding.Replacement);
+
+        // The directive lines are blanked rather than removed, so the reported line is still the
+        // line the sample is on — without that, a finding would point one line short.
+        Assert.Equal(2, finding.Line);
+    }
+
     /// <summary>
     /// A label in the preceding list item marks a sample in the next one — deliberately.
     /// </summary>

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateInstrumentTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateInstrumentTests.cs
@@ -1012,6 +1012,32 @@ public class AgentKitDocGateInstrumentTests
     }
 
     /// <summary>
+    /// A blockquoted fence ends when its container does, even if it is never closed.
+    /// </summary>
+    /// <remarks>
+    /// The close scan stripped up to the opening depth without requiring that depth to still be
+    /// present, so an unclosed <c>&gt; ```text</c> absorbed a following top-level
+    /// ```` ```csharp ```` block and that sample shipped unscanned. The completeness fact derives
+    /// its covered set from the same scan, so it could not have seen it either.
+    /// </remarks>
+    [Fact]
+    public void An_Unclosed_Blockquoted_Fence_Does_Not_Swallow_What_Follows()
+    {
+        const string Markdown = """
+            > ```text
+            > an unclosed quoted block
+
+            ```csharp
+            FlexColumn(children).FlexPadding(16)
+            ```
+            """;
+
+        var snippet = Assert.Single(AgentKitDocCorpus.ExtractFences("fixture/exit.md", Markdown));
+
+        Assert.Equal("FlexColumn(children).FlexPadding(16)", snippet.Text);
+    }
+
+    /// <summary>
     /// Both facts require a marked counterexample to name its remedy.
     /// </summary>
     /// <remarks>

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateInstrumentTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateInstrumentTests.cs
@@ -287,6 +287,8 @@ public class AgentKitDocGateInstrumentTests
     [InlineData("- Wrong, and it costs a build-check cycle:", true)]
     // Explanations that merely contain a marker word.
     [InlineData("// avoid re-enumerating children", false)]
+    [InlineData("// avoid allocations", false)]
+    [InlineData("// never cache", false)]
     [InlineData("// Show ❌ when validation fails", false)]
     [InlineData("// Never hardcode hex on themed surfaces — reviewers reject it", false)]
     [InlineData("// Good: proper hierarchy", false)]
@@ -774,6 +776,16 @@ public class AgentKitDocGateInstrumentTests
         Assert.Equal(
             "FlexColumn(children).FlexPadding(16)",
             Assert.Single(AgentKitDocCorpus.ExtractFences("fixture/continuation.md", Continuation)).Text);
+
+        // An info string separates the language from its attributes with any whitespace, so a
+        // tab-delimited attribute must not be read as part of the language name.
+        const string Tabbed = "```csharp\tlinenos\nFlexColumn(children).FlexPadding(16)\n```";
+
+        Assert.Equal(
+            "FlexColumn(children).FlexPadding(16)",
+            Assert.Single(AgentKitDocCorpus.ExtractFences("fixture/tab.md", Tabbed)).Text);
+
+        Assert.Matches(AgentKitDocCorpus.CSharpFenceProbe, "```csharp\tlinenos");
     }
 
     /// <summary>

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateInstrumentTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateInstrumentTests.cs
@@ -508,7 +508,7 @@ public class AgentKitDocGateInstrumentTests
     /// stopped recognising ```` ```csharp ```` — into a failure.
     /// </summary>
     /// <remarks>
-    /// The thresholds are set well under the measured values (63 documents, 374 snippets, 345
+    /// The thresholds are set well under the measured values (63 documents, 376 snippets, 348
     /// resolved chains, 115 factories at the time of writing) because they are guards against a
     /// mechanism breaking, not pins on the corpus. Raise one only if it stops discriminating; do
     /// <b>not</b> lower one to make a red build green, because the collapse it is describing is
@@ -614,8 +614,8 @@ public class AgentKitDocGateInstrumentTests
     /// <para>
     /// This is the fact that would have caught the four-space fences under list items 10 and 11 of
     /// <c>skills/design-docs/typography-and-colors.md</c>, which the original 0–3 space indent cap
-    /// silently skipped. The aggregate snippet floor did <b>not</b> catch it and could not: 372
-    /// blocks clear a floor of 150 just as comfortably as 374 do. A floor bounds the corpus from
+    /// silently skipped. The aggregate snippet floor did <b>not</b> catch it and could not: 374
+    /// blocks clear a floor of 150 just as comfortably as 376 do. A floor bounds the corpus from
     /// below; only a differential comparison against an independent derivation can say the
     /// extractor saw <em>everything</em>.
     /// </para>
@@ -640,17 +640,19 @@ public class AgentKitDocGateInstrumentTests
 
         foreach (var document in AgentKitCorpus.Documents.Where(d => d.EndsWith(".md", StringComparison.OrdinalIgnoreCase)))
         {
-            var lines = File.ReadAllText(Path.Combine(repoRoot, document.Replace('/', Path.DirectorySeparatorChar)))
-                .Replace("\r\n", "\n")
-                .Split('\n');
+            var markdown = File.ReadAllText(Path.Combine(repoRoot, document.Replace('/', Path.DirectorySeparatorChar)));
+            var lines = markdown.Replace("\r\n", "\n").Split('\n');
 
             extracted.TryGetValue(document, out var snippets);
             snippets ??= new List<AgentKitSnippet>();
 
-            // A snippet's own body may quote a fence as literal text; that line is content the
-            // extractor already read, not a block it skipped.
-            var covered = snippets
-                .SelectMany(s => Enumerable.Range(s.StartLine, s.Text.Split('\n').Length))
+            // Lines inside *any* fenced block, C# or not. A ````csharp` line quoted as literal text
+            // — inside a ```text block demonstrating fences, or inside a longer ```` block — is
+            // content the scanner already accounted for, not a block it skipped. Scoping this to
+            // extracted C# bodies alone would fail the moment a document explained fence syntax.
+            var covered = AgentKitDocCorpus.Fences(markdown)
+                .Where(region => region.BodyEndLine >= region.BodyStartLine)
+                .SelectMany(region => Enumerable.Range(region.BodyStartLine, region.BodyEndLine - region.BodyStartLine + 1))
                 .ToHashSet();
 
             var openedAt = snippets.Select(s => s.StartLine - 1).ToHashSet();
@@ -743,6 +745,64 @@ public class AgentKitDocGateInstrumentTests
         Assert.Equal(
             "TextBlock(paragraph).TextWrapping(TextWrapping.WrapWholeWords)",
             snippets[2].Text);
+    }
+
+    /// <summary>
+    /// A C# fence quoted as literal text inside another block is content, not a missed block.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="Every_CSharp_Fence_In_The_Corpus_Is_Extracted"/> compares an indentation-blind
+    /// probe against the extractor, and the probe has no idea about block structure. Scoping its
+    /// exclusions to extracted <em>C#</em> bodies would fail the moment a document explained fence
+    /// syntax inside a <c>```text</c> block — a CI failure on correct documentation, triggered by
+    /// writing about the very feature this gate depends on. Excluding every fence body, whatever
+    /// its language, is what makes the comparison sound.
+    /// </remarks>
+    [Fact]
+    public void A_Fence_Quoted_Inside_Another_Block_Is_Not_A_Missed_Snippet()
+    {
+        const string Markdown = """
+            # Heading
+
+            ```text
+            Write a C# sample like this:
+            ```csharp
+            FlexColumn(children).Padding(16)
+            ```
+
+            ````csharp
+            // a real one, inside a longer fence
+            ```csharp
+            Border(child).Padding(8)
+            ````
+            """;
+
+        var fences = AgentKitDocCorpus.Fences(Markdown);
+        var extracted = AgentKitDocCorpus.ExtractFences("fixture/quoted.md", Markdown);
+
+        var covered = fences
+            .Where(r => r.BodyEndLine >= r.BodyStartLine)
+            .SelectMany(r => Enumerable.Range(r.BodyStartLine, r.BodyEndLine - r.BodyStartLine + 1))
+            .ToHashSet();
+
+        var openedAt = extracted.Select(s => s.StartLine - 1).ToHashSet();
+        var lines = Markdown.Replace("\r\n", "\n").Split('\n');
+
+        var missed = new List<int>();
+        for (var i = 0; i < lines.Length; i++)
+        {
+            if (!AgentKitDocCorpus.CSharpFenceProbe.IsMatch(lines[i]))
+                continue;
+
+            var line = i + 1;
+            if (!covered.Contains(line) && !openedAt.Contains(line))
+                missed.Add(line);
+        }
+
+        Assert.Empty(missed);
+
+        // The probe must have had something to find here, or this proves nothing about quoting.
+        Assert.Contains(lines, line => AgentKitDocCorpus.CSharpFenceProbe.IsMatch(line));
     }
 
     /// <summary>

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateInstrumentTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateInstrumentTests.cs
@@ -1305,6 +1305,32 @@ public class AgentKitDocGateInstrumentTests
     }
 
     /// <summary>
+    /// An unresolvable written type stays unprovable, and unprovable does not exempt.
+    /// </summary>
+    /// <remarks>
+    /// Review proposed reading "matches no reflected parameter type" as "reference type, therefore
+    /// null", to cover an aliased <c>default(BrushAlias)</c>. It is declined: <c>Thickness</c> is
+    /// not among <c>Padding</c>'s reflected single-argument types either, so
+    /// <c>.Padding(default(Thickness))</c> takes the same path, and exempting it would lose a
+    /// value-typed-default finding that is real and already pinned. The alias shape does not occur
+    /// in documentation; the value-typed one does.
+    /// </remarks>
+    [Fact]
+    [Trait("Category", "AgentKitDocGate")]
+    public void An_Unresolvable_Written_Type_Stays_Unprovable()
+    {
+        Assert.False(ReactorSurface.Instance.DefaultIsProvablyNull("Background", "BrushAlias"));
+
+        // The case that makes this the right trade: same path, and it must keep reporting.
+        Assert.False(ReactorSurface.Instance.DefaultIsProvablyNull("Padding", "Thickness"));
+        Assert.Empty(ReactorSurface.Instance.SingleArgumentModifierTypes("Padding")
+            .Where(t => t.Name == "Thickness"));
+
+        // Control: a name that does resolve is still answered from the type.
+        Assert.True(ReactorSurface.Instance.DefaultIsProvablyNull("Background", "Brush"));
+    }
+
+    /// <summary>
     /// A label in the preceding list item marks a sample in the next one — deliberately.
     /// </summary>
     /// <remarks>

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateInstrumentTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateInstrumentTests.cs
@@ -1,0 +1,270 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.UI.Reactor.Analyzers;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests.AnalyzerTests;
+
+/// <summary>
+/// Proves that <see cref="AgentKitDocGateTests"/> is measuring something.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Both facts in that class pass with almost nothing to report — two exempted counterexamples and
+/// zero wrapper workarounds. A walker whose parser stopped matching, a factory map that resolved to
+/// nothing, or an emptied <see cref="NoOpModifierAnalyzer.ElementReplacements"/> would all read
+/// exactly the same way from the outside. A no-match is not a measurement until a positive control
+/// shows the same probe, through the same code path, can still match.
+/// </para>
+/// <para>
+/// So: two known violations replayed through <see cref="AgentKitSnippetWalker.Scan"/>, and floors
+/// under the corpus size, the resolution counts, and the tables the rules are derived from.
+/// </para>
+/// </remarks>
+public class AgentKitDocGateInstrumentTests
+{
+    /// <summary>
+    /// <c>skills/design.md</c> as it stood at <c>43a751b7^</c> — the canonical window shell #1119
+    /// rewrote, verbatim.
+    /// </summary>
+    /// <remarks>
+    /// Pinned as a literal rather than read from git so it cannot rot with the working tree. This
+    /// is the sample that shipped contradicting <c>reactor-design/SKILL.md</c>: a <c>Border</c>
+    /// wrapping a <c>FlexColumn</c> for no reason but to carry <c>.Padding(24)</c>. Note that
+    /// <c>REACTOR_MOD_003</c> is silent on it — <c>Border</c> is inside <c>Padding</c>'s gate —
+    /// which is precisely why the second rule has to exist.
+    /// </remarks>
+    private const string Pre1119AppShell = """
+        ReactorApp.Run<App>("MyApp", width: 900, height: 600);
+
+        class App : Component
+        {
+            public override Element Render()
+            {
+                var titleBar = TitleBar("MyApp").Flex(shrink: 0);
+
+                var body = Border(
+                    FlexColumn(/* page content */) with { RowGap = 16 }
+                ).Padding(24).Flex(grow: 1, basis: 0);
+
+                return FlexColumn(titleBar, body)
+                    .Backdrop(BackdropKind.Mica);
+            }
+        }
+        """;
+
+    [Fact]
+    public void Walker_Reports_The_Pre1119_Border_Workaround()
+    {
+        var scan = AgentKitSnippetWalker.Scan(new[]
+        {
+            new AgentKitSnippet("fixture/pre-1119-design.md", 1, Pre1119AppShell),
+        });
+
+        var finding = Assert.Single(scan.Of(AgentKitFindingKind.WrapperWorkaround));
+
+        Assert.Equal("Padding", finding.Modifier);
+        Assert.Equal("FlexElement", finding.ElementName);
+        Assert.Equal("FlexPadding", finding.Replacement);
+
+        // Line 11 of the fixture is `).Padding(24).Flex(grow: 1, basis: 0);` — the modifier itself,
+        // which is where a reader looks; line 9 is `var body = Border(`, where the chain starts and
+        // where a `// Wrong:` marker would sit. Pinning both keeps the span→line arithmetic honest:
+        // an off-by-one would send every real failure message to a line nobody can find, and
+        // nothing else in the suite would notice.
+        Assert.Equal(11, finding.Line);
+        Assert.Equal(9, finding.ChainStartLine);
+
+        // The sibling rule must stay quiet on this input. If it ever fires here, the two rules have
+        // started overlapping and this fixture has stopped proving what it claims to.
+        Assert.Empty(scan.Of(AgentKitFindingKind.DroppedModifier));
+    }
+
+    [Fact]
+    public void Walker_Reports_A_Modifier_Its_Receiver_Drops()
+    {
+        var scan = AgentKitSnippetWalker.Scan(new[]
+        {
+            new AgentKitSnippet("fixture/dropped.md", 1, "FlexColumn(children).Padding(16)"),
+        });
+
+        var finding = Assert.Single(scan.Of(AgentKitFindingKind.DroppedModifier));
+
+        Assert.Equal("Padding", finding.Modifier);
+        Assert.Equal("FlexElement", finding.ElementName);
+        Assert.Equal("FlexPadding", finding.Replacement);
+        Assert.Contains("FlexPanel", finding.Detail, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The receivers the gate admits must stay admitted. Without this, a walker that reported
+    /// <em>everything</em> would still pass the two positive controls above while making the real
+    /// facts fail for the wrong reason.
+    /// </summary>
+    [Theory]
+    [InlineData("Border(child).Padding(16)")]
+    [InlineData("VStack(8, items).Padding(16)")]
+    [InlineData("Button(\"Go\").Padding(12)")]
+    [InlineData("TextBlock(\"Hello\").Padding(8)")]
+    [InlineData("FlexColumn(children).FlexPadding(16)")]
+    [InlineData("FlexRow(items).FlexPadding(horizontal: 16, vertical: 8)")]
+    [InlineData("VStack(8, FlexColumn(children), Button(\"Go\")).Padding(16)")]
+    [InlineData("Border(FlexColumn(children)).Padding(16).Background(Theme.CardBackground)")]
+    public void Walker_Stays_Silent_On_Sound_Code(string snippet)
+    {
+        var scan = AgentKitSnippetWalker.Scan(new[] { new AgentKitSnippet("fixture/sound.md", 1, snippet) });
+
+        Assert.Empty(scan.Findings);
+    }
+
+    /// <summary>
+    /// Floors over the corpus and the reflection behind it. Each one turns a silent collapse — a
+    /// glob that stopped matching, a factory map that resolved to nothing, a fence parser that
+    /// stopped recognising ```` ```csharp ```` — into a failure.
+    /// </summary>
+    /// <remarks>
+    /// The thresholds are set well under the measured values (63 documents, 374 snippets, 345
+    /// resolved chains, 115 factories at the time of writing) because they are guards against a
+    /// mechanism breaking, not pins on the corpus. Raise one only if it stops discriminating; do
+    /// <b>not</b> lower one to make a red build green, because the collapse it is describing is
+    /// exactly the failure it exists to report.
+    /// </remarks>
+    [Fact]
+    public void The_Corpus_And_Its_Resolution_Are_Not_Empty()
+    {
+        var documents = AgentKitCorpus.Documents;
+        var snippets = AgentKitCorpus.Snippets;
+        var scan = AgentKitCorpus.Scan;
+
+        Assert.True(
+            documents.Count >= 50,
+            $"Only {documents.Count} agent-kit documents were discovered from Reactor.csproj; " +
+            "expected 50+. The agentkit/ <None> globs have probably stopped resolving, which would " +
+            "make every fact in AgentKitDocGateTests pass over an empty corpus.");
+
+        Assert.True(
+            snippets.Count >= 150,
+            $"Only {snippets.Count} C# snippets were extracted from {documents.Count} documents; " +
+            "expected 150+. The fence parser has probably stopped matching ```csharp blocks.");
+
+        Assert.True(
+            scan.ResolvedChains >= 100,
+            $"Only {scan.ResolvedChains} modifier chains resolved to a known element across the " +
+            "corpus; expected 100+. Factory or element reflection has probably stopped resolving, " +
+            "in which case both gates are inspecting nothing.");
+
+        Assert.True(
+            ReactorSurface.Instance.ResolvableFactoryCount >= 100,
+            $"Only {ReactorSurface.Instance.ResolvableFactoryCount} DSL factory names resolved to a " +
+            "single element type; expected 100+.");
+
+        // The wrapper rule is generated from this table. Emptying it would silence that fact
+        // entirely, and nothing downstream would say so.
+        Assert.NotEmpty(NoOpModifierAnalyzer.ElementReplacements);
+        Assert.Contains(
+            "Microsoft.UI.Reactor.Core.FlexElement|Padding",
+            NoOpModifierAnalyzer.ElementReplacements.Keys);
+    }
+
+    /// <summary>
+    /// Every <c>agentkit/</c> glob must match at least one file, and the corpus must contain the
+    /// three documents #1119 had to fix by hand.
+    /// </summary>
+    /// <remarks>
+    /// A folder renamed without updating the csproj stops shipping silently — the package simply
+    /// loses a skill. That is a packaging defect in its own right, and it is also the quietest way
+    /// for this gate's coverage to shrink.
+    /// </remarks>
+    [Fact]
+    public void Every_AgentKit_Pack_Glob_Still_Matches_Files()
+    {
+        var entries = AgentKitCorpus.PackEntries;
+
+        var empty = entries
+            .Where(entry => entry.Files.Count == 0)
+            .Select(entry => $"{entry.Include} → {entry.PackagePath}")
+            .ToList();
+
+        Assert.True(
+            empty.Count == 0,
+            "An agentkit/ pack item matches no file on disk, so the NuGet ships without it and this " +
+            "gate never inspects it:\n  " + string.Join("\n  ", empty));
+
+        var documents = AgentKitCorpus.Documents;
+
+        foreach (var required in new[]
+                 {
+                     "skills/design.md",
+                     "plugins/reactor/skills/reactor-design/SKILL.md",
+                     "plugins/reactor/skills/reactor-build-and-check/SKILL.md",
+                 })
+        {
+            Assert.True(
+                documents.Contains(required, StringComparer.OrdinalIgnoreCase),
+                $"{required} is no longer in the packed agent kit. It is one of the three documents " +
+                "#1119 had to reconcile by hand; if it genuinely stopped shipping, remove it here " +
+                "deliberately rather than leaving this gate pointed at a file nobody receives.");
+        }
+    }
+
+    /// <summary>
+    /// The fence reader must respect CommonMark's same-character, at-least-as-long closing rule,
+    /// and must report the body's real starting line.
+    /// </summary>
+    /// <remarks>
+    /// Both properties are load-bearing and neither is exercised by the corpus today: getting the
+    /// close wrong would swallow the rest of a document into one snippet (findings reported at
+    /// wildly wrong lines), and getting the line wrong would point every failure at the wrong place.
+    /// </remarks>
+    [Fact]
+    public void Fence_Extraction_Handles_Nesting_And_Reports_Real_Line_Numbers()
+    {
+        const string Markdown = """
+            # Heading
+
+            ```csharp
+            FlexColumn(children).FlexPadding(16)
+            ```
+
+            ```text
+            not C#
+            ```
+
+            ````csharp
+            // a longer fence survives an inner ``` run
+            ```
+            Border(child).Padding(8)
+            ````
+            """;
+
+        var snippets = AgentKitDocCorpus.ExtractFences("fixture/fences.md", Markdown);
+
+        Assert.Equal(2, snippets.Count);
+
+        Assert.Equal(4, snippets[0].StartLine);
+        Assert.Equal("FlexColumn(children).FlexPadding(16)", snippets[0].Text);
+
+        Assert.Equal(12, snippets[1].StartLine);
+        Assert.Contains("Border(child).Padding(8)", snippets[1].Text, StringComparison.Ordinal);
+        Assert.DoesNotContain("not C#", snippets[1].Text, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The corpus really is read from the working tree, not from a stale copy under
+    /// <c>bin/</c>.
+    /// </summary>
+    [Fact]
+    public void The_Corpus_Is_Read_From_The_Working_Tree()
+    {
+        var repoRoot = AgentKitCorpus.RepoRoot;
+
+        Assert.True(
+            File.Exists(Path.Combine(repoRoot, "src", "Reactor", "Reactor.csproj")),
+            $"Repo root resolved to {repoRoot}, which has no src/Reactor/Reactor.csproj.");
+
+        var design = Path.Combine(repoRoot, "skills", "design.md");
+        Assert.True(File.Exists(design), $"skills/design.md not found at {design}");
+    }
+}

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateInstrumentTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateInstrumentTests.cs
@@ -1363,8 +1363,7 @@ public class AgentKitDocGateInstrumentTests
 
         // The case that makes this the right trade: same path, and it must keep reporting.
         Assert.False(ReactorSurface.Instance.DefaultIsProvablyNull("Padding", "Thickness"));
-        Assert.Empty(ReactorSurface.Instance.SingleArgumentModifierTypes("Padding")
-            .Where(t => t.Name == "Thickness"));
+        Assert.DoesNotContain(ReactorSurface.Instance.SingleArgumentModifierTypes("Padding"), t => t.Name == "Thickness");
 
         // Control: a name that does resolve is still answered from the type.
         Assert.True(ReactorSurface.Instance.DefaultIsProvablyNull("Background", "Brush"));

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateInstrumentTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateInstrumentTests.cs
@@ -616,23 +616,65 @@ public class AgentKitDocGateInstrumentTests
     {
         Assert.Contains("Semantics", ReactorSurface.Instance.TypeChangingModifiers.Keys);
 
+        // The chain's element is the SemanticElement, not the Border that opened it.
+        Assert.Equal(
+            ReactorSurface.Instance.TypeChangingModifiers["Semantics"],
+            ReactorSurface.Instance.Element("Semantics", 0));
+
+        // ...and because SemanticElement declares no `Set` overload, the receiver is unresolvable,
+        // so the chain is skipped rather than attributed to the Border. That matches the analyzer,
+        // which is silent on receivers it cannot resolve the same way. The value of the stop is
+        // therefore *non*-attribution: without it the walk would judge a SemanticPanel against
+        // Border's gate.
         var scan = AgentKitSnippetWalker.Scan(new[]
         {
             new AgentKitSnippet("fixture/semantics.md", 1, "Border(child).Semantics(role: \"button\").Padding(16)"),
         });
 
-        var finding = Assert.Single(scan.Of(AgentKitFindingKind.DroppedModifier));
-        Assert.Equal("Padding", finding.Modifier);
-        Assert.Equal("SemanticElement", finding.ElementName);
+        Assert.Empty(scan.Findings);
+        Assert.Null(ReactorSurface.Instance.MountedControl(ReactorSurface.Instance.Element("Semantics", 0)!));
+    }
 
-        // Control: without the type change the same chain is sound, so this is not simply
-        // reporting every Border.
-        var plain = AgentKitSnippetWalker.Scan(new[]
-        {
-            new AgentKitSnippet("fixture/semantics.md", 1, "Border(child).Padding(16)"),
-        });
+    /// <summary>
+    /// A shape replacement is only named once it exists on that element.
+    /// </summary>
+    /// <remarks>
+    /// The analyzer resolves candidates in order and skips any that is not an invocable member on
+    /// the receiver, which is why <c>LineElement</c> — having no <c>Fill</c> — falls through to
+    /// <c>Stroke</c>. Taking the first candidate blindly named a remedy that does not compile, and
+    /// would reject a Line counterexample correctly documenting <c>.Stroke(...)</c>.
+    /// </remarks>
+    [Theory]
+    [InlineData("Rectangle().Background(brush)", "Fill")]
+    [InlineData("Line().Background(brush)", "Stroke")]
+    public void A_Shape_Replacement_Must_Exist_On_That_Element(string snippet, string expected)
+    {
+        var scan = AgentKitSnippetWalker.Scan(new[] { new AgentKitSnippet("fixture/shape.md", 1, snippet) });
 
-        Assert.Empty(plain.Findings);
+        Assert.Equal(expected, Assert.Single(scan.Of(AgentKitFindingKind.DroppedModifier)).Replacement);
+    }
+
+    /// <summary>
+    /// The mounted control comes from the <c>Set</c> overload alone, as the analyzer's does.
+    /// </summary>
+    /// <remarks>
+    /// An earlier revision fell back to the generator attribute, which made this gate report on
+    /// receivers <c>NoOpModifierAnalyzer.TryGetMountedControl</c> cannot resolve — a documentation
+    /// gate stricter than the rule it enforces, producing findings a reader cannot act on.
+    /// </remarks>
+    [Fact]
+    public void An_Element_With_No_Set_Overload_Is_Unresolvable()
+    {
+        var semantic = ReactorSurface.Instance.Element("Semantics", 0);
+
+        Assert.NotNull(semantic);
+        Assert.Empty(ReactorSurface.Instance.SetControls(semantic!));
+        Assert.Null(ReactorSurface.Instance.MountedControl(semantic!));
+
+        // Control: an element that *does* declare Set still resolves, so this is not passing
+        // because MountedControl stopped working.
+        var border = ReactorSurface.Instance.Element("Border", 0);
+        Assert.NotNull(ReactorSurface.Instance.MountedControl(border!));
     }
 
     /// <summary>

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateInstrumentTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateInstrumentTests.cs
@@ -813,6 +813,20 @@ public class AgentKitDocGateInstrumentTests
         Assert.Equal(
             "FlexColumn(children).FlexPadding(16)",
             Assert.Single(AgentKitDocCorpus.ExtractFences("fixture/padded.md", PaddedMarker)).Text);
+
+        // A fence may also open on a list marker's own line (`- ```csharp`); the marker sets the
+        // content column, and the probe accepts the shape too so the oracle is not blind to it.
+        const string InlineMarker = """
+            - ```csharp
+              FlexColumn(children).FlexPadding(16)
+              ```
+            """;
+
+        Assert.Equal(
+            "FlexColumn(children).FlexPadding(16)",
+            Assert.Single(AgentKitDocCorpus.ExtractFences("fixture/inline.md", InlineMarker)).Text);
+
+        Assert.Matches(AgentKitDocCorpus.CSharpFenceProbe, "- ```csharp");
     }
 
     /// <summary>

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateInstrumentTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateInstrumentTests.cs
@@ -369,6 +369,64 @@ public class AgentKitDocGateInstrumentTests
     }
 
     /// <summary>
+    /// A styled factory that happens to return a <c>BorderElement</c> is not a passive wrapper.
+    /// </summary>
+    /// <remarks>
+    /// <c>Factories.Card</c> is
+    /// <c>Border(child).Background(...).WithBorder(...).CornerRadius(8).Padding(16)</c> — its
+    /// decoration is baked in where no chain inspection can see it, and its own XML doc offers
+    /// <c>Card(child).Padding(24)</c> as the sanctioned way to override the preset. Judging
+    /// passivity by element type reported that as a workaround, which is a false positive on
+    /// documented usage. The same applies to a style applied from a resource.
+    /// </remarks>
+    [Theory]
+    [InlineData("Card(FlexColumn(children)).Padding(24)")]
+    [InlineData("Border(FlexColumn(children)).Padding(24).ApplyStyle(\"CardStyle\")")]
+    public void A_Decorated_Wrapper_Is_Not_A_Padding_Workaround(string snippet)
+    {
+        var scan = AgentKitSnippetWalker.Scan(new[] { new AgentKitSnippet("fixture/card.md", 1, snippet) });
+
+        Assert.Empty(scan.Of(AgentKitFindingKind.WrapperWorkaround));
+
+        // Positive control on the same shape: the plain factory, undecorated, must still report —
+        // otherwise this would pass because the wrapper rule had stopped working altogether.
+        var plain = AgentKitSnippetWalker.Scan(new[]
+        {
+            new AgentKitSnippet("fixture/card.md", 1, "Border(FlexColumn(children)).Padding(24)"),
+        });
+
+        Assert.Single(plain.Of(AgentKitFindingKind.WrapperWorkaround));
+    }
+
+    /// <summary>
+    /// A pack item is selected by where it ships, whichever separator the csproj spells it with.
+    /// </summary>
+    /// <remarks>
+    /// NuGet accepts both, and this project already uses backslashes for other items. An
+    /// <c>agentkit\…</c> item would ship and never enter the corpus, and since the entry is dropped
+    /// whole, <see cref="Every_AgentKit_Pack_Glob_Still_Matches_Files"/> could not see the gap
+    /// either — the corpus would simply be smaller than the package, silently.
+    /// </remarks>
+    [Fact]
+    public void Pack_Entries_Are_Found_Whichever_Separator_The_Csproj_Uses()
+    {
+        const string Project = """
+            <Project>
+              <ItemGroup>
+                <None Include="..\..\skills\*.md" Pack="true" PackagePath="agentkit/skills/" />
+                <None Include="..\..\SKILL.md" Pack="true" PackagePath="agentkit\" />
+                <None Include="..\..\LICENSE" Pack="true" PackagePath="" />
+              </ItemGroup>
+            </Project>
+            """;
+
+        var packagePaths = AgentKitDocCorpus.AgentKitPackagePaths(Project);
+
+        Assert.Equal(2, packagePaths.Count);
+        Assert.Contains(@"agentkit\", packagePaths);
+    }
+
+    /// <summary>
     /// Floors over the corpus and the reflection behind it. Each one turns a silent collapse — a
     /// glob that stopped matching, a factory map that resolved to nothing, a fence parser that
     /// stopped recognising ```` ```csharp ```` — into a failure.

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateInstrumentTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateInstrumentTests.cs
@@ -1009,6 +1009,55 @@ public class AgentKitDocGateInstrumentTests
     }
 
     /// <summary>
+    /// A label in a <em>deeper</em> blockquote does not mark a sample in the container around it.
+    /// </summary>
+    /// <remarks>
+    /// The walk stripped every quote level before matching, so <c>&gt; &gt; Avoid this:</c> read as
+    /// an ordinary label and exempted the parent quote's sample below it. That nested line belongs
+    /// to its own container and introduces its own example; borrowing it silently suppressed a real
+    /// finding one level out — the mirror of the depth bookkeeping the fence scanner already does.
+    /// </remarks>
+    [Fact]
+    [Trait("Category", "AgentKitDocGate")]
+    public void A_Deeper_Blockquoted_Label_Does_Not_Mark_The_Enclosing_Sample()
+    {
+        var nested = new[]
+        {
+            "> > Avoid this:",
+            ">",
+            "> ```csharp",
+            "> FlexColumn(children).Padding(16)",
+        };
+
+        Assert.False(AgentKitDocGateTests.IsMarkedAt(nested, 4));
+
+        // Positive control: the identical shape with the label at the sample's own depth must
+        // exempt, so the assertion above fails on the depth test rather than on the walk being
+        // unable to reach that line at all.
+        var sameDepth = new[]
+        {
+            "> Avoid this:",
+            ">",
+            "> ```csharp",
+            "> FlexColumn(children).Padding(16)",
+        };
+
+        Assert.True(AgentKitDocGateTests.IsMarkedAt(sameDepth, 4));
+
+        // A shallower label still counts: it encloses the quote, so it does introduce what is
+        // inside it. Exempting is the safe direction for an ambiguous container boundary.
+        var shallower = new[]
+        {
+            "Avoid this:",
+            "",
+            "> ```csharp",
+            "> FlexColumn(children).Padding(16)",
+        };
+
+        Assert.True(AgentKitDocGateTests.IsMarkedAt(shallower, 4));
+    }
+
+    /// <summary>
     /// A nested blockquote inside a quoted fence does not close it.
     /// </summary>
     /// <remarks>

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateInstrumentTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateInstrumentTests.cs
@@ -961,6 +961,14 @@ public class AgentKitDocGateInstrumentTests
     [InlineData("Border(FlexColumn(children)).Padding(16).OnMount(fe => Configure(fe))", false)]
     [InlineData("Border(FlexColumn(children)).Padding(16).Ref(borderRef)", false)]
     [InlineData("Border(FlexColumn(children)).Padding(16).ApplyStyle(\"CardStyle\")", false)]
+    // Parent-relative modifiers on the *inner* chain: deleting the wrapper reparents that element,
+    // so a `.Flex` that is inert inside the Border starts driving layout once it is gone. The
+    // remedy is not behaviour-preserving, so it is not recommended.
+    [InlineData("Border(FlexColumn(children).Flex(grow: 1)).Padding(16)", false)]
+    [InlineData("Border(FlexColumn(children).Dock(Dock.Top)).Padding(16)", false)]
+    [InlineData("Border(FlexColumn(children).Margin(8)).Padding(16)", false)]
+    // ...but an inner modifier the parent does not interpret leaves the remedy sound.
+    [InlineData("Border(FlexColumn(children).Background(brush)).Padding(16)", true)]
     public void Only_Relocatable_Modifiers_Leave_A_Wrapper_Removable(string snippet, bool reported)
     {
         var scan = AgentKitSnippetWalker.Scan(new[] { new AgentKitSnippet("fixture/relocatable.md", 1, snippet) });

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateInstrumentTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateInstrumentTests.cs
@@ -786,6 +786,21 @@ public class AgentKitDocGateInstrumentTests
             Assert.Single(AgentKitDocCorpus.ExtractFences("fixture/tab.md", Tabbed)).Text);
 
         Assert.Matches(AgentKitDocCorpus.CSharpFenceProbe, "```csharp\tlinenos");
+
+        // Marker padding sets the content column: `-    item` puts content at 5, so a fence eight
+        // spaces in is three past it and valid. Consuming a single space read the column as 2 and
+        // rejected it.
+        const string PaddedMarker = """
+            -    item
+
+                    ```csharp
+                    FlexColumn(children).FlexPadding(16)
+                    ```
+            """;
+
+        Assert.Equal(
+            "FlexColumn(children).FlexPadding(16)",
+            Assert.Single(AgentKitDocCorpus.ExtractFences("fixture/padded.md", PaddedMarker)).Text);
     }
 
     /// <summary>

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateInstrumentTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateInstrumentTests.cs
@@ -142,6 +142,9 @@ public class AgentKitDocGateInstrumentTests
     [InlineData("Rectangle().Background(null!)")]
     [InlineData("Rectangle().Background(((Brush)null)!)")]
     [InlineData("Rectangle().Background(default(Brush)!)")]
+    [InlineData("Rectangle().Background(default(Microsoft.UI.Xaml.Media.Brush))")]
+    [InlineData("Rectangle().Background(default(global::Microsoft.UI.Xaml.Media.Brush))")]
+    [InlineData("Rectangle().Background(default(Brush?))")]
     [InlineData("FlexColumn(children).Padding(null)")]
     public void Walker_Mirrors_The_Analyzers_Constant_Null_Gate(string snippet)
     {
@@ -344,34 +347,6 @@ public class AgentKitDocGateInstrumentTests
     }
 
     /// <summary>
-    /// An unrelated modifier that merely ends in "Set" does not justify a wrapper.
-    /// </summary>
-    /// <remarks>
-    /// <c>.Set(...)</c> justifies one because its lambda is opaque to this walker. As a substring
-    /// that also swallowed <c>.PositionInSet(...)</c>, an accessibility modifier that can live on
-    /// the inner element — so a Border that is still only a padding workaround stopped being
-    /// reported.
-    /// </remarks>
-    [Fact]
-    public void Only_An_Exact_Set_Justifies_A_Wrapper()
-    {
-        var suppressed = AgentKitSnippetWalker.Scan(new[]
-        {
-            new AgentKitSnippet("fixture/set.md", 1, "Border(FlexColumn(children)).Padding(16).Set(b => b.Tag = x)"),
-        });
-
-        Assert.Empty(suppressed.Of(AgentKitFindingKind.WrapperWorkaround));
-
-        var reported = AgentKitSnippetWalker.Scan(new[]
-        {
-            new AgentKitSnippet("fixture/set.md", 1, "Border(FlexColumn(children)).Padding(16).PositionInSet(2, 5)"),
-        });
-
-        var finding = Assert.Single(reported.Of(AgentKitFindingKind.WrapperWorkaround));
-        Assert.Equal("FlexPadding", finding.Replacement);
-    }
-
-    /// <summary>
     /// A styled factory that happens to return a <c>BorderElement</c> is not a passive wrapper.
     /// </summary>
     /// <remarks>
@@ -562,52 +537,6 @@ public class AgentKitDocGateInstrumentTests
     }
 
     /// <summary>
-    /// A modifier that does nothing cannot justify the wrapper that carries it.
-    /// </summary>
-    /// <remarks>
-    /// A constant-null argument makes a modifier inert — the premise the constant-null gate already
-    /// rests on — so <c>Border(...).Padding(16).Background((Brush)null)</c> is still a Border
-    /// supplying nothing but padding. Accepting it by name hid the exact workaround this rule
-    /// exists to catch behind a decorator that does nothing, and contradicted the same call being
-    /// skipped as inert two checks earlier.
-    /// </remarks>
-    [Theory]
-    [InlineData("Border(FlexColumn(children)).Padding(16).Background((Brush)null)")]
-    [InlineData("Border(FlexColumn(children)).Padding(16).Background(null)")]
-    [InlineData("Border(FlexColumn(children)).Padding(16).Background(null!)")]
-    [InlineData("Border(FlexColumn(children)).Padding(16).Background(default(Brush)!)")]
-    public void An_Inert_Modifier_Does_Not_Justify_A_Wrapper(string snippet)
-    {
-        var scan = AgentKitSnippetWalker.Scan(new[] { new AgentKitSnippet("fixture/inert.md", 1, snippet) });
-
-        var finding = Assert.Single(scan.Of(AgentKitFindingKind.WrapperWorkaround));
-        Assert.Equal("FlexPadding", finding.Replacement);
-    }
-
-    /// <summary>
-    /// A real decoration still justifies it, so the check above is not simply reporting everything.
-    /// </summary>
-    [Fact]
-    public void A_Live_Modifier_Still_Justifies_A_Wrapper()
-    {
-        var scan = AgentKitSnippetWalker.Scan(new[]
-        {
-            new AgentKitSnippet("fixture/inert.md", 1, "Border(FlexColumn(children)).Padding(16).Background(Theme.CardBackground)"),
-        });
-
-        Assert.Empty(scan.Of(AgentKitFindingKind.WrapperWorkaround));
-
-        // A value-typed `default` is a real zero-valued write, not an inert null, so it justifies
-        // the wrapper too — the same distinction the constant-null gate draws.
-        var zeroValued = AgentKitSnippetWalker.Scan(new[]
-        {
-            new AgentKitSnippet("fixture/inert.md", 1, "Border(FlexColumn(children)).Padding(16).CornerRadius(default(CornerRadius))"),
-        });
-
-        Assert.Empty(zeroValued.Of(AgentKitFindingKind.WrapperWorkaround));
-    }
-
-    /// <summary>
     /// A standalone block-comment label marks the block below it.
     /// </summary>
     /// <remarks>
@@ -637,28 +566,6 @@ public class AgentKitDocGateInstrumentTests
         };
 
         Assert.False(AgentKitDocGateTests.IsMarkedAt(unmarked, 3));
-    }
-
-    /// <summary>
-    /// An opaque lifecycle or identity escape hatch on the wrapper makes it non-deletable.
-    /// </summary>
-    /// <remarks>
-    /// <c>Set</c> was already handled; the rest are the same problem. <c>OnMount</c> can write any
-    /// native property at mount time, <c>OnUnmount</c> makes the wrapper's <em>lifecycle</em>
-    /// significant whether or not it paints anything, and <c>Ref</c> hands the control out by
-    /// identity. "Remove the wrapper" is not behaviour-preserving for any of them.
-    /// </remarks>
-    [Theory]
-    [InlineData("Border(FlexColumn(children)).Padding(16).OnMount(fe => Configure(fe))")]
-    [InlineData("Border(FlexColumn(children)).Padding(16).OnMountAdd(fe => Configure(fe))")]
-    [InlineData("Border(FlexColumn(children)).Padding(16).OnUnmount(fe => Teardown(fe))")]
-    [InlineData("Border(FlexColumn(children)).Padding(16).OnUnmountAdd(fe => Teardown(fe))")]
-    [InlineData("Border(FlexColumn(children)).Padding(16).Ref(borderRef)")]
-    public void A_Lifecycle_Escape_Hatch_Justifies_A_Wrapper(string snippet)
-    {
-        var scan = AgentKitSnippetWalker.Scan(new[] { new AgentKitSnippet("fixture/lifecycle.md", 1, snippet) });
-
-        Assert.Empty(scan.Of(AgentKitFindingKind.WrapperWorkaround));
     }
 
     /// <summary>
@@ -869,6 +776,46 @@ public class AgentKitDocGateInstrumentTests
             ReactorSurface.MergeTypeChange(map, "Modifier", typeof(int));
 
         Assert.Equal(typeof(int), map["Modifier"]);
+    }
+
+    /// <summary>
+    /// Only modifiers proven relocatable let the wrapper finding through; everything else
+    /// suppresses it.
+    /// </summary>
+    /// <remarks>
+    /// The allowlist replaced a denylist whose failure mode was backwards: an unrecognised modifier
+    /// counted as "the wrapper contributes nothing" and produced a finding, so
+    /// <c>Border(...).Padding(16).OnTapped(...)</c> was reported as removable even though the
+    /// Border is the routed-event source and hit-test boundary. Events, flyouts, tooltips and
+    /// connected animations are an open-ended set that cannot be enumerated safely, so the default
+    /// has to be "suppress".
+    /// </remarks>
+    [Theory]
+    // Positional / identity modifiers the inner element inherits: the finding still stands.
+    [InlineData("Border(FlexColumn(children)).Padding(16)", true)]
+    [InlineData("Border(FlexColumn(children)).Padding(16).Flex(grow: 1, basis: 0)", true)]
+    [InlineData("Border(FlexColumn(children)).Padding(16).Margin(8)", true)]
+    [InlineData("Border(FlexColumn(children)).Padding(16).WithKey(\"k\")", true)]
+    // Inert: does nothing, so it cannot be what the wrapper is for.
+    [InlineData("Border(FlexColumn(children)).Padding(16).Background((Brush)null)", true)]
+    // Behaviour-bearing or opaque: the wrapper is load-bearing, so no finding.
+    [InlineData("Border(FlexColumn(children)).Padding(16).OnTapped((s, e) => Handle(e))", false)]
+    [InlineData("Border(FlexColumn(children)).Padding(16).WithFlyout(menu)", false)]
+    [InlineData("Border(FlexColumn(children)).Padding(16).ToolTip(\"hint\")", false)]
+    [InlineData("Border(FlexColumn(children)).Padding(16).Background(Theme.CardBackground)", false)]
+    [InlineData("Border(FlexColumn(children)).Padding(16).Set(b => b.Tag = x)", false)]
+    [InlineData("Border(FlexColumn(children)).Padding(16).OnMount(fe => Configure(fe))", false)]
+    [InlineData("Border(FlexColumn(children)).Padding(16).Ref(borderRef)", false)]
+    [InlineData("Border(FlexColumn(children)).Padding(16).ApplyStyle(\"CardStyle\")", false)]
+    public void Only_Relocatable_Modifiers_Leave_A_Wrapper_Removable(string snippet, bool reported)
+    {
+        var scan = AgentKitSnippetWalker.Scan(new[] { new AgentKitSnippet("fixture/relocatable.md", 1, snippet) });
+        var findings = scan.Of(AgentKitFindingKind.WrapperWorkaround);
+
+        if (reported)
+            Assert.Equal("FlexPadding", Assert.Single(findings).Replacement);
+        else
+            Assert.Empty(findings);
     }
 
     /// <summary>

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateInstrumentTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateInstrumentTests.cs
@@ -1405,6 +1405,43 @@ public class AgentKitDocGateInstrumentTests
     }
 
     /// <summary>
+    /// The container opener's boundary: the scanner and its probe agree about what they skip.
+    /// </summary>
+    /// <remarks>
+    /// CommonMark nests containers arbitrarily, so <c>- &gt; ```csharp</c> is a legal opener that
+    /// neither half matches. What makes that safe rather than silent is that they agree: the
+    /// completeness fact still means what it says, and the cost is an unscanned block rather than a
+    /// finding on prose. Pinned so the boundary is a decision, and so it cannot drift into the two
+    /// disagreeing — which would fail CI on a correct document.
+    /// </remarks>
+    [Fact]
+    [Trait("Category", "AgentKitDocGate")]
+    public void The_Container_Opener_Boundary_Is_Agreed_By_Both_Halves()
+    {
+        const string Nested = """
+            - > ```csharp
+              > FlexColumn(children).Padding(16)
+              > ```
+            """;
+
+        Assert.Empty(AgentKitDocCorpus.ExtractFences("fixture/nestedcontainer.md", Nested));
+        Assert.DoesNotMatch(AgentKitDocCorpus.CSharpFenceProbe, "- > ```csharp");
+
+        // Positive controls: each container on its own is matched by both, so the assertions above
+        // are the combination rather than either half having stopped working.
+        Assert.Matches(AgentKitDocCorpus.CSharpFenceProbe, "- ```csharp");
+        Assert.Matches(AgentKitDocCorpus.CSharpFenceProbe, "> ```csharp");
+
+        Assert.Single(AgentKitDocCorpus.ExtractFences(
+            "fixture/list.md",
+            "- ```csharp\n  FlexColumn(children).FlexPadding(16)\n  ```"));
+
+        Assert.Single(AgentKitDocCorpus.ExtractFences(
+            "fixture/quote.md",
+            "> ```csharp\n> FlexColumn(children).FlexPadding(16)\n> ```"));
+    }
+
+    /// <summary>
     /// A label in the preceding list item marks a sample in the next one — deliberately.
     /// </summary>
     /// <remarks>

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateInstrumentTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateInstrumentTests.cs
@@ -896,6 +896,20 @@ public class AgentKitDocGateInstrumentTests
         // Positive control at three columns, where both are still container syntax.
         Assert.Matches(AgentKitDocCorpus.CSharpFenceProbe, "   - ```csharp");
         Assert.Matches(AgentKitDocCorpus.CSharpFenceProbe, "   > ```csharp");
+
+        // A tab advances to the next four-column tab stop (`Md4cFixtures/spec.txt`, "Tabs"), so a
+        // tab-indented fence at top level is an indented code block. Measuring one column per
+        // character read it as width 1 and scanned the literal as a sample.
+        const string TabIndented = """
+            Some prose.
+
+            <TAB>```csharp
+            <TAB>FlexColumn(children).Padding(16)
+            <TAB>```
+            """;
+
+        Assert.Empty(AgentKitDocCorpus.ExtractFences("fixture/tab.md", TabIndented.Replace("<TAB>", "\t")));
+        Assert.DoesNotMatch(AgentKitDocCorpus.CSharpFenceProbe, "\t```csharp");
     }
 
     /// <summary>
@@ -1170,6 +1184,49 @@ public class AgentKitDocGateInstrumentTests
         Assert.False(AgentKitDocGateTests.IsMarkedAt(unmarked, 4));
     }
 
+    /// <summary>
+    /// A terminal period does not turn an ordinary short comment into a counterexample label.
+    /// </summary>
+    /// <remarks>
+    /// The two-word safeguard names `// avoid allocations` as exactly what it must reject, but the
+    /// period was counted as a delimiter, so the punctuated form split into a two-word head and
+    /// qualified. Identical text, opposite verdicts.
+    /// </remarks>
+    [Theory]
+    [Trait("Category", "AgentKitDocGate")]
+    [InlineData("// avoid allocations", false)]
+    [InlineData("// avoid allocations.", false)]
+    [InlineData("// never cache;", false)]
+    // A mid-comment period still delimits, so a real label keeps its meaning.
+    [InlineData("// Bad. This allocates.", true)]
+    [InlineData("// Wrong.", true)]
+    [InlineData("// Wrong: no effect", true)]
+    [InlineData("// Wrong", true)]
+    public void A_Terminal_Period_Does_Not_Make_A_Label(string comment, bool label)
+    {
+        Assert.Equal(label, AgentKitDocGateTests.IsCounterexampleLabel(AgentKitDocGateTests.CommentText(comment)));
+    }
+
+    /// <summary>
+    /// A named argument selects the overload before <c>default</c> is judged.
+    /// </summary>
+    /// <remarks>
+    /// `.Background(brush: default)` binds only to the Brush overload, so it is provably null.
+    /// Judging it against the ambiguous string/Brush/ThemeRef set answered a question the call did
+    /// not ask, which would make this gate stricter than the analyzer it mirrors.
+    /// </remarks>
+    [Fact]
+    [Trait("Category", "AgentKitDocGate")]
+    public void A_Named_Argument_Narrows_The_Overload_Set()
+    {
+        Assert.True(ReactorSurface.Instance.DefaultIsProvablyNull("Background", null, "brush"));
+
+        // Control: the same modifier without the name, and an unrecognised name, both fall back to
+        // the full set — so the assertion above is the narrowing rather than a blanket true.
+        Assert.Equal(
+            ReactorSurface.Instance.DefaultIsProvablyNull("Background"),
+            ReactorSurface.Instance.DefaultIsProvablyNull("Background", null, "notAParameter"));
+    }
     /// <summary>
     /// A label in the preceding list item marks a sample in the next one — deliberately.
     /// </summary>

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateInstrumentTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateInstrumentTests.cs
@@ -210,13 +210,95 @@ public class AgentKitDocGateInstrumentTests
     }
 
     /// <summary>
-    /// The fence reader must respect CommonMark's same-character, at-least-as-long closing rule,
-    /// and must report the body's real starting line.
+    /// Every C# fence a naive, indentation-blind probe can see in the packed corpus must have
+    /// produced a snippet.
     /// </summary>
     /// <remarks>
-    /// Both properties are load-bearing and neither is exercised by the corpus today: getting the
-    /// close wrong would swallow the rest of a document into one snippet (findings reported at
-    /// wildly wrong lines), and getting the line wrong would point every failure at the wrong place.
+    /// <para>
+    /// This is the fact that would have caught the four-space fences under list items 10 and 11 of
+    /// <c>skills/design-docs/typography-and-colors.md</c>, which the original 0–3 space indent cap
+    /// silently skipped. The aggregate snippet floor did <b>not</b> catch it and could not: 372
+    /// blocks clear a floor of 150 just as comfortably as 374 do. A floor bounds the corpus from
+    /// below; only a differential comparison against an independent derivation can say the
+    /// extractor saw <em>everything</em>.
+    /// </para>
+    /// <para>
+    /// The comparison is one-directional by design. <see cref="AgentKitDocCorpus.CSharpFenceProbe"/>
+    /// requires the language to stand alone on the line, so the extractor may legitimately find
+    /// fences the probe cannot (an info string carrying extra words). The reverse — a probe hit
+    /// with no snippet — is always either a miss or an empty block.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public void Every_CSharp_Fence_In_The_Corpus_Is_Extracted()
+    {
+        var repoRoot = AgentKitCorpus.RepoRoot;
+
+        var extracted = AgentKitCorpus.Snippets
+            .GroupBy(s => s.Path, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(g => g.Key, g => g.ToList(), StringComparer.OrdinalIgnoreCase);
+
+        var probed = 0;
+        var missed = new List<string>();
+
+        foreach (var document in AgentKitCorpus.Documents.Where(d => d.EndsWith(".md", StringComparison.OrdinalIgnoreCase)))
+        {
+            var lines = File.ReadAllText(Path.Combine(repoRoot, document.Replace('/', Path.DirectorySeparatorChar)))
+                .Replace("\r\n", "\n")
+                .Split('\n');
+
+            extracted.TryGetValue(document, out var snippets);
+            snippets ??= new List<AgentKitSnippet>();
+
+            // A snippet's own body may quote a fence as literal text; that line is content the
+            // extractor already read, not a block it skipped.
+            var covered = snippets
+                .SelectMany(s => Enumerable.Range(s.StartLine, s.Text.Split('\n').Length))
+                .ToHashSet();
+
+            var openedAt = snippets.Select(s => s.StartLine - 1).ToHashSet();
+
+            for (var i = 0; i < lines.Length; i++)
+            {
+                if (!AgentKitDocCorpus.CSharpFenceProbe.IsMatch(lines[i]))
+                    continue;
+
+                var line = i + 1;
+                if (covered.Contains(line))
+                    continue;
+
+                probed++;
+
+                if (!openedAt.Contains(line))
+                    missed.Add($"{document}:{line} — `{lines[i].TrimEnd()}` opens a C# block that ExtractFences did not return");
+            }
+        }
+
+        // Positive control. Zero probe hits would make the loop above vacuous, and it would read
+        // exactly like a corpus the extractor covers perfectly.
+        Assert.True(
+            probed >= 150,
+            $"The indentation-blind probe found only {probed} C# fences in the packed corpus; " +
+            "expected 150+. The probe itself has stopped matching, so this comparison is measuring " +
+            "nothing and would pass over an extractor that returned no snippets at all.");
+
+        Assert.True(
+            missed.Count == 0,
+            $"{missed.Count} C# fence(s) in the shipped agent kit are not reaching the doc gate, so " +
+            "their samples ship unchecked:\n  " + string.Join("\n  ", missed));
+    }
+
+    /// <summary>
+    /// The fence reader must respect CommonMark's same-character, at-least-as-long closing rule,
+    /// must un-nest a fence indented inside a list item, and must report the body's real starting
+    /// line.
+    /// </summary>
+    /// <remarks>
+    /// Every property here is load-bearing and none is exercised by the corpus in a way that would
+    /// fail visibly: getting the close wrong would swallow the rest of a document into one snippet
+    /// (findings reported at wildly wrong lines), getting the line wrong would point every failure
+    /// at the wrong place, and getting the indent wrong drops whole blocks — which is exactly what
+    /// shipped in the first revision of this gate, silently, past a green floor.
     /// </remarks>
     [Fact]
     public void Fence_Extraction_Handles_Nesting_And_Reports_Real_Line_Numbers()
@@ -237,11 +319,18 @@ public class AgentKitDocGateInstrumentTests
             ```
             Border(child).Padding(8)
             ````
+
+            10. **A list item** — its fenced block is indented to the item's content column,
+                which is four spaces, not the three CommonMark allows at top level:
+
+                ```csharp
+                TextBlock(paragraph).TextWrapping(TextWrapping.WrapWholeWords)
+                ```
             """;
 
         var snippets = AgentKitDocCorpus.ExtractFences("fixture/fences.md", Markdown);
 
-        Assert.Equal(2, snippets.Count);
+        Assert.Equal(3, snippets.Count);
 
         Assert.Equal(4, snippets[0].StartLine);
         Assert.Equal("FlexColumn(children).FlexPadding(16)", snippets[0].Text);
@@ -249,6 +338,14 @@ public class AgentKitDocGateInstrumentTests
         Assert.Equal(12, snippets[1].StartLine);
         Assert.Contains("Border(child).Padding(8)", snippets[1].Text, StringComparison.Ordinal);
         Assert.DoesNotContain("not C#", snippets[1].Text, StringComparison.Ordinal);
+
+        // The list-nested block: found at all (the regression this pins), reported at its real
+        // line, and un-nested from the four-space list indent rather than carrying it into the
+        // snippet text.
+        Assert.Equal(21, snippets[2].StartLine);
+        Assert.Equal(
+            "TextBlock(paragraph).TextWrapping(TextWrapping.WrapWholeWords)",
+            snippets[2].Text);
     }
 
     /// <summary>

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateInstrumentTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateInstrumentTests.cs
@@ -692,6 +692,111 @@ public class AgentKitDocGateInstrumentTests
     }
 
     /// <summary>
+    /// A type-changing modifier decides the chain's element, so a gated modifier after it is
+    /// judged against the type it produced.
+    /// </summary>
+    /// <remarks>
+    /// <c>Semantics</c> is the framework's only one. <c>Border(child).Semantics(...)</c> is a
+    /// <c>SemanticElement</c> mounting a <c>SemanticPanel</c> — a <c>Panel</c>, outside
+    /// <c>Padding</c>'s gate — so a trailing <c>.Padding(16)</c> really is dropped, even though the
+    /// head is a Border and a Border is a legal receiver. Walking through it resolved the wrong
+    /// element, reported nothing, and still counted the chain as resolved, which is the shape of
+    /// shortfall the floors are meant to expose.
+    /// </remarks>
+    [Fact]
+    public void A_Type_Changing_Modifier_Decides_The_Element()
+    {
+        Assert.Contains("Semantics", ReactorSurface.Instance.TypeChangingModifiers.Keys);
+
+        var scan = AgentKitSnippetWalker.Scan(new[]
+        {
+            new AgentKitSnippet("fixture/semantics.md", 1, "Border(child).Semantics(role: \"button\").Padding(16)"),
+        });
+
+        var finding = Assert.Single(scan.Of(AgentKitFindingKind.DroppedModifier));
+        Assert.Equal("Padding", finding.Modifier);
+        Assert.Equal("SemanticElement", finding.ElementName);
+
+        // Control: without the type change the same chain is sound, so this is not simply
+        // reporting every Border.
+        var plain = AgentKitSnippetWalker.Scan(new[]
+        {
+            new AgentKitSnippet("fixture/semantics.md", 1, "Border(child).Padding(16)"),
+        });
+
+        Assert.Empty(plain.Findings);
+    }
+
+    /// <summary>
+    /// An item that is not packed is not inspected.
+    /// </summary>
+    /// <remarks>
+    /// A <c>&lt;None&gt;</c> item ships only if it opts in with <c>Pack="true"</c>, so an
+    /// <c>agentkit/</c> path alone does not mean a consumer receives the file. Scanning one anyway
+    /// could fail the gate over a document nobody gets, breaking the property the whole corpus
+    /// rests on — that it is the same list the pack target consumes.
+    /// </remarks>
+    [Fact]
+    public void Only_Items_That_Actually_Pack_Are_Inspected()
+    {
+        const string Project = """
+            <Project>
+              <ItemGroup>
+                <None Include="a.md" Pack="true"  PackagePath="agentkit/skills/" />
+                <None Include="b.md" Pack="false" PackagePath="agentkit/skills/" />
+                <None Include="c.md"              PackagePath="agentkit/skills/" />
+              </ItemGroup>
+            </Project>
+            """;
+
+        Assert.Equal(new[] { "a.md" }, AgentKitDocCorpus.AgentKitIncludes(Project));
+    }
+
+    /// <summary>
+    /// A fence indented as a code block is literal text and must not open a region.
+    /// </summary>
+    /// <remarks>
+    /// Four spaces outside a list is an indented code block. Honouring a fence written there
+    /// swallowed everything up to the next close — including the genuine top-level
+    /// ```` ```csharp ```` opener below it, which then shipped uninspected. The differential probe
+    /// cannot catch this, because it derives its exclusions from the same scan.
+    /// </remarks>
+    [Fact]
+    public void An_Indented_Literal_Fence_Does_Not_Swallow_A_Real_Block()
+    {
+        const string Markdown = """
+            # Heading
+
+            Some prose, then an indented code block quoting a fence:
+
+                ```text
+                not a real fence
+
+            ```csharp
+            FlexColumn(children).FlexPadding(16)
+            ```
+            """;
+
+        var snippets = AgentKitDocCorpus.ExtractFences("fixture/indented.md", Markdown);
+
+        var real = Assert.Single(snippets);
+        Assert.Equal("FlexColumn(children).FlexPadding(16)", real.Text);
+
+        // Positive control: the same indentation *inside a list item* is a real fence, which is how
+        // the two blocks in typography-and-colors.md reach the corpus.
+        const string InList = """
+            10. **An item** — its block is indented to the item's content column:
+
+                ```csharp
+                TextBlock(p).TextWrapping(TextWrapping.WrapWholeWords)
+                ```
+            """;
+
+        var nested = Assert.Single(AgentKitDocCorpus.ExtractFences("fixture/list.md", InList));
+        Assert.Equal("TextBlock(p).TextWrapping(TextWrapping.WrapWholeWords)", nested.Text);
+    }
+
+    /// <summary>
     /// Floors over the corpus and the reflection behind it. Each one turns a silent collapse — a
     /// glob that stopped matching, a factory map that resolved to nothing, a fence parser that
     /// stopped recognising ```` ```csharp ```` — into a failure.

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateInstrumentTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateInstrumentTests.cs
@@ -910,6 +910,22 @@ public class AgentKitDocGateInstrumentTests
 
         Assert.Empty(AgentKitDocCorpus.ExtractFences("fixture/tab.md", TabIndented.Replace("<TAB>", "\t")));
         Assert.DoesNotMatch(AgentKitDocCorpus.CSharpFenceProbe, "\t```csharp");
+
+        // The closing test measures columns too. A tab-indented ``` is four columns in, past the
+        // three CommonMark allows, so it is literal text inside the sample rather than the close —
+        // counting characters ended the block early and left the rest of it unscanned.
+        const string TabbedInnerFence = """
+            ```csharp
+            <TAB>```
+            FlexColumn(children).FlexPadding(16)
+            ```
+            """;
+
+        Assert.Equal(
+            "\t```\nFlexColumn(children).FlexPadding(16)",
+            Assert.Single(AgentKitDocCorpus.ExtractFences(
+                "fixture/tabclose.md",
+                TabbedInnerFence.Replace("<TAB>", "\t"))).Text.Replace("\r\n", "\n"));
     }
 
     /// <summary>

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateInstrumentTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateInstrumentTests.cs
@@ -753,21 +753,21 @@ public class AgentKitDocGateInstrumentTests
     }
 
     /// <summary>
-    /// A fence indented as a code block is literal text and must not open a region.
+    /// Fence indentation is measured against the container, at both ends.
     /// </summary>
     /// <remarks>
-    /// Four spaces outside a list is an indented code block. Honouring a fence written there
-    /// swallowed everything up to the next close — including the genuine top-level
-    /// ```` ```csharp ```` opener below it, which then shipped uninspected. The differential probe
-    /// cannot catch this, because it derives its exclusions from the same scan.
+    /// Three distinct ways to get this wrong, all pinned here: a top-level indented block whose
+    /// literal fence must not open; a shallow list item where the same absolute indent <em>is</em>
+    /// too deep; and an indented <c>```</c> inside a sample that must not close it early. Each
+    /// leaves real C# outside the gate, and the differential probe cannot see any of them because
+    /// it trusts this scanner for block structure.
     /// </remarks>
     [Fact]
-    public void An_Indented_Literal_Fence_Does_Not_Swallow_A_Real_Block()
+    public void Fence_Indentation_Is_Measured_Against_Its_Container()
     {
-        const string Markdown = """
-            # Heading
-
-            Some prose, then an indented code block quoting a fence:
+        // Top level: four spaces is an indented code block, so the fence in it is literal.
+        const string TopLevel = """
+            Prose, then an indented code block quoting a fence:
 
                 ```text
                 not a real fence
@@ -777,23 +777,98 @@ public class AgentKitDocGateInstrumentTests
             ```
             """;
 
-        var snippets = AgentKitDocCorpus.ExtractFences("fixture/indented.md", Markdown);
+        Assert.Equal(
+            "FlexColumn(children).FlexPadding(16)",
+            Assert.Single(AgentKitDocCorpus.ExtractFences("fixture/top.md", TopLevel)).Text);
 
-        var real = Assert.Single(snippets);
-        Assert.Equal("FlexColumn(children).FlexPadding(16)", real.Text);
-
-        // Positive control: the same indentation *inside a list item* is a real fence, which is how
-        // the two blocks in typography-and-colors.md reach the corpus.
-        const string InList = """
-            10. **An item** — its block is indented to the item's content column:
+        // `10. ` has content column 4, so a fence at 4 is flush with it and real.
+        const string NumberedItem = """
+            10. **An item** — its block sits at the item's content column:
 
                 ```csharp
                 TextBlock(p).TextWrapping(TextWrapping.WrapWholeWords)
                 ```
             """;
 
-        var nested = Assert.Single(AgentKitDocCorpus.ExtractFences("fixture/list.md", InList));
-        Assert.Equal("TextBlock(p).TextWrapping(TextWrapping.WrapWholeWords)", nested.Text);
+        Assert.Equal(
+            "TextBlock(p).TextWrapping(TextWrapping.WrapWholeWords)",
+            Assert.Single(AgentKitDocCorpus.ExtractFences("fixture/numbered.md", NumberedItem)).Text);
+
+        // `- ` has content column 2, so six spaces is four past it — literal, not a fence.
+        const string ShallowItem = """
+            - item
+
+                  ```text
+                  not a real fence
+
+            ```csharp
+            Border(child).Padding(8)
+            ```
+            """;
+
+        Assert.Equal(
+            "Border(child).Padding(8)",
+            Assert.Single(AgentKitDocCorpus.ExtractFences("fixture/shallow.md", ShallowItem)).Text);
+    }
+
+    /// <summary>
+    /// An indented <c>```</c> inside a sample does not close the block early.
+    /// </summary>
+    [Fact]
+    public void An_Indented_Run_Does_Not_Close_A_Top_Level_Fence()
+    {
+        // Four-quote delimiter so the sample can contain a three-quote raw string of its own.
+        const string Markdown = """"
+            ```csharp
+            var doc = """
+                ```
+                """;
+            FlexColumn(children).Padding(16)
+            ```
+            """";
+
+        var snippet = Assert.Single(AgentKitDocCorpus.ExtractFences("fixture/raw.md", Markdown));
+
+        Assert.Contains("FlexColumn(children).Padding(16)", snippet.Text, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// A disagreement between overloads poisons a type-changing modifier permanently.
+    /// </summary>
+    /// <remarks>
+    /// The A, B, A ordering is the point. Removing the entry on disagreement let the third overload
+    /// re-add it, so an ambiguous modifier resolved to one arbitrary answer — and since
+    /// <c>GetMethods</c> order is unspecified, which answer was not reproducible. The live surface
+    /// cannot reach this state (one type-changing modifier, all overloads agreeing), so the merge
+    /// is tested directly rather than through reflection.
+    /// </remarks>
+    [Theory]
+    [InlineData("A,B,A")]
+    [InlineData("A,A,B")]
+    [InlineData("B,A,A")]
+    [InlineData("A,B,A,B,A")]
+    public void Disagreeing_Overloads_Poison_A_Type_Changing_Modifier(string order)
+    {
+        var types = new Dictionary<string, Type> { ["A"] = typeof(int), ["B"] = typeof(string) };
+        var map = new Dictionary<string, Type?>(StringComparer.Ordinal);
+
+        foreach (var step in order.Split(','))
+            ReactorSurface.MergeTypeChange(map, "Modifier", types[step]);
+
+        Assert.True(map.ContainsKey("Modifier"), "The name must stay known so the walk still stops on it.");
+        Assert.Null(map["Modifier"]);
+    }
+
+    /// <summary>Agreeing overloads, however many, still resolve.</summary>
+    [Fact]
+    public void Agreeing_Overloads_Resolve_A_Type_Changing_Modifier()
+    {
+        var map = new Dictionary<string, Type?>(StringComparer.Ordinal);
+
+        for (var i = 0; i < 4; i++)
+            ReactorSurface.MergeTypeChange(map, "Modifier", typeof(int));
+
+        Assert.Equal(typeof(int), map["Modifier"]);
     }
 
     /// <summary>

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateInstrumentTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateInstrumentTests.cs
@@ -1171,6 +1171,61 @@ public class AgentKitDocGateInstrumentTests
     }
 
     /// <summary>
+    /// A label in the preceding list item marks a sample in the next one — deliberately.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// `- Avoid this:` above a `- ```csharp` item is one list making one point, and it is how these
+    /// documents are written. Treating the item boundary as a barrier would report a labelled
+    /// counterexample and fail CI on correct documentation, which is the failure mode this gate
+    /// cannot afford; over-reaching costs a missed finding instead.
+    /// </para>
+    /// <para>
+    /// Pinned as a test rather than left implicit so the trade-off is a decision, not an accident.
+    /// It stays bounded by the eight-line budget and the previous block's fence, and an exemption
+    /// still requires the document to name the remedy.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    [Trait("Category", "AgentKitDocGate")]
+    public void A_Label_In_The_Preceding_List_Item_Marks_The_Next_One()
+    {
+        var siblings = new[]
+        {
+            "- Avoid this:",
+            "- ```csharp",
+            "  FlexColumn(children).Padding(16)",
+        };
+
+        Assert.True(AgentKitDocGateTests.IsMarkedAt(siblings, 3));
+
+        // The reach is bounded, not unlimited: an earlier block's fence ends the walk, so a label
+        // introducing *that* block cannot be borrowed by this one.
+        var previousBlock = new[]
+        {
+            "- Avoid this:",
+            "- ```csharp",
+            "  FlexColumn(children).Padding(16)",
+            "  ```",
+            "- ```csharp",
+            "  FlexRow(children).Padding(16)",
+        };
+
+        Assert.False(AgentKitDocGateTests.IsMarkedAt(previousBlock, 6));
+
+        // Negative control: ordinary sibling prose must not exempt, or the first assertion is
+        // passing on reachability rather than on the label matching.
+        var unlabelled = new[]
+        {
+            "- Here is the layout:",
+            "- ```csharp",
+            "  FlexColumn(children).Padding(16)",
+        };
+
+        Assert.False(AgentKitDocGateTests.IsMarkedAt(unlabelled, 3));
+    }
+
+    /// <summary>
     /// The remedy must be named at identifier boundaries, not as a substring of a longer name.
     /// </summary>
     /// <remarks>

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateInstrumentTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateInstrumentTests.cs
@@ -1288,6 +1288,20 @@ public class AgentKitDocGateInstrumentTests
         // The directive lines are blanked rather than removed, so the reported line is still the
         // line the sample is on — without that, a finding would point one line short.
         Assert.Equal(2, finding.Line);
+
+        // Each arm is parsed on its own. Concatenating them puts two valid alternatives in adjacent
+        // expression positions, where Roslyn can place the later one in skipped trivia and the
+        // violation in it is never seen.
+        var branches = AgentKitSnippetWalker.Scan(new[]
+        {
+            new AgentKitSnippet(
+                "fixture/branches.md",
+                1,
+                "#if DEBUG\nvar a = FlexColumn(children).FlexPadding(16);\n#else\nvar a = FlexColumn(children).Padding(16);\n#endif"),
+        });
+
+        var inElse = Assert.Single(branches.Of(AgentKitFindingKind.DroppedModifier));
+        Assert.Equal(4, inElse.Line);
     }
 
     /// <summary>

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateInstrumentTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateInstrumentTests.cs
@@ -640,6 +640,58 @@ public class AgentKitDocGateInstrumentTests
     }
 
     /// <summary>
+    /// An opaque lifecycle or identity escape hatch on the wrapper makes it non-deletable.
+    /// </summary>
+    /// <remarks>
+    /// <c>Set</c> was already handled; the rest are the same problem. <c>OnMount</c> can write any
+    /// native property at mount time, <c>OnUnmount</c> makes the wrapper's <em>lifecycle</em>
+    /// significant whether or not it paints anything, and <c>Ref</c> hands the control out by
+    /// identity. "Remove the wrapper" is not behaviour-preserving for any of them.
+    /// </remarks>
+    [Theory]
+    [InlineData("Border(FlexColumn(children)).Padding(16).OnMount(fe => Configure(fe))")]
+    [InlineData("Border(FlexColumn(children)).Padding(16).OnMountAdd(fe => Configure(fe))")]
+    [InlineData("Border(FlexColumn(children)).Padding(16).OnUnmount(fe => Teardown(fe))")]
+    [InlineData("Border(FlexColumn(children)).Padding(16).OnUnmountAdd(fe => Teardown(fe))")]
+    [InlineData("Border(FlexColumn(children)).Padding(16).Ref(borderRef)")]
+    public void A_Lifecycle_Escape_Hatch_Justifies_A_Wrapper(string snippet)
+    {
+        var scan = AgentKitSnippetWalker.Scan(new[] { new AgentKitSnippet("fixture/lifecycle.md", 1, snippet) });
+
+        Assert.Empty(scan.Of(AgentKitFindingKind.WrapperWorkaround));
+    }
+
+    /// <summary>
+    /// A <c>with</c> mutation anywhere on the chain suppresses the wrapper finding.
+    /// </summary>
+    /// <remarks>
+    /// The chain walkers step through <c>with</c> to reach the receiver, so its assignments are
+    /// never seen: <c>with { Background = brush }</c> supplies the decoration that would justify
+    /// the wrapper, and <c>with { Child = other }</c> replaces the very element the finding names.
+    /// Element records are configured this way by design, so reporting through one is a false
+    /// positive on idiomatic code.
+    /// </remarks>
+    [Theory]
+    [InlineData("Border(FlexColumn(children)).Padding(16) with { Background = brush }")]
+    [InlineData("Border(FlexColumn(children)).Padding(16) with { Child = other }")]
+    [InlineData("(Border(FlexColumn(children)) with { Background = brush }).Padding(16)")]
+    public void A_With_Mutation_Suppresses_The_Wrapper_Finding(string snippet)
+    {
+        var scan = AgentKitSnippetWalker.Scan(new[] { new AgentKitSnippet("fixture/with.md", 1, snippet) });
+
+        Assert.Empty(scan.Of(AgentKitFindingKind.WrapperWorkaround));
+
+        // Positive control on the same shape: the identical chain with no `with` must still report,
+        // or this would pass because the rule had stopped working rather than because it deferred.
+        var plain = AgentKitSnippetWalker.Scan(new[]
+        {
+            new AgentKitSnippet("fixture/with.md", 1, "Border(FlexColumn(children)).Padding(16)"),
+        });
+
+        Assert.Single(plain.Of(AgentKitFindingKind.WrapperWorkaround));
+    }
+
+    /// <summary>
     /// Floors over the corpus and the reflection behind it. Each one turns a silent collapse — a
     /// glob that stopped matching, a factory map that resolved to nothing, a fence parser that
     /// stopped recognising ```` ```csharp ```` — into a failure.

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateInstrumentTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateInstrumentTests.cs
@@ -139,6 +139,9 @@ public class AgentKitDocGateInstrumentTests
     [InlineData("Rectangle().Background(null)")]
     [InlineData("Rectangle().Background(((Brush)null))")]
     [InlineData("Rectangle().Background(default(Brush))")]
+    [InlineData("Rectangle().Background(null!)")]
+    [InlineData("Rectangle().Background(((Brush)null)!)")]
+    [InlineData("Rectangle().Background(default(Brush)!)")]
     [InlineData("FlexColumn(children).Padding(null)")]
     public void Walker_Mirrors_The_Analyzers_Constant_Null_Gate(string snippet)
     {
@@ -556,6 +559,84 @@ public class AgentKitDocGateInstrumentTests
             scan.ResolvedChains >= 1,
             "A `LazyVStack(items, ...)` chain resolved nothing, so generic factories written without " +
             "explicit type arguments — the common form — are still invisible to the gate.");
+    }
+
+    /// <summary>
+    /// A modifier that does nothing cannot justify the wrapper that carries it.
+    /// </summary>
+    /// <remarks>
+    /// A constant-null argument makes a modifier inert — the premise the constant-null gate already
+    /// rests on — so <c>Border(...).Padding(16).Background((Brush)null)</c> is still a Border
+    /// supplying nothing but padding. Accepting it by name hid the exact workaround this rule
+    /// exists to catch behind a decorator that does nothing, and contradicted the same call being
+    /// skipped as inert two checks earlier.
+    /// </remarks>
+    [Theory]
+    [InlineData("Border(FlexColumn(children)).Padding(16).Background((Brush)null)")]
+    [InlineData("Border(FlexColumn(children)).Padding(16).Background(null)")]
+    [InlineData("Border(FlexColumn(children)).Padding(16).Background(null!)")]
+    [InlineData("Border(FlexColumn(children)).Padding(16).Background(default(Brush)!)")]
+    public void An_Inert_Modifier_Does_Not_Justify_A_Wrapper(string snippet)
+    {
+        var scan = AgentKitSnippetWalker.Scan(new[] { new AgentKitSnippet("fixture/inert.md", 1, snippet) });
+
+        var finding = Assert.Single(scan.Of(AgentKitFindingKind.WrapperWorkaround));
+        Assert.Equal("FlexPadding", finding.Replacement);
+    }
+
+    /// <summary>
+    /// A real decoration still justifies it, so the check above is not simply reporting everything.
+    /// </summary>
+    [Fact]
+    public void A_Live_Modifier_Still_Justifies_A_Wrapper()
+    {
+        var scan = AgentKitSnippetWalker.Scan(new[]
+        {
+            new AgentKitSnippet("fixture/inert.md", 1, "Border(FlexColumn(children)).Padding(16).Background(Theme.CardBackground)"),
+        });
+
+        Assert.Empty(scan.Of(AgentKitFindingKind.WrapperWorkaround));
+
+        // A value-typed `default` is a real zero-valued write, not an inert null, so it justifies
+        // the wrapper too — the same distinction the constant-null gate draws.
+        var zeroValued = AgentKitSnippetWalker.Scan(new[]
+        {
+            new AgentKitSnippet("fixture/inert.md", 1, "Border(FlexColumn(children)).Padding(16).CornerRadius(default(CornerRadius))"),
+        });
+
+        Assert.Empty(zeroValued.Of(AgentKitFindingKind.WrapperWorkaround));
+    }
+
+    /// <summary>
+    /// A standalone block-comment label marks the block below it.
+    /// </summary>
+    /// <remarks>
+    /// <c>IsCounterexampleLabel</c> documents <c>/* Wrong */</c> as supported and
+    /// <c>CommentText</c> reads multi-line trivia, but the upward walk accepted only <c>//</c>
+    /// lines — so the documented placement produced a CI failure. Same class of defect as the
+    /// prose lead-in: a contract stated in one place and not honoured in another.
+    /// </remarks>
+    [Fact]
+    public void A_Block_Comment_Label_Marks_The_Line_Below()
+    {
+        var marked = new[]
+        {
+            "```csharp",
+            "/* Wrong */",
+            "FlexColumn(children).Padding(16)",
+        };
+
+        Assert.True(AgentKitDocGateTests.IsMarkedAt(marked, 3));
+
+        // Negative control: a block comment that is not a label must not exempt.
+        var unmarked = new[]
+        {
+            "```csharp",
+            "/* spacing sample */",
+            "FlexColumn(children).Padding(16)",
+        };
+
+        Assert.False(AgentKitDocGateTests.IsMarkedAt(unmarked, 3));
     }
 
     /// <summary>

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateInstrumentTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateInstrumentTests.cs
@@ -1331,6 +1331,40 @@ public class AgentKitDocGateInstrumentTests
     }
 
     /// <summary>
+    /// An unrecognised intermediate call stops head resolution instead of being walked through.
+    /// </summary>
+    /// <remarks>
+    /// Stepping over any name not in the type-changing map assumed it returned its receiver, so
+    /// <c>FlexColumn(children).AsBorder().Padding(16)</c> resolved to a FlexElement and was
+    /// reported — though <c>AsBorder</c> returns a Border and <c>Padding</c> is legal there. That
+    /// is uncertainty creating a finding on valid guidance, which is the direction this walker is
+    /// built to avoid.
+    /// </remarks>
+    [Fact]
+    [Trait("Category", "AgentKitDocGate")]
+    public void An_Unknown_Intermediate_Call_Stops_Resolution()
+    {
+        var unknown = AgentKitSnippetWalker.Scan(new[]
+        {
+            new AgentKitSnippet("fixture/unknown.md", 1, "FlexColumn(children).AsBorder().Padding(16)"),
+        });
+
+        Assert.Empty(unknown.Findings);
+        Assert.Equal(0, unknown.ResolvedChains);
+
+        // Control: a modifier whose signature does prove it returns its receiver is still walked
+        // through, so the walk has not simply stopped at every member access.
+        Assert.True(ReactorSurface.Instance.PreservesElementType("WithKey"));
+
+        var known = AgentKitSnippetWalker.Scan(new[]
+        {
+            new AgentKitSnippet("fixture/known.md", 1, "FlexColumn(children).WithKey(\"k\").Padding(16)"),
+        });
+
+        Assert.Equal("FlexPadding", Assert.Single(known.Of(AgentKitFindingKind.DroppedModifier)).Replacement);
+    }
+
+    /// <summary>
     /// A label in the preceding list item marks a sample in the next one — deliberately.
     /// </summary>
     /// <remarks>

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateTests.cs
@@ -116,7 +116,18 @@ public class AgentKitDocGateTests
 
         var words = head.Split(new[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries);
 
-        return words.Length is > 0 and <= 2 && MarkerWord.IsMatch(words[0]);
+        if (words.Length == 0 || !MarkerWord.IsMatch(words[0]))
+            return false;
+
+        // The marker word alone is a label: `/* Wrong */`, `// Bad`.
+        if (words.Length == 1)
+            return true;
+
+        // Otherwise it must read as a label rather than a sentence — at most one more word, and
+        // punctuation introducing what follows. Without the delimiter requirement, ordinary short
+        // comments such as `// avoid allocations` and `// never cache` were treated as labels and
+        // silently exempted the sample beneath them.
+        return words.Length == 2 && cut >= 0;
     }
 
     /// <summary>

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateTests.cs
@@ -149,14 +149,8 @@ public class AgentKitDocGateTests
                 continue;
             }
 
-            if (finding.Replacement is { } replacement
-                && !documents.Text(finding.Path).Contains(replacement, StringComparison.Ordinal))
-            {
-                problems.Add(
-                    $"{finding.Path}:{finding.Line} — marked as a counterexample, but the document " +
-                    $"never names the replacement `{replacement}`. A shipped 'do not write this' " +
-                    "with no 'write this instead' is the half of #1119 that caused the contradiction");
-            }
+            if (MissingRemedy(finding, documents) is { } missingRemedy)
+                problems.Add(missingRemedy);
         }
 
         Assert.True(
@@ -186,10 +180,24 @@ public class AgentKitDocGateTests
         var scan = AgentKitCorpus.Scan;
         var documents = new DocumentCache(repoRoot);
 
-        var problems = scan.Of(AgentKitFindingKind.WrapperWorkaround)
-            .Where(finding => !IsMarkedCounterexample(documents.Lines(finding.Path), finding))
-            .Select(finding => $"{finding.Path}:{finding.Line} — {finding.Detail}")
-            .ToList();
+        var problems = new List<string>();
+
+        foreach (var finding in scan.Of(AgentKitFindingKind.WrapperWorkaround))
+        {
+            if (!IsMarkedCounterexample(documents.Lines(finding.Path), finding))
+            {
+                problems.Add($"{finding.Path}:{finding.Line} — {finding.Detail}");
+                continue;
+            }
+
+            // The same "names its remedy" condition the dropped-modifier fact applies, and it
+            // matters more here: this is the #1119 shape, and the sibling fact cannot cover for it,
+            // because a Border really is a legal Padding receiver and so nothing else objects. A
+            // document showing the workaround under a `// Wrong:` label while never mentioning
+            // FlexPadding would ship exactly the half-guidance that caused the contradiction.
+            if (MissingRemedy(finding, documents) is { } missing)
+                problems.Add(missing);
+        }
 
         Assert.True(
             problems.Count == 0,
@@ -198,6 +206,31 @@ public class AgentKitDocGateTests
             "not to reach for a wrapper, while a sample packed beside it does:\n  " +
             string.Join("\n  ", problems));
     }
+
+    /// <summary>
+    /// The complaint when a document marks a counterexample but never names what to write instead,
+    /// or <see langword="null"/> when it does.
+    /// </summary>
+    private static string? MissingRemedy(AgentKitFinding finding, DocumentCache documents) =>
+        NamesRemedy(documents.Text(finding.Path), finding.Replacement)
+            ? null
+            : $"{finding.Path}:{finding.Line} — marked as a counterexample, but the document never " +
+              $"names the replacement `{finding.Replacement}`. A shipped 'do not write this' with no " +
+              "'write this instead' is the half of #1119 that caused the contradiction";
+
+    /// <summary>
+    /// True when a document names the replacement for a counterexample it shows, or when the
+    /// framework offers no replacement to name.
+    /// </summary>
+    /// <remarks>
+    /// Both facts apply this, and it matters most on the wrapper one: that is the #1119 shape, and
+    /// no other check can cover for it, because the wrapper really is a legal receiver so nothing
+    /// else objects. A document showing the workaround under a <c>// Wrong:</c> label while never
+    /// mentioning <c>FlexPadding</c> would ship exactly the half-guidance that caused the
+    /// contradiction.
+    /// </remarks>
+    internal static bool NamesRemedy(string documentText, string? replacement) =>
+        replacement is null || documentText.Contains(replacement, StringComparison.Ordinal);
 
     /// <summary>
     /// True when the sample is marked as deliberately wrong — on the offending line itself, or in

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateTests.cs
@@ -242,14 +242,23 @@ public class AgentKitDocGateTests
     /// framework offers no replacement to name.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// Both facts apply this, and it matters most on the wrapper one: that is the #1119 shape, and
     /// no other check can cover for it, because the wrapper really is a legal receiver so nothing
     /// else objects. A document showing the workaround under a <c>// Wrong:</c> label while never
     /// mentioning <c>FlexPadding</c> would ship exactly the half-guidance that caused the
     /// contradiction.
+    /// </para>
+    /// <para>
+    /// The name must appear at identifier boundaries. A plain substring test let an unrelated
+    /// compound satisfy it — a document mentioning <c>FillColor</c> counted as naming <c>Fill</c> —
+    /// and because this is the clause that <em>permits</em> an otherwise-invalid snippet, a loose
+    /// match silently exempts the sample it was supposed to hold to account.
+    /// </para>
     /// </remarks>
     internal static bool NamesRemedy(string documentText, string? replacement) =>
-        replacement is null || documentText.Contains(replacement, StringComparison.Ordinal);
+        replacement is null
+        || Regex.IsMatch(documentText, $@"\b{Regex.Escape(replacement)}\b");
 
     /// <summary>
     /// True when the sample is marked as deliberately wrong — on the offending line itself, or in
@@ -318,7 +327,13 @@ public class AgentKitDocGateTests
             if (text.Length == 0)
                 continue;
 
-            if (text.StartsWith("```", StringComparison.Ordinal) || text.StartsWith("~~~", StringComparison.Ordinal))
+            // The extractor accepts a fence opening on a list marker's own line (`- ```csharp`),
+            // so strip the marker before testing for one. Without this the walk read that opener
+            // as C# code, abandoned the search, and failed a counterexample the extractor had
+            // happily scanned — the two disagreeing about the same document.
+            var fenceText = AgentKitDocCorpus.StripListMarker(text);
+
+            if (fenceText.StartsWith("```", StringComparison.Ordinal) || fenceText.StartsWith("~~~", StringComparison.Ordinal))
             {
                 // The second fence encountered closes an earlier, unrelated block; anything above it
                 // introduces that block, not this one.

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateTests.cs
@@ -364,6 +364,14 @@ public class AgentKitDocGateTests
                 continue;
             }
 
+            // Prose introducing the block, including a sibling list item's text. `- Avoid this:`
+            // above a `- ```csharp` item is one list making one point, and it is how these
+            // documents are actually written, so the label marks the sample. Stopping at the item
+            // boundary would report a deliberately labelled counterexample and fail CI on correct
+            // documentation — the failure mode this gate cannot afford. Over-reaching costs a
+            // missed finding instead, and it stays bounded: the walk gives up after eight lines or
+            // at the previous block's fence, whichever comes first, and an exemption still requires
+            // the document to name the remedy, so half-guidance is caught either way.
             if (IsCounterexampleLabel(Urls.Replace(text, " ")))
                 return true;
         }

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateTests.cs
@@ -263,8 +263,15 @@ public class AgentKitDocGateTests
             if (!crossedFence)
             {
                 // Still inside the fence, so only a comment can carry a marker; real code above
-                // means any marker further up belongs to that line rather than this one.
-                if (!text.StartsWith("//", StringComparison.Ordinal))
+                // means any marker further up belongs to that line rather than this one. A whole
+                // line that is a block comment counts too — `IsCounterexampleLabel` documents
+                // `/* Wrong */` as a supported label and `CommentText` reads that trivia, so
+                // rejecting the placement here contradicted both.
+                var isComment = text.StartsWith("//", StringComparison.Ordinal)
+                                || (text.StartsWith("/*", StringComparison.Ordinal)
+                                    && text.EndsWith("*/", StringComparison.Ordinal));
+
+                if (!isComment)
                     return false;
 
                 if (IsCounterexampleLabel(CommentText(text)))

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateTests.cs
@@ -1,0 +1,227 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Microsoft.UI.Reactor.Analyzers;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests.AnalyzerTests;
+
+/// <summary>
+/// Gates the C# in the agent-kit documents <c>Microsoft.UI.Reactor.nupkg</c> ships against the
+/// modifier rules the same package's analyzers enforce. Issue #1121.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>The defect class.</b> <c>src/Reactor/Reactor.csproj</c> packs ~60 documents under
+/// <c>agentkit/</c>. Nothing checked that they agree with the framework, so #1119 was able to ship
+/// a rule in <c>reactor-design/SKILL.md</c> — "Flex containers take FlexPadding, NOT Padding […]
+/// do not reach for a Border wrapper" — inside the same NuGet as two documents saying the
+/// opposite. A consuming agent received the rule and its contradiction with no way to tell which
+/// was current.
+/// </para>
+/// <para>
+/// <b>Two facts, because one is not enough.</b> #1121 proposes running <c>REACTOR_MOD_003</c> over
+/// the snippets. That is <see cref="Shipped_Snippets_Never_Apply_A_Modifier_Its_Receiver_Drops"/>,
+/// and it is worth having — but it would <em>not</em> have caught #1119. The offending sample was
+/// <c>Border(FlexColumn(…)).Padding(24)</c>, and <c>ModifierTable</c> gates <c>Padding</c> to
+/// <c>Control/Border/Grid/StackPanel/RelativePanel/TextBlock</c>: <c>Border</c> is a legal
+/// receiver, so the analyzer was correctly silent. What was wrong was that the sample demonstrated
+/// the Border-wrapper workaround the new rule forbids. That is
+/// <see cref="Shipped_Snippets_Never_Reach_For_A_Wrapper_Instead_Of_The_Replacement"/>.
+/// </para>
+/// <para>
+/// <b>Why the corpus is derived.</b> The document list comes out of the csproj's <c>agentkit/</c>
+/// <c>&lt;None&gt;</c> globs, not a list in this file. #1121's complaint is that the <em>next</em>
+/// divergence lands unnoticed; a hand-maintained path list would reproduce that defect one level
+/// up, in the gate itself.
+/// </para>
+/// <para>
+/// <b>Non-vacuity.</b> Both facts pass with almost nothing to report today (two exempted
+/// counterexamples, zero workarounds), which is indistinguishable from a broken walker unless
+/// something proves the walker can still fire. <see cref="AgentKitDocGateInstrumentTests"/> is that
+/// proof: it replays the pre-#1119 snippet and an unmarked violation through the same code path and
+/// requires both to be reported, and it floors the corpus and resolution counts.
+/// </para>
+/// </remarks>
+public class AgentKitDocGateTests
+{
+    /// <summary>
+    /// The conventions this repo already uses to mark a deliberately-broken sample, surveyed across
+    /// <c>skills/</c> and <c>plugins/</c>: <c>// Wrong:</c>, <c>// Bad:</c>, <c>// ❌ WRONG</c>,
+    /// <c>### ❌ The anti-pattern …</c>, <c>// Never hardcode …</c>.
+    /// </summary>
+    private static readonly Regex CounterexampleMarker = new(
+        @"\b(wrong|bad|don'?t|do not|avoid|never|incorrect|anti-?pattern)\b|❌",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    /// <summary>
+    /// No shipped sample may apply a common modifier to a receiver
+    /// <c>Reconciler.ApplyModifiers</c> never writes it to — the documentation form of
+    /// <c>REACTOR_MOD_003</c>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Deliberate counterexamples are allowed, because the corpus contains two of them: #1119 added
+    /// <c>// Wrong: no effect, and costs a build-check cycle</c> above
+    /// <c>FlexColumn(children).Padding(16)</c> in both design documents, and a gate that failed on
+    /// those would be deleted within the week. The exemption carries a condition — the document
+    /// must also name the replacement — so "here is the broken form" can never ship without
+    /// "here is what to write instead", which is the half of #1119 that was actually missing.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public void Shipped_Snippets_Never_Apply_A_Modifier_Its_Receiver_Drops()
+    {
+        var repoRoot = AgentKitCorpus.RepoRoot;
+        var scan = AgentKitCorpus.Scan;
+        var documents = new DocumentCache(repoRoot);
+
+        var problems = new List<string>();
+
+        foreach (var finding in scan.Of(AgentKitFindingKind.DroppedModifier))
+        {
+            if (!IsMarkedCounterexample(documents.Lines(finding.Path), finding))
+            {
+                problems.Add(
+                    $"{finding.Path}:{finding.Line} — {finding.Detail}. " +
+                    (finding.Replacement is { } fix
+                        ? $"Use .{fix}(...) instead"
+                        : "Apply the modifier to an element whose control supports it") +
+                    ", or mark the line as a counterexample (`// Wrong: …`) if it is meant to " +
+                    "demonstrate the mistake");
+                continue;
+            }
+
+            if (finding.Replacement is { } replacement
+                && !documents.Text(finding.Path).Contains(replacement, StringComparison.Ordinal))
+            {
+                problems.Add(
+                    $"{finding.Path}:{finding.Line} — marked as a counterexample, but the document " +
+                    $"never names the replacement `{replacement}`. A shipped 'do not write this' " +
+                    "with no 'write this instead' is the half of #1119 that caused the contradiction");
+            }
+        }
+
+        Assert.True(
+            problems.Count == 0,
+            "Shipped agent-kit C# applies a modifier that ApplyModifiers drops for that receiver. " +
+            "These documents are packed into Microsoft.UI.Reactor.nupkg and read as guidance, so a " +
+            "sample the framework's own analyzer would reject is advice to write broken code:\n  " +
+            string.Join("\n  ", problems));
+    }
+
+    /// <summary>
+    /// No shipped sample may introduce a wrapper element purely to receive a modifier the element
+    /// it wraps silently drops, when a first-class replacement exists. This is the #1119 shape.
+    /// </summary>
+    /// <remarks>
+    /// The rule is stated in prose by the very document that shipped alongside the violation —
+    /// <c>reactor-design/SKILL.md</c>: "Don't add a Border solely to get padding; a Border is still
+    /// right when you also need its background, corner radius, or border brush." This fact applies
+    /// that rule to the package it ships in, parameterised off
+    /// <see cref="NoOpModifierAnalyzer.ElementReplacements"/> so a second entry there extends it
+    /// with no edit here.
+    /// </remarks>
+    [Fact]
+    public void Shipped_Snippets_Never_Reach_For_A_Wrapper_Instead_Of_The_Replacement()
+    {
+        var repoRoot = AgentKitCorpus.RepoRoot;
+        var scan = AgentKitCorpus.Scan;
+        var documents = new DocumentCache(repoRoot);
+
+        var problems = scan.Of(AgentKitFindingKind.WrapperWorkaround)
+            .Where(finding => !IsMarkedCounterexample(documents.Lines(finding.Path), finding))
+            .Select(finding => $"{finding.Path}:{finding.Line} — {finding.Detail}")
+            .ToList();
+
+        Assert.True(
+            problems.Count == 0,
+            "Shipped agent-kit C# demonstrates a wrapper workaround for a dropped modifier. This is " +
+            "the exact contradiction #1119 fixed by hand: reactor-design/SKILL.md tells the reader " +
+            "not to reach for a wrapper, while a sample packed beside it does:\n  " +
+            string.Join("\n  ", problems));
+    }
+
+    /// <summary>
+    /// True when the sample is marked as deliberately wrong — on the offending line itself, or in
+    /// the comment block above the line the chain starts on.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Both lines are consulted because a multi-line chain puts its marker above the head:
+    /// <c>// Wrong:</c> sits above <c>Border(</c>, while the modifier this fires on is three lines
+    /// further down past a <c>)</c>. Anchoring only at the modifier would read that <c>)</c> as
+    /// "real code above" and declare an obviously-marked counterexample unmarked.
+    /// </para>
+    /// <para>
+    /// Only the <em>comment</em> part of a line is considered. Reading the whole line would let
+    /// <c>Button("Never")</c> exempt itself, which is the sort of accidental self-exemption that
+    /// turns a gate into decoration.
+    /// </para>
+    /// </remarks>
+    private static bool IsMarkedCounterexample(IReadOnlyList<string> lines, AgentKitFinding finding) =>
+        IsMarkedAt(lines, finding.Line) || IsMarkedAt(lines, finding.ChainStartLine);
+
+    private static bool IsMarkedAt(IReadOnlyList<string> lines, int line)
+    {
+        var index = line - 1;
+        if (index < 0 || index >= lines.Count)
+            return false;
+
+        var trailing = lines[index].IndexOf("//", StringComparison.Ordinal);
+        if (trailing >= 0 && CounterexampleMarker.IsMatch(lines[index][trailing..]))
+            return true;
+
+        // Walk up through the comment block, and — once past the fence — the markdown heading or
+        // lead-in paragraph, which is where `### ❌ The anti-pattern that breaks everything` lives.
+        for (var i = index - 1; i >= 0 && index - i <= 8; i--)
+        {
+            var text = lines[i].Trim();
+            if (text.Length == 0)
+                continue;
+
+            var isContext = text.StartsWith("//", StringComparison.Ordinal)
+                            || text.StartsWith("```", StringComparison.Ordinal)
+                            || text.StartsWith("~~~", StringComparison.Ordinal)
+                            || text.StartsWith("#", StringComparison.Ordinal)
+                            || text.StartsWith(">", StringComparison.Ordinal)
+                            || text.StartsWith("-", StringComparison.Ordinal);
+
+            if (!isContext)
+                return false;   // real code above: any marker up there belongs to that line.
+
+            if (CounterexampleMarker.IsMatch(text))
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>Reads each document once; a scan touches the same file for every finding in it.</summary>
+    private sealed class DocumentCache(string repoRoot)
+    {
+        private readonly Dictionary<string, string[]> _lines = new(StringComparer.OrdinalIgnoreCase);
+        private readonly Dictionary<string, string> _text = new(StringComparer.OrdinalIgnoreCase);
+
+        public IReadOnlyList<string> Lines(string path)
+        {
+            if (!_lines.TryGetValue(path, out var lines))
+                _lines[path] = lines = Text(path).Replace("\r\n", "\n").Split('\n');
+
+            return lines;
+        }
+
+        public string Text(string path)
+        {
+            if (!_text.TryGetValue(path, out var text))
+            {
+                _text[path] = text = File.ReadAllText(
+                    Path.Combine(repoRoot, path.Replace('/', Path.DirectorySeparatorChar)));
+            }
+
+            return text;
+        }
+    }
+}

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateTests.cs
@@ -287,6 +287,10 @@ public class AgentKitDocGateTests
         if (IsCounterexampleLabel(CommentText(AgentKitDocCorpus.StripBlockquote(lines[index]).Content)))
             return true;
 
+        // The sample's own blockquote depth. A marker speaks for it only from the same container or
+        // one enclosing it; `> > Avoid this:` introduces the nested quote's example, not the parent's.
+        var depth = AgentKitDocCorpus.BlockquoteDepth(lines[index]);
+
         // Walk up: first through the code above, then — once the opening fence is crossed — through
         // the markdown that introduces the block. Whether the fence has been crossed is tracked
         // rather than inferred from each line's shape, because a lead-in is often an ordinary
@@ -302,7 +306,15 @@ public class AgentKitDocGateTests
             // opener as code — so `> Avoid this:` above a blockquoted sample stopped exempting it
             // and a deliberately-marked counterexample failed CI. Adding blockquote support to the
             // extractor without adding it here left the two disagreeing about the same document.
-            var text = AgentKitDocCorpus.StripBlockquote(lines[i]).Content.Trim();
+            //
+            // Depth is part of that agreement. Stripping every level made a line in a *deeper*
+            // quote readable as a label for a shallower sample, so nested guidance could silently
+            // exempt an unrelated finding one container out. Skip those; a shallower line still
+            // counts, because a lead-in outside the quote does introduce the sample inside it.
+            if (AgentKitDocCorpus.BlockquoteDepth(lines[i]) > depth)
+                continue;
+
+            var text = AgentKitDocCorpus.StripBlockquote(lines[i], depth).Content.Trim();
             if (text.Length == 0)
                 continue;
 

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateTests.cs
@@ -56,8 +56,16 @@ public class AgentKitDocGateTests
         @"^(wrong|bad|don'?t|avoid|never|incorrect|anti-?pattern)\b",
         RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
-    /// <summary>An explicit cross, which is a counterexample label all by itself.</summary>
-    private static readonly Regex CrossMark = new("[❌✗✘]", RegexOptions.Compiled);
+    /// <summary>
+    /// An explicit cross <em>opening</em> the label, which is a counterexample marker by itself.
+    /// </summary>
+    /// <remarks>
+    /// Anchored, like every other marker here. Unanchored, an ordinary explanatory comment such as
+    /// <c>// Show ❌ when validation fails</c> exempted the sample beneath it — the same
+    /// incidental-occurrence defect the word list was tightened to avoid, reintroduced through the
+    /// symbol.
+    /// </remarks>
+    private static readonly Regex CrossMark = new("^[❌✗✘]", RegexOptions.Compiled);
 
     /// <summary>A bare URL, stripped from prose before the marker is matched against it.</summary>
     private static readonly Regex Urls = new(@"\b\w+://\S+", RegexOptions.Compiled);

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateTests.cs
@@ -50,16 +50,66 @@ namespace Microsoft.UI.Reactor.Tests.AnalyzerTests;
 public class AgentKitDocGateTests
 {
     /// <summary>
-    /// The conventions this repo already uses to mark a deliberately-broken sample, surveyed across
-    /// <c>skills/</c> and <c>plugins/</c>: <c>// Wrong:</c>, <c>// Bad:</c>, <c>// ❌ WRONG</c>,
-    /// <c>### ❌ The anti-pattern …</c>, <c>// Never hardcode …</c>.
+    /// A word that can open a deliberate-counterexample label.
     /// </summary>
-    internal static readonly Regex CounterexampleMarker = new(
-        @"\b(wrong|bad|don'?t|do not|avoid|never|incorrect|anti-?pattern)\b|❌",
+    private static readonly Regex MarkerWord = new(
+        @"^(wrong|bad|don'?t|avoid|never|incorrect|anti-?pattern)\b",
         RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
+    /// <summary>An explicit cross, which is a counterexample label all by itself.</summary>
+    private static readonly Regex CrossMark = new("[❌✗✘]", RegexOptions.Compiled);
+
     /// <summary>A bare URL, stripped from prose before the marker is matched against it.</summary>
-    internal static readonly Regex Urls = new(@"\b\w+://\S+", RegexOptions.Compiled);
+    private static readonly Regex Urls = new(@"\b\w+://\S+", RegexOptions.Compiled);
+
+    /// <summary>Leading list numbering, e.g. the <c>10.</c> of a numbered markdown item.</summary>
+    private static readonly Regex LeadingListNumber = new(@"^\d+[.)]\s*", RegexOptions.Compiled);
+
+    /// <summary>
+    /// True when the text reads as a deliberate-counterexample <b>label</b> — the shape this repo
+    /// already uses: <c>// Wrong:</c>, <c>// Bad: skipping levels</c>,
+    /// <c>// ❌ WRONG — feeds the host's shape back</c>,
+    /// <c>### ❌ The anti-pattern that breaks everything</c>, <c>Avoid this:</c>, <c>/* Wrong */</c>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A label, not a word that merely appears somewhere. Matching any occurrence of these words
+    /// exempted <c>// avoid re-enumerating children</c> — an ordinary explanatory comment — and a
+    /// broken sample underneath it would then ship unnoticed, which is the one outcome this gate
+    /// exists to prevent.
+    /// </para>
+    /// <para>
+    /// What separates the two is length, not vocabulary. A label is the short run of text before
+    /// the first delimiter: "Wrong", "Bad", "Avoid this". An explanation keeps going —
+    /// "avoid re-enumerating children", "Never hardcode hex on themed surfaces" — so requiring the
+    /// leading run to be at most two words separates them without needing to enumerate phrasings.
+    /// An explicit ❌ short-circuits all of it, being unambiguous on its own.
+    /// </para>
+    /// </remarks>
+    internal static bool IsCounterexampleLabel(string? text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+            return false;
+
+        // Strip comment slashes, markdown bullets/headings/emphasis, and any closing `*/`.
+        var stripped = text.Trim().TrimStart('/', '*', '#', '>', '-', '`', ' ', '\t');
+        stripped = LeadingListNumber.Replace(stripped, string.Empty)
+            .TrimStart('*', '`', ' ', '\t')
+            .TrimEnd('*', '/', '`', ' ', '\t');
+
+        if (stripped.Length == 0)
+            return false;
+
+        if (CrossMark.IsMatch(stripped))
+            return true;
+
+        var cut = stripped.IndexOfAny(new[] { ':', '—', '–', ',', '!', '.', ';' });
+        var head = (cut >= 0 ? stripped[..cut] : stripped).Trim();
+
+        var words = head.Split(new[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries);
+
+        return words.Length is > 0 and <= 2 && MarkerWord.IsMatch(words[0]);
+    }
 
     /// <summary>
     /// No shipped sample may apply a common modifier to a receiver
@@ -182,29 +232,48 @@ public class AgentKitDocGateTests
         if (index < 0 || index >= lines.Count)
             return false;
 
-        if (CounterexampleMarker.IsMatch(CommentText(lines[index])))
+        if (IsCounterexampleLabel(CommentText(lines[index])))
             return true;
 
-        // Walk up through the comment block, and — once past the fence — the markdown heading or
-        // lead-in paragraph, which is where `### ❌ The anti-pattern that breaks everything` lives.
+        // Walk up: first through the code above, then — once the opening fence is crossed — through
+        // the markdown that introduces the block. Whether the fence has been crossed is tracked
+        // rather than inferred from each line's shape, because a lead-in is often an ordinary
+        // paragraph (`Avoid this:`) with no `#`, `>` or `-` to recognise it by. Testing shape alone
+        // read that paragraph as code and abandoned the walk, turning a clearly labelled
+        // counterexample into a CI failure.
+        var crossedFence = false;
+
         for (var i = index - 1; i >= 0 && index - i <= 8; i--)
         {
             var text = lines[i].Trim();
             if (text.Length == 0)
                 continue;
 
-            var isComment = text.StartsWith("//", StringComparison.Ordinal);
-            var isProse = text.StartsWith("```", StringComparison.Ordinal)
-                          || text.StartsWith("~~~", StringComparison.Ordinal)
-                          || text.StartsWith("#", StringComparison.Ordinal)
-                          || text.StartsWith(">", StringComparison.Ordinal)
-                          || text.StartsWith("-", StringComparison.Ordinal);
+            if (text.StartsWith("```", StringComparison.Ordinal) || text.StartsWith("~~~", StringComparison.Ordinal))
+            {
+                // The second fence encountered closes an earlier, unrelated block; anything above it
+                // introduces that block, not this one.
+                if (crossedFence)
+                    return false;
 
-            if (!isComment && !isProse)
-                return false;   // real code above: any marker up there belongs to that line.
+                crossedFence = true;
+                continue;
+            }
 
-            var candidate = isComment ? CommentText(text) : Urls.Replace(text, " ");
-            if (CounterexampleMarker.IsMatch(candidate))
+            if (!crossedFence)
+            {
+                // Still inside the fence, so only a comment can carry a marker; real code above
+                // means any marker further up belongs to that line rather than this one.
+                if (!text.StartsWith("//", StringComparison.Ordinal))
+                    return false;
+
+                if (IsCounterexampleLabel(CommentText(text)))
+                    return true;
+
+                continue;
+            }
+
+            if (IsCounterexampleLabel(Urls.Replace(text, " ")))
                 return true;
         }
 

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateTests.cs
@@ -111,6 +111,16 @@ public class AgentKitDocGateTests
         if (CrossMark.IsMatch(stripped))
             return true;
 
+        // A trailing period or semicolon terminates a comment; it does not introduce a label body.
+        // Counting one let `// avoid allocations.` split into the two-word head `avoid allocations`
+        // and qualify, while the identical `// avoid allocations` — named below as exactly what the
+        // safeguard exists to reject — did not. A mid-comment period still delimits, so `// Bad.
+        // This allocates.` keeps its label.
+        stripped = stripped.TrimEnd('.', ';', ' ', '\t');
+
+        if (stripped.Length == 0)
+            return false;
+
         var cut = stripped.IndexOfAny(new[] { ':', '—', '–', ',', '!', '.', ';' });
         var head = (cut >= 0 ? stripped[..cut] : stripped).Trim();
 

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateTests.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.UI.Reactor.Analyzers;
 using Xunit;
 
@@ -52,9 +54,12 @@ public class AgentKitDocGateTests
     /// <c>skills/</c> and <c>plugins/</c>: <c>// Wrong:</c>, <c>// Bad:</c>, <c>// ❌ WRONG</c>,
     /// <c>### ❌ The anti-pattern …</c>, <c>// Never hardcode …</c>.
     /// </summary>
-    private static readonly Regex CounterexampleMarker = new(
+    internal static readonly Regex CounterexampleMarker = new(
         @"\b(wrong|bad|don'?t|do not|avoid|never|incorrect|anti-?pattern)\b|❌",
         RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    /// <summary>A bare URL, stripped from prose before the marker is matched against it.</summary>
+    internal static readonly Regex Urls = new(@"\b\w+://\S+", RegexOptions.Compiled);
 
     /// <summary>
     /// No shipped sample may apply a common modifier to a receiver
@@ -156,22 +161,28 @@ public class AgentKitDocGateTests
     /// "real code above" and declare an obviously-marked counterexample unmarked.
     /// </para>
     /// <para>
-    /// Only the <em>comment</em> part of a line is considered. Reading the whole line would let
-    /// <c>Button("Never")</c> exempt itself, which is the sort of accidental self-exemption that
-    /// turns a gate into decoration.
+    /// Only genuine <em>comment trivia</em> is considered, obtained by lexing the line with Roslyn
+    /// rather than scanning for <c>//</c>. A textual search cannot tell a comment from a string:
+    /// <c>FlexColumn(TextBlock("https://example/avoid")).Padding(16)</c> contains both <c>//</c>
+    /// and the word "avoid", and would silently exempt itself. Reading the whole line has the same
+    /// defect in a plainer form — <c>Button("Never")</c> would do it.
+    /// </para>
+    /// <para>
+    /// The prose lines above a fence are matched with URLs stripped, for the same reason in the
+    /// markdown direction: a link ending in <c>/avoid</c> is a citation, not an instruction to
+    /// treat the block below it as wrong.
     /// </para>
     /// </remarks>
-    private static bool IsMarkedCounterexample(IReadOnlyList<string> lines, AgentKitFinding finding) =>
+    internal static bool IsMarkedCounterexample(IReadOnlyList<string> lines, AgentKitFinding finding) =>
         IsMarkedAt(lines, finding.Line) || IsMarkedAt(lines, finding.ChainStartLine);
 
-    private static bool IsMarkedAt(IReadOnlyList<string> lines, int line)
+    internal static bool IsMarkedAt(IReadOnlyList<string> lines, int line)
     {
         var index = line - 1;
         if (index < 0 || index >= lines.Count)
             return false;
 
-        var trailing = lines[index].IndexOf("//", StringComparison.Ordinal);
-        if (trailing >= 0 && CounterexampleMarker.IsMatch(lines[index][trailing..]))
+        if (CounterexampleMarker.IsMatch(CommentText(lines[index])))
             return true;
 
         // Walk up through the comment block, and — once past the fence — the markdown heading or
@@ -182,21 +193,43 @@ public class AgentKitDocGateTests
             if (text.Length == 0)
                 continue;
 
-            var isContext = text.StartsWith("//", StringComparison.Ordinal)
-                            || text.StartsWith("```", StringComparison.Ordinal)
-                            || text.StartsWith("~~~", StringComparison.Ordinal)
-                            || text.StartsWith("#", StringComparison.Ordinal)
-                            || text.StartsWith(">", StringComparison.Ordinal)
-                            || text.StartsWith("-", StringComparison.Ordinal);
+            var isComment = text.StartsWith("//", StringComparison.Ordinal);
+            var isProse = text.StartsWith("```", StringComparison.Ordinal)
+                          || text.StartsWith("~~~", StringComparison.Ordinal)
+                          || text.StartsWith("#", StringComparison.Ordinal)
+                          || text.StartsWith(">", StringComparison.Ordinal)
+                          || text.StartsWith("-", StringComparison.Ordinal);
 
-            if (!isContext)
+            if (!isComment && !isProse)
                 return false;   // real code above: any marker up there belongs to that line.
 
-            if (CounterexampleMarker.IsMatch(text))
+            var candidate = isComment ? CommentText(text) : Urls.Replace(text, " ");
+            if (CounterexampleMarker.IsMatch(candidate))
                 return true;
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// The comment trivia on one line of C#, concatenated — everything outside a comment removed.
+    /// </summary>
+    /// <remarks>
+    /// Lexing is enough: comment trivia is recognised without the fragment having to parse, which
+    /// matters because these lines are snippets pulled out of markdown with no enclosing class.
+    /// </remarks>
+    internal static string CommentText(string line)
+    {
+        if (!line.Contains("//", StringComparison.Ordinal) && !line.Contains("/*", StringComparison.Ordinal))
+            return string.Empty;
+
+        var trivia = CSharpSyntaxTree.ParseText(line)
+            .GetRoot()
+            .DescendantTrivia(descendIntoTrivia: true)
+            .Where(t => t.IsKind(SyntaxKind.SingleLineCommentTrivia) || t.IsKind(SyntaxKind.MultiLineCommentTrivia))
+            .Select(t => t.ToString());
+
+        return string.Join(" ", trivia);
     }
 
     /// <summary>Reads each document once; a scan touches the same file for every finding in it.</summary>

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateTests.cs
@@ -273,7 +273,7 @@ public class AgentKitDocGateTests
         if (index < 0 || index >= lines.Count)
             return false;
 
-        if (IsCounterexampleLabel(CommentText(lines[index])))
+        if (IsCounterexampleLabel(CommentText(AgentKitDocCorpus.StripBlockquote(lines[index]).Content)))
             return true;
 
         // Walk up: first through the code above, then — once the opening fence is crossed — through
@@ -286,7 +286,12 @@ public class AgentKitDocGateTests
 
         for (var i = index - 1; i >= 0 && index - i <= 8; i--)
         {
-            var text = lines[i].Trim();
+            // Strip the blockquote container prefix, exactly as the fence scanner does. Without
+            // this the walk saw a raw `>` on `> ```csharp`, failed the fence test, and treated the
+            // opener as code — so `> Avoid this:` above a blockquoted sample stopped exempting it
+            // and a deliberately-marked counterexample failed CI. Adding blockquote support to the
+            // extractor without adding it here left the two disagreeing about the same document.
+            var text = AgentKitDocCorpus.StripBlockquote(lines[i]).Content.Trim();
             if (text.Length == 0)
                 continue;
 

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitSnippetWalker.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitSnippetWalker.cs
@@ -335,13 +335,21 @@ internal static class AgentKitSnippetWalker
     /// on purpose: <c>WithBorder</c>, <c>ThemeBackground</c> and <c>BorderBrush</c> all qualify, and
     /// over-matching here only ever suppresses a finding.
     /// </summary>
-    /// <remarks>
-    /// <c>Set</c> is in the list for a different reason: its lambda can write anything, and this
-    /// walker cannot see inside it. Treating an opaque write as a justification keeps the failure
-    /// mode on the safe side of the false-positive/false-negative trade this gate has to make.
-    /// </remarks>
     private static readonly string[] WrapperJustifications =
-        { "Background", "Border", "CornerRadius", "Shadow", "Clip", "Set" };
+        { "Background", "Border", "CornerRadius", "Shadow", "Clip" };
+
+    /// <summary>
+    /// Modifiers that justify a wrapper but must match <b>exactly</b>.
+    /// </summary>
+    /// <remarks>
+    /// <c>Set</c> counts because its lambda can write anything and this walker cannot see inside
+    /// it, so an opaque write is treated as carrying its own weight. As a substring it also
+    /// swallowed <c>PositionInSet</c>, <c>SetsSize</c> and anything else ending in "Set" — an
+    /// accessibility modifier that can live perfectly well on the inner element, silently
+    /// suppressing a genuine wrapper finding.
+    /// </remarks>
+    private static readonly HashSet<string> ExactWrapperJustifications =
+        new(StringComparer.Ordinal) { "Set" };
 
     /// <summary>
     /// Element types whose sole contribution is decoration, so relocating a modifier inward and
@@ -613,7 +621,8 @@ internal static class AgentKitSnippetWalker
                 continue;
 
             if (ChainModifiers(invocation).Any(name =>
-                    WrapperJustifications.Any(j => name.Contains(j, StringComparison.Ordinal))))
+                    ExactWrapperJustifications.Contains(name)
+                    || WrapperJustifications.Any(j => name.Contains(j, StringComparison.Ordinal))))
                 continue;
 
             return new AgentKitFinding(

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitSnippetWalker.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitSnippetWalker.cs
@@ -539,9 +539,11 @@ internal static class AgentKitSnippetWalker
         {
             var expression = argument.Expression;
 
-            // (Brush)null, ((Brush)null) — unwrap to whatever is really passed. The cast's own type
-            // is deliberately ignored: `(Brush)null` and `(object)null` are both null, and reading
-            // the cast would only re-introduce the guesswork DefaultIsProvablyNull exists to avoid.
+            // (Brush)null, ((Brush)null), null! — unwrap to whatever is really passed. The cast's
+            // own type is deliberately ignored: `(Brush)null` and `(object)null` are both null, and
+            // reading the cast would only re-introduce the guesswork DefaultIsProvablyNull exists
+            // to avoid. `!` is unwrapped for the same reason the chain walkers treat it as
+            // transparent — it changes nullability analysis, never the value.
             while (true)
             {
                 switch (expression)
@@ -551,6 +553,9 @@ internal static class AgentKitSnippetWalker
                         continue;
                     case ParenthesizedExpressionSyntax parenthesized:
                         expression = parenthesized.Expression;
+                        continue;
+                    case PostfixUnaryExpressionSyntax { RawKind: (int)SyntaxKind.SuppressNullableWarningExpression } forgiving:
+                        expression = forgiving.Operand;
                         continue;
                 }
 
@@ -694,9 +699,7 @@ internal static class AgentKitSnippetWalker
             if (inner is null || !string.Equals(inner.FullName, innerFullName, StringComparison.Ordinal))
                 continue;
 
-            if (ChainModifiers(invocation).Any(name =>
-                    ExactWrapperJustifications.Contains(name)
-                    || WrapperJustifications.Any(j => name.Contains(j, StringComparison.Ordinal))))
+            if (ChainModifiers(invocation).Any(IsJustification))
                 continue;
 
             return new AgentKitFinding(
@@ -735,8 +738,28 @@ internal static class AgentKitSnippetWalker
         return null;
     }
 
-    /// <summary>Every modifier name applied anywhere on the fluent chain this invocation belongs to.</summary>
-    private static IEnumerable<string> ChainModifiers(InvocationExpressionSyntax invocation)
+    /// <summary>
+    /// True when a modifier on the wrapper's chain really justifies the wrapper's existence.
+    /// </summary>
+    /// <remarks>
+    /// The name is necessary but not sufficient. A constant-null argument makes the modifier inert
+    /// — that is the premise <see cref="HasConstantNullArgument"/> already relies on — so
+    /// <c>Border(FlexColumn(children)).Padding(16).Background((Brush)null)</c> is still a Border
+    /// that supplies nothing but padding. Counting it hid the exact workaround this rule exists to
+    /// catch, behind a decorator that does nothing: a no-op suppression, and an internal
+    /// contradiction, since the same call is skipped as inert two checks earlier.
+    /// </remarks>
+    private static bool IsJustification((string Name, InvocationExpressionSyntax Invocation) modifier)
+    {
+        var named = ExactWrapperJustifications.Contains(modifier.Name)
+                    || WrapperJustifications.Any(j => modifier.Name.Contains(j, StringComparison.Ordinal));
+
+        return named && !HasConstantNullArgument(modifier.Invocation, modifier.Name);
+    }
+
+    /// <summary>Every modifier applied anywhere on the fluent chain this invocation belongs to.</summary>
+    private static IEnumerable<(string Name, InvocationExpressionSyntax Invocation)> ChainModifiers(
+        InvocationExpressionSyntax invocation)
     {
         // Walk out to the outermost invocation first — `.Padding(24)` may be followed by
         // `.Background(...)`, and a justification that appears later still justifies the wrapper.
@@ -768,9 +791,9 @@ internal static class AgentKitSnippetWalker
 
         for (var node = outermost; node is not null;)
         {
-            if (node is InvocationExpressionSyntax { Expression: MemberAccessExpressionSyntax access })
+            if (node is InvocationExpressionSyntax { Expression: MemberAccessExpressionSyntax access } chained)
             {
-                yield return access.Name.Identifier.Text;
+                yield return (access.Name.Identifier.Text, chained);
                 node = access.Expression;
                 continue;
             }

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitSnippetWalker.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitSnippetWalker.cs
@@ -684,6 +684,15 @@ internal static class AgentKitSnippetWalker
     /// arm's body. Numbering them flat instead reset to the unconditional arm at every inner
     /// <c>#endif</c>, and no variant then held both halves of such a chain.
     /// </para>
+    /// <para>
+    /// One arm at a time is the deliberate boundary. A chain split across two <em>independent</em>
+    /// blocks — its factory in one <c>#if</c> and its modifier in another — is present only in a
+    /// configuration that selects an arm from each, and no variant here holds both, so it is a
+    /// documented miss rather than an oversight. Covering it means combining arms across blocks,
+    /// which is exponential and needs a cap to stay safe; the shipped corpus contains a single
+    /// conditional block, unnested and single-armed, so that machinery would guard nothing and add
+    /// a failure mode of its own. If a second block ever appears, this is the thing to revisit.
+    /// </para>
     /// </remarks>
     private static IEnumerable<(string Text, bool IsPrimary)> ConditionalVariants(string text)
     {

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitSnippetWalker.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitSnippetWalker.cs
@@ -866,16 +866,24 @@ internal static class AgentKitSnippetWalker
     /// True when a modifier on the wrapper's chain would survive the wrapper being removed.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// Two ways to qualify: it is a positional/identity modifier the inner element inherits when it
-    /// takes the wrapper's place, or it is inert. A constant-null argument makes a modifier do
-    /// nothing — the premise <see cref="HasConstantNullArgument"/> already rests on — so
-    /// <c>Border(inner).Padding(16).Background((Brush)null)</c> is still a Border supplying nothing
-    /// but padding. Without the second arm, a decorator that does nothing would hide the exact
-    /// workaround this rule exists to catch.
+    /// takes the wrapper's place, or it is a <em>gated common modifier</em> with a constant-null
+    /// argument, which does nothing at all.
+    /// </para>
+    /// <para>
+    /// The null arm is restricted to <see cref="ModifierTable.Properties"/> on purpose. "A null
+    /// argument makes it inert" holds for the gated modifiers <c>HasConstantNullArgument</c>
+    /// mirrors the analyzer over; it does not generalise. <c>.Stagger(delay, null)</c> still
+    /// installs a stagger configuration, and moving it onto the inner element changes which
+    /// children animate — so an unknown modifier taking a null must keep suppressing the finding,
+    /// like any other unknown.
+    /// </para>
     /// </remarks>
     private static bool IsRelocatable((string Name, InvocationExpressionSyntax Invocation) modifier) =>
         RelocatableModifiers.Contains(modifier.Name)
-        || HasConstantNullArgument(modifier.Invocation, modifier.Name);
+        || (ModifierTable.Properties.ContainsKey(modifier.Name)
+            && HasConstantNullArgument(modifier.Invocation, modifier.Name));
 
     /// <summary>
     /// True when any <c>with</c> expression appears on the fluent chain this invocation belongs to.

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitSnippetWalker.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitSnippetWalker.cs
@@ -31,6 +31,7 @@ internal sealed class ReactorSurface
 {
     private readonly Dictionary<string, Type?> _factories = new(StringComparer.Ordinal);
     private readonly Dictionary<Type, HashSet<Type>> _setControls = new();
+    private readonly Dictionary<string, HashSet<Type>> _modifierArguments = new(StringComparer.Ordinal);
 
     [UnconditionalSuppressMessage(
         "Trimming", "IL2026",
@@ -69,9 +70,29 @@ internal sealed class ReactorSurface
             controls.Add(parameters[1].ParameterType.GetGenericArguments()[0]);
         }
 
+        // Single-argument generic modifiers, keyed by name. Feeds DefaultIsProvablyNull: `default`
+        // is target-typed, so only the real parameter types can say whether it means null.
+        foreach (var method in elementExtensions.GetMethods(BindingFlags.Public | BindingFlags.Static))
+        {
+            if (!method.IsGenericMethodDefinition)
+                continue;
+
+            var parameters = method.GetParameters();
+            if (parameters.Length != 2 || !parameters[0].ParameterType.IsGenericParameter)
+                continue;   // not `M<T>(this T el, TArg value)`
+
+            var argument = parameters[1].ParameterType;
+            if (argument.IsGenericParameter)
+                continue;   // unconstrained: says nothing about reference-ness.
+
+            if (!_modifierArguments.TryGetValue(method.Name, out var types))
+                _modifierArguments[method.Name] = types = new HashSet<Type>();
+
+            types.Add(argument);
+        }
+
         var factories = reactor.GetType("Microsoft.UI.Reactor.Factories")
             ?? throw new InvalidOperationException("Microsoft.UI.Reactor.Factories not found.");
-
         FactoriesType = factories;
 
         foreach (var method in factories.GetMethods(BindingFlags.Public | BindingFlags.Static))
@@ -177,7 +198,70 @@ internal sealed class ReactorSurface
         return null;
     }
 
-    /// <summary>The control's own name followed by every base type name, most derived first.</summary>
+    /// <summary>
+    /// The parameter types of every single-argument generic overload of a modifier on
+    /// <c>ElementExtensions</c>, used to decide whether <c>default</c> at that position is
+    /// provably <see langword="null"/>.
+    /// </summary>
+    public IReadOnlyCollection<Type> SingleArgumentModifierTypes(string modifier) =>
+        _modifierArguments.TryGetValue(modifier, out var types) ? types : Array.Empty<Type>();
+
+    /// <summary>
+    /// True when a <c>default</c> at this modifier's single argument position must be
+    /// <see langword="null"/>.
+    /// </summary>
+    /// <param name="modifier">Modifier name, e.g. <c>Background</c>.</param>
+    /// <param name="explicitTypeName">
+    /// The <c>T</c> of <c>default(T)</c> as written, or <see langword="null"/> for a bare
+    /// <c>default</c>.
+    /// </param>
+    /// <remarks>
+    /// <para>
+    /// <c>default</c> is target-typed, so syntax alone says nothing: <c>default(Brush)</c> is null,
+    /// <c>default(double)</c> is <c>0</c>, and <c>0</c> is a real write that <c>ApplyModifiers</c>
+    /// really does drop on a Flex receiver. Exempting it would hide a true finding — a silent miss,
+    /// which is the failure this gate is least able to detect in itself.
+    /// </para>
+    /// <para>
+    /// With an explicit <c>T</c> the answer comes from <c>T</c>. Without one, every overload the
+    /// call could bind to must be nullable, which is strictly conservative:
+    /// <c>.Background(default)</c> is in fact ambiguous across
+    /// <c>string</c>/<c>Brush</c>/<c>ThemeRef</c> and does not compile, so refusing to exempt it
+    /// costs nothing. Unprovable never exempts.
+    /// </para>
+    /// </remarks>
+    public bool DefaultIsProvablyNull(string modifier, string? explicitTypeName = null)
+    {
+        var types = SingleArgumentModifierTypes(modifier);
+        if (types.Count == 0)
+            return false;
+
+        if (explicitTypeName is null)
+            return types.All(IsNullable);
+
+        // A value-type keyword settles it without any lookup, and covers the `default(double)` case
+        // whose parameter type may not even be in this modifier's overload set.
+        if (ValueTypeKeywords.Contains(explicitTypeName))
+            return false;
+
+        if (explicitTypeName is "string" or "object")
+            return true;
+
+        var matches = types.Where(t => string.Equals(t.Name, explicitTypeName, StringComparison.Ordinal)).ToList();
+        return matches.Count > 0 && matches.All(IsNullable);
+    }
+
+    private static bool IsNullable(Type type) =>
+        !type.IsValueType || Nullable.GetUnderlyingType(type) is not null;
+
+    private static readonly HashSet<string> ValueTypeKeywords = new(StringComparer.Ordinal)
+    {
+        "int", "double", "float", "bool", "char", "byte", "sbyte",
+        "short", "ushort", "uint", "long", "ulong", "decimal", "nint", "nuint",
+    };
+
+    /// <summary>
+    /// The control's own name followed by every base type name, most derived first.</summary>
     public static IEnumerable<string> ControlBaseChain(Type control)
     {
         for (var current = control; current is not null; current = current.BaseType)
@@ -259,6 +343,28 @@ internal static class AgentKitSnippetWalker
     private static readonly string[] WrapperJustifications =
         { "Background", "Border", "CornerRadius", "Shadow", "Clip", "Set" };
 
+    /// <summary>
+    /// Element types whose sole contribution is decoration, so relocating a modifier inward and
+    /// deleting the wrapper preserves behaviour.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Exactly one entry, and it should stay hard to add to. <c>BorderElement</c> is the #1119
+    /// shape and the one <c>reactor-design/SKILL.md</c> names in prose: a <c>Border</c> contributes
+    /// background, corner radius, border brush and padding, so a <c>Border</c> supplying only
+    /// padding contributes nothing once <c>.FlexPadding(...)</c> exists.
+    /// </para>
+    /// <para>
+    /// "Single child" is <b>not</b> a substitute for this test.
+    /// <c>ScrollViewer(FlexColumn(children)).Padding(16)</c> has one child and is a gate-legal
+    /// receiver, yet deleting it deletes scrolling — the wrapper is load-bearing and the sample is
+    /// correct. Before adding a type here, establish that removing it changes nothing but
+    /// appearance; if it does anything else, the rule does not apply to it.
+    /// </para>
+    /// </remarks>
+    private static readonly HashSet<string> PassiveWrapperElements =
+        new(StringComparer.Ordinal) { "BorderElement" };
+
     public static AgentKitScan Scan(IEnumerable<AgentKitSnippet> snippets)
     {
         var findings = new List<AgentKitFinding>();
@@ -303,7 +409,7 @@ internal static class AgentKitSnippetWalker
                 // Mirrors NoOpModifierAnalyzer's constant-null gate (its line 232). Reporting here
                 // would let this gate reject a sample the packaged analyzer accepts, which is worse
                 // than the drift it exists to catch.
-                if (HasConstantNullArgument(invocation))
+                if (HasConstantNullArgument(invocation, modifier))
                     continue;
 
                 var line = LineOf(tree, snippet, access.Name);
@@ -345,13 +451,15 @@ internal static class AgentKitSnippetWalker
     /// <c>const</c> null is not a shape that occurs.
     /// </para>
     /// </remarks>
-    private static bool HasConstantNullArgument(InvocationExpressionSyntax invocation)
+    private static bool HasConstantNullArgument(InvocationExpressionSyntax invocation, string modifier)
     {
         foreach (var argument in invocation.ArgumentList.Arguments)
         {
             var expression = argument.Expression;
 
-            // (Brush)null, ((Brush)null), (Brush)default — unwrap to whatever is really passed.
+            // (Brush)null, ((Brush)null) — unwrap to whatever is really passed. The cast's own type
+            // is deliberately ignored: `(Brush)null` and `(object)null` are both null, and reading
+            // the cast would only re-introduce the guesswork DefaultIsProvablyNull exists to avoid.
             while (true)
             {
                 switch (expression)
@@ -367,10 +475,23 @@ internal static class AgentKitSnippetWalker
                 break;
             }
 
-            if (expression.IsKind(SyntaxKind.NullLiteralExpression)
-                || expression.IsKind(SyntaxKind.DefaultLiteralExpression)
-                || expression is DefaultExpressionSyntax)
+            // `null` is null whatever it is assigned to.
+            if (expression.IsKind(SyntaxKind.NullLiteralExpression))
                 return true;
+
+            // `default` and `default(T)` are not. `.Background(default(Brush))` is null, but
+            // `.Padding(default(double))` is 0 — a real write the analyzer reports and
+            // ApplyModifiers really does drop on a Flex receiver. Exempting it would hide a true
+            // finding, so the question is answered from the written type where there is one and
+            // from the modifier's overload set otherwise; unprovable never exempts.
+            if (expression.IsKind(SyntaxKind.DefaultLiteralExpression) || expression is DefaultExpressionSyntax)
+            {
+                var written = (expression as DefaultExpressionSyntax)?.Type.ToString();
+
+                if (invocation.ArgumentList.Arguments.Count == 1
+                    && ReactorSurface.Instance.DefaultIsProvablyNull(modifier, written))
+                    return true;
+            }
         }
 
         return false;
@@ -471,10 +592,15 @@ internal static class AgentKitSnippetWalker
                 || !ReactorSurface.ControlBaseChain(wrapperControl).Any(name => gate.Contains(name, StringComparer.Ordinal)))
                 continue;
 
-            // Single-child wrappers only. `Border(inner)` is unambiguously "this element exists to
-            // hold that one", which is the shape the rule is about; a multi-argument container such
-            // as `VStack(8, flex, button)` is a real layout whose padding is its own business, and
-            // flagging it would be a false positive on correct documentation.
+            // The wrapper must be semantically passive: something whose *only* contribution is
+            // decoration, so moving the modifier inward and deleting it is behaviour-preserving.
+            // A single child does not establish that. `ScrollViewer(FlexColumn(children))` is also
+            // a one-child, gate-legal receiver, but deleting it deletes scrolling — reporting there
+            // would be a false positive on correct documentation, and the reader's only way to
+            // satisfy the gate would be to break the sample.
+            if (!PassiveWrapperElements.Contains(wrapperElement.Name))
+                continue;
+
             if (wrapperArguments.Count != 1)
                 continue;
 

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitSnippetWalker.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitSnippetWalker.cs
@@ -98,20 +98,31 @@ internal sealed class ReactorSurface
         foreach (var method in factories.GetMethods(BindingFlags.Public | BindingFlags.Static))
         {
             var returned = method.ReturnType;
-            if (returned.IsGenericParameter || returned.ContainsGenericParameters || !ElementType.IsAssignableFrom(returned))
+            if (returned.IsGenericParameter || !ElementType.IsAssignableFrom(returned))
                 continue;
 
-            // An overload set that returns two different element types cannot be resolved from a
-            // bare name, so the name is poisoned to null rather than resolved to whichever
-            // overload reflection happened to hand back first.
-            if (_factories.TryGetValue(method.Name, out var existing))
+            // A generic factory returns an open constructed type — `ListView<T>` gives
+            // `TemplatedListViewElement<T>`. Keyed by its generic type definition so the map has an
+            // entry at all: dropping these made `ListView<Todo>(...)`, `LazyVStack<T>(...)` and
+            // friends invisible to the walker, and because a skipped chain neither reports nor
+            // counts, the aggregate floor stayed green over the blind spot. Those factories appear
+            // in the shipped corpus.
+            if (returned.ContainsGenericParameters)
+                returned = returned.GetGenericTypeDefinition();
+
+            var key = Key(method.Name, method.GetGenericArguments().Length);
+
+            // An overload set that returns two different element types at the same arity cannot be
+            // resolved from the call site, so the entry is poisoned to null rather than resolved to
+            // whichever overload reflection happened to hand back first.
+            if (_factories.TryGetValue(key, out var existing))
             {
                 if (existing != returned)
-                    _factories[method.Name] = null;
+                    _factories[key] = null;
             }
             else
             {
-                _factories[method.Name] = returned;
+                _factories[key] = returned;
             }
         }
     }
@@ -125,17 +136,32 @@ internal sealed class ReactorSurface
     public Type FactoriesType { get; }
 
     /// <summary>
-    /// Number of factory names that resolve to exactly one element type. A floor over this is what
-    /// tells a reading of "no findings" apart from "the reflection stopped resolving".
+    /// Number of factory signatures that resolve to exactly one element type. A floor over this is
+    /// what tells a reading of "no findings" apart from "the reflection stopped resolving".
     /// </summary>
     public int ResolvableFactoryCount => _factories.Count(pair => pair.Value is not null);
 
     /// <summary>
-    /// The element type a DSL factory name produces, or <see langword="null"/> when the name is
-    /// unknown or its overloads disagree.
+    /// The element type a DSL factory call produces, or <see langword="null"/> when the name is
+    /// unknown or its overloads at that arity disagree.
     /// </summary>
-    public Type? Element(string factoryName) =>
-        _factories.TryGetValue(factoryName, out var element) ? element : null;
+    /// <param name="factoryName">Factory name as written, e.g. <c>ListView</c>.</param>
+    /// <param name="typeArgumentCount">
+    /// Number of type arguments at the call site — <c>0</c> for <c>Border(...)</c>, <c>1</c> for
+    /// <c>ListView&lt;Todo&gt;(...)</c>.
+    /// </param>
+    /// <remarks>
+    /// Keyed by arity as well as name because several factories are both:
+    /// <c>ListView(...)</c> returns <c>ListViewElement</c> while <c>ListView&lt;T&gt;(...)</c>
+    /// returns <c>TemplatedListViewElement&lt;T&gt;</c>. Keyed by name alone the two collide and the
+    /// name is discarded as ambiguous, which silently excluded every such factory from the walker.
+    /// The call site states its own arity, so nothing has to be guessed.
+    /// </remarks>
+    public Type? Element(string factoryName, int typeArgumentCount) =>
+        _factories.TryGetValue(Key(factoryName, typeArgumentCount), out var element) ? element : null;
+
+    private static string Key(string factoryName, int typeArgumentCount) =>
+        typeArgumentCount == 0 ? factoryName : factoryName + "`" + typeArgumentCount;
 
     /// <summary>
     /// The controls an element's <c>Set</c> overloads name, empty when it declares none.
@@ -422,7 +448,7 @@ internal static class AgentKitSnippetWalker
                 if (head is null)
                     continue;
 
-                var element = ReactorSurface.Instance.Element(head.Value.Factory);
+                var element = ReactorSurface.Instance.Element(head.Value.Factory, head.Value.TypeArgumentCount);
                 if (element is null)
                     continue;
 
@@ -630,7 +656,7 @@ internal static class AgentKitSnippetWalker
             if (innerHead is null)
                 continue;
 
-            var inner = ReactorSurface.Instance.Element(innerHead.Value.Factory);
+            var inner = ReactorSurface.Instance.Element(innerHead.Value.Factory, innerHead.Value.TypeArgumentCount);
             if (inner is null || !string.Equals(inner.FullName, innerFullName, StringComparison.Ordinal))
                 continue;
 
@@ -680,11 +706,30 @@ internal static class AgentKitSnippetWalker
     {
         // Walk out to the outermost invocation first — `.Padding(24)` may be followed by
         // `.Background(...)`, and a justification that appears later still justifies the wrapper.
+        // Parentheses, `with` and the null-forgiving `!` are stepped through, because the downward
+        // walk below already treats them as transparent: stopping here but not there made
+        // `(Border(FlexColumn(children)).Padding(16)).Background(...)` report a workaround, never
+        // having reached the `Background` that justifies the Border.
         SyntaxNode outermost = invocation;
-        while (outermost.Parent is MemberAccessExpressionSyntax parentAccess
-               && parentAccess.Parent is InvocationExpressionSyntax parentInvocation)
+
+        while (true)
         {
-            outermost = parentInvocation;
+            var parent = outermost.Parent;
+
+            while (parent is ParenthesizedExpressionSyntax
+                   or WithExpressionSyntax
+                   or PostfixUnaryExpressionSyntax { RawKind: (int)SyntaxKind.SuppressNullableWarningExpression })
+            {
+                parent = parent.Parent;
+            }
+
+            if (parent is MemberAccessExpressionSyntax { Parent: InvocationExpressionSyntax parentInvocation })
+            {
+                outermost = parentInvocation;
+                continue;
+            }
+
+            break;
         }
 
         for (var node = outermost; node is not null;)
@@ -715,14 +760,21 @@ internal static class AgentKitSnippetWalker
     /// runtime, which is the same reason <see cref="NoOpModifierAnalyzer"/> refuses to report on a
     /// receiver typed as <c>Element</c>.
     /// </remarks>
-    private static (string Factory, SeparatedSyntaxList<ArgumentSyntax> Arguments)? ResolveHead(ExpressionSyntax expression)
+    private static (string Factory, int TypeArgumentCount, SeparatedSyntaxList<ArgumentSyntax> Arguments)? ResolveHead(ExpressionSyntax expression)
     {
         for (var node = expression; node is not null;)
         {
             switch (node)
             {
+                // `Border(...)` and `ListView<Todo>(...)` alike — a generic factory's name lives on
+                // GenericNameSyntax, and rejecting that shape was half of the blind spot that kept
+                // generic factories out of this walker entirely. The call site's own type-argument
+                // count is what tells `ListView(...)` from `ListView<T>(...)`.
+                case InvocationExpressionSyntax { Expression: GenericNameSyntax generic } genericInvocation:
+                    return (generic.Identifier.Text, generic.TypeArgumentList.Arguments.Count, genericInvocation.ArgumentList.Arguments);
+
                 case InvocationExpressionSyntax { Expression: IdentifierNameSyntax identifier } invocation:
-                    return (identifier.Identifier.Text, invocation.ArgumentList.Arguments);
+                    return (identifier.Identifier.Text, 0, invocation.ArgumentList.Arguments);
 
                 case InvocationExpressionSyntax { Expression: MemberAccessExpressionSyntax access }:
                     node = access.Expression;

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitSnippetWalker.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitSnippetWalker.cs
@@ -713,6 +713,18 @@ internal static class AgentKitSnippetWalker
             return null;
 
         // A type-specific overload writes the element record directly and is always sound.
+        //
+        // Known imprecision, in the safe direction. This exempts the *element*, not the *call*, so
+        // it also covers a call that actually binds the generic modifier because no type-specific
+        // overload accepts its argument: RichTextBlockElement declares Foreground(string) and
+        // Foreground(Brush) but no ThemeRef overload, so `RichTextBlock(...).Foreground(Theme.X)`
+        // binds the generic one and REACTOR_MOD_003 does report it, while this returns null.
+        //
+        // Narrowing it needs the argument's type, which a syntax-only walk cannot have: refusing to
+        // exempt would report `RichTextBlock(...).Foreground("#fff")`, which binds type-specific and
+        // is correct. That trades a latent missed finding for a live false positive on valid
+        // documentation — the one outcome this gate must not produce. The shape does not occur in
+        // the corpus today; if it ever does, the fix is a semantic model, not a sharper guess.
         if (info.ElementTypes is { } elementTypes && elementTypes.Contains(element.Name, StringComparer.Ordinal))
             return null;
 

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitSnippetWalker.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitSnippetWalker.cs
@@ -618,6 +618,73 @@ internal static class AgentKitSnippetWalker
         @"^[ \t]*#[ \t]*(if|elif|else|endif|define|undef)\b[^\r\n]*",
         RegexOptions.Compiled | RegexOptions.Multiline);
 
+    /// <summary>
+    /// One parse variant per conditional arm, plus the arm-free configuration, each preserving
+    /// every line's original index.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The first variant keeps no arm, so it is the snippet's unconditional code and is the one the
+    /// chain count is taken from. Each further variant keeps exactly one arm and blanks the rest,
+    /// which is a configuration that arm really occurs in. Arms are enumerated rather than
+    /// combined: an expression written <c>#if A x #else y #endif</c> has two valid alternatives
+    /// that concatenate into adjacent expressions, and Roslyn may put the second in skipped trivia,
+    /// so the violation in it would go unreported exactly as it did before.
+    /// </para>
+    /// <para>
+    /// Linear in the number of arms rather than exponential in the number of blocks, so a snippet
+    /// cannot make this expensive. Nesting is not modelled: an inner block's arms are treated as
+    /// arms of the enclosing one, which over-produces variants but never drops a line from all of
+    /// them, and unparseable text yields no resolvable chain rather than a finding.
+    /// </para>
+    /// </remarks>
+    private static IEnumerable<(string Text, bool IsPrimary)> ConditionalVariants(string text)
+    {
+        if (!Preprocessor.IsMatch(text))
+        {
+            yield return (text, true);
+            yield break;
+        }
+
+        var lines = text.Split('\n');
+        var arm = new int[lines.Length];
+        var current = 0;
+        var arms = 0;
+
+        for (var i = 0; i < lines.Length; i++)
+        {
+            var directive = Preprocessor.Match(lines[i]);
+            if (directive.Success)
+            {
+                var kind = directive.Groups[1].Value;
+                current = kind is "endif" or "define" or "undef" ? 0 : ++arms;
+                arm[i] = -1;    // the directive line itself belongs to no arm.
+                continue;
+            }
+
+            arm[i] = current;
+        }
+
+        yield return (Keep(lines, arm, 0), true);
+
+        for (var a = 1; a <= arms; a++)
+            yield return (Keep(lines, arm, a), false);
+    }
+
+    /// <summary>
+    /// The snippet with only <paramref name="keep"/>'s arm retained, other arms and all directive
+    /// lines blanked so each remaining line keeps its index.
+    /// </summary>
+    private static string Keep(string[] lines, int[] arm, int keep)
+    {
+        var kept = new string[lines.Length];
+
+        for (var i = 0; i < lines.Length; i++)
+            kept[i] = arm[i] == 0 || arm[i] == keep ? lines[i] : string.Empty;
+
+        return string.Join("\n", kept);
+    }
+
     public static AgentKitScan Scan(IEnumerable<AgentKitSnippet> snippets)
     {
         var findings = new List<AgentKitFinding>();
@@ -640,53 +707,64 @@ internal static class AgentKitSnippetWalker
             // Conditional compilation: `ParseText` uses the default symbol set, so an inactive
             // branch survives only as DisabledTextTrivia and never reaches DescendantNodes — a
             // sample inside `#if DEBUG` would ship unscanned, and the corpus already contains one
-            // (`skills/devtools.md`). Blanking the directive lines makes every branch ordinary
-            // text while keeping each remaining line at its original index, so reported line
-            // numbers stay right. Concatenated `#else` arms may not parse; that costs nothing,
-            // because an unresolvable chain is skipped rather than reported.
-            var text = Preprocessor.IsMatch(snippet.Text)
-                ? Preprocessor.Replace(snippet.Text, string.Empty)
-                : snippet.Text;
+            // (`skills/devtools.md`). Each arm is parsed on its own, with the other arms blanked,
+            // because concatenating them does not make both independently parseable: two valid
+            // alternatives in an expression position become adjacent expressions, and Roslyn may
+            // put the later one in skipped trivia, so a violation there would still be missed.
+            // Blanking keeps every remaining line at its original index, so findings report the
+            // line they are really on.
+            var seen = new HashSet<(string, int, string?, string?)>();
 
-            var tree = CSharpSyntaxTree.ParseText(text);
-            var root = tree.GetRoot();
-
-            foreach (var invocation in root.DescendantNodes().OfType<InvocationExpressionSyntax>())
+            foreach (var (text, isPrimary) in ConditionalVariants(snippet.Text))
             {
-                if (invocation.Expression is not MemberAccessExpressionSyntax access)
-                    continue;
+                var tree = CSharpSyntaxTree.ParseText(text);
+                var root = tree.GetRoot();
 
-                var modifier = access.Name.Identifier.Text;
-                if (!ModifierTable.Properties.TryGetValue(modifier, out var info))
-                    continue;
-
-                var head = ResolveHead(access.Expression);
-                if (head is null)
-                    continue;
-
-                var element = ReactorSurface.Instance.Element(head.Value.Factory, head.Value.TypeArgumentCount);
-                if (element is null)
-                    continue;
-
-                resolvedChains++;
-
-                // Mirrors NoOpModifierAnalyzer's constant-null gate (its line 232). Reporting here
-                // would let this gate reject a sample the packaged analyzer accepts, which is worse
-                // than the drift it exists to catch.
-                if (HasConstantNullArgument(invocation, modifier))
-                    continue;
-
-                var line = LineOf(tree, snippet, access.Name);
-                var chainStart = LineOf(tree, snippet, invocation);
-
-                if (DroppedModifier(element, modifier, info) is { } dropped)
+                foreach (var invocation in root.DescendantNodes().OfType<InvocationExpressionSyntax>())
                 {
-                    findings.Add(dropped with { Path = snippet.Path, Line = line, ChainStartLine = chainStart });
-                    continue;
-                }
+                    if (invocation.Expression is not MemberAccessExpressionSyntax access)
+                        continue;
 
-                if (WrapperWorkaround(element, head.Value.Factory, head.Value.Arguments, modifier, invocation) is { } wrapper)
-                    findings.Add(wrapper with { Path = snippet.Path, Line = line, ChainStartLine = chainStart });
+                    var modifier = access.Name.Identifier.Text;
+                    if (!ModifierTable.Properties.TryGetValue(modifier, out var info))
+                        continue;
+
+                    var head = ResolveHead(access.Expression);
+                    if (head is null)
+                        continue;
+
+                    var element = ReactorSurface.Instance.Element(head.Value.Factory, head.Value.TypeArgumentCount);
+                    if (element is null)
+                        continue;
+
+                    // Counted once per snippet. Every variant contains the unconditional code, so
+                    // counting them all would inflate the floors the corpus is measured against and
+                    // make a shortfall easier to pass rather than harder.
+                    if (isPrimary)
+                        resolvedChains++;
+
+                    // Mirrors NoOpModifierAnalyzer's constant-null gate (its line 232). Reporting here
+                    // would let this gate reject a sample the packaged analyzer accepts, which is worse
+                    // than the drift it exists to catch.
+                    if (HasConstantNullArgument(invocation, modifier))
+                        continue;
+
+                    var line = LineOf(tree, snippet, access.Name);
+                    var chainStart = LineOf(tree, snippet, invocation);
+
+                    // The same unconditional line is reached by every variant; report it once.
+                    if (!seen.Add((snippet.Path, line, modifier, element.FullName)))
+                        continue;
+
+                    if (DroppedModifier(element, modifier, info) is { } dropped)
+                    {
+                        findings.Add(dropped with { Path = snippet.Path, Line = line, ChainStartLine = chainStart });
+                        continue;
+                    }
+
+                    if (WrapperWorkaround(element, head.Value.Factory, head.Value.Arguments, modifier, invocation) is { } wrapper)
+                        findings.Add(wrapper with { Path = snippet.Path, Line = line, ChainStartLine = chainStart });
+                }
             }
         }
 

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitSnippetWalker.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitSnippetWalker.cs
@@ -237,21 +237,49 @@ internal sealed class ReactorSurface
     /// <see langword="null"/> when that cannot be established.
     /// </summary>
     /// <remarks>
-    /// Prefers the <c>Set</c> overload because that is the signal the shipped analyzer uses — the
-    /// generator attributes live in <c>Reactor.Wrappers.Abstractions</c> and are referenced with
-    /// <c>PrivateAssets="all"</c>, so they are unresolvable in a consumer compilation. The
-    /// attribute is the fallback for elements that declare no <c>Set</c> overload;
-    /// <c>ModifierTableIntegrityTests.Every_Element_Set_Overload_Names_The_Control_Its_Descriptor_Mounts</c>
-    /// pins the two to each other, so the fallback cannot disagree with the primary.
+    /// <para>
+    /// Read from the <c>Set(this TElement, Action&lt;TControl&gt;)</c> overload, and <b>only</b>
+    /// from there — no generator-attribute fallback. <c>NoOpModifierAnalyzer.TryGetMountedControl</c>
+    /// resolves the same way and stays silent when an element declares no <c>Set</c> overload
+    /// (pinned by its <c>Does_Not_Fire_For_An_Element_With_No_Set_Overload</c> test), because the
+    /// generator attributes live in <c>Reactor.Wrappers.Abstractions</c> and do not flow to
+    /// consumers.
+    /// </para>
+    /// <para>
+    /// An earlier revision fell back to the attribute, which made this gate report on receivers the
+    /// packaged analyzer cannot resolve — <c>SemanticElement</c> among them. A documentation gate
+    /// stricter than the rule it enforces produces findings a reader cannot act on, so the two
+    /// resolve identically or the claim "this mirrors REACTOR_MOD_003" is not true.
+    /// </para>
     /// </remarks>
     public Type? MountedControl(Type element)
     {
         var fromSet = SetControls(element);
-        if (fromSet.Count == 1)
-            return fromSet.Single();
-
-        return fromSet.Count == 0 ? DeclaredControl(element) : null;
+        return fromSet.Count == 1 ? fromSet.Single() : null;
     }
+
+    /// <summary>
+    /// True when <paramref name="modifier"/> resolves as a method on <paramref name="element"/> —
+    /// either a type-specific overload or a generic one.
+    /// </summary>
+    /// <remarks>
+    /// The analyzer offers a replacement only once it resolves as an invocable member on the
+    /// receiver, which is why <c>LineElement</c> — having no <c>Fill</c> — falls through to
+    /// <c>Stroke</c>. Naming a replacement that does not exist would hand the reader a remedy that
+    /// does not compile, and would reject a Line counterexample that correctly documents
+    /// <c>.Stroke(...)</c>.
+    /// </remarks>
+    [UnconditionalSuppressMessage(
+        "Trimming", "IL2075",
+        Justification = "Test-only surface reader: reflects the public static methods of ElementExtensions, resolved by name from the Reactor assembly. Intentional and JIT-only; behaviour-neutral.")]
+    public bool HasModifier(Type element, string modifier) =>
+        ElementExtensionsType
+            .GetMethods(BindingFlags.Public | BindingFlags.Static)
+            .Where(m => m.Name == modifier)
+            .Select(m => m.GetParameters())
+            .Any(p => p.Length > 0
+                      && (p[0].ParameterType.IsGenericParameter
+                          || p[0].ParameterType.IsAssignableFrom(element)));
 
     /// <summary>
     /// The control named by an element's <c>[GenerateReactorWrapper]</c> /
@@ -869,7 +897,13 @@ internal static class AgentKitSnippetWalker
         if (control is not null
             && ReactorSurface.ControlBaseChain(control).Contains("Shape", StringComparer.Ordinal)
             && NoOpModifierAnalyzer.ShapeReplacements.TryGetValue(modifier, out var shape))
-            return shape.FirstOrDefault();
+        {
+            // In order, and only if it exists on this element — the analyzer's rule, and the reason
+            // LineElement falls through from Fill to Stroke. Taking the first candidate blindly
+            // would name a remedy that does not compile, and would reject a Line counterexample
+            // that correctly documents `.Stroke(...)`.
+            return shape.FirstOrDefault(candidate => ReactorSurface.Instance.HasModifier(element, candidate));
+        }
 
         return null;
     }

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitSnippetWalker.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitSnippetWalker.cs
@@ -33,6 +33,7 @@ internal sealed class ReactorSurface
     private readonly Dictionary<string, HashSet<Type>> _factoriesByName = new(StringComparer.Ordinal);
     private readonly Dictionary<Type, HashSet<Type>> _setControls = new();
     private readonly Dictionary<string, HashSet<Type>> _modifierArguments = new(StringComparer.Ordinal);
+    private readonly Dictionary<(string Modifier, string Parameter), HashSet<Type>> _modifierArgumentsByParameter = new();
     private readonly Dictionary<string, Type?> _typeChangingModifiers = new(StringComparer.Ordinal);
 
     [UnconditionalSuppressMessage(
@@ -91,6 +92,15 @@ internal sealed class ReactorSurface
                 _modifierArguments[method.Name] = types = new HashSet<Type>();
 
             types.Add(argument);
+
+            // Indexed by parameter name too, because a named argument picks the overload:
+            // `.Background(brush: default)` binds only to the Brush one, so judging `default`
+            // against the whole ambiguous set answers a question the call did not ask.
+            var key = (method.Name, parameters[1].Name ?? string.Empty);
+            if (!_modifierArgumentsByParameter.TryGetValue(key, out var named))
+                _modifierArgumentsByParameter[key] = named = new HashSet<Type>();
+
+            named.Add(argument);
         }
 
         // Type-changing modifiers: `M<T>(this T el, …)` that returns a concrete element rather than
@@ -344,9 +354,18 @@ internal sealed class ReactorSurface
     /// costs nothing. Unprovable never exempts.
     /// </para>
     /// </remarks>
-    public bool DefaultIsProvablyNull(string modifier, string? explicitTypeName = null)
+    public bool DefaultIsProvablyNull(string modifier, string? explicitTypeName = null, string? parameterName = null)
     {
-        var types = SingleArgumentModifierTypes(modifier);
+        // A named argument selects the overload, so narrow to it before deciding. Judging
+        // `.Background(brush: default)` against the ambiguous string/Brush/ThemeRef set answered a
+        // question the call did not ask and could refuse to exempt a sample the analyzer accepts —
+        // this gate being stricter than the analyzer it mirrors is worse than the drift it catches.
+        // An unrecognised name falls back to the full set rather than to an empty one.
+        var types = parameterName is not null
+                    && _modifierArgumentsByParameter.TryGetValue((modifier, parameterName), out var named)
+            ? named
+            : SingleArgumentModifierTypes(modifier);
+
         if (types.Count == 0)
             return false;
 
@@ -720,7 +739,10 @@ internal static class AgentKitSnippetWalker
                 var written = (expression as DefaultExpressionSyntax)?.Type.ToString() ?? castType;
 
                 if (invocation.ArgumentList.Arguments.Count == 1
-                    && ReactorSurface.Instance.DefaultIsProvablyNull(modifier, written))
+                    && ReactorSurface.Instance.DefaultIsProvablyNull(
+                        modifier,
+                        written,
+                        invocation.ArgumentList.Arguments[0].NameColon?.Name.Identifier.Text))
                     return true;
             }
         }

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitSnippetWalker.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitSnippetWalker.cs
@@ -36,6 +36,8 @@ internal sealed class ReactorSurface
     private readonly Dictionary<string, HashSet<Type>> _modifierArguments = new(StringComparer.Ordinal);
     private readonly Dictionary<(string Modifier, string Parameter), HashSet<Type>> _modifierArgumentsByParameter = new();
     private readonly Dictionary<string, Type?> _typeChangingModifiers = new(StringComparer.Ordinal);
+    private readonly HashSet<string> _identityModifiers = new(StringComparer.Ordinal);
+    private readonly HashSet<string> _nonIdentityModifiers = new(StringComparer.Ordinal);
 
     [UnconditionalSuppressMessage(
         "Trimming", "IL2026",
@@ -103,6 +105,30 @@ internal sealed class ReactorSurface
 
             named.Add(argument);
         }
+
+        // Identity-preserving modifiers: the chain walk may step over a call only when its
+        // signature proves it hands back what it was given. An overload set that disagrees with
+        // itself is not proof, so a name is recorded as non-identity the moment one overload of it
+        // does anything else, and that verdict wins.
+        foreach (var method in elementExtensions.GetMethods(BindingFlags.Public | BindingFlags.Static))
+        {
+            var parameters = method.GetParameters();
+            if (parameters.Length == 0)
+                continue;
+
+            var receiver = parameters[0].ParameterType;
+
+            var preserves = method.IsGenericMethodDefinition
+                ? receiver.IsGenericParameter && method.ReturnType == receiver
+                : ElementType.IsAssignableFrom(receiver) && method.ReturnType == receiver;
+
+            if (preserves)
+                _identityModifiers.Add(method.Name);
+            else
+                _nonIdentityModifiers.Add(method.Name);
+        }
+
+        _identityModifiers.ExceptWith(_nonIdentityModifiers);
 
         // Type-changing modifiers: `M<T>(this T el, …)` that returns a concrete element rather than
         // T. The chain's element is decided by the last of these, not by the head factory.
@@ -455,6 +481,19 @@ internal sealed class ReactorSurface
     /// the chain is skipped, and nothing is claimed.
     /// </remarks>
     public bool IsTypeChanging(string name) => _typeChangingModifiers.ContainsKey(name);
+
+    /// <summary>
+    /// True when every <c>ElementExtensions</c> overload of this name provably returns the element
+    /// it was called on.
+    /// </summary>
+    /// <remarks>
+    /// The chain walk may only step over a call that hands back its receiver. Two shapes qualify:
+    /// <c>M&lt;T&gt;(this T el, …) → T</c>, and a non-generic <c>M(this FooElement el, …) →
+    /// FooElement</c>. Everything else — an unknown name, a sample's own helper, an overload set
+    /// that disagrees with itself — leaves the head unresolvable, and an unresolvable head is
+    /// skipped rather than attributed to whatever happened to be underneath it.
+    /// </remarks>
+    public bool PreservesElementType(string name) => _identityModifiers.Contains(name);
 
     /// <summary>
     /// Folds one overload's return type into the type-changing map, poisoning the name to
@@ -1218,6 +1257,15 @@ internal static class AgentKitSnippetWalker
                     // Border while the value really lands on a SemanticPanel.
                     if (ReactorSurface.Instance.IsTypeChanging(access.Name.Identifier.Text))
                         return (access.Name.Identifier.Text, 0, default);
+
+                    // Anything else is only safe to walk through if its signature proves it hands
+                    // back what it was given. Stepping over an unrecognised call assumed it did:
+                    // `FlexColumn(children).AsBorder().Padding(16)` resolved to a FlexElement and
+                    // was reported, though `AsBorder` returns a Border and `Padding` is legal
+                    // there — uncertainty creating a finding, against the walker's own rule, on
+                    // valid shipped guidance.
+                    if (!ReactorSurface.Instance.PreservesElementType(access.Name.Identifier.Text))
+                        return null;
 
                     node = access.Expression;
                     continue;

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitSnippetWalker.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitSnippetWalker.cs
@@ -300,6 +300,12 @@ internal static class AgentKitSnippetWalker
 
                 resolvedChains++;
 
+                // Mirrors NoOpModifierAnalyzer's constant-null gate (its line 232). Reporting here
+                // would let this gate reject a sample the packaged analyzer accepts, which is worse
+                // than the drift it exists to catch.
+                if (HasConstantNullArgument(invocation))
+                    continue;
+
                 var line = LineOf(tree, snippet, access.Name);
                 var chainStart = LineOf(tree, snippet, invocation);
 
@@ -315,6 +321,59 @@ internal static class AgentKitSnippetWalker
         }
 
         return new AgentKitScan(findings, snippetCount, resolvedChains);
+    }
+
+    /// <summary>
+    /// Mirrors <c>NoOpModifierAnalyzer.HasConstantNullArgument</c>: a syntactically constant
+    /// <see langword="null"/> argument makes the modifier inert whatever the receiver is, so the
+    /// control gate is not what stops it doing anything, and the replacement would not be
+    /// equivalent — <c>Optional&lt;T&gt;</c> turns <c>with { X = null }</c> into an explicit clear
+    /// rather than <c>Unset</c>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Without this, the documentation gate would reject a sample the packaged analyzer accepts
+    /// (<c>NoOpModifierAnalyzerTests.Does_Not_Fire_For_A_Constant_Null_Argument</c> pins the
+    /// analyzer's side of it). A gate stricter than the rule it enforces produces unfixable
+    /// findings, and the only remedy a reader would find is to delete the gate.
+    /// </para>
+    /// <para>
+    /// Syntactic only, matching this walker's boundary rather than the analyzer's: the analyzer
+    /// uses <c>GetConstantValue</c>, which additionally resolves <c>const</c> fields, and there is
+    /// no semantic model here. The gap is safe in one direction only — a constant this fails to
+    /// recognise yields a finding, never a silent miss — and a documentation sample passing a
+    /// <c>const</c> null is not a shape that occurs.
+    /// </para>
+    /// </remarks>
+    private static bool HasConstantNullArgument(InvocationExpressionSyntax invocation)
+    {
+        foreach (var argument in invocation.ArgumentList.Arguments)
+        {
+            var expression = argument.Expression;
+
+            // (Brush)null, ((Brush)null), (Brush)default — unwrap to whatever is really passed.
+            while (true)
+            {
+                switch (expression)
+                {
+                    case CastExpressionSyntax cast:
+                        expression = cast.Expression;
+                        continue;
+                    case ParenthesizedExpressionSyntax parenthesized:
+                        expression = parenthesized.Expression;
+                        continue;
+                }
+
+                break;
+            }
+
+            if (expression.IsKind(SyntaxKind.NullLiteralExpression)
+                || expression.IsKind(SyntaxKind.DefaultLiteralExpression)
+                || expression is DefaultExpressionSyntax)
+                return true;
+        }
+
+        return false;
     }
 
     /// <summary>

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitSnippetWalker.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitSnippetWalker.cs
@@ -388,6 +388,13 @@ internal sealed class ReactorSurface
             return true;
 
         var matches = types.Where(t => string.Equals(t.Name, simpleName, StringComparison.Ordinal)).ToList();
+
+        // A name matching none of them stays unprovable, and unprovable never exempts. Review
+        // proposed reading "no match" as "reference type, therefore null", to cover an aliased
+        // `default(BrushAlias)`. That trades a tested true positive for a shape documentation does
+        // not contain: `Thickness` is not among Padding's reflected single-argument types, so
+        // `.Padding(default(Thickness))` reaches here too, and exempting it loses the very
+        // value-typed-default finding `Walker_Still_Reports_A_Value_Typed_Default` pins.
         return matches.Count > 0 && matches.All(IsNullable);
     }
 

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitSnippetWalker.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitSnippetWalker.cs
@@ -33,7 +33,7 @@ internal sealed class ReactorSurface
     private readonly Dictionary<string, HashSet<Type>> _factoriesByName = new(StringComparer.Ordinal);
     private readonly Dictionary<Type, HashSet<Type>> _setControls = new();
     private readonly Dictionary<string, HashSet<Type>> _modifierArguments = new(StringComparer.Ordinal);
-    private readonly Dictionary<string, Type> _typeChangingModifiers = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, Type?> _typeChangingModifiers = new(StringComparer.Ordinal);
 
     [UnconditionalSuppressMessage(
         "Trimming", "IL2026",
@@ -110,13 +110,7 @@ internal sealed class ReactorSurface
                 || !ElementType.IsAssignableFrom(returned))
                 continue;   // type-preserving (returns T) or not an element at all.
 
-            // Two overloads disagreeing would make the name unusable; none do today, and poisoning
-            // to "unknown" would silently restore the walk-through this exists to stop, so a
-            // disagreement removes the entry and ModifierTableIntegrity-style floors stay honest.
-            if (_typeChangingModifiers.TryGetValue(method.Name, out var existing) && existing != returned)
-                _typeChangingModifiers.Remove(method.Name);
-            else
-                _typeChangingModifiers[method.Name] = returned;
+            MergeTypeChange(_typeChangingModifiers, method.Name, returned);
         }
 
         var factories = reactor.GetType("Microsoft.UI.Reactor.Factories")
@@ -206,7 +200,7 @@ internal sealed class ReactorSurface
         // A type-changing modifier is not a factory, but ResolveHead reports it in the same slot
         // because it decides the chain's element the same way.
         if (_typeChangingModifiers.TryGetValue(factoryName, out var changed))
-            return changed;
+            return changed;   // null when the name is poisoned by disagreeing overloads.
 
         if (_factories.TryGetValue(Key(factoryName, typeArgumentCount), out var exact))
             return exact;
@@ -365,7 +359,54 @@ internal sealed class ReactorSurface
     /// nothing, while still incrementing the resolution count that is supposed to detect exactly
     /// that kind of silent shortfall.
     /// </remarks>
-    public IReadOnlyDictionary<string, Type> TypeChangingModifiers => _typeChangingModifiers;
+    public IReadOnlyDictionary<string, Type> TypeChangingModifiers =>
+        _typeChangingModifiers
+            .Where(pair => pair.Value is not null)
+            .ToDictionary(pair => pair.Key, pair => pair.Value!, StringComparer.Ordinal);
+
+    /// <summary>
+    /// True for any name known to change the chain's element type, including one poisoned by
+    /// disagreeing overloads.
+    /// </summary>
+    /// <remarks>
+    /// The walk must stop at a poisoned name too. Treating "ambiguous" as "not type-changing" would
+    /// resume walking down to the head factory and resolve the chain to an element it is no longer
+    /// — the very substitution this stop exists to prevent. Stopping yields an unresolvable name,
+    /// the chain is skipped, and nothing is claimed.
+    /// </remarks>
+    public bool IsTypeChanging(string name) => _typeChangingModifiers.ContainsKey(name);
+
+    /// <summary>
+    /// Folds one overload's return type into the type-changing map, poisoning the name to
+    /// <see langword="null"/> the moment two overloads disagree.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The poison must be <b>irreversible</b>, which is why this writes null rather than removing
+    /// the entry. Removing let the next overload re-add the name: with return types arriving as
+    /// A, B, A — the ordinary shape when several overloads return A and one returns B — the B
+    /// removed it and the second A restored it, leaving a genuinely ambiguous modifier resolving to
+    /// one arbitrary answer. <c>GetMethods</c> order is unspecified, so that was not even
+    /// reproducible.
+    /// </para>
+    /// <para>
+    /// Extracted so the ordering can be tested directly. The live surface has one type-changing
+    /// modifier whose overloads all agree, so no reflection over the real assembly can reach the
+    /// state this guards.
+    /// </para>
+    /// </remarks>
+    internal static void MergeTypeChange(Dictionary<string, Type?> map, string name, Type returned)
+    {
+        if (map.TryGetValue(name, out var existing))
+        {
+            if (existing != returned)
+                map[name] = null;
+        }
+        else
+        {
+            map[name] = returned;
+        }
+    }
 
     /// <summary>
     /// The control's own name followed by every base type name, most derived first.</summary>
@@ -948,7 +989,7 @@ internal static class AgentKitSnippetWalker
                     // describes what it wrapped, not what the chain now is. `Semantics` is the only
                     // one today, and walking through it resolved `Border(child).Semantics(...)` as a
                     // Border while the value really lands on a SemanticPanel.
-                    if (ReactorSurface.Instance.TypeChangingModifiers.ContainsKey(access.Name.Identifier.Text))
+                    if (ReactorSurface.Instance.IsTypeChanging(access.Name.Identifier.Text))
                         return (access.Name.Identifier.Text, 0, default);
 
                     node = access.Expression;

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitSnippetWalker.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitSnippetWalker.cs
@@ -325,16 +325,41 @@ internal sealed class ReactorSurface
         if (explicitTypeName is null)
             return types.All(IsNullable);
 
+        // `default(Microsoft.UI.Xaml.Media.Brush)`, `default(global::…Brush)` and `default(Brush?)`
+        // all name the same type as `default(Brush)`. Comparing the written syntax verbatim found
+        // no match for the qualified forms and refused to exempt them, making this gate stricter
+        // than the analyzer it mirrors — a finding on a sample REACTOR_MOD_003 accepts.
+        var simpleName = SimpleTypeName(explicitTypeName);
+
         // A value-type keyword settles it without any lookup, and covers the `default(double)` case
         // whose parameter type may not even be in this modifier's overload set.
-        if (ValueTypeKeywords.Contains(explicitTypeName))
+        if (ValueTypeKeywords.Contains(simpleName))
             return false;
 
-        if (explicitTypeName is "string" or "object")
+        if (simpleName is "string" or "object")
             return true;
 
-        var matches = types.Where(t => string.Equals(t.Name, explicitTypeName, StringComparison.Ordinal)).ToList();
+        var matches = types.Where(t => string.Equals(t.Name, simpleName, StringComparison.Ordinal)).ToList();
         return matches.Count > 0 && matches.All(IsNullable);
+    }
+
+    /// <summary>
+    /// Reduces written type syntax to the bare name reflection reports: strips <c>global::</c>,
+    /// any namespace qualification, a trailing <c>?</c>, and generic arguments.
+    /// </summary>
+    private static string SimpleTypeName(string written)
+    {
+        var text = written.Trim().TrimEnd('?').Trim();
+
+        var generic = text.IndexOf('<');
+        if (generic >= 0)
+            text = text[..generic];
+
+        var lastDot = text.LastIndexOf('.');
+        if (lastDot >= 0)
+            text = text[(lastDot + 1)..];
+
+        return text.Trim();
     }
 
     private static bool IsNullable(Type type) =>
@@ -478,39 +503,30 @@ internal sealed record AgentKitScan(
 internal static class AgentKitSnippetWalker
 {
     /// <summary>
-    /// Modifiers whose presence on a wrapper chain means the wrapper is carrying its own weight, so
-    /// it is not merely a workaround for the modifier the inner element drops. Matched by substring
-    /// on purpose: <c>WithBorder</c>, <c>ThemeBackground</c> and <c>BorderBrush</c> all qualify, and
-    /// over-matching here only ever suppresses a finding.
-    /// </summary>
-    /// <remarks>
-    /// <c>Style</c> is here for the same reason <c>Card</c> is not a passive factory: a style can
-    /// supply background, border and corner radius from a resource this walker cannot read, so
-    /// <c>Border(...).ApplyStyle(...)</c> is decorated in a way no chain inspection would reveal.
-    /// </remarks>
-    private static readonly string[] WrapperJustifications =
-        { "Background", "Border", "CornerRadius", "Shadow", "Clip", "Style" };
-
-    /// <summary>
-    /// Modifiers that justify a wrapper but must match <b>exactly</b>.
+    /// Modifiers that can move from the wrapper to the element it wraps without changing
+    /// behaviour, so their presence does not stop the wrapper being removable.
     /// </summary>
     /// <remarks>
     /// <para>
-    /// These are the escape hatches whose effect this walker cannot see. <c>Set</c> takes a lambda
-    /// that can write any native property; <c>OnMount</c>/<c>OnMountAdd</c> can do the same at
-    /// mount time; <c>OnUnmount</c>/<c>OnUnmountAdd</c> make the wrapper's <em>lifecycle</em>
-    /// significant, so deleting it drops a callback whether or not it painted anything;
-    /// <c>Ref</c> hands the control out by identity. In every case "remove the wrapper" is not
-    /// behaviour-preserving, so the rule must not claim it is.
+    /// An <b>allowlist</b>, deliberately. The earlier denylist had the failure mode backwards: an
+    /// unrecognised modifier counted as "wrapper contributes nothing" and produced a finding, so
+    /// every modifier nobody had thought of became a false positive.
+    /// <c>Border(FlexColumn(children)).Padding(16).OnTapped(...)</c> was reported as removable even
+    /// though the Border is the routed-event source and hit-test boundary. The same applies to
+    /// flyouts, tooltips, connected animations and anything else keyed on control identity — an
+    /// open-ended set that cannot be enumerated safely.
     /// </para>
     /// <para>
-    /// Exact, not substring. <c>Set</c> as a substring also swallowed <c>PositionInSet</c> and
-    /// anything else ending in "Set" — an accessibility modifier that can live perfectly well on
-    /// the inner element, silently suppressing a genuine wrapper finding.
+    /// Everything here describes the wrapper's <em>position in its parent</em> or its reconciler
+    /// identity, which the inner element inherits when it takes the wrapper's place. Anything else
+    /// suppresses the finding. Adding an entry means claiming it is relocatable, so the burden sits
+    /// where the risk is.
     /// </para>
     /// </remarks>
-    private static readonly HashSet<string> ExactWrapperJustifications =
-        new(StringComparer.Ordinal) { "Set", "OnMount", "OnMountAdd", "OnUnmount", "OnUnmountAdd", "Ref" };
+    private static readonly HashSet<string> RelocatableModifiers = new(StringComparer.Ordinal)
+    {
+        "Flex", "Grid", "Margin", "WithKey", "HAlign", "VAlign", "Dock",
+    };
 
     /// <summary>
     /// DSL <b>factories</b> whose sole contribution is decoration, so relocating a modifier inward
@@ -795,7 +811,11 @@ internal static class AgentKitSnippetWalker
             if (inner is null || !string.Equals(inner.FullName, innerFullName, StringComparison.Ordinal))
                 continue;
 
-            if (ChainModifiers(invocation).Any(IsJustification))
+            // Report only when every *other* modifier on the chain would survive the wrapper being
+            // removed. Inverted from a denylist deliberately: an unrecognised modifier now
+            // suppresses rather than reports, so the open-ended set of behaviour-bearing modifiers
+            // (events, flyouts, tooltips, animations) costs a missed finding instead of a false one.
+            if (ChainModifiers(invocation).Any(m => m.Invocation != invocation && !IsRelocatable(m)))
                 continue;
 
             // A `with` initializer anywhere on the chain is opaque to the checks above: the chain
@@ -843,23 +863,19 @@ internal static class AgentKitSnippetWalker
     }
 
     /// <summary>
-    /// True when a modifier on the wrapper's chain really justifies the wrapper's existence.
+    /// True when a modifier on the wrapper's chain would survive the wrapper being removed.
     /// </summary>
     /// <remarks>
-    /// The name is necessary but not sufficient. A constant-null argument makes the modifier inert
-    /// — that is the premise <see cref="HasConstantNullArgument"/> already relies on — so
-    /// <c>Border(FlexColumn(children)).Padding(16).Background((Brush)null)</c> is still a Border
-    /// that supplies nothing but padding. Counting it hid the exact workaround this rule exists to
-    /// catch, behind a decorator that does nothing: a no-op suppression, and an internal
-    /// contradiction, since the same call is skipped as inert two checks earlier.
+    /// Two ways to qualify: it is a positional/identity modifier the inner element inherits when it
+    /// takes the wrapper's place, or it is inert. A constant-null argument makes a modifier do
+    /// nothing — the premise <see cref="HasConstantNullArgument"/> already rests on — so
+    /// <c>Border(inner).Padding(16).Background((Brush)null)</c> is still a Border supplying nothing
+    /// but padding. Without the second arm, a decorator that does nothing would hide the exact
+    /// workaround this rule exists to catch.
     /// </remarks>
-    private static bool IsJustification((string Name, InvocationExpressionSyntax Invocation) modifier)
-    {
-        var named = ExactWrapperJustifications.Contains(modifier.Name)
-                    || WrapperJustifications.Any(j => modifier.Name.Contains(j, StringComparison.Ordinal));
-
-        return named && !HasConstantNullArgument(modifier.Invocation, modifier.Name);
-    }
+    private static bool IsRelocatable((string Name, InvocationExpressionSyntax Invocation) modifier) =>
+        RelocatableModifiers.Contains(modifier.Name)
+        || HasConstantNullArgument(modifier.Invocation, modifier.Name);
 
     /// <summary>
     /// True when any <c>with</c> expression appears on the fluent chain this invocation belongs to.

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitSnippetWalker.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitSnippetWalker.cs
@@ -33,6 +33,7 @@ internal sealed class ReactorSurface
     private readonly Dictionary<string, HashSet<Type>> _factoriesByName = new(StringComparer.Ordinal);
     private readonly Dictionary<Type, HashSet<Type>> _setControls = new();
     private readonly Dictionary<string, HashSet<Type>> _modifierArguments = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, Type> _typeChangingModifiers = new(StringComparer.Ordinal);
 
     [UnconditionalSuppressMessage(
         "Trimming", "IL2026",
@@ -90,6 +91,32 @@ internal sealed class ReactorSurface
                 _modifierArguments[method.Name] = types = new HashSet<Type>();
 
             types.Add(argument);
+        }
+
+        // Type-changing modifiers: `M<T>(this T el, …)` that returns a concrete element rather than
+        // T. The chain's element is decided by the last of these, not by the head factory.
+        foreach (var method in elementExtensions.GetMethods(BindingFlags.Public | BindingFlags.Static))
+        {
+            if (!method.IsGenericMethodDefinition)
+                continue;
+
+            var parameters = method.GetParameters();
+            if (parameters.Length == 0 || !parameters[0].ParameterType.IsGenericParameter)
+                continue;
+
+            var returned = method.ReturnType;
+            if (returned.IsGenericParameter
+                || returned.ContainsGenericParameters
+                || !ElementType.IsAssignableFrom(returned))
+                continue;   // type-preserving (returns T) or not an element at all.
+
+            // Two overloads disagreeing would make the name unusable; none do today, and poisoning
+            // to "unknown" would silently restore the walk-through this exists to stop, so a
+            // disagreement removes the entry and ModifierTableIntegrity-style floors stay honest.
+            if (_typeChangingModifiers.TryGetValue(method.Name, out var existing) && existing != returned)
+                _typeChangingModifiers.Remove(method.Name);
+            else
+                _typeChangingModifiers[method.Name] = returned;
         }
 
         var factories = reactor.GetType("Microsoft.UI.Reactor.Factories")
@@ -176,6 +203,11 @@ internal sealed class ReactorSurface
     /// </remarks>
     public Type? Element(string factoryName, int typeArgumentCount)
     {
+        // A type-changing modifier is not a factory, but ResolveHead reports it in the same slot
+        // because it decides the chain's element the same way.
+        if (_typeChangingModifiers.TryGetValue(factoryName, out var changed))
+            return changed;
+
         if (_factories.TryGetValue(Key(factoryName, typeArgumentCount), out var exact))
             return exact;
 
@@ -319,6 +351,21 @@ internal sealed class ReactorSurface
         "int", "double", "float", "bool", "char", "byte", "sbyte",
         "short", "ushort", "uint", "long", "ulong", "decimal", "nint", "nuint",
     };
+
+    /// <summary>
+    /// Fluent modifiers that return a <em>different</em> element type than their receiver, mapped
+    /// to that type. <c>Semantics</c> is the framework's only one today.
+    /// </summary>
+    /// <remarks>
+    /// These break the assumption that a chain's element is decided by its head factory.
+    /// <c>Border(child).Semantics(...)</c> is a <c>SemanticElement</c> mounting a
+    /// <c>SemanticPanel</c>, which is a <c>Panel</c> and therefore outside <c>Padding</c>'s gate —
+    /// so a trailing <c>.Padding(16)</c> is dropped at runtime even though the head is a Border,
+    /// a perfectly legal receiver. Walking through them resolved the wrong element and reported
+    /// nothing, while still incrementing the resolution count that is supposed to detect exactly
+    /// that kind of silent shortfall.
+    /// </remarks>
+    public IReadOnlyDictionary<string, Type> TypeChangingModifiers => _typeChangingModifiers;
 
     /// <summary>
     /// The control's own name followed by every base type name, most derived first.</summary>
@@ -897,6 +944,13 @@ internal static class AgentKitSnippetWalker
                     return (identifier.Identifier.Text, 0, invocation.ArgumentList.Arguments);
 
                 case InvocationExpressionSyntax { Expression: MemberAccessExpressionSyntax access }:
+                    // A type-changing modifier decides the element outright: everything below it
+                    // describes what it wrapped, not what the chain now is. `Semantics` is the only
+                    // one today, and walking through it resolved `Border(child).Semantics(...)` as a
+                    // Border while the value really lands on a SemanticPanel.
+                    if (ReactorSurface.Instance.TypeChangingModifiers.ContainsKey(access.Name.Identifier.Text))
+                        return (access.Name.Identifier.Text, 0, default);
+
                     node = access.Expression;
                     continue;
 

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitSnippetWalker.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitSnippetWalker.cs
@@ -407,14 +407,22 @@ internal static class AgentKitSnippetWalker
     /// Modifiers that justify a wrapper but must match <b>exactly</b>.
     /// </summary>
     /// <remarks>
-    /// <c>Set</c> counts because its lambda can write anything and this walker cannot see inside
-    /// it, so an opaque write is treated as carrying its own weight. As a substring it also
-    /// swallowed <c>PositionInSet</c>, <c>SetsSize</c> and anything else ending in "Set" — an
-    /// accessibility modifier that can live perfectly well on the inner element, silently
-    /// suppressing a genuine wrapper finding.
+    /// <para>
+    /// These are the escape hatches whose effect this walker cannot see. <c>Set</c> takes a lambda
+    /// that can write any native property; <c>OnMount</c>/<c>OnMountAdd</c> can do the same at
+    /// mount time; <c>OnUnmount</c>/<c>OnUnmountAdd</c> make the wrapper's <em>lifecycle</em>
+    /// significant, so deleting it drops a callback whether or not it painted anything;
+    /// <c>Ref</c> hands the control out by identity. In every case "remove the wrapper" is not
+    /// behaviour-preserving, so the rule must not claim it is.
+    /// </para>
+    /// <para>
+    /// Exact, not substring. <c>Set</c> as a substring also swallowed <c>PositionInSet</c> and
+    /// anything else ending in "Set" — an accessibility modifier that can live perfectly well on
+    /// the inner element, silently suppressing a genuine wrapper finding.
+    /// </para>
     /// </remarks>
     private static readonly HashSet<string> ExactWrapperJustifications =
-        new(StringComparer.Ordinal) { "Set" };
+        new(StringComparer.Ordinal) { "Set", "OnMount", "OnMountAdd", "OnUnmount", "OnUnmountAdd", "Ref" };
 
     /// <summary>
     /// DSL <b>factories</b> whose sole contribution is decoration, so relocating a modifier inward
@@ -702,6 +710,14 @@ internal static class AgentKitSnippetWalker
             if (ChainModifiers(invocation).Any(IsJustification))
                 continue;
 
+            // A `with` initializer anywhere on the chain is opaque to the checks above: the chain
+            // walkers step through it to reach the receiver, so its assignments are never seen.
+            // `Border(inner).Padding(16) with { Background = brush }` supplies a background, and
+            // `with { Child = other }` replaces the very element the finding names — both make the
+            // report wrong, and element records are configured this way by design.
+            if (HasWithMutation(invocation))
+                continue;
+
             return new AgentKitFinding(
                 AgentKitFindingKind.WrapperWorkaround,
                 Path: string.Empty,
@@ -757,39 +773,51 @@ internal static class AgentKitSnippetWalker
         return named && !HasConstantNullArgument(modifier.Invocation, modifier.Name);
     }
 
+    /// <summary>
+    /// True when any <c>with</c> expression appears on the fluent chain this invocation belongs to.
+    /// </summary>
+    /// <remarks>
+    /// Conservative by construction: a <c>with</c> initializer can supply the very decoration that
+    /// would justify the wrapper (<c>with { Background = brush }</c>) or replace the element the
+    /// finding names (<c>with { Child = other }</c>), and reading it properly would mean modelling
+    /// record initializers well enough to be trusted. Skipping costs a finding on an unusual shape;
+    /// guessing costs a false report on correct documentation, which is the more expensive mistake
+    /// for a gate that runs in CI.
+    /// </remarks>
+    private static bool HasWithMutation(InvocationExpressionSyntax invocation)
+    {
+        for (var node = Outermost(invocation); node is not null;)
+        {
+            switch (node)
+            {
+                case WithExpressionSyntax:
+                    return true;
+
+                case InvocationExpressionSyntax { Expression: MemberAccessExpressionSyntax access }:
+                    node = access.Expression;
+                    continue;
+
+                case ParenthesizedExpressionSyntax parenthesized:
+                    node = parenthesized.Expression;
+                    continue;
+
+                case PostfixUnaryExpressionSyntax postfix:
+                    node = postfix.Operand;
+                    continue;
+
+                default:
+                    return false;
+            }
+        }
+
+        return false;
+    }
+
     /// <summary>Every modifier applied anywhere on the fluent chain this invocation belongs to.</summary>
     private static IEnumerable<(string Name, InvocationExpressionSyntax Invocation)> ChainModifiers(
         InvocationExpressionSyntax invocation)
     {
-        // Walk out to the outermost invocation first — `.Padding(24)` may be followed by
-        // `.Background(...)`, and a justification that appears later still justifies the wrapper.
-        // Parentheses, `with` and the null-forgiving `!` are stepped through, because the downward
-        // walk below already treats them as transparent: stopping here but not there made
-        // `(Border(FlexColumn(children)).Padding(16)).Background(...)` report a workaround, never
-        // having reached the `Background` that justifies the Border.
-        SyntaxNode outermost = invocation;
-
-        while (true)
-        {
-            var parent = outermost.Parent;
-
-            while (parent is ParenthesizedExpressionSyntax
-                   or WithExpressionSyntax
-                   or PostfixUnaryExpressionSyntax { RawKind: (int)SyntaxKind.SuppressNullableWarningExpression })
-            {
-                parent = parent.Parent;
-            }
-
-            if (parent is MemberAccessExpressionSyntax { Parent: InvocationExpressionSyntax parentInvocation })
-            {
-                outermost = parentInvocation;
-                continue;
-            }
-
-            break;
-        }
-
-        for (var node = outermost; node is not null;)
+        for (var node = Outermost(invocation); node is not null;)
         {
             if (node is InvocationExpressionSyntax { Expression: MemberAccessExpressionSyntax access } chained)
             {
@@ -805,6 +833,41 @@ internal static class AgentKitSnippetWalker
                 PostfixUnaryExpressionSyntax postfix => postfix.Operand,
                 _ => null,
             };
+        }
+    }
+
+    /// <summary>
+    /// Walks out to the outermost invocation of the fluent chain this one belongs to.
+    /// </summary>
+    /// <remarks>
+    /// Parentheses, <c>with</c> and the null-forgiving <c>!</c> are stepped through, because the
+    /// downward walks treat them as transparent: stopping here but not there made
+    /// <c>(Border(FlexColumn(children)).Padding(16)).Background(...)</c> report a workaround,
+    /// never having reached the <c>Background</c> that justifies the Border.
+    /// </remarks>
+    private static SyntaxNode Outermost(InvocationExpressionSyntax invocation)
+    {
+        SyntaxNode outermost = invocation;
+
+        while (true)
+        {
+            var parent = outermost.Parent;
+
+            while (parent is ParenthesizedExpressionSyntax
+                   or WithExpressionSyntax
+                   or PostfixUnaryExpressionSyntax { RawKind: (int)SyntaxKind.SuppressNullableWarningExpression })
+            {
+                outermost = parent;
+                parent = parent.Parent;
+            }
+
+            if (parent is MemberAccessExpressionSyntax { Parent: InvocationExpressionSyntax parentInvocation })
+            {
+                outermost = parentInvocation;
+                continue;
+            }
+
+            return outermost;
         }
     }
 

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitSnippetWalker.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitSnippetWalker.cs
@@ -30,6 +30,7 @@ namespace Microsoft.UI.Reactor.Tests.AnalyzerTests;
 internal sealed class ReactorSurface
 {
     private readonly Dictionary<string, Type?> _factories = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, HashSet<Type>> _factoriesByName = new(StringComparer.Ordinal);
     private readonly Dictionary<Type, HashSet<Type>> _setControls = new();
     private readonly Dictionary<string, HashSet<Type>> _modifierArguments = new(StringComparer.Ordinal);
 
@@ -125,6 +126,22 @@ internal sealed class ReactorSurface
                 _factories[key] = returned;
             }
         }
+
+        // Name → the element types it can produce at any arity, for the inferred-generic fallback
+        // in Element(...). Built after the loop so poisoned entries are already resolved to null.
+        foreach (var (key, element) in _factories)
+        {
+            if (element is null)
+                continue;
+
+            var tick = key.IndexOf('`');
+            var name = tick < 0 ? key : key[..tick];
+
+            if (!_factoriesByName.TryGetValue(name, out var types))
+                _factoriesByName[name] = types = new HashSet<Type>();
+
+            types.Add(element);
+        }
     }
 
     public static ReactorSurface Instance { get; } = new();
@@ -157,8 +174,25 @@ internal sealed class ReactorSurface
     /// name is discarded as ambiguous, which silently excluded every such factory from the walker.
     /// The call site states its own arity, so nothing has to be guessed.
     /// </remarks>
-    public Type? Element(string factoryName, int typeArgumentCount) =>
-        _factories.TryGetValue(Key(factoryName, typeArgumentCount), out var element) ? element : null;
+    public Type? Element(string factoryName, int typeArgumentCount)
+    {
+        if (_factories.TryGetValue(Key(factoryName, typeArgumentCount), out var exact))
+            return exact;
+
+        // An explicit `<T>` that matched nothing is simply unknown.
+        if (typeArgumentCount != 0)
+            return null;
+
+        // No arity-0 entry, but the name may still be a generic factory whose T the compiler infers
+        // — `LazyVStack(items, (x, _) => Row(x))` is written without `<T>` and arrives here as a
+        // plain identifier. Resolve it only when every arity for the name agrees on one element
+        // type; disagreement means the binding cannot be recovered without a semantic model, and
+        // guessing there would attribute the chain to the wrong control.
+        if (!_factoriesByName.TryGetValue(factoryName, out var candidates))
+            return null;
+
+        return candidates.Count == 1 ? candidates.Single() : null;
+    }
 
     private static string Key(string factoryName, int typeArgumentCount) =>
         typeArgumentCount == 0 ? factoryName : factoryName + "`" + typeArgumentCount;

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitSnippetWalker.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitSnippetWalker.cs
@@ -679,9 +679,10 @@ internal static class AgentKitSnippetWalker
     /// </para>
     /// <para>
     /// Linear in the number of arms rather than exponential in the number of blocks, so a snippet
-    /// cannot make this expensive. Nesting is not modelled: an inner block's arms are treated as
-    /// arms of the enclosing one, which over-produces variants but never drops a line from all of
-    /// them, and unparseable text yields no resolvable chain rather than a finding.
+    /// cannot make this expensive. Nesting is tracked with a parent chain: a variant keeps its own
+    /// arm and every arm enclosing it, so an outer arm's chain head stays together with an inner
+    /// arm's body. Numbering them flat instead reset to the unconditional arm at every inner
+    /// <c>#endif</c>, and no variant then held both halves of such a chain.
     /// </para>
     /// </remarks>
     private static IEnumerable<(string Text, bool IsPrimary)> ConditionalVariants(string text)
@@ -693,40 +694,69 @@ internal static class AgentKitSnippetWalker
         }
 
         var lines = text.Split('\n');
-        var arm = new int[lines.Length];
-        var current = 0;
-        var arms = 0;
+        var lineArm = new int[lines.Length];
+        var parent = new List<int> { 0 };
+        var open = new Stack<int>();
 
         for (var i = 0; i < lines.Length; i++)
         {
             var directive = Preprocessor.Match(lines[i]);
             if (directive.Success)
             {
-                var kind = directive.Groups[1].Value;
-                current = kind is "endif" or "define" or "undef" ? 0 : ++arms;
-                arm[i] = -1;    // the directive line itself belongs to no arm.
+                switch (directive.Groups[1].Value)
+                {
+                    case "if":
+                        parent.Add(open.Count > 0 ? open.Peek() : 0);
+                        open.Push(parent.Count - 1);
+                        break;
+
+                    case "elif":
+                    case "else":
+                        // A sibling arm of the same block: same parent, new identity.
+                        var enclosing = open.Count > 0 ? parent[open.Pop()] : 0;
+                        parent.Add(enclosing);
+                        open.Push(parent.Count - 1);
+                        break;
+
+                    case "endif":
+                        if (open.Count > 0)
+                            open.Pop();
+
+                        break;
+                }
+
+                lineArm[i] = -1;    // the directive line itself belongs to no arm.
                 continue;
             }
 
-            arm[i] = current;
+            lineArm[i] = open.Count > 0 ? open.Peek() : 0;
         }
 
-        yield return (Keep(lines, arm, 0), true);
+        yield return (Keep(lines, lineArm, parent, 0), true);
 
-        for (var a = 1; a <= arms; a++)
-            yield return (Keep(lines, arm, a), false);
+        for (var a = 1; a < parent.Count; a++)
+            yield return (Keep(lines, lineArm, parent, a), false);
     }
 
     /// <summary>
-    /// The snippet with only <paramref name="keep"/>'s arm retained, other arms and all directive
-    /// lines blanked so each remaining line keeps its index.
+    /// The snippet with <paramref name="keep"/>'s arm and every arm enclosing it retained, other
+    /// arms and all directive lines blanked so each remaining line keeps its index.
     /// </summary>
-    private static string Keep(string[] lines, int[] arm, int keep)
+    private static string Keep(string[] lines, int[] lineArm, List<int> parent, int keep)
     {
+        var selected = new HashSet<int>();
+
+        for (var a = keep; ; a = parent[a])
+        {
+            selected.Add(a);
+            if (a == 0)
+                break;
+        }
+
         var kept = new string[lines.Length];
 
         for (var i = 0; i < lines.Length; i++)
-            kept[i] = arm[i] == 0 || arm[i] == keep ? lines[i] : string.Empty;
+            kept[i] = lineArm[i] >= 0 && selected.Contains(lineArm[i]) ? lines[i] : string.Empty;
 
         return string.Join("\n", kept);
     }
@@ -798,17 +828,20 @@ internal static class AgentKitSnippetWalker
                     var line = LineOf(tree, snippet, access.Name);
                     var chainStart = LineOf(tree, snippet, invocation);
 
-                    // The same unconditional line is reached by every variant; report it once.
-                    if (!seen.Add((snippet.Path, line, modifier, element.FullName)))
-                        continue;
-
+                    // The same unconditional line is reached by every variant; report it once. Recorded
+                    // only when something is actually emitted — keying it here regardless let a
+                    // silent variant reserve the key and mask a real finding at the same line in a
+                    // later arm.
                     if (DroppedModifier(element, modifier, info) is { } dropped)
                     {
-                        findings.Add(dropped with { Path = snippet.Path, Line = line, ChainStartLine = chainStart });
+                        if (seen.Add((snippet.Path, line, modifier, element.FullName)))
+                            findings.Add(dropped with { Path = snippet.Path, Line = line, ChainStartLine = chainStart });
+
                         continue;
                     }
 
-                    if (WrapperWorkaround(element, head.Value.Factory, head.Value.Arguments, modifier, invocation) is { } wrapper)
+                    if (WrapperWorkaround(element, head.Value.Factory, head.Value.Arguments, modifier, invocation) is { } wrapper
+                        && seen.Add((snippet.Path, line, modifier, element.FullName)))
                         findings.Add(wrapper with { Path = snippet.Path, Line = line, ChainStartLine = chainStart });
                 }
             }

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitSnippetWalker.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitSnippetWalker.cs
@@ -1,0 +1,551 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.UI.Reactor.Analyzers;
+
+namespace Microsoft.UI.Reactor.Tests.AnalyzerTests;
+
+/// <summary>
+/// Reactor's element surface, read from the real assemblies as metadata.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Two maps, both taken from the same signals <see cref="NoOpModifierAnalyzer"/> reads at compile
+/// time: a factory's declared return type, and the control named by an element's
+/// <c>Set(this TElement, Action&lt;TControl&gt;)</c> overload. Nothing is derived from a parallel
+/// list, so widening a gate or re-pointing a factory moves this type with it.
+/// </para>
+/// <para>
+/// Reflection is metadata-only — no WinUI object is constructed — which is what makes it legal in
+/// the headless <c>Reactor.Tests</c> host, where instantiating any <c>Microsoft.UI.Xaml</c> type
+/// throws <c>COMException</c>.
+/// </para>
+/// </remarks>
+internal sealed class ReactorSurface
+{
+    private readonly Dictionary<string, Type?> _factories = new(StringComparer.Ordinal);
+    private readonly Dictionary<Type, HashSet<Type>> _setControls = new();
+
+    [UnconditionalSuppressMessage(
+        "Trimming", "IL2026",
+        Justification = "Test-only surface reader: enumerates the Reactor assemblies' types and factory methods by design. This host is never trimmed; behaviour-neutral.")]
+    [UnconditionalSuppressMessage(
+        "Trimming", "IL2075",
+        Justification = "Test-only surface reader: reflects the public static methods of Factories/ElementExtensions, resolved by name from the Reactor assembly. Intentional and JIT-only; behaviour-neutral.")]
+    private ReactorSurface()
+    {
+        ElementType = typeof(Microsoft.UI.Reactor.Core.Element);
+        var reactor = ElementType.Assembly;
+
+        var elementExtensions = reactor.GetType("Microsoft.UI.Reactor.ElementExtensions")
+            ?? throw new InvalidOperationException("Microsoft.UI.Reactor.ElementExtensions not found.");
+
+        ElementExtensionsType = elementExtensions;
+
+        foreach (var parameters in elementExtensions
+                     .GetMethods(BindingFlags.Public | BindingFlags.Static)
+                     .Where(m => m.Name == "Set")
+                     .Select(m => m.GetParameters())
+                     .Where(p => p.Length == 2
+                                 && p[1].ParameterType.IsGenericType
+                                 && p[1].ParameterType.GetGenericTypeDefinition() == typeof(Action<>)))
+        {
+            var receiver = parameters[0].ParameterType;
+            if (receiver.IsGenericParameter)
+                continue;   // Set<T>(this T, …) says nothing about which control T mounts.
+
+            if (receiver.IsGenericType)
+                receiver = receiver.GetGenericTypeDefinition();
+
+            if (!_setControls.TryGetValue(receiver, out var controls))
+                _setControls[receiver] = controls = new HashSet<Type>();
+
+            controls.Add(parameters[1].ParameterType.GetGenericArguments()[0]);
+        }
+
+        var factories = reactor.GetType("Microsoft.UI.Reactor.Factories")
+            ?? throw new InvalidOperationException("Microsoft.UI.Reactor.Factories not found.");
+
+        FactoriesType = factories;
+
+        foreach (var method in factories.GetMethods(BindingFlags.Public | BindingFlags.Static))
+        {
+            var returned = method.ReturnType;
+            if (returned.IsGenericParameter || returned.ContainsGenericParameters || !ElementType.IsAssignableFrom(returned))
+                continue;
+
+            // An overload set that returns two different element types cannot be resolved from a
+            // bare name, so the name is poisoned to null rather than resolved to whichever
+            // overload reflection happened to hand back first.
+            if (_factories.TryGetValue(method.Name, out var existing))
+            {
+                if (existing != returned)
+                    _factories[method.Name] = null;
+            }
+            else
+            {
+                _factories[method.Name] = returned;
+            }
+        }
+    }
+
+    public static ReactorSurface Instance { get; } = new();
+
+    public Type ElementType { get; }
+
+    public Type ElementExtensionsType { get; }
+
+    public Type FactoriesType { get; }
+
+    /// <summary>
+    /// Number of factory names that resolve to exactly one element type. A floor over this is what
+    /// tells a reading of "no findings" apart from "the reflection stopped resolving".
+    /// </summary>
+    public int ResolvableFactoryCount => _factories.Count(pair => pair.Value is not null);
+
+    /// <summary>
+    /// The element type a DSL factory name produces, or <see langword="null"/> when the name is
+    /// unknown or its overloads disagree.
+    /// </summary>
+    public Type? Element(string factoryName) =>
+        _factories.TryGetValue(factoryName, out var element) ? element : null;
+
+    /// <summary>
+    /// The controls an element's <c>Set</c> overloads name, empty when it declares none.
+    /// </summary>
+    public IReadOnlyCollection<Type> SetControls(Type element)
+    {
+        var key = element.IsGenericType ? element.GetGenericTypeDefinition() : element;
+        return _setControls.TryGetValue(key, out var controls) ? controls : Array.Empty<Type>();
+    }
+
+    /// <summary>
+    /// The single control <c>ApplyModifiers</c> will be handed for this element, or
+    /// <see langword="null"/> when that cannot be established.
+    /// </summary>
+    /// <remarks>
+    /// Prefers the <c>Set</c> overload because that is the signal the shipped analyzer uses — the
+    /// generator attributes live in <c>Reactor.Wrappers.Abstractions</c> and are referenced with
+    /// <c>PrivateAssets="all"</c>, so they are unresolvable in a consumer compilation. The
+    /// attribute is the fallback for elements that declare no <c>Set</c> overload;
+    /// <c>ModifierTableIntegrityTests.Every_Element_Set_Overload_Names_The_Control_Its_Descriptor_Mounts</c>
+    /// pins the two to each other, so the fallback cannot disagree with the primary.
+    /// </remarks>
+    public Type? MountedControl(Type element)
+    {
+        var fromSet = SetControls(element);
+        if (fromSet.Count == 1)
+            return fromSet.Single();
+
+        return fromSet.Count == 0 ? DeclaredControl(element) : null;
+    }
+
+    /// <summary>
+    /// The control named by an element's <c>[GenerateReactorWrapper]</c> /
+    /// <c>[GenerateReactorDescriptor]</c> attribute, walking up the record hierarchy.
+    /// </summary>
+    /// <remarks>
+    /// <c>GetCustomAttributesData</c>, not <c>GetCustomAttributes</c>: the former reads metadata
+    /// without constructing the attribute, which matters because the constructor argument is a
+    /// WinUI <c>Type</c> and the generator assembly is not always loadable here.
+    /// </remarks>
+    [UnconditionalSuppressMessage(
+        "Trimming", "IL2075",
+        Justification = "Test-only contract guard: reads the generator attribute off an element type resolved from the Reactor assembly. Behaviour-neutral.")]
+    public static Type? DeclaredControl(Type element)
+    {
+        for (var current = element; current is not null; current = current.BaseType)
+        {
+            foreach (var attribute in current.GetCustomAttributesData())
+            {
+                var name = attribute.AttributeType.Name;
+                if (name is not ("GenerateReactorWrapperAttribute" or "GenerateReactorDescriptorAttribute")
+                    || attribute.ConstructorArguments.Count < 1)
+                    continue;
+
+                if (attribute.ConstructorArguments[0].Value is Type control)
+                    return control;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>The control's own name followed by every base type name, most derived first.</summary>
+    public static IEnumerable<string> ControlBaseChain(Type control)
+    {
+        for (var current = control; current is not null; current = current.BaseType)
+            yield return current.Name;
+    }
+}
+
+/// <summary>What a finding accuses a shipped snippet of.</summary>
+internal enum AgentKitFindingKind
+{
+    /// <summary>
+    /// A common modifier applied to a receiver <c>Reconciler.ApplyModifiers</c> never writes it
+    /// to — the shipped-documentation form of <c>REACTOR_MOD_003</c>.
+    /// </summary>
+    DroppedModifier,
+
+    /// <summary>
+    /// A wrapper element introduced only to receive a modifier the inner element drops, where the
+    /// inner element has a first-class replacement.
+    /// </summary>
+    WrapperWorkaround,
+}
+
+/// <summary>One accusation against one line of one shipped document.</summary>
+/// <param name="Line">Line of the offending modifier itself — where a reader looks.</param>
+/// <param name="ChainStartLine">Line the fluent chain starts on. A multi-line chain puts its
+/// <c>// Wrong:</c> marker above the <em>head</em>, not above the modifier three lines down, so
+/// counterexample detection anchors here while the message points at <paramref name="Line"/>.</param>
+internal sealed record AgentKitFinding(
+    AgentKitFindingKind Kind,
+    string Path,
+    int Line,
+    int ChainStartLine,
+    string Modifier,
+    string ElementName,
+    string? Replacement,
+    string Detail);
+
+/// <summary>Everything one pass over the corpus produced, findings and instrumentation alike.</summary>
+internal sealed record AgentKitScan(
+    IReadOnlyList<AgentKitFinding> Findings,
+    int SnippetCount,
+    int ResolvedChains)
+{
+    public IEnumerable<AgentKitFinding> Of(AgentKitFindingKind kind) => Findings.Where(f => f.Kind == kind);
+}
+
+/// <summary>
+/// Runs Reactor's own modifier-gate rules over the C# in the shipped agent kit.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Syntax only.</b> The snippets are fragments — undeclared <c>children</c>, no enclosing class,
+/// no usings — so they do not bind. A semantic pass would resolve every receiver to an error type,
+/// every check would skip, and the fact would report "no findings" while measuring nothing. Instead
+/// the chain head is resolved by <em>name</em> through <see cref="ReactorSurface"/>, and anything
+/// that does not resolve is skipped. That asymmetry is deliberate and mirrors
+/// <see cref="NoOpModifierAnalyzer"/>: uncertainty must never produce a finding, because this gate
+/// runs in CI over prose-adjacent artifacts and one false positive gets it deleted.
+/// </para>
+/// <para>
+/// The floors reported in <see cref="AgentKitScan"/> are what keep the skipping honest — a parser
+/// that stopped matching reads identically to a clean corpus otherwise.
+/// </para>
+/// </remarks>
+internal static class AgentKitSnippetWalker
+{
+    /// <summary>
+    /// Modifiers whose presence on a wrapper chain means the wrapper is carrying its own weight, so
+    /// it is not merely a workaround for the modifier the inner element drops. Matched by substring
+    /// on purpose: <c>WithBorder</c>, <c>ThemeBackground</c> and <c>BorderBrush</c> all qualify, and
+    /// over-matching here only ever suppresses a finding.
+    /// </summary>
+    /// <remarks>
+    /// <c>Set</c> is in the list for a different reason: its lambda can write anything, and this
+    /// walker cannot see inside it. Treating an opaque write as a justification keeps the failure
+    /// mode on the safe side of the false-positive/false-negative trade this gate has to make.
+    /// </remarks>
+    private static readonly string[] WrapperJustifications =
+        { "Background", "Border", "CornerRadius", "Shadow", "Clip", "Set" };
+
+    public static AgentKitScan Scan(IEnumerable<AgentKitSnippet> snippets)
+    {
+        var findings = new List<AgentKitFinding>();
+        var snippetCount = 0;
+        var resolvedChains = 0;
+
+        foreach (var snippet in snippets)
+        {
+            snippetCount++;
+
+            // Cheap pre-filter. The walker can only ever report on an invocation whose name is a
+            // ModifierTable key, so a snippet mentioning none of them can produce neither a finding
+            // nor a resolved chain — skipping its Roslyn parse is exactly equivalent, not merely
+            // cheaper, and it is most of the corpus. Note this is a bare-name test, deliberately
+            // looser than the syntax it stands in for: over-matching costs a parse, under-matching
+            // would cost coverage.
+            if (!MentionsAGatedModifier(snippet.Text))
+                continue;
+
+            var tree = CSharpSyntaxTree.ParseText(snippet.Text);
+            var root = tree.GetRoot();
+
+            foreach (var invocation in root.DescendantNodes().OfType<InvocationExpressionSyntax>())
+            {
+                if (invocation.Expression is not MemberAccessExpressionSyntax access)
+                    continue;
+
+                var modifier = access.Name.Identifier.Text;
+                if (!ModifierTable.Properties.TryGetValue(modifier, out var info))
+                    continue;
+
+                var head = ResolveHead(access.Expression);
+                if (head is null)
+                    continue;
+
+                var element = ReactorSurface.Instance.Element(head.Value.Factory);
+                if (element is null)
+                    continue;
+
+                resolvedChains++;
+
+                var line = LineOf(tree, snippet, access.Name);
+                var chainStart = LineOf(tree, snippet, invocation);
+
+                if (DroppedModifier(element, modifier, info) is { } dropped)
+                {
+                    findings.Add(dropped with { Path = snippet.Path, Line = line, ChainStartLine = chainStart });
+                    continue;
+                }
+
+                if (WrapperWorkaround(element, head.Value.Arguments, modifier, invocation) is { } wrapper)
+                    findings.Add(wrapper with { Path = snippet.Path, Line = line, ChainStartLine = chainStart });
+            }
+        }
+
+        return new AgentKitScan(findings, snippetCount, resolvedChains);
+    }
+
+    /// <summary>
+    /// The shipped-documentation form of <c>REACTOR_MOD_003</c>: does
+    /// <c>Reconciler.ApplyModifiers</c> write <paramref name="modifier"/> to the control this
+    /// element mounts?
+    /// </summary>
+    /// <remarks>
+    /// Every early return mirrors one of the analyzer's hard gates. In particular a null
+    /// <see cref="ModifierInfo.ControlGate"/> is <b>not</b> read as "applies everywhere" — the
+    /// table leaves it null for properties WinUI only declares on <c>Control</c>, where the
+    /// <c>.Set</c> direction needs no predicate.
+    /// </remarks>
+    private static AgentKitFinding? DroppedModifier(Type element, string modifier, ModifierInfo info)
+    {
+        if (info.ControlGate is not { } gate)
+            return null;
+
+        // A type-specific overload writes the element record directly and is always sound.
+        if (info.ElementTypes is { } elementTypes && elementTypes.Contains(element.Name, StringComparer.Ordinal))
+            return null;
+
+        // The element's own descriptor consumes the common-modifier slot, so the gate is not the
+        // authority — RichTextBlockElement.Padding is the framework's only such case today.
+        if (NoOpModifierAnalyzer.DescriptorAppliedModifiers.Contains(
+                NoOpModifierAnalyzer.ElementModifierKey(element.FullName ?? element.Name, modifier)))
+            return null;
+
+        var control = ReactorSurface.Instance.MountedControl(element);
+        if (control is null)
+            return null;
+
+        // Polymorphic hosts stand in for "whatever was handed to us"; the declared type says
+        // nothing about what ApplyModifiers will see.
+        if (control.Name is "FrameworkElement" or "UIElement")
+            return null;
+
+        if (ReactorSurface.ControlBaseChain(control).Any(name => gate.Contains(name, StringComparer.Ordinal)))
+            return null;
+
+        return new AgentKitFinding(
+            AgentKitFindingKind.DroppedModifier,
+            Path: string.Empty,
+            Line: 0,
+            ChainStartLine: 0,
+            modifier,
+            element.Name,
+            Replacement(element, modifier),
+            $".{modifier}(...) on {element.Name} mounts {control.Name}, which is outside the gate " +
+            $"[{string.Join("|", gate.OrderBy(g => g, StringComparer.Ordinal))}] — ApplyModifiers drops the value");
+    }
+
+    /// <summary>
+    /// The #1119 shape: a wrapper element introduced purely to receive a modifier that the element
+    /// it wraps silently drops, when that element has a first-class replacement.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is the rule <c>reactor-design/SKILL.md</c> states in prose — "don't add a Border solely
+    /// to get padding; a Border is still right when you also need its background, corner radius, or
+    /// border brush" — applied to the documents that ship alongside it. It is parameterised off
+    /// <see cref="NoOpModifierAnalyzer.ElementReplacements"/>, so a second entry in that table
+    /// extends the rule with no edit here.
+    /// </para>
+    /// <para>
+    /// Note the deliberate difference from <see cref="DroppedModifier"/>: the wrapper is a
+    /// <em>legal</em> receiver, so no gate is violated and <c>REACTOR_MOD_003</c> is correctly
+    /// silent. That is exactly why #1119 shipped — the contradiction lived in a sample the analyzer
+    /// had nothing to say about.
+    /// </para>
+    /// </remarks>
+    private static AgentKitFinding? WrapperWorkaround(
+        Type wrapperElement,
+        SeparatedSyntaxList<ArgumentSyntax> wrapperArguments,
+        string modifier,
+        InvocationExpressionSyntax invocation)
+    {
+        foreach (var (key, replacement) in NoOpModifierAnalyzer.ElementReplacements)
+        {
+            var separator = key.LastIndexOf('|');
+            if (separator < 0)
+                continue;
+
+            var innerFullName = key[..separator];
+            if (!string.Equals(key[(separator + 1)..], modifier, StringComparison.Ordinal))
+                continue;
+
+            // The wrapper must itself be a legal receiver; if it is not, the dropped-modifier rule
+            // already owns this line and reporting twice helps nobody.
+            if (!ModifierTable.Properties.TryGetValue(modifier, out var info) || info.ControlGate is not { } gate)
+                continue;
+
+            var wrapperControl = ReactorSurface.Instance.MountedControl(wrapperElement);
+            if (wrapperControl is null
+                || !ReactorSurface.ControlBaseChain(wrapperControl).Any(name => gate.Contains(name, StringComparer.Ordinal)))
+                continue;
+
+            // Single-child wrappers only. `Border(inner)` is unambiguously "this element exists to
+            // hold that one", which is the shape the rule is about; a multi-argument container such
+            // as `VStack(8, flex, button)` is a real layout whose padding is its own business, and
+            // flagging it would be a false positive on correct documentation.
+            if (wrapperArguments.Count != 1)
+                continue;
+
+            var innerHead = ResolveHead(wrapperArguments[0].Expression);
+            if (innerHead is null)
+                continue;
+
+            var inner = ReactorSurface.Instance.Element(innerHead.Value.Factory);
+            if (inner is null || !string.Equals(inner.FullName, innerFullName, StringComparison.Ordinal))
+                continue;
+
+            if (ChainModifiers(invocation).Any(name =>
+                    WrapperJustifications.Any(j => name.Contains(j, StringComparison.Ordinal))))
+                continue;
+
+            return new AgentKitFinding(
+                AgentKitFindingKind.WrapperWorkaround,
+                Path: string.Empty,
+                Line: 0,
+                ChainStartLine: 0,
+                modifier,
+                inner.Name,
+                replacement,
+                $"{wrapperElement.Name} wraps a {inner.Name} only to carry .{modifier}(...) — use " +
+                $".{replacement}(...) on the {inner.Name} instead. A {wrapperElement.Name} is still " +
+                "right when it also supplies background, corner radius, or border brush");
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// The replacement Reactor documents for this dropped modifier, element-specific first, then
+    /// the shape paint modifiers, then <see langword="null"/> when the framework offers none.
+    /// </summary>
+    private static string? Replacement(Type element, string modifier)
+    {
+        if (NoOpModifierAnalyzer.ElementReplacements.TryGetValue(
+                NoOpModifierAnalyzer.ElementModifierKey(element.FullName ?? element.Name, modifier),
+                out var elementSpecific))
+            return elementSpecific;
+
+        var control = ReactorSurface.Instance.MountedControl(element);
+        if (control is not null
+            && ReactorSurface.ControlBaseChain(control).Contains("Shape", StringComparer.Ordinal)
+            && NoOpModifierAnalyzer.ShapeReplacements.TryGetValue(modifier, out var shape))
+            return shape.FirstOrDefault();
+
+        return null;
+    }
+
+    /// <summary>Every modifier name applied anywhere on the fluent chain this invocation belongs to.</summary>
+    private static IEnumerable<string> ChainModifiers(InvocationExpressionSyntax invocation)
+    {
+        // Walk out to the outermost invocation first — `.Padding(24)` may be followed by
+        // `.Background(...)`, and a justification that appears later still justifies the wrapper.
+        SyntaxNode outermost = invocation;
+        while (outermost.Parent is MemberAccessExpressionSyntax parentAccess
+               && parentAccess.Parent is InvocationExpressionSyntax parentInvocation)
+        {
+            outermost = parentInvocation;
+        }
+
+        for (var node = outermost; node is not null;)
+        {
+            if (node is InvocationExpressionSyntax { Expression: MemberAccessExpressionSyntax access })
+            {
+                yield return access.Name.Identifier.Text;
+                node = access.Expression;
+                continue;
+            }
+
+            node = node switch
+            {
+                ParenthesizedExpressionSyntax parenthesized => parenthesized.Expression,
+                WithExpressionSyntax with => with.Expression,
+                PostfixUnaryExpressionSyntax postfix => postfix.Operand,
+                _ => null,
+            };
+        }
+    }
+
+    /// <summary>
+    /// Walks a fluent chain down to the factory call that started it.
+    /// </summary>
+    /// <remarks>
+    /// Returns <see langword="null"/> for anything that is not a bare factory invocation —
+    /// a local, a parameter, <c>this.Something</c>, a qualified call. Those could be any element at
+    /// runtime, which is the same reason <see cref="NoOpModifierAnalyzer"/> refuses to report on a
+    /// receiver typed as <c>Element</c>.
+    /// </remarks>
+    private static (string Factory, SeparatedSyntaxList<ArgumentSyntax> Arguments)? ResolveHead(ExpressionSyntax expression)
+    {
+        for (var node = expression; node is not null;)
+        {
+            switch (node)
+            {
+                case InvocationExpressionSyntax { Expression: IdentifierNameSyntax identifier } invocation:
+                    return (identifier.Identifier.Text, invocation.ArgumentList.Arguments);
+
+                case InvocationExpressionSyntax { Expression: MemberAccessExpressionSyntax access }:
+                    node = access.Expression;
+                    continue;
+
+                case ParenthesizedExpressionSyntax parenthesized:
+                    node = parenthesized.Expression;
+                    continue;
+
+                case WithExpressionSyntax with:
+                    node = with.Expression;
+                    continue;
+
+                case PostfixUnaryExpressionSyntax postfix:
+                    node = postfix.Operand;
+                    continue;
+
+                default:
+                    return null;
+            }
+        }
+
+        return null;
+    }
+
+    private static int LineOf(SyntaxTree tree, AgentKitSnippet snippet, SyntaxNode node) =>
+        snippet.StartLine + tree.GetLineSpan(node.Span).StartLinePosition.Line;
+
+    /// <summary>Every property name the gate rules can fire on, materialised once.</summary>
+    private static readonly string[] GatedModifierNames = ModifierTable.Properties.Keys.ToArray();
+
+    private static bool MentionsAGatedModifier(string text) =>
+        GatedModifierNames.Any(name => text.Contains(name, StringComparison.Ordinal));
+}

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitSnippetWalker.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitSnippetWalker.cs
@@ -678,17 +678,20 @@ internal static class AgentKitSnippetWalker
         foreach (var argument in invocation.ArgumentList.Arguments)
         {
             var expression = argument.Expression;
+            string? castType = null;
 
             // (Brush)null, ((Brush)null), null! — unwrap to whatever is really passed. The cast's
-            // own type is deliberately ignored: `(Brush)null` and `(object)null` are both null, and
-            // reading the cast would only re-introduce the guesswork DefaultIsProvablyNull exists
-            // to avoid. `!` is unwrapped for the same reason the chain walkers treat it as
-            // transparent — it changes nullability analysis, never the value.
+            // type is remembered rather than discarded, because for `(Brush)default` it is the only
+            // statement of the target type: reduced to a bare `default`, `Background` looks
+            // unprovable thanks to its ThemeRef overload and the call would be reported even though
+            // the analyzer skips it. `!` is unwrapped for the same reason the chain walkers treat it
+            // as transparent — it changes nullability analysis, never the value.
             while (true)
             {
                 switch (expression)
                 {
                     case CastExpressionSyntax cast:
+                        castType = cast.Type.ToString();
                         expression = cast.Expression;
                         continue;
                     case ParenthesizedExpressionSyntax parenthesized:
@@ -713,7 +716,8 @@ internal static class AgentKitSnippetWalker
             // from the modifier's overload set otherwise; unprovable never exempts.
             if (expression.IsKind(SyntaxKind.DefaultLiteralExpression) || expression is DefaultExpressionSyntax)
             {
-                var written = (expression as DefaultExpressionSyntax)?.Type.ToString();
+                // `default(T)` states its own type; `(T)default` states it on the cast.
+                var written = (expression as DefaultExpressionSyntax)?.Type.ToString() ?? castType;
 
                 if (invocation.ArgumentList.Arguments.Count == 1
                     && ReactorSurface.Instance.DefaultIsProvablyNull(modifier, written))

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitSnippetWalker.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitSnippetWalker.cs
@@ -4,6 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Text.RegularExpressions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -606,6 +607,17 @@ internal static class AgentKitSnippetWalker
     private static readonly HashSet<string> PassiveWrapperFactories =
         new(StringComparer.Ordinal) { "Border" };
 
+    /// <summary>
+    /// A preprocessor directive line, matched so it can be blanked without moving any other line.
+    /// </summary>
+    /// <remarks>
+    /// The directive text is replaced with nothing rather than the line being removed, so every
+    /// following line keeps its index and a finding still reports the line it is really on.
+    /// </remarks>
+    private static readonly Regex Preprocessor = new(
+        @"^[ \t]*#[ \t]*(if|elif|else|endif|define|undef)\b[^\r\n]*",
+        RegexOptions.Compiled | RegexOptions.Multiline);
+
     public static AgentKitScan Scan(IEnumerable<AgentKitSnippet> snippets)
     {
         var findings = new List<AgentKitFinding>();
@@ -625,7 +637,18 @@ internal static class AgentKitSnippetWalker
             if (!MentionsAGatedModifier(snippet.Text))
                 continue;
 
-            var tree = CSharpSyntaxTree.ParseText(snippet.Text);
+            // Conditional compilation: `ParseText` uses the default symbol set, so an inactive
+            // branch survives only as DisabledTextTrivia and never reaches DescendantNodes — a
+            // sample inside `#if DEBUG` would ship unscanned, and the corpus already contains one
+            // (`skills/devtools.md`). Blanking the directive lines makes every branch ordinary
+            // text while keeping each remaining line at its original index, so reported line
+            // numbers stay right. Concatenated `#else` arms may not parse; that costs nothing,
+            // because an unresolvable chain is skipped rather than reported.
+            var text = Preprocessor.IsMatch(snippet.Text)
+                ? Preprocessor.Replace(snippet.Text, string.Empty)
+                : snippet.Text;
+
+            var tree = CSharpSyntaxTree.ParseText(text);
             var root = tree.GetRoot();
 
             foreach (var invocation in root.DescendantNodes().OfType<InvocationExpressionSyntax>())

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitSnippetWalker.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitSnippetWalker.cs
@@ -335,8 +335,13 @@ internal static class AgentKitSnippetWalker
     /// on purpose: <c>WithBorder</c>, <c>ThemeBackground</c> and <c>BorderBrush</c> all qualify, and
     /// over-matching here only ever suppresses a finding.
     /// </summary>
+    /// <remarks>
+    /// <c>Style</c> is here for the same reason <c>Card</c> is not a passive factory: a style can
+    /// supply background, border and corner radius from a resource this walker cannot read, so
+    /// <c>Border(...).ApplyStyle(...)</c> is decorated in a way no chain inspection would reveal.
+    /// </remarks>
     private static readonly string[] WrapperJustifications =
-        { "Background", "Border", "CornerRadius", "Shadow", "Clip" };
+        { "Background", "Border", "CornerRadius", "Shadow", "Clip", "Style" };
 
     /// <summary>
     /// Modifiers that justify a wrapper but must match <b>exactly</b>.
@@ -352,26 +357,35 @@ internal static class AgentKitSnippetWalker
         new(StringComparer.Ordinal) { "Set" };
 
     /// <summary>
-    /// Element types whose sole contribution is decoration, so relocating a modifier inward and
-    /// deleting the wrapper preserves behaviour.
+    /// DSL <b>factories</b> whose sole contribution is decoration, so relocating a modifier inward
+    /// and deleting the call preserves behaviour.
     /// </summary>
     /// <remarks>
     /// <para>
-    /// Exactly one entry, and it should stay hard to add to. <c>BorderElement</c> is the #1119
-    /// shape and the one <c>reactor-design/SKILL.md</c> names in prose: a <c>Border</c> contributes
-    /// background, corner radius, border brush and padding, so a <c>Border</c> supplying only
-    /// padding contributes nothing once <c>.FlexPadding(...)</c> exists.
+    /// Keyed by factory name, not element type, and that distinction is load-bearing.
+    /// <c>Factories.Card</c> also returns a <c>BorderElement</c>, but it is
+    /// <c>Border(child).Background(...).WithBorder(...).CornerRadius(8).Padding(16)</c> — its
+    /// decoration is baked into the factory where no chain inspection can see it, and its own
+    /// documentation offers <c>Card(child).Padding(24)</c> as the sanctioned way to override the
+    /// preset. Judging by element type reported that as a workaround: a false positive on
+    /// documented, correct usage.
+    /// </para>
+    /// <para>
+    /// Exactly one entry, and it should stay hard to add to. <c>Border</c> contributes background,
+    /// corner radius, border brush and padding, so a plain <c>Border</c> supplying only padding
+    /// contributes nothing once <c>.FlexPadding(...)</c> exists.
     /// </para>
     /// <para>
     /// "Single child" is <b>not</b> a substitute for this test.
     /// <c>ScrollViewer(FlexColumn(children)).Padding(16)</c> has one child and is a gate-legal
     /// receiver, yet deleting it deletes scrolling — the wrapper is load-bearing and the sample is
-    /// correct. Before adding a type here, establish that removing it changes nothing but
-    /// appearance; if it does anything else, the rule does not apply to it.
+    /// correct. Before adding a factory here, establish that removing it changes nothing but
+    /// appearance <em>and</em> that it applies no decoration of its own; if either fails, the rule
+    /// does not apply to it.
     /// </para>
     /// </remarks>
-    private static readonly HashSet<string> PassiveWrapperElements =
-        new(StringComparer.Ordinal) { "BorderElement" };
+    private static readonly HashSet<string> PassiveWrapperFactories =
+        new(StringComparer.Ordinal) { "Border" };
 
     public static AgentKitScan Scan(IEnumerable<AgentKitSnippet> snippets)
     {
@@ -429,7 +443,7 @@ internal static class AgentKitSnippetWalker
                     continue;
                 }
 
-                if (WrapperWorkaround(element, head.Value.Arguments, modifier, invocation) is { } wrapper)
+                if (WrapperWorkaround(element, head.Value.Factory, head.Value.Arguments, modifier, invocation) is { } wrapper)
                     findings.Add(wrapper with { Path = snippet.Path, Line = line, ChainStartLine = chainStart });
             }
         }
@@ -576,6 +590,7 @@ internal static class AgentKitSnippetWalker
     /// </remarks>
     private static AgentKitFinding? WrapperWorkaround(
         Type wrapperElement,
+        string wrapperFactory,
         SeparatedSyntaxList<ArgumentSyntax> wrapperArguments,
         string modifier,
         InvocationExpressionSyntax invocation)
@@ -602,11 +617,10 @@ internal static class AgentKitSnippetWalker
 
             // The wrapper must be semantically passive: something whose *only* contribution is
             // decoration, so moving the modifier inward and deleting it is behaviour-preserving.
-            // A single child does not establish that. `ScrollViewer(FlexColumn(children))` is also
-            // a one-child, gate-legal receiver, but deleting it deletes scrolling — reporting there
-            // would be a false positive on correct documentation, and the reader's only way to
-            // satisfy the gate would be to break the sample.
-            if (!PassiveWrapperElements.Contains(wrapperElement.Name))
+            // Neither a single child nor the element type establishes that — `Card(...)` is also a
+            // one-child BorderElement, and `ScrollViewer(...)` is also a one-child gate-legal
+            // receiver, but deleting either loses something the sample needs.
+            if (!PassiveWrapperFactories.Contains(wrapperFactory))
                 continue;
 
             if (wrapperArguments.Count != 1)

--- a/tests/Reactor.Tests/AnalyzerTests/AgentKitSnippetWalker.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AgentKitSnippetWalker.cs
@@ -870,6 +870,17 @@ internal static class AgentKitSnippetWalker
             if (HasWithMutation(invocation))
                 continue;
 
+            // The remedy deletes the wrapper, which reparents the inner element. Modifiers on the
+            // *inner* chain that are interpreted by the parent — `.Flex`, `.Grid`, `.Dock` and the
+            // alignment family — then resolve against a different container than they were written
+            // for: in `Border(FlexColumn(children).Flex(grow: 1)).Padding(16)` the `.Flex` is inert
+            // inside the Border and starts driving layout once it is gone. Suppress rather than
+            // recommend a fix that is not behaviour-preserving. Reusing the relocation allowlist
+            // keeps one table for "modifiers whose meaning depends on the parent", and the #1119
+            // shape is unaffected — its inner chain carries a `with` initializer, not modifiers.
+            if (ModifiersFrom(wrapperArguments[0].Expression).Any(IsRelocatable))
+                continue;
+
             return new AgentKitFinding(
                 AgentKitFindingKind.WrapperWorkaround,
                 Path: string.Empty,
@@ -977,9 +988,21 @@ internal static class AgentKitSnippetWalker
 
     /// <summary>Every modifier applied anywhere on the fluent chain this invocation belongs to.</summary>
     private static IEnumerable<(string Name, InvocationExpressionSyntax Invocation)> ChainModifiers(
-        InvocationExpressionSyntax invocation)
+        InvocationExpressionSyntax invocation) =>
+        ModifiersFrom(Outermost(invocation));
+
+    /// <summary>
+    /// Every modifier from <paramref name="start"/> inward, without first climbing out of the chain.
+    /// </summary>
+    /// <remarks>
+    /// The inner expression of a wrapper is already the outermost node of its own chain, and
+    /// <see cref="Outermost"/> would walk straight back out of it into the wrapper's chain — so a
+    /// check meant to inspect the wrapped element would have re-read the wrapper's modifiers.
+    /// </remarks>
+    private static IEnumerable<(string Name, InvocationExpressionSyntax Invocation)> ModifiersFrom(
+        SyntaxNode? start)
     {
-        for (var node = Outermost(invocation); node is not null;)
+        for (var node = start; node is not null;)
         {
             if (node is InvocationExpressionSyntax { Expression: MemberAccessExpressionSyntax access } chained)
             {

--- a/tests/Reactor.Tests/AnalyzerTests/ModifierTableIntegrityTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/ModifierTableIntegrityTests.cs
@@ -860,27 +860,11 @@ public class ModifierTableIntegrityTests
     public void Every_Element_Set_Overload_Names_The_Control_Its_Descriptor_Mounts()
     {
         var elementType = typeof(Microsoft.UI.Reactor.Core.Element);
-        var elementExtensions = elementType.Assembly.GetType("Microsoft.UI.Reactor.ElementExtensions");
-        Assert.NotNull(elementExtensions);
 
-        var setControls = new Dictionary<Type, HashSet<Type>>();
-        var setOverloads = elementExtensions!.GetMethods(BindingFlags.Public | BindingFlags.Static)
-            .Where(m => m.Name == "Set")
-            .Select(m => m.GetParameters())
-            .Where(parameters => parameters.Length == 2
-                                 && parameters[1].ParameterType.IsGenericType
-                                 && parameters[1].ParameterType.GetGenericTypeDefinition() == typeof(Action<>));
-
-        foreach (var parameters in setOverloads)
-        {
-            var receiver = parameters[0].ParameterType;
-            if (receiver.IsGenericType)
-                receiver = receiver.GetGenericTypeDefinition();
-
-            if (!setControls.TryGetValue(receiver, out var controls))
-                setControls[receiver] = controls = new HashSet<Type>();
-            controls.Add(parameters[1].ParameterType.GetGenericArguments()[0]);
-        }
+        // The Set-overload map and the generator-attribute lookup both live on ReactorSurface, so
+        // this fact and the agent-kit doc gate resolve an element's mounted control through exactly
+        // one implementation. Two copies is how the pairing they pin would drift apart unnoticed.
+        Assert.NotNull(ReactorSurface.Instance.ElementExtensionsType);
 
         var checkedElements = 0;
         var problems = new List<string>();
@@ -889,14 +873,14 @@ public class ModifierTableIntegrityTests
         // resolving the declared control twice.
         var attributed = elementType.Assembly.GetTypes()
             .Where(t => elementType.IsAssignableFrom(t) && !t.IsAbstract)
-            .Select(element => (Element: element, Declared: DeclaredControl(element)))
+            .Select(element => (Element: element, Declared: ReactorSurface.DeclaredControl(element)))
             .Where(pair => pair.Declared is not null)
             .OrderBy(pair => pair.Element.Name, StringComparer.Ordinal);
 
         foreach (var (element, declared) in attributed)
         {
-            var key = element.IsGenericType ? element.GetGenericTypeDefinition() : element;
-            if (!setControls.TryGetValue(key, out var fromSet))
+            var fromSet = ReactorSurface.Instance.SetControls(element);
+            if (fromSet.Count == 0)
                 continue;   // no Set overload; the analyzer skips these elements entirely.
 
             checkedElements++;
@@ -921,28 +905,6 @@ public class ModifierTableIntegrityTests
             checkedElements >= 40,
             $"Only {checkedElements} elements were cross-checked; expected 40+. The Set/attribute " +
             "reflection has probably stopped resolving.");
-    }
-
-    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage(
-        "Trimming", "IL2075",
-        Justification = "Test-only contract guard: reads the generator attribute off a type enumerated by the surrounding Assembly.GetTypes scan. Behaviour-neutral.")]
-    private static Type? DeclaredControl(Type element)
-    {
-        for (var current = element; current is not null; current = current.BaseType)
-        {
-            foreach (var attribute in current.GetCustomAttributesData())
-            {
-                var name = attribute.AttributeType.Name;
-                if (name is not ("GenerateReactorWrapperAttribute" or "GenerateReactorDescriptorAttribute")
-                    || attribute.ConstructorArguments.Count < 1)
-                    continue;
-
-                if (attribute.ConstructorArguments[0].Value is Type control)
-                    return control;
-            }
-        }
-
-        return null;
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

`src/Reactor/Reactor.csproj` packs ~63 agent-kit documents into `Microsoft.UI.Reactor.nupkg` under `agentkit/`, and nothing checked that the C# they show a consuming agent is code the framework's own analyzers would accept. That is how #1119 was able to ship a rule in `reactor-design/SKILL.md` ("Flex containers take FlexPadding, NOT Padding [...] do not reach for a Border wrapper") inside the same NuGet as two documents saying the opposite. #1119 fixed the documents by hand and left no gate, so the next divergence would land the same way. This adds two `Reactor.Tests` facts that check the *claims* in those documents against `ModifierTable` and `NoOpModifierAnalyzer`.

**One finding changed the shape of the fix.** The issue proposes running `REACTOR_MOD_003` over the snippets and states it would have caught the `design.md` sample. It would not. The pre-#1119 sample was `Border(FlexColumn(...)).Padding(24)`, and `ModifierTable.cs:406` gates `Padding` to `Control/Border/Grid/StackPanel/RelativePanel/TextBlock` -- `Border` is a legal receiver, so the analyzer was correctly silent. What was wrong was that the sample demonstrated the Border-wrapper workaround the new rule forbids. So the gate ships two rules:

| Fact | Catches | Findings on `main` |
|---|---|---|
| `Shipped_Snippets_Never_Apply_A_Modifier_Its_Receiver_Drops` | a future doc writing `FlexColumn(x).Padding(16)` as a positive sample | 2, both the deliberate `// Wrong:` counterexamples #1119 added |
| `Shipped_Snippets_Never_Reach_For_A_Wrapper_Instead_Of_The_Replacement` | the actual #1119 regression | 0 |

Counterexamples are exempt from the first rule only when the document **also names the replacement**. A shipped "do not write this" with no "write this instead" is precisely the half of #1119 that caused the contradiction.

### Approach

Syntax-only Roslyn (`CSharpSyntaxTree.ParseText`) plus metadata reflection over the already-referenced assemblies. No compilation and no semantic model: the snippets are fragments with undeclared identifiers and no class context, so a semantic pass would bind every receiver to an error type, every check would skip, and the fact would report "no findings" while measuring nothing. Instead the chain head resolves by name through the `Factories` return type and the element's `Set(this TElement, Action<TControl>)` overload -- the same signal `NoOpModifierAnalyzer` reads -- and anything unresolvable is skipped. Uncertainty never produces a finding, because this gate runs in CI over prose-adjacent artifacts and one false positive gets it deleted.

The corpus is **derived from the csproj's `agentkit/` `<None>` globs** rather than listed in the test. The complaint in #1121 is that the next divergence lands unnoticed; a hand-maintained path list would reproduce that defect one level up, inside the gate itself. A glob that stops matching any file is itself reported, since a renamed folder silently drops a skill from the package.

`ModifierTableIntegrityTests` now resolves an element's mounted control through the same shared `ReactorSurface`, so that pairing has one implementation instead of two.

### Worth a careful look

- **The wrapper rule is intentionally narrow.** It only fires on single-child wrappers whose chain applies none of `Background` / `Border*` / `CornerRadius` / `Shadow` / `Clip` / `Set`. `Set` is on that list because its lambda can write anything and the walker cannot see inside it. Multi-child containers such as `VStack(8, flex, button).Padding(16)` are real layouts, not workarounds, and are not flagged. All of this was measured against the current corpus before being written, not guessed.
- **Not included, deliberately:** compiling the snippets (the issue's follow-on -- fragments will not bind, so it would be vacuous), single-sourcing the two design docs (the issue's own "much larger change" alternative), and the `REACTOR_MOD_003`-never-runs-on-`src/` analyzer coverage gap, which the issue itself scopes out as a separate concern.

## Linked issue / spec

Fixes: #1121

Prior art this follows: `ModifierGateProseParityTests` (#1062), which pins the `REACTOR_MOD_003` `Gates:` prose to the same table.

## Test plan

- [x] Added `tests/Reactor.Tests/AnalyzerTests/AgentKitDocGateTests.cs` (the two gates) and `AgentKitDocGateInstrumentTests.cs` (positive controls + floors)
- [x] Ran `dotnet test tests/Reactor.Tests` -- 13,384 tests pass
- [x] Release build of `Reactor.Tests` and its project references: 0 warnings, 0 errors

**Mutation-checked, each mutation restored afterwards.** A gate that reports nothing reads identically to a broken one, so every oracle was made to fail on purpose:

| Mutation | Expected result | Observed |
|---|---|---|
| Revert the `design.md` app shell to its pre-#1119 form | wrapper fact reddens | fails at `skills/design.md:33`; the dropped-modifier fact stays silent, confirming one rule alone was insufficient |
| Strip the `// Wrong:` marker above `FlexColumn(children).Padding(16)` | dropped-modifier fact reddens | fails |
| Rename `FlexPadding` out of `design.md` | names-its-remedy clause reddens | fails |
| Typo a packed skill folder in the csproj | pack-glob fact reddens | fails, naming the unmatched glob |
| Empty `NoOpModifierAnalyzer.ElementReplacements` | rules derived from it collapse | 3 facts fail |

Floors (50 documents, 150 snippets, 100 resolved chains, 100 factories) sit under the values measured by temporarily raising each to an impossible threshold and reading the actual: 63 / 374 / 345 / 115. The pre-filter that skips parsing snippets naming no gated modifier is count-preserving -- 345 resolved chains before and after.

## Risk / breaking changes

No public API change, no product code, no analyzer change, and no shipped document modified. Test-only.

Two things a reviewer should know:

- **CI impact is a new failure mode, not a new API.** These facts fail the build when a shipped doc contradicts the framework. That is the point, but it means the fix for a red build is to correct the document, not to widen the gate.
- **`CompilationLoaderTests.Cold_load_under_500ms_warm_under_50ms_for_minimal_project` is a pre-existing wall-clock flake** and may show up red alongside this branch. I measured it: a stashed clean baseline failed 4 of 6 full-suite runs under machine load (and 0 of 2 when idle), versus 5 of 6 with this branch -- within noise for a `Stopwatch` budget under parallel test load, and it passes in isolation either way. I still reduced this branch's contribution to that load: the three facts share one lazy corpus scan instead of running three, and snippets naming no gated modifier skip their Roslyn parse. Both changes were verified equivalence-preserving rather than assumed.