### PR TITLE
docs: document the preview.N version scheme, not experimental.N

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,8 +40,9 @@ permissions:
 #
 #   - Past tag `v0.1.0-preview.1` by N commits → `0.1.0-preview.1.N+<sha7>`
 #   - Exactly at a tag → that tag's version
-#   - No tags yet → `0.1.0-experimental.0.<height>+<sha7>` (defaults below;
-#     fallback only — see the `-p` flag note in "Resolve version")
+#   - Past a stable tag (e.g. `v0.1.0`) → patch bumped plus the `-p` identifiers,
+#     e.g. `0.1.1-experimental.0.N+<sha7>`
+#   - No tags yet → `0.1.0-experimental.0.<height>+<sha7>` (defaults below)
 #
 # Every commit gets a unique, ordered version with zero coordination — height
 # strictly increases as commits land. Bump to a new milestone by tagging the
@@ -94,12 +95,15 @@ jobs:
           } else {
             # MinVer flags:
             #   -t v                          tag prefix
-            #   -p experimental.0             fallback prerelease identifiers — used ONLY when no
-            #                                 `v*` tag is reachable. Shipped releases are tagged
-            #                                 `v0.1.0-preview.N` and this job checks out with
-            #                                 fetch-depth: 0, so a tag is always reachable and this
-            #                                 fallback never fires — no `experimental` version has
-            #                                 ever been published.
+            #   -p experimental.0             default prerelease identifiers. MinVer applies these
+            #                                 whenever it must invent a label: when no `v*` tag is
+            #                                 reachable, and also after a STABLE tag, where it bumps
+            #                                 the patch and adds them (`v0.1.0` → `0.1.1-experimental.0.N`).
+            #                                 Dormant on the current history — every tag so far is
+            #                                 itself a prerelease (`v0.1.0-preview.N`), which MinVer
+            #                                 carries forward with height instead, so no `experimental`
+            #                                 version has ever been published. It would activate after
+            #                                 the first stable tag.
             #   -m 0.1                        minimum major.minor when no tag (so untagged → 0.1.x)
             $version = (& minver -t v -p experimental.0 -m 0.1).Trim()
           }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,16 +43,15 @@ permissions:
 #   - No tags yet → `0.1.0-experimental.0.<height>+<sha7>` (defaults below;
 #     fallback only — see the `-p` flag note in "Resolve version")
 #
-# The repo is already bootstrapped: it has been tagged since `v0.1.0-preview.1`,
-# so every commit gets a unique, ordered version with zero coordination —
-# height strictly increases as commits land. Bump to a new milestone by
-# tagging the next `v0.1.0-preview.N`; MinVer takes it from there.
+# Every commit gets a unique, ordered version with zero coordination — height
+# strictly increases as commits land. Bump to a new milestone by tagging the
+# next `v0.1.0-preview.N`; MinVer takes it from there.
 #
 # Tag pushes (`v*`) produce a clean version and create a GitHub Release.
 # Pushes to main and PR builds get the same MinVer-computed version (they
 # differ by sha → unique workflow artifacts; the .nupkg filename may collide
-# across PR pushes from the same merge base, which is acceptable for the
-# experimental channel).
+# across PR pushes from the same merge base, which is acceptable for
+# pre-release CI builds).
 
 jobs:
   package:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,14 +38,15 @@ permissions:
 # ─── Version strategy ───────────────────────────────────────────────────────
 # Versions come from MinVer (commit-height past the latest `v*` tag). Pattern:
 #
-#   - Past tag `v0.1.0-experimental.1` by N commits → `0.1.0-experimental.1.N+<sha7>`
+#   - Past tag `v0.1.0-preview.1` by N commits → `0.1.0-preview.1.N+<sha7>`
 #   - Exactly at a tag → that tag's version
-#   - No tags yet → `0.1.0-experimental.0.<height>+<sha7>` (defaults below)
+#   - No tags yet → `0.1.0-experimental.0.<height>+<sha7>` (defaults below;
+#     fallback only — see the `-p` flag note in "Resolve version")
 #
-# Bootstrap once: `git tag v0.1.0-experimental.0 && git push --tags`. After
-# that, every commit gets a unique, ordered version with zero coordination —
+# The repo is already bootstrapped: it has been tagged since `v0.1.0-preview.1`,
+# so every commit gets a unique, ordered version with zero coordination —
 # height strictly increases as commits land. Bump to a new milestone by
