### PR TITLE
docs(animation): drive ScaleDemo and CombinedDemo with .Scale()

### DIFF
--- a/docs/_pipeline/apps/animation/App.cs
+++ b/docs/_pipeline/apps/animation/App.cs
@@ -42,6 +42,7 @@ class ScaleDemo : Component
             ).Padding(12)
              .CornerRadius(8)
              .Background("#e8e8e8")
+             .Scale(enlarged ? 1.5f : 1.0f)
              .ScaleTransition()
         ).Padding(24);
     }
@@ -109,8 +110,10 @@ class CombinedDemo : Component
              .CornerRadius(8)
              .Background("#7b2ab5")
              .Opacity(active ? 1.0 : 0.4)
+             .Scale(active ? 1.2f : 1.0f)
              .Translation(active ? 40f : 0f, 0f, 0f)
              .OpacityTransition(TimeSpan.FromMilliseconds(400))
+             .ScaleTransition()
              .TranslationTransition()
         ).Padding(24);
     }

--- a/docs/_pipeline/templates/animation.md.dt
+++ b/docs/_pipeline/templates/animation.md.dt
@@ -81,9 +81,10 @@ factor:
 
 ![Scale transition](screenshot://animation/scale-transition)
 
-Scale uses the element's center as the transform origin. A value of `1.0f` is
-normal size, `1.5f` is 150%. You can pass a custom `Vector3Transition` to
-control which axes animate.
+A value of `1.0f` is normal size, `1.5f` is 150%. Scale grows from the
+element's top-left corner by default — set `.CenterPoint()` to scale around a
+different origin. You can pass a custom `Vector3Transition` to control which
+axes animate.
 
 ## Translation Transition
 

--- a/docs/guide/animation.md
+++ b/docs/guide/animation.md
@@ -96,6 +96,7 @@ class ScaleDemo : Component
             ).Padding(12)
              .CornerRadius(8)
              .Background("#e8e8e8")
+             .Scale(enlarged ? 1.5f : 1.0f)
              .ScaleTransition()
         ).Padding(24);
     }
@@ -104,9 +105,10 @@ class ScaleDemo : Component
 
 ![Scale transition](images/animation/scale-transition.png)
 
-Scale uses the element's center as the transform origin. A value of `1.0f` is
-normal size, `1.5f` is 150%. You can pass a custom `Vector3Transition` to
-control which axes animate.
+A value of `1.0f` is normal size, `1.5f` is 150%. Scale grows from the
+element's top-left corner by default — set `.CenterPoint()` to scale around a
+different origin. You can pass a custom `Vector3Transition` to control which
+axes animate.
 
 ## Translation Transition
 
@@ -196,8 +198,10 @@ class CombinedDemo : Component
              .CornerRadius(8)
              .Background("#7b2ab5")
              .Opacity(active ? 1.0 : 0.4)
+             .Scale(active ? 1.2f : 1.0f)
              .Translation(active ? 40f : 0f, 0f, 0f)
              .OpacityTransition(TimeSpan.FromMilliseconds(400))
+             .ScaleTransition()
              .TranslationTransition()
         ).Padding(24);
     }


### PR DESCRIPTION
## The bugs

Two related defects in the animation docs demo app. Both were found by **running** the app and clicking the buttons — a green build never caught either one, which is the whole point of this PR.

### 1. `ScaleDemo` did nothing

`ScaleDemo` called `.ScaleTransition()` but never called `.Scale()`. A transition with no property to animate is inert, so the `enlarged` state was dead — it only flipped the button label. Clicking **Enlarge** / **Shrink** produced no visual change whatsoever.

Every sibling demo pairs the property with its transition:

| Demo | Property | Transition |
|---|---|---|
| `TranslationDemo` | `.Translation(moved ? 120f : 0f, 0f, 0f)` | `.TranslationTransition()` |
| `BackgroundDemo` | `.Background(warm ? "#da3b01" : "#0078d4")` | `.BackgroundTransition(...)` |
| `ScaleDemo` | *(missing)* | `.ScaleTransition()` |

Fixed by adding `.Scale(enlarged ? 1.5f : 1.0f)`.

