### PR TITLE
Fix stale global tool install and ship Roslyn with the packed CLI

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -113,6 +113,32 @@ jobs:
           mur doctor
           if ($LASTEXITCODE -ne 0) { throw "mur doctor failed (exit $LASTEXITCODE)" }
 
+      # Regression guard: `mur check` loads Roslyn at runtime, and a
+      # PrivateAssets="all" reference once excluded Microsoft.CodeAnalysis*.dll
+      # from the packed tools/ payload. The assemblies were still in bin/, so
+      # `dotnet run` worked while every *installed* `mur check` threw
+      # FileNotFoundException at startup — invisible to every check above,
+      # which only exercise commands that don't touch Roslyn.
+      #
+      # --list-rules is the cheapest command that forces the load: it resolves
+      # the rule registry and exits without running a build.
+      - name: Verify installed mur check loads Roslyn
+        shell: pwsh
+        run: |
+          $env:Path = "$env:USERPROFILE\.dotnet\tools;$env:Path"
+          $out = mur check --list-rules 2>&1 | Out-String
+          if ($LASTEXITCODE -ne 0) {
+              Write-Host $out
+              throw "mur check --list-rules exited $LASTEXITCODE"
+          }
+          # Exit 0 alone is not proof: assert the registry actually rendered.
+          # A rule name that vanishes is a real signal, not a formatting nit.
+          if ($out -notmatch 'GridSizePxRenameRule') {
+              Write-Host $out
+              throw "mur check --list-rules did not list the expected ruleset"
+          }
+          Write-Host $out
+
       - name: Verify local-nupkgs/ produced
         shell: pwsh
         run: |

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -560,7 +560,23 @@ if ($SkipMurInstall) {
         $expectedSha = & git -C $repoRoot rev-parse HEAD 2>$null
         if ($LASTEXITCODE -ne 0) { $expectedSha = $null }
     }