-# tagging (e.g. `v0.1.0-experimental.1`); MinVer takes it from there.
+# tagging the next `v0.1.0-preview.N`; MinVer takes it from there.
 #
 # Tag pushes (`v*`) produce a clean version and create a GitHub Release.
 # Pushes to main and PR builds get the same MinVer-computed version (they
@@ -94,7 +95,12 @@ jobs:
           } else {
             # MinVer flags:
             #   -t v                          tag prefix
-            #   -p experimental.0             default prerelease identifiers — flags pre-P1 builds as experimental
+            #   -p experimental.0             fallback prerelease identifiers — used ONLY when no
+            #                                 `v*` tag is reachable. Shipped releases are tagged
+            #                                 `v0.1.0-preview.N` and this job checks out with
+            #                                 fetch-depth: 0, so a tag is always reachable and this
+            #                                 fallback never fires — no `experimental` version has
+            #                                 ever been published.
             #   -m 0.1                        minimum major.minor when no tag (so untagged → 0.1.x)
             $version = (& minver -t v -p experimental.0 -m 0.1).Trim()
           }

--- a/build/pipelines/templates/reactor-build-steps.yml
+++ b/build/pipelines/templates/reactor-build-steps.yml
@@ -140,8 +140,10 @@ steps:
             throw "minver not found at $minver"
           }
           # Keep parity with the GitHub workflow / ob-release.yml MinVer settings.
-          # `-p experimental.0` is the fallback prerelease identifier for an untagged
-          # repo only; shipped releases are tagged `v0.1.0-preview.N`, so it never fires.
+          # `-p experimental.0` supplies MinVer's default prerelease identifiers, applied
+          # when it must invent a label: no reachable tag, or a STABLE latest tag (patch
+          # bumped → `0.1.1-experimental.0.N`). Dormant on the current
+          # `v0.1.0-preview.N` lineage, which MinVer carries forward with height instead.
           $version = (& $minver -t v -p experimental.0 -m 0.1).Trim()
 
           # Per-PR builds: append a unique, monotonic suffix so repeated iterations /

--- a/build/pipelines/templates/reactor-build-steps.yml
+++ b/build/pipelines/templates/reactor-build-steps.yml
@@ -140,6 +140,8 @@ steps:
             throw "minver not found at $minver"
           }
           # Keep parity with the GitHub workflow / ob-release.yml MinVer settings.
+          # `-p experimental.0` is the fallback prerelease identifier for an untagged
+          # repo only; shipped releases are tagged `v0.1.0-preview.N`, so it never fires.
           $version = (& $minver -t v -p experimental.0 -m 0.1).Trim()
 
           # Per-PR builds: append a unique, monotonic suffix so repeated iterations /