### 2. `CombinedDemo` contradicted its own documentation

`CombinedDemo` animated opacity and translation only — no `.Scale()`, no `.ScaleTransition()`. Two independent sources said it should show scale:

- The prose directly beneath it: *"`.OpacityTransition()` animates opacity while `.ScaleTransition()` animates scale simultaneously. Set the target values (`.Opacity()`, `.Scale()`, `.Translation()`)…"*
- `doc-manifest.yaml:29`: *"Element combining opacity, scale, and translation transitions"*

Fixed by adding `.Scale(active ? 1.2f : 1.0f)` and `.ScaleTransition()`, so the sample matches what the docs claim it demonstrates.

## Doc correction: scale transform origin

The template stated *"Scale uses the element's center as the transform origin."* That is wrong. Before this PR the claim was untestable because nothing scaled; now the demo visibly contradicts it — the box's top-left corner stays pinned and it grows right and down.

`.Scale()` routes through `ModifyVisual` → `Reconciler.cs:3836` → `AnimationHelper.cs:325`, which sets `UIElement.CenterPoint` — the Composition facade, whose default is `Vector3.Zero`, i.e. the top-left.

The clincher is in Reactor's own code. `TransitionEngine.cs` explicitly re-centers before scaling, in both branches:

```csharp
outVisual.CenterPoint = new Vector3(outVisual.Size / 2, 0);   // :208
inVisual.CenterPoint  = new Vector3(inVisual.Size / 2, 0);    // :222
```

Those two lines exist **only because** the default isn't center — they would be redundant otherwise.

The sentence now describes the actual top-left default and points readers at `.CenterPoint()`.

## Verification

Built **and ran** the app, driving each demo live and observing the animation:

- **Enlarge / Shrink** — the box grows, and returns to a resting frame pixel-identical to the baseline capture.
- **Animate / Reset** — opacity `0.4 → 1.0`, translation `+40px`, height `80 → 96px` (the 1.2× scale), all three simultaneously.

The demos sit in one tall `ScrollView` that resists automation (mouse wheel, `PART_VerticalScrollBar` `set_value`, PageDown and Tab all no-op; offscreen demos aren't even realized in the UIA tree). So verification went through the same capture server the screenshot pipeline uses — launch with `--preview --vscode --fps 5`, then POST `{"component":"…"}` to `/preview` — to render each demo full-window and click it. Re-ran both after rebasing and rebuilding.

Snippet parity was checked rather than assumed: all three snippet regions byte-match their `animation.md` blocks, and a positive control (the same probe against a deliberately mutated snippet) correctly reported a mismatch — so the match result isn't a broken-probe artifact.

## No screenshot recapture needed

Both scales rest at `1.0f`, and all 14 entries in `doc-manifest.yaml` capture at initial render with no interaction steps. The initial render is therefore unchanged, `--no-screenshots` was correct, and the committed PNGs are provably untouched (zero image files in the diff).

## Generated output

`docs/guide/animation.md` is generated. Source changes were made in `docs/_pipeline/apps/animation/App.cs` and `docs/_pipeline/templates/animation.md.dt`, then regenerated via:

```
dotnet run --project src/Reactor.Cli -- docs compile --no-screenshots
```

The regeneration diff touched only the `scale-transition` and `combined-transitions` code blocks plus the scale prose paragraph. No other guide page drifted.

## Known limitation (deliberately not fixed)

Because the `Border` stretches full-width, a 1.5× scale clips at the window edge. It still reads clearly as scaling. Making it grow entirely in-frame would require the Border to stop stretching, which changes the resting layout and would force a real screenshot recapture. Called out so it isn't filed as a defect.

## Prior art

- **#1114** (closed) diagnosed the `ScaleDemo` bug correctly on 2026-08-24 but was declined for hand-editing the generated `docs/guide/animation.md`. This PR supersedes it by fixing the pipeline **source** and regenerating, which is why a closed PR is being revisited. Credit to @afshin29 for the original report.
- **#1115** (the layout-animation fix) merged as `ff8ef599`. This branch is based directly on that commit, so there is no interaction — the `layout-animation` region is untouched and retains its merged form.