-    $murVersionLine = & mur --version 2>$null | Select-Object -First 1
+
+    # Collect the output fully before inspecting it. Piping a native command
+    # straight into `Select-Object -First 1` closes the pipeline early, which
+    # can surface as a broken pipe and leaves $LASTEXITCODE non-deterministic —
+    # so the exit code is captured from the unpiped call.
+    $murOutput = & mur --version 2>$null
+    $murExit = $LASTEXITCODE
+    $murVersionLine = @($murOutput) | Select-Object -First 1
+
+    # A `mur` that runs but fails is a broken install, not an unverifiable one.
+    # Falling through to the warning below would mask exactly the class of
+    # defect this block exists to catch.
+    if ($murExit -ne 0) {
+        Fail ("The installed ``mur`` failed to run (``mur --version`` exited $murExit). " +
+              "The global tool is present but broken. Run: dotnet tool uninstall -g Microsoft.UI.Reactor.Cli, then re-run ./bootstrap.ps1.")
+    }
+
     if ($expectedSha -and $murVersionLine -match '\+([0-9a-fA-F]{40})') {
         $installedSha = $Matches[1]
         if ($installedSha -ne $expectedSha) {

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -473,11 +473,40 @@ Write-Dbg "Local nupkg feed: $feed"
 # apphost) succeeds. The packed IL itself is platform-portable.
 Write-Dbg "Host arch resolved to: $hostArch"
 
+# Stamp a monotonically-increasing local version.
+#
+# Without an explicit -p:Version the SDK defaults to 1.0.0 on *every* commit,
+# so re-running bootstrap packed a byte-new binary under a version NuGet had
+# already seen. `dotnet tool update` then compared 1.0.0 to 1.0.0, decided
+# nothing was newer, no-opped, and exited 0 — leaving a months-stale `mur` on
+# PATH while bootstrap reported success.
+#
+# The scheme has to clear three constraints simultaneously, and the two
+# obvious encodings each fail one of them:
+#   * AssemblyVersion/FileVersion derive from the numeric components and cap
+#     each at 65534 (UInt16), so a date-based minor such as 1.260826.1511
+#     fails the build outright with CS7034.
+#   * `dotnet tool update` refuses to move to a *lower* version even when the
+#     version is pinned with --version, and a prerelease label such as
+#     1.0.0-local.<stamp> sorts BELOW the stable 1.0.0 that is already
+#     installed — it fails with "is lower than existing version 1.0.0".
+# So: a stable (non-prerelease) version, strictly greater than 1.0.0, with
+# every component inside UInt16. Minor = days since 2020-01-01 (~2400 today,
+# and good for ~179 years); patch = minute of day (0-1439). Both roll over
+# correctly: the last minute of a day is 1.N.1439 and the first minute of the
+# next is 1.N+1.0, which compares higher.
+$nowUtc = (Get-Date).ToUniversalTime()
+$cliLocalVersion = '1.{0}.{1}' -f `
+    [int]($nowUtc.Date - [datetime]'2020-01-01').TotalDays, `
+    [int]$nowUtc.TimeOfDay.TotalMinutes
+Write-Dbg "Local mur version stamp: $cliLocalVersion"
+
 $cliPackArgs = @(
     'pack',
     (Join-Path $repoRoot 'src\Reactor.Cli\Reactor.Cli.csproj'),
     '-c', $Configuration,
     "-p:Platform=$hostArch",
+    "-p:Version=$cliLocalVersion",
     '-o', $feed,
     '--nologo', '-v:m'
 )
@@ -510,7 +539,8 @@ if ($SkipMurInstall) {
     $toolArgs = Get-ReactorToolArguments `
         -Feed $feed `
         -NuGetConfig $effectiveNuGetConfig `
-        -NuGetSource $effectiveNuGetSource
+        -NuGetSource $effectiveNuGetSource `
+        -Version $cliLocalVersion
     if ($existing) {
         Write-Dbg "Existing global tool detected ($($existing.Line.Trim())); using 'dotnet tool update'"
         & dotnet tool update @toolArgs
@@ -533,6 +563,30 @@ if ($SkipMurInstall) {
             Write-Dbg "$dotnetTools already on current-process PATH"
         }
     }
+
+    # Prove the binary on PATH is the one we just built.
+    #
+    # The exit-code check above cannot detect a stale tool: a no-op `dotnet
+    # tool update` exits 0. That is exactly how installs drifted months behind
+    # HEAD while every bootstrap run reported success. The SDK appends the
+    # source revision to AssemblyInformationalVersion, so `mur --version`
+    # prints `mur <ver>+<40-hex-sha>` — compare that against HEAD.
+    $expectedSha = & git -C $repoRoot rev-parse HEAD 2>$null
+    if ($LASTEXITCODE -ne 0) { $expectedSha = $null }
+    $murVersionLine = & mur --version 2>$null | Select-Object -First 1
+    if ($expectedSha -and $murVersionLine -match '\+([0-9a-fA-F]{40})') {
+        $installedSha = $Matches[1]
+        if ($installedSha -ne $expectedSha) {
+            Fail ("Installed mur reports revision $($installedSha.Substring(0,8)) but HEAD is $($expectedSha.Substring(0,8)). " +
+                  "The global tool was not replaced. Run: dotnet tool uninstall -g Microsoft.UI.Reactor.Cli, then re-run ./bootstrap.ps1.")
+        }
+        Write-Ok "mur verified at revision $($expectedSha.Substring(0,8)) (version $cliLocalVersion)"
+    } else {
+        # Non-fatal: a shallow/exported tree has no git, and a consumer build
+        # may strip the revision suffix. Say so rather than implying success.
+        Write-Host "    [warn] Could not verify the installed mur revision (mur --version returned '$murVersionLine')." -ForegroundColor Yellow
+    }
+
     Write-Ok "mur installed as global tool (also on this shell's PATH)"
 }
 

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -473,32 +473,11 @@ Write-Dbg "Local nupkg feed: $feed"
 # apphost) succeeds. The packed IL itself is platform-portable.
 Write-Dbg "Host arch resolved to: $hostArch"
 
-# Stamp a monotonically-increasing local version.
-#
-# Without an explicit -p:Version the SDK defaults to 1.0.0 on *every* commit,
-# so re-running bootstrap packed a byte-new binary under a version NuGet had
-# already seen. `dotnet tool update` then compared 1.0.0 to 1.0.0, decided
-# nothing was newer, no-opped, and exited 0 — leaving a months-stale `mur` on
-# PATH while bootstrap reported success.
-#
-# The scheme has to clear three constraints simultaneously, and the two
-# obvious encodings each fail one of them:
-#   * AssemblyVersion/FileVersion derive from the numeric components and cap
-#     each at 65534 (UInt16), so a date-based minor such as 1.260826.1511
-#     fails the build outright with CS7034.
-#   * `dotnet tool update` refuses to move to a *lower* version even when the
-#     version is pinned with --version, and a prerelease label such as
-#     1.0.0-local.<stamp> sorts BELOW the stable 1.0.0 that is already
-#     installed — it fails with "is lower than existing version 1.0.0".
-# So: a stable (non-prerelease) version, strictly greater than 1.0.0, with
-# every component inside UInt16. Minor = days since 2020-01-01 (~2400 today,
-# and good for ~179 years); patch = minute of day (0-1439). Both roll over
-# correctly: the last minute of a day is 1.N.1439 and the first minute of the
-# next is 1.N+1.0, which compares higher.
-$nowUtc = (Get-Date).ToUniversalTime()
-$cliLocalVersion = '1.{0}.{1}' -f `
-    [int]($nowUtc.Date - [datetime]'2020-01-01').TotalDays, `
-    [int]$nowUtc.TimeOfDay.TotalMinutes
+# Stamp a unique, monotonically-increasing local version. Get-ReactorLocalCliVersion
+# (tools/BootstrapFeedResolver.ps1) documents why the encoding looks the way it
+# does; it lives there rather than inline so its shape, bounds, and ordering are
+# covered by tests/vs_reactor/ci/BootstrapFeedResolver.Tests.ps1.
+$cliLocalVersion = Get-ReactorLocalCliVersion
 Write-Dbg "Local mur version stamp: $cliLocalVersion"
 
 $cliPackArgs = @(
@@ -571,9 +550,29 @@ if ($SkipMurInstall) {
     # HEAD while every bootstrap run reported success. The SDK appends the
     # source revision to AssemblyInformationalVersion, so `mur --version`
     # prints `mur <ver>+<40-hex-sha>` — compare that against HEAD.
-    $expectedSha = & git -C $repoRoot rev-parse HEAD 2>$null
-    if ($LASTEXITCODE -ne 0) { $expectedSha = $null }
+    #
+    # git is resolved via Get-Command rather than invoked speculatively: under
+    # $ErrorActionPreference = 'Stop' a missing executable raises a terminating
+    # CommandNotFoundException, so `& git ...` would abort bootstrap instead of
+    # reaching the non-fatal warning below.
+    $expectedSha = $null
+    if (Get-Command git -ErrorAction SilentlyContinue) {
+        $expectedSha = & git -C $repoRoot rev-parse HEAD 2>$null
+        if ($LASTEXITCODE -ne 0) { $expectedSha = $null }
+    }
     $murVersionLine = & mur --version 2>$null | Select-Object -First 1
+    if ($expectedSha -and $murVersionLine -match '\+([0-9a-fA-F]{40})') {
+        $installedSha = $Matches[1]
+        if ($installedSha -ne $expectedSha) {
+            Fail ("Installed mur reports revision $($installedSha.Substring(0,8)) but HEAD is $($expectedSha.Substring(0,8)). " +
+                  "The global tool was not replaced. Run: dotnet tool uninstall -g Microsoft.UI.Reactor.Cli, then re-run ./bootstrap.ps1.")
+        }
+        Write-Ok "mur verified at revision $($expectedSha.Substring(0,8)) (version $cliLocalVersion)"
+    } else {
+        # Non-fatal: a shallow/exported tree has no git, and a consumer build
+        # may strip the revision suffix. Say so rather than implying success.
+        Write-Host "    [warn] Could not verify the installed mur revision (mur --version returned '$murVersionLine')." -ForegroundColor Yellow
+    }
     if ($expectedSha -and $murVersionLine -match '\+([0-9a-fA-F]{40})') {
         $installedSha = $Matches[1]
         if ($installedSha -ne $expectedSha) {

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -573,18 +573,6 @@ if ($SkipMurInstall) {
         # may strip the revision suffix. Say so rather than implying success.
         Write-Host "    [warn] Could not verify the installed mur revision (mur --version returned '$murVersionLine')." -ForegroundColor Yellow
     }
-    if ($expectedSha -and $murVersionLine -match '\+([0-9a-fA-F]{40})') {
-        $installedSha = $Matches[1]
-        if ($installedSha -ne $expectedSha) {
-            Fail ("Installed mur reports revision $($installedSha.Substring(0,8)) but HEAD is $($expectedSha.Substring(0,8)). " +
-                  "The global tool was not replaced. Run: dotnet tool uninstall -g Microsoft.UI.Reactor.Cli, then re-run ./bootstrap.ps1.")
-        }
-        Write-Ok "mur verified at revision $($expectedSha.Substring(0,8)) (version $cliLocalVersion)"
-    } else {
-        # Non-fatal: a shallow/exported tree has no git, and a consumer build
-        # may strip the revision suffix. Say so rather than implying success.
-        Write-Host "    [warn] Could not verify the installed mur revision (mur --version returned '$murVersionLine')." -ForegroundColor Yellow
-    }
 
     Write-Ok "mur installed as global tool (also on this shell's PATH)"
 }

--- a/src/Reactor.Cli/Reactor.Cli.csproj
+++ b/src/Reactor.Cli/Reactor.Cli.csproj
@@ -74,7 +74,16 @@
 
   <ItemGroup>
     <PackageReference Include="GitHub.Copilot.SDK" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all" />
+    <!-- No PrivateAssets here. `mur check` *executes* Roslyn at runtime
+         (Check/CompilationLoader.cs, Check/FactoryIndex.cs,
+         Check/SuggesterOrchestrator.cs, Loc/InterpolationConverter.cs).
+         PrivateAssets="all" is the correct idiom for an analyzer project,
+         which must not flow Roslyn to consumers — but this is a PackAsTool
+         global tool, and it excluded Microsoft.CodeAnalysis{,.CSharp}.dll
+         from the packed tools/ payload. The assemblies were present in bin/,
+         so every local `dotnet run` worked, while every bootstrap-installed
+         `mur check` died at startup with FileNotFoundException. -->
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
     <PackageReference Include="System.Drawing.Common" />
     <PackageReference Include="YamlDotNet" />
     <PackageReference Include="Vecc.YamlDotNet.Analyzers.StaticGenerator">

--- a/src/Reactor.Cli/Reactor.Cli.csproj
+++ b/src/Reactor.Cli/Reactor.Cli.csproj
@@ -14,6 +14,11 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <WindowsPackageType>None</WindowsPackageType>
+    <!-- Roslyn ships ~13 localized satellite assemblies per package. `mur`
+         surfaces compiler diagnostics verbatim, so localized Roslyn resources
+         would only translate a fraction of its output; they cost ~1.9 MB in the
+         packed tool payload and the release publish for no coherent benefit. -->
+    <SatelliteResourceLanguages>en</SatelliteResourceLanguages>
     <!-- Mirror the deployed skill-kit layout under <repo>/bin/<arch>/ so devs
          can put that directory on PATH and `mur` resolves to the freshly-built
          binary. The release workflow produces the same bin/x64 + bin/arm64

--- a/tests/vs_reactor/ci/BootstrapFeedResolver.Tests.ps1
+++ b/tests/vs_reactor/ci/BootstrapFeedResolver.Tests.ps1
@@ -288,21 +288,37 @@ try {
     # has to satisfy at once, each of which a plausible alternative violates.
 
     $v = Get-ReactorLocalCliVersion -Now ([datetime]::new(2026, 8, 26, 15, 13, 7, [DateTimeKind]::Utc))
-    Assert-Equal '1.2429.913.7' $v 'stamp encodes days-since-2020, minute-of-day, and second'
+    Assert-Equal '1.2429.913.7000' $v 'stamp encodes days-since-2020, minute-of-day, and second+millisecond'
 
     # Must outrank the stable 1.0.0 that older bootstraps installed, or
     # `dotnet tool update` refuses to move to it.
     Assert-True ([version]$v -gt [version]'1.0.0') 'stamp sorts above the legacy constant 1.0.0'
 
     # AssemblyVersion/FileVersion components are UInt16; 1.<yyMMdd>.<HHmm>
-    # overflows and fails the build with CS7034.
-    foreach ($part in ([version]$v).ToString().Split('.')) {
-        Assert-True ([int]$part -le 65534) "stamp component '$part' fits in UInt16"
+    # overflows and fails the build with CS7034. The revision is the tightest
+    # component: 59*1000+999 = 59999.
+    $maxRevision = Get-ReactorLocalCliVersion -Now ([datetime]::new(2026, 8, 26, 23, 59, 59, 999, [DateTimeKind]::Utc))
+    foreach ($part in $maxRevision.Split('.')) {
+        Assert-True ([int]$part -le 65534) "stamp component '$part' fits in UInt16 at the worst-case instant"
     }
 
-    # Unique per run: two packs in the same minute must still yield distinct
-    # versions, otherwise the second install is a no-op that keeps the older
-    # binary.
+    # minute-of-day must stay within 0-1439. A plain [int] cast rounds
+    # half-to-even, so the last 30 seconds of every minute would be stamped with
+    # the following minute and 23:59:59.999 would emit 1440.
+    Assert-Equal '1.2429.1439.59999' $maxRevision 'the last instant of a day floors to minute 1439, not 1440'
+    Assert-Equal '1.2429.913.42000' `
+        (Get-ReactorLocalCliVersion -Now ([datetime]::new(2026, 8, 26, 15, 13, 42, [DateTimeKind]::Utc))) `
+        'a second past the half-minute stays in the current minute'
+
+    # Unique per run: two packs within the same *second* must still yield
+    # distinct, ordered versions, otherwise the second install is a no-op that
+    # silently keeps the older binary.
+    $sameSecondA = Get-ReactorLocalCliVersion -Now ([datetime]::new(2026, 8, 26, 15, 13, 7, 120, [DateTimeKind]::Utc))
+    $sameSecondB = Get-ReactorLocalCliVersion -Now ([datetime]::new(2026, 8, 26, 15, 13, 7, 880, [DateTimeKind]::Utc))
+    Assert-True ([version]$sameSecondB -gt [version]$sameSecondA) `
+        'two stamps in the same second are distinct and ordered'
+
+    # Ordering must also hold across the coarser boundaries.
     $sameMinuteA = Get-ReactorLocalCliVersion -Now ([datetime]::new(2026, 8, 26, 15, 13, 7, [DateTimeKind]::Utc))
     $sameMinuteB = Get-ReactorLocalCliVersion -Now ([datetime]::new(2026, 8, 26, 15, 13, 42, [DateTimeKind]::Utc))
     Assert-True ([version]$sameMinuteB -gt [version]$sameMinuteA) `

--- a/tests/vs_reactor/ci/BootstrapFeedResolver.Tests.ps1
+++ b/tests/vs_reactor/ci/BootstrapFeedResolver.Tests.ps1
@@ -275,13 +275,48 @@ try {
     # Regression guard for the stale-global-tool bug: bootstrap packs a per-run
     # version stamp and must pin it explicitly, because `dotnet tool update`
     # silently no-ops (exit 0) when the resolved version equals the installed
-    # one. Sample value matches the shipped stamp shape: 1.<days since
-    # 2020-01-01>.<minute of day>.
+    # one. Sample value matches the shipped stamp shape.
     $toolArgs = Get-ReactorToolArguments `
         -Feed 'C:\repo\local-nupkgs' `
-        -Version '1.2429.1352'
-    Assert-Equal '-g|--add-source|C:\repo\local-nupkgs|Microsoft.UI.Reactor.Cli|--version|1.2429.1352|--no-cache|--ignore-failed-sources' `
+        -Version '1.2429.1352.7'
+    Assert-Equal '-g|--add-source|C:\repo\local-nupkgs|Microsoft.UI.Reactor.Cli|--version|1.2429.1352.7|--no-cache|--ignore-failed-sources' `
         ($toolArgs -join '|') 'tool arguments pin the explicitly supplied version'
+
+    # ---- Get-ReactorLocalCliVersion -------------------------------------
+    # The stamp is what actually broke: a constant 1.0.0 made `dotnet tool
+    # update` a silent no-op. These assert the three constraints the encoding
+    # has to satisfy at once, each of which a plausible alternative violates.
+
+    $v = Get-ReactorLocalCliVersion -Now ([datetime]::new(2026, 8, 26, 15, 13, 7, [DateTimeKind]::Utc))
+    Assert-Equal '1.2429.913.7' $v 'stamp encodes days-since-2020, minute-of-day, and second'
+
+    # Must outrank the stable 1.0.0 that older bootstraps installed, or
+    # `dotnet tool update` refuses to move to it.
+    Assert-True ([version]$v -gt [version]'1.0.0') 'stamp sorts above the legacy constant 1.0.0'
+
+    # AssemblyVersion/FileVersion components are UInt16; 1.<yyMMdd>.<HHmm>
+    # overflows and fails the build with CS7034.
+    foreach ($part in ([version]$v).ToString().Split('.')) {
+        Assert-True ([int]$part -le 65534) "stamp component '$part' fits in UInt16"
+    }
+
+    # Unique per run: two packs in the same minute must still yield distinct
+    # versions, otherwise the second install is a no-op that keeps the older
+    # binary.
+    $sameMinuteA = Get-ReactorLocalCliVersion -Now ([datetime]::new(2026, 8, 26, 15, 13, 7, [DateTimeKind]::Utc))
+    $sameMinuteB = Get-ReactorLocalCliVersion -Now ([datetime]::new(2026, 8, 26, 15, 13, 42, [DateTimeKind]::Utc))
+    Assert-True ([version]$sameMinuteB -gt [version]$sameMinuteA) `
+        'two stamps in the same minute are distinct and ordered'
+
+    # Ordering must hold across a day boundary, where minute-of-day resets.
+    $endOfDay = Get-ReactorLocalCliVersion -Now ([datetime]::new(2026, 8, 26, 23, 59, 59, [DateTimeKind]::Utc))
+    $nextDay  = Get-ReactorLocalCliVersion -Now ([datetime]::new(2026, 8, 27, 0, 0, 0, [DateTimeKind]::Utc))
+    Assert-True ([version]$nextDay -gt [version]$endOfDay) 'stamp keeps ordering across a day boundary'
+
+    # A wrong system clock would otherwise emit a negative or absurd minor and
+    # produce a confusing NuGet error far from the cause.
+    Assert-Throws { Get-ReactorLocalCliVersion -Now ([datetime]::new(2019, 12, 31, 0, 0, 0, [DateTimeKind]::Utc)) } `
+        'a pre-epoch clock is rejected rather than emitting a bad version'
 
     $env:RestoreConfigFile = 'before.config'
     $env:RestoreSources = 'before-source'

--- a/tests/vs_reactor/ci/BootstrapFeedResolver.Tests.ps1
+++ b/tests/vs_reactor/ci/BootstrapFeedResolver.Tests.ps1
@@ -230,6 +230,7 @@ try {
     Assert-Equal '-g|--add-source|C:\repo\local-nupkgs|--add-source|https://packagefeedproxy.microsoft.io/nuget/v3/index.json|Microsoft.UI.Reactor.Cli|--no-cache|--ignore-failed-sources' `
         ($toolArgs -join '|') 'tool arguments include both local and automatic proxy sources'
 
+<<<<<<< HEAD
     # Resolve-ReactorNuGetFeedOverride is what scripts a developer runs directly
     # (Build-Vsix.ps1) use: explicit arguments first, then the same user-config
     # discovery, and no network probe. $profile still carries `profile-proxy`
@@ -266,6 +267,22 @@ try {
     New-Item -ItemType Directory -Path $emptyHome | Out-Null
     Assert-Equal $null (Resolve-ReactorNuGetFeedOverride -AppData $emptyHome -UserProfile $emptyHome) `
         'no configured proxy yields no override, preserving the repo public default'
+
+    # An omitted -Version must not emit a --version flag (back-compat with the
+    # pre-existing call shape asserted above).
+    Assert-True ($toolArgs -notcontains '--version') `
+        'tool arguments omit --version when no version is supplied'
+
+    # Regression guard for the stale-global-tool bug: bootstrap packs a per-run
+    # version stamp and must pin it explicitly, because `dotnet tool update`
+    # silently no-ops (exit 0) when the resolved version equals the installed
+    # one. Sample value matches the shipped stamp shape: 1.<days since
+    # 2020-01-01>.<minute of day>.
+    $toolArgs = Get-ReactorToolArguments `
+        -Feed 'C:\repo\local-nupkgs' `
+        -Version '1.2429.1352'
+    Assert-Equal '-g|--add-source|C:\repo\local-nupkgs|Microsoft.UI.Reactor.Cli|--version|1.2429.1352|--no-cache|--ignore-failed-sources' `
+        ($toolArgs -join '|') 'tool arguments pin the explicitly supplied version'
 
     $env:RestoreConfigFile = 'before.config'
     $env:RestoreSources = 'before-source'

--- a/tests/vs_reactor/ci/BootstrapFeedResolver.Tests.ps1
+++ b/tests/vs_reactor/ci/BootstrapFeedResolver.Tests.ps1
@@ -230,7 +230,6 @@ try {
     Assert-Equal '-g|--add-source|C:\repo\local-nupkgs|--add-source|https://packagefeedproxy.microsoft.io/nuget/v3/index.json|Microsoft.UI.Reactor.Cli|--no-cache|--ignore-failed-sources' `
         ($toolArgs -join '|') 'tool arguments include both local and automatic proxy sources'
 
-<<<<<<< HEAD
     # Resolve-ReactorNuGetFeedOverride is what scripts a developer runs directly
     # (Build-Vsix.ps1) use: explicit arguments first, then the same user-config
     # discovery, and no network probe. $profile still carries `profile-proxy`

--- a/tools/BootstrapFeedResolver.ps1
+++ b/tools/BootstrapFeedResolver.ps1
@@ -261,11 +261,17 @@ function Get-ReactorRestoreArguments {
 #     stable 1.0.0 already installed; `dotnet tool update` refuses to move to a
 #     lower version even when pinned with --version.
 # So: a stable version, strictly greater than 1.0.0, every component inside
-# UInt16, and unique per run so a same-minute re-pack is still installable.
+# UInt16, and unique per run so a rapid re-pack is still installable.
 #   major    1
 #   minor    days since 2020-01-01 UTC   (~2400 today; UInt16 lasts ~179 years)
 #   patch    minute of day               (0-1439)
-#   revision second within the minute     (0-59)
+#   revision second*1000 + millisecond   (0-59999)
+#
+# The revision folds milliseconds in rather than using the second alone: two
+# runs started within the same second would otherwise collide, and a pinned
+# `dotnet tool update --version <same>` reports "already installed" and keeps
+# the older binary — the original failure mode. 59*1000+999 = 59999 still fits
+# UInt16.
 #
 # -Now is injectable so the shape, bounds, and ordering can be tested without
 # depending on the wall clock.
@@ -280,7 +286,13 @@ function Get-ReactorLocalCliVersion {
         throw "Local CLI version stamp is out of range: days-since-2020 = $days must be 1..65534 (system clock wrong?)."
     }
 
-    return '1.{0}.{1}.{2}' -f $days, [int]$utc.TimeOfDay.TotalMinutes, $utc.Second
+    # Floor, not [int]: PowerShell's [int] cast rounds half-to-even, so
+    # 23:59:59.999 (TotalMinutes 1439.99998) would become 1440 — outside the
+    # documented range, and every minute's last 30 seconds would be stamped
+    # with the *next* minute.
+    $minuteOfDay = [int][Math]::Floor($utc.TimeOfDay.TotalMinutes)
+
+    return '1.{0}.{1}.{2}' -f $days, $minuteOfDay, ($utc.Second * 1000 + $utc.Millisecond)
 }
 
 function Get-ReactorToolArguments {

--- a/tools/BootstrapFeedResolver.ps1
+++ b/tools/BootstrapFeedResolver.ps1
@@ -245,6 +245,44 @@ function Get-ReactorRestoreArguments {
     return @($arguments)
 }
 
+# Version stamp for the locally-packed `mur` global tool.
+#
+# Without an explicit -p:Version the SDK defaults to 1.0.0 on *every* commit, so
+# re-running bootstrap packed a byte-new binary under a version NuGet had already
+# seen. `dotnet tool update` compared 1.0.0 to 1.0.0, decided nothing was newer,
+# no-opped, and exited 0 — leaving a months-stale `mur` on PATH while bootstrap
+# reported success.
+#
+# The encoding has to clear three constraints at once, and the two obvious
+# candidates each fail one:
+#   * 1.<yyMMdd>.<HHmm> overflows AssemblyVersion/FileVersion, whose components
+#     are capped at 65534 (UInt16) -> CS7034 at build time.
+#   * 1.0.0-local.<stamp> is a prerelease of 1.0.0 and therefore sorts BELOW the
+#     stable 1.0.0 already installed; `dotnet tool update` refuses to move to a
+#     lower version even when pinned with --version.
+# So: a stable version, strictly greater than 1.0.0, every component inside
+# UInt16, and unique per run so a same-minute re-pack is still installable.
+#   major    1
+#   minor    days since 2020-01-01 UTC   (~2400 today; UInt16 lasts ~179 years)
+#   patch    minute of day               (0-1439)
+#   revision second within the minute     (0-59)
+#
+# -Now is injectable so the shape, bounds, and ordering can be tested without
+# depending on the wall clock.
+function Get-ReactorLocalCliVersion {
+    param(
+        [datetime]$Now = (Get-Date).ToUniversalTime()
+    )
+
+    $utc = $Now.ToUniversalTime()
+    $days = [int]($utc.Date - [datetime]'2020-01-01').TotalDays
+    if ($days -lt 1 -or $days -gt 65534) {
+        throw "Local CLI version stamp is out of range: days-since-2020 = $days must be 1..65534 (system clock wrong?)."
+    }
+
+    return '1.{0}.{1}.{2}' -f $days, [int]$utc.TimeOfDay.TotalMinutes, $utc.Second
+}
+
 function Get-ReactorToolArguments {
     param(
         [Parameter(Mandatory)][string]$Feed,
@@ -266,9 +304,14 @@ function Get-ReactorToolArguments {
     # resolves the highest version in the feed and compares it to what is
     # installed — and because the pack used to produce a constant `1.0.0` on
     # every commit, that comparison said "already up to date" and silently
-    # no-opped with exit 0. An explicit --version removes the dependency on
-    # version ordering entirely: the requested version is installed whether it
-    # sorts higher, lower, or equal.
+    # no-opped with exit 0.
+    #
+    # Pinning does NOT make ordering irrelevant: `dotnet tool update --version`
+    # still refuses to move to a *lower* version ("is lower than existing
+    # version ..."), and treats an equal version as already-installed. It only
+    # removes the "highest in feed" resolution step. Get-ReactorLocalCliVersion
+    # is therefore responsible for producing a version that is both strictly
+    # greater than 1.0.0 and unique per run.
     if (-not [string]::IsNullOrWhiteSpace($Version)) {
         $arguments.Add('--version')
         $arguments.Add($Version)

--- a/tools/BootstrapFeedResolver.ps1
+++ b/tools/BootstrapFeedResolver.ps1
@@ -249,7 +249,8 @@ function Get-ReactorToolArguments {
     param(
         [Parameter(Mandatory)][string]$Feed,
         [string]$NuGetConfig,
-        [string]$NuGetSource
+        [string]$NuGetSource,
+        [string]$Version
     )
 
     $arguments = New-Object System.Collections.Generic.List[string]
@@ -261,6 +262,17 @@ function Get-ReactorToolArguments {
         $arguments.Add($NuGetSource)
     }
     $arguments.Add('Microsoft.UI.Reactor.Cli')
+    # Pin the exact version we just packed. Without this, `dotnet tool update`
+    # resolves the highest version in the feed and compares it to what is
+    # installed — and because the pack used to produce a constant `1.0.0` on
+    # every commit, that comparison said "already up to date" and silently
+    # no-opped with exit 0. An explicit --version removes the dependency on
+    # version ordering entirely: the requested version is installed whether it
+    # sorts higher, lower, or equal.
+    if (-not [string]::IsNullOrWhiteSpace($Version)) {
+        $arguments.Add('--version')
+        $arguments.Add($Version)
+    }
     $arguments.Add('--no-cache')
     $arguments.Add('--ignore-failed-sources')
     if (-not [string]::IsNullOrWhiteSpace($NuGetConfig)) {


### PR DESCRIPTION
## Summary

Two independent bugs that both made the **installed** `mur` differ from the one contributors actually exercise. Neither is detectable from a dev machine, because in both cases the local path works and only the shipped path is broken.

Found while investigating why a locally-installed `mur` was reporting a build from 2026-06-02 on a checkout 1,249 commits ahead.

---

### 1. `bootstrap.ps1` silently left a stale global tool installed

`dotnet pack src/Reactor.Cli` ran without `-p:Version`, so **every commit packed as `1.0.0`**. Bootstrap detects an existing install and calls `dotnet tool update`, which compared `1.0.0` to `1.0.0`, concluded nothing was newer, and **no-opped with exit 0**. The only guard was `if ($LASTEXITCODE -ne 0)`, so bootstrap printed success while leaving the previously-installed binary in place.

Anyone who bootstrapped once has been running a frozen `mur` ever since, while every subsequent `./bootstrap.ps1` reported success. `mur upgrade` doesn't help either — it explicitly disclaims updating the tool itself (`UpgradeCommand.cs:13-16`) and refers you back to `bootstrap.ps1`, which no-ops. **Both documented refresh paths dead-ended.**

The fix stamps a per-run version and pins it on install. The encoding has to clear four constraints at once, and each obvious candidate fails one — all four are asserted by tests so they can't be reintroduced:

| Constraint | What violates it |
|---|---|
| components ≤ 65534 (UInt16) | `1.<yyMMdd>.<HHmm>` → **CS7034** at build time |
| must sort above the installed stable `1.0.0` | `1.0.0-local.<stamp>` is a *prerelease of* 1.0.0, so it sorts lower; `dotnet tool update` refuses to downgrade even with `--version` pinned |
| unique per run | `1.<days>.<minute>` collides on a same-minute re-run, so the install no-ops and keeps the older binary |
| ordered across a day boundary | any encoding that resets a high-order component |

Landed encoding: `1.<days since 2020-01-01>.<minute of day>.<second>`, e.g. `1.2430.276.24`.

**The more important half is the assertion.** An exit-code check structurally cannot detect a no-op, which is exactly what let this drift for months. Bootstrap now compares the SHA in `mur --version` against `HEAD` and fails loudly with remediation steps. It earned its keep during development — it correctly reported a mismatch while `dotnet tool update` was exiting 0.

### 2. `mur check` was dead on arrival in every installed copy

```
Unhandled exception. System.IO.FileNotFoundException: Could not load file or assembly
'Microsoft.CodeAnalysis.CSharp, Version=5.9.0.0, ...'
   at Microsoft.UI.Reactor.Cli.Check.CheckCommand.Run(String[] args)
```

`Reactor.Cli` referenced Roslyn with `PrivateAssets="all"` — the correct idiom for an **analyzer** project, which must not flow Roslyn to consumers, but wrong for a `PackAsTool` global tool: it excluded `Microsoft.CodeAnalysis{,.CSharp}.dll` from the shipped payload. The CLI doesn't just compile against Roslyn, it **executes** it (`Check/CompilationLoader.cs`, `Check/FactoryIndex.cs`, `Check/SuggesterOrchestrator.cs`, `Loc/InterpolationConverter.cs`).

The assemblies were still copied to `bin/`, so `dotnet run --project src/Reactor.Cli -- check` worked fine on a dev machine while the installed tool threw at startup.

This matters more than a normal packaging slip: `plugins/reactor/agents/reactor-dev.agent.md` prescribes `mur check` as the authoritative agent build loop (*"scaffold → edit → `mur check`"*), and spec 038 justifies it with a measured ~150K-token saving per agent loop. That workflow could not have been running for anyone using an installed `mur`.

**Blast-radius correction:** an earlier revision of this description said only the packed global tool was affected, and that the `dotnet publish` path used by `release.yml` was unverified. That was wrong — review confirmed the publish output was missing Roslyn too, so the **released skill-kit `mur` was equally broken**, not just locally-bootstrapped ones.

### 3. CI now runs `mur check` against the installed tool

`bootstrap.yml` exercised `mur --version`, `mur doctor`, and `mur upgrade` — none of which load Roslyn. That is precisely why bug #2 shipped invisibly. The new step runs `mur check --list-rules` from the installed tool and asserts the ruleset actually rendered, not merely that the exit code was 0.

Roslyn satellite resources are excluded (`SatelliteResourceLanguages=en`): removing `PrivateAssets` pulled in 26 localized resource assemblies, and `mur` surfaces compiler diagnostics verbatim so they translate only a fraction of its output. Packed payload **9.3 MB → 7.5 MB**, both Roslyn runtime assemblies retained.

---

## Verification

**End to end on a real machine:** `dotnet tool update` moved `1.0.0` → `1.2430.276.24` (previously a no-op); `mur --version` reports `HEAD`; the SHA assertion passes; re-running is idempotent; and `mur check --list-rules` — an unhandled exception before this PR — prints the six registered rules and exits 0.

**Payload, inspected at each step:**

```
total dlls in tools/ payload : 10 → 39 → 13   (13 after satellite exclusion)
Microsoft.CodeAnalysis*.dll  :  0 → 2
satellite resource dlls      :  0 → 26 → 0
```

**Tests.** The version stamp lives in `Get-ReactorLocalCliVersion` with an injectable `-Now`, covered by six assertions — one per constraint in the table above. Each was mutation-checked independently: dropping the seconds component, substituting the minutes component for minute-of-day, removing the range guard, and lowering major to `0` each redden the suite. The same-minute assertion was separately verified live by inverting its comparison, because a first failure aborts the block and can mask later ones.

All suites green under **both** hosts CI runs (pwsh 7 and Windows PowerShell 5.1): feed resolver 57, exit-code 27, VSIX feed 29.

## Notes for reviewers

- **Release was not built locally.** `nuget.org` is unreachable from this environment and `TreatWarningsAsErrors` is Release-only, so `NU1900` fails a local Release build regardless of these changes. CI is the Release gate.
- Rebased onto `main` after #1128 and #1129 merged; the conflict was additive in `BootstrapFeedResolver.Tests.ps1` (both sides appended cases) and both are kept.
- #1128's new CP1252 parse guard passes with these changes — the em-dashes added here are in comments, which that guard correctly treats as safe.