--- a/docs/specs/022-packaging-and-distribution.md
+++ b/docs/specs/022-packaging-and-distribution.md
@@ -251,15 +251,9 @@ Versions come from [MinVer](https://github.com/adamralph/minver), driven by git 
 
 ### Cutting a release
 
-The one-time bootstrap tag this section originally called for is long done — the repo has been tagged since `v0.1.0-preview.1`. Milestone bumps are explicit tags (`v0.1.0-preview.N`, `v0.2.0-preview.1`, …):
+The one-time bootstrap tag this section originally called for is long done — the repo has been tagged since `v0.1.0-preview.1`. Milestone bumps are explicit tags (`v0.1.0-preview.N`, `v0.2.0-preview.1`, …); between tags, every commit gets a unique, ordered version with zero coordination — height strictly increases as commits land, and MinVer takes it from there.
 
-```sh
-# N = one past the highest existing v0.1.0-preview.* tag
-git tag v0.1.0-preview.N
-git push --tags
-```
-
-Between tags, every commit gets a unique, ordered version with zero coordination — height strictly increases as commits land; MinVer takes it from there.
+The procedure itself is not repeated here: follow [`docs/contributing/release-runbook.md`](../contributing/release-runbook.md), which pushes an annotated tag by name (`git push origin v<version>`). Do not use `git push --tags` — it pushes *every* local tag, so a typo or a stale tag in someone's clone can match the `v*` trigger ([057 §8.1](057-release-channels.md)).
 
 ### Why MinVer over the alternatives
 
@@ -462,7 +456,7 @@ Verified locally:
 
 Still TODO under P0:
 - ~~**Bootstrap MinVer**~~ — done. The repo has been tagged since `v0.1.0-preview.1`, so MinVer always resolves against a real tag and the untagged `-p` fallback never applies.
-- First end-to-end test: after bootstrapping, push a tag like `v0.1.0-preview.1`, verify the workflow produces both assets, install into a throwaway consumer repo from the Release page.
+- First end-to-end test: push a future unused `v0.1.0-preview.N` tag, verify the workflow produces both assets, install into a throwaway consumer repo from the Release page.
 - Verify the on-PR pack produces a complete kit zip (no environment-specific path issues in `Compress-Archive`).
 - Decide whether the skill kit should also be smoke-tested by piping it through `install-skill-kit.ps1` on a clean Windows VM.
 

--- a/docs/specs/022-packaging-and-distribution.md
+++ b/docs/specs/022-packaging-and-distribution.md
@@ -240,13 +240,14 @@ Versions come from [MinVer](https://github.com/adamralph/minver), driven by git 
 | Past tag `v0.1.0-preview.1` by N commits | `0.1.0-preview.1.N+<sha7>` |
 | Exactly at tag `v0.1.0-preview.1` | `0.1.0-preview.1` |
 | Tag push of `v0.1.0` | `0.1.0` (stable, P3 only) |
-| No tags yet (defaults below) | `0.1.0-experimental.0.<height>+<sha7>` (fallback only — never reached, see below) |
+| Past a stable tag `v0.1.0` by N commits | `0.1.1-experimental.0.N+<sha7>` (patch bumped, `-p` identifiers applied) |
+| No tags yet (defaults below) | `0.1.0-experimental.0.<height>+<sha7>` |
 | `workflow_dispatch` with explicit `version` input | as supplied |
 
 `minver-cli` flags:
 
 - `-t v` — tag prefix
-- `-p experimental.0` — fallback prerelease identifiers, applied **only** when no `v*` tag is reachable. Shipped releases are tagged `v0.1.0-preview.N` and CI clones with full history, so this fallback never fires; no `experimental` version has ever been published.
+- `-p experimental.0` — MinVer's default prerelease identifiers, applied whenever it has to invent a label. Two cases, per [MinVer's algorithm](https://github.com/adamralph/minver#how-it-works): when no `v*` tag is reachable, and after a **stable** tag, where the patch is bumped and these identifiers are added (`v0.1.0` → `0.1.1-experimental.0.N`). It is dormant on the current history because every tag so far is itself a prerelease, which MinVer carries forward with height instead — which is why no `experimental` version has ever been published. It would activate after the first stable tag, so realigning it to `preview.0` is worth settling before then.
 - `-m 0.1` — minimum major.minor when no tag (so an untagged repo doesn't start at `0.0.x`)
 
 ### Cutting a release
@@ -455,7 +456,7 @@ Verified locally:
 - `dotnet pack src/Reactor -c Release -p:Platform=x64 -p:Version=0.0.1-smoke` → produces `.nupkg` containing `lib/net10.0-windows10.0.22621.0/Reactor.dll`, `analyzers/dotnet/cs/Reactor.Analyzers.dll`, `analyzers/dotnet/cs/Reactor.Localization.Generator.dll`, `LICENSE`, `Reactor.xml`.
 
 Still TODO under P0:
-- ~~**Bootstrap MinVer**~~ — done. The repo has been tagged since `v0.1.0-preview.1`, so MinVer always resolves against a real tag and the untagged `-p` fallback never applies.
+- ~~**Bootstrap MinVer**~~ — done. The repo has been tagged since `v0.1.0-preview.1`, so MinVer always resolves against a real tag.
 - First end-to-end test: push a future unused `v0.1.0-preview.N` tag, verify the workflow produces both assets, install into a throwaway consumer repo from the Release page.
 - Verify the on-PR pack produces a complete kit zip (no environment-specific path issues in `Compress-Archive`).
 - Decide whether the skill kit should also be smoke-tested by piping it through `install-skill-kit.ps1` on a clean Windows VM.

--- a/docs/specs/022-packaging-and-distribution.md
+++ b/docs/specs/022-packaging-and-distribution.md
@@ -240,25 +240,26 @@ Versions come from [MinVer](https://github.com/adamralph/minver), driven by git 
 | Past tag `v0.1.0-preview.1` by N commits | `0.1.0-preview.1.N+<sha7>` |
 | Exactly at tag `v0.1.0-preview.1` | `0.1.0-preview.1` |
 | Tag push of `v0.1.0` | `0.1.0` (stable, P3 only) |
-| No tags yet (defaults below) | `0.1.0-experimental.0.<height>+<sha7>` |
+| No tags yet (defaults below) | `0.1.0-experimental.0.<height>+<sha7>` (fallback only — never reached, see below) |
 | `workflow_dispatch` with explicit `version` input | as supplied |
 
 `minver-cli` flags:
 
 - `-t v` — tag prefix
-- `-p experimental.0` — default prerelease identifiers when no tag is reachable
+- `-p experimental.0` — fallback prerelease identifiers, applied **only** when no `v*` tag is reachable. Shipped releases are tagged `v0.1.0-preview.N` and CI clones with full history, so this fallback never fires; no `experimental` version has ever been published.
 - `-m 0.1` — minimum major.minor when no tag (so an untagged repo doesn't start at `0.0.x`)
 
-### Bootstrap
+### Cutting a release
 
-Tag the repo once before the first CI run:
+The one-time bootstrap tag this section originally called for is long done — the repo has been tagged since `v0.1.0-preview.1`. Milestone bumps are explicit tags (`v0.1.0-preview.N`, `v0.2.0-preview.1`, …):
 
 ```sh
-git tag v0.1.0-experimental.0
+# N = one past the highest existing v0.1.0-preview.* tag
+git tag v0.1.0-preview.N
 git push --tags
 ```
 
-After that, every commit gets a unique, ordered version with zero coordination — height strictly increases as commits land. Milestone bumps are explicit tags (`v0.1.0-preview.1`, `v0.2.0-experimental.0`, …); MinVer takes it from there.
+Between tags, every commit gets a unique, ordered version with zero coordination — height strictly increases as commits land; MinVer takes it from there.
 
 ### Why MinVer over the alternatives
 
@@ -270,7 +271,7 @@ MinVer hits the sweet spot: tag-driven, no extra files in the repo, conventional
 
 ### PR vs main distinguishability
 
-Pure MinVer doesn't add a PR identifier — both PR and main builds with the same git height produce the same `0.1.0-experimental.0.<height>` filename. This is acceptable because:
+Pure MinVer doesn't add a PR identifier — both PR and main builds with the same git height produce the same `0.1.0-preview.N.<height>` filename. This is acceptable because:
 
 - The `+<sha7>` build metadata in the SemVer string differs (visible in package metadata, even if NuGet drops it from the filename).
 - Workflow artifact uploads are run-scoped — each workflow run gets its own download URL regardless of version collision.
@@ -460,7 +461,7 @@ Verified locally:
 - `dotnet pack src/Reactor -c Release -p:Platform=x64 -p:Version=0.0.1-smoke` → produces `.nupkg` containing `lib/net10.0-windows10.0.22621.0/Reactor.dll`, `analyzers/dotnet/cs/Reactor.Analyzers.dll`, `analyzers/dotnet/cs/Reactor.Localization.Generator.dll`, `LICENSE`, `Reactor.xml`.
 
 Still TODO under P0:
-- **Bootstrap MinVer**: `git tag v0.1.0-experimental.0 && git push --tags` so the first CI run produces `0.1.0-experimental.0.<height>` rather than the pre-bootstrap default.
+- ~~**Bootstrap MinVer**~~ — done. The repo has been tagged since `v0.1.0-preview.1`, so MinVer always resolves against a real tag and the untagged `-p` fallback never applies.
 - First end-to-end test: after bootstrapping, push a tag like `v0.1.0-preview.1`, verify the workflow produces both assets, install into a throwaway consumer repo from the Release page.
 - Verify the on-PR pack produces a complete kit zip (no environment-specific path issues in `Compress-Archive`).
 - Decide whether the skill kit should also be smoke-tested by piping it through `install-skill-kit.ps1` on a clean Windows VM.


### PR DESCRIPTION
The release tooling's comments and spec 022 §8 describe an `experimental.N` version scheme that was **never used for any actual release**. Every shipped release uses `preview.N`.

## Evidence

- Every git tag is `v0.1.0-preview.N` — 13 of them, contiguous `preview.1` (2026-06-09) through `preview.13` (2026-08-04).
- **No `experimental` tag has ever existed.** `git ls-remote --tags --refs origin | Select-String experimental` returns nothing (positive control: the same command returns all 13 `preview` tags, so the zero is a real measurement).
- `Directory.Build.props:47` pins `<ReactorPublicVersion>0.1.0-preview.13</ReactorPublicVersion>`.
- The NuGet feed only has `0.1.0-preview.{1,3,4,5,10,11,12,13}`.

**A spec that references 022 §8 already contradicts it.** `docs/specs/057-release-channels.md` cites 022 §8 and uses `preview` consistently throughout (`0.2.0-preview.3`, `Version="0.*-preview*"`). That's stronger than 022's self-contradiction alone — the divergence was already visible from a neighbouring document.

Both edited files also contradicted themselves internally:

- `release.yml` L41 said `v0.1.0-experimental.1`, while L117 in the *same file* already said `MinVer height versions (e.g. 0.1.0-preview.N.M+sha)`.
- The spec's own table rows L240–241 already used `v0.1.0-preview.1`, immediately above L243 claiming `0.1.0-experimental.0.<height>`.

This has already misled a reader into concluding a published blog post cited a stale package version.

## The minver flags are intentionally unchanged

The two live invocations that pass `-p experimental.0` are **not touched**:

- `.github/workflows/release.yml`
- `build/pipelines/templates/reactor-build-steps.yml`

Changing them would be a behavior change with no upside, and would widen a docs PR into a release-tooling PR. Instead, the comment beside each now describes accurately when `-p` applies.

**Why `experimental` has never shipped, stated correctly.** Per [MinVer's algorithm](https://github.com/adamralph/minver#how-it-works), `-p` supplies the default prerelease identifiers whenever MinVer must *invent* a label — which happens in **two** cases: no reachable tag, **and** after a stable/RTM tag, where the patch is bumped and the identifiers are added (`v0.1.0` → `0.1.1-experimental.0.N`). It is dormant on this repo's history because every tag so far is itself a *prerelease*, which MinVer carries forward with height instead. It is not dormant merely because tags exist.

An earlier revision of this PR claimed `-p` applies "only when no tag is reachable" and therefore "never fires." That was wrong, and it would have become visibly wrong the moment the repo did what §8 already plans — tag a stable `v0.1.0` ("P3 only"). Caught in review and corrected in 819a2067; the version-strategy bullet list and the spec table also gained the previously-missing stable-tag row.

**Question for maintainers:** since `-p` *will* activate after the first stable tag, realigning it to `-p preview.0` is worth settling before then rather than after. Happy to do it in a follow-up.

## Also fixed

**The nonexistent "experimental channel."** `release.yml` described a `.nupkg` filename collision as "acceptable for the experimental channel." Spec 057 §3 ("Prerelease Labels _Are_ Channels") defines the taxonomy as exactly **stable**, **preview**, **nightly** — so "channel" is a term of art here and `experimental` is not one of its values.

**The moot "Bootstrap" sections.** Spec §8 and the P0 TODO list instructed the reader to bootstrap a repo tagged 13 times. `### Bootstrap` → `### Cutting a release`; the P0 TODO bullet struck through as done.

**A conflicting release path I introduced.** Renaming that heading silently promoted a pre-existing one-time snippet (`git tag` + `git push --tags`) into what read as a release procedure — conflicting with `docs/contributing/release-runbook.md:11`, which requires an annotated tag pushed by name, and using the exact form `057 §8.1` warns against (`git push --tags` pushes *every* local tag, so a typo or stale tag matches the `v*` trigger). The snippet is removed and the section now defers to the runbook rather than duplicating it.

## Deliberately left alone

The **"First end-to-end test"** bullet was de-staled (no longer says "after bootstrapping", no longer names the already-existing `v0.1.0-preview.1`) but is **intentionally not marked done**, unlike `Bootstrap MinVer`. The latter has direct proof of completion — 13 tags. The former asserts a testing activity including "install into a throwaway consumer repo from the Release page," which leaves no artifact verifiable from the repo. Marking it done because it is old rather than because it is evidenced would fabricate a verification record — the same failure mode as the stale text this PR fixes, pointed the other way.

## Scope

Comments, prose, and tables only. No behavior change — every added/removed line in the two YAML files is a comment, and both `minver` invocations are byte-identical to `main` (verified by filtering the diff for `minver -t|& minver|$minver` → zero hits, against a positive control confirming the probe matches both lines).

## Verification

- Premise re-verified against `origin` with a positive control.
- Every remaining `experimental` hit is deliberate: the two unchanged minver flags, the comments describing them, the no-tag and stable-tag rows (which state the flag's literal output and are accurate *because* the flag is unchanged), and genuine quality claims about the VSIX at `release.yml` L350/L400 that are unrelated to versioning.
- Both YAML files re-parse cleanly (`yaml.safe_load`), and the `Resolve version` step in `Pack (x64 + arm64)` — the only place these edits sit inside executable PowerShell — passes on CI.
- Both new relative links (`../contributing/release-runbook.md`, `057-release-channels.md`) resolve from `docs/specs/`.
- The renamed `### Bootstrap` heading had no inbound anchor links anywhere in the repo.

`docs/blog/` is untouched.