### PR TITLE
Gate doc-app snippets against the analyzers their readers actually get

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -637,6 +637,70 @@ jobs:
       - name: Tier-lint
         run: dotnet run --project src/Reactor.Cli -- docs check-tier
 
+  docs-snippet-gate:
+    name: Doc snippet analyzer gate
+    needs: changes
+    if: needs.changes.outputs.non-md == 'true'
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Restore
+        run: dotnet restore docs/_pipeline/apps/DocApps.proj -p:Platform=x64
+
+      # Every `snippet=` block in docs/guide/ is extracted verbatim from a doc app
+      # under docs/_pipeline/apps/, so a doc app IS the code we tell users to write.
+      # Two gaps let 276 analyzer diagnostics reach the published guides:
+      #
+      #   1. Only win2d-canvas was listed in Reactor.slnx, so the other 52 doc apps
+      #      were never compiled by CI at all.
+      #   2. A ProjectReference to src/Reactor does not flow Reactor.Analyzers —
+      #      it ships as a packed <None Pack="true"> item — so even that one app
+      #      compiled without the rules its own readers are subject to.
+      #
+      # Directory.Build.props now wires the consumer analyzer bundle in, and this
+      # job builds every app through it. The failure mode being prevented is a
+      # snippet that compiles yet warns (hard-coded colours), or worse, silently
+      # does nothing the surrounding prose claims (REACTOR_MOD_003 inert modifiers,
+      # REACTOR_HOOKS_001 conditional hooks).
+      #
+      # Warnings are scanned rather than promoted with -warnaserror because the
+      # restore in this environment also emits unrelated NU1900 noise, and a
+      # blanket promotion would fail on that instead of on snippet quality.
+      - name: Build doc apps with consumer analyzers
+        shell: pwsh
+        run: |
+          $log = dotnet build docs/_pipeline/apps/DocApps.proj -c Debug -p:Platform=x64 --no-restore -v:minimal -nologo 2>&1
+          $log | ForEach-Object { $_.ToString() }
+          $exit = $LASTEXITCODE
+
+          # Case-sensitive: an insensitive match also hits the restore's
+          # "warning NU1900: Error occurred while getting package vulnerability
+          # data", which would make this gate fail for reasons unrelated to docs.
+          # MSBuild prints each diagnostic twice (inline + summary), hence -Unique.
+          $diags = $log |
+            Select-String ': (warning|error) REACTOR_' -CaseSensitive |
+            ForEach-Object { ($_.Line -replace '\s*\[[^\]]*\]\s*$', '').Trim() } |
+            Sort-Object -Unique
+
+          if ($diags.Count -gt 0) {
+            Write-Host "::error::$($diags.Count) Reactor analyzer diagnostic(s) in doc-app snippets."
+            $diags | ForEach-Object { Write-Host "::error::$_" }
+            Write-Host ''
+            Write-Host 'These snippets are extracted verbatim into docs/guide/, so every one of'
+            Write-Host 'these warns in a reader''s project too. Fix them at the source in'
+            Write-Host 'docs/_pipeline/apps/<topic>/App.cs -- do not add NoWarn or #pragma.'
+            exit 1
+          }
+
+          if ($exit -ne 0) { throw "Doc apps failed to build (exit $exit)." }
+          Write-Host "OK: all doc apps built clean under the consumer analyzer bundle."
+
   docs-build:
     name: Docs build
     needs: changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -669,13 +669,15 @@ jobs:
       # does nothing the surrounding prose claims (REACTOR_MOD_003 inert modifiers,
       # REACTOR_HOOKS_001 conditional hooks).
       #
-      # Warnings are scanned rather than promoted with -warnaserror because the
-      # restore in this environment also emits unrelated NU1900 noise, and a
-      # blanket promotion would fail on that instead of on snippet quality.
+      # Warnings are promoted with MSBuild's own mechanism so the build itself fails on a
+      # diagnostic -- the scan below only turns that into readable annotations. Relying on the
+      # scan alone would make the gate depend on MSBuild's output text, which is not a contract.
+      # NU1900 ("Error occurred while getting package vulnerability data") is exempted rather than
+      # NoWarn'd, because NoWarn would replace each project's own list instead of adding to it.
       - name: Build doc apps with consumer analyzers
         shell: pwsh
         run: |
-          $log = dotnet build docs/_pipeline/apps/DocApps.proj -c Debug -p:Platform=x64 --no-restore -v:minimal -nologo 2>&1
+          $log = dotnet build docs/_pipeline/apps/DocApps.proj -c Debug -p:Platform=x64 --no-restore -v:minimal -nologo -p:TreatWarningsAsErrors=true -p:WarningsNotAsErrors=NU1900 2>&1
           $log | ForEach-Object { $_.ToString() }
           $exit = $LASTEXITCODE
 

--- a/docs/_pipeline/apps/Directory.Build.props
+++ b/docs/_pipeline/apps/Directory.Build.props
@@ -1,6 +1,20 @@
 <Project>
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)..\..\..\'))" />
 
+  <!-- Doc apps are *consumer* code: they are the literal source of every `snippet=`
+       block in docs/guide/. Consumers get Reactor.Analyzers automatically from the
+       nupkg (Reactor.csproj packs it to analyzers/dotnet/cs), but a ProjectReference
+       to src/Reactor does NOT flow that <None Pack="true"> item. Without this the doc
+       apps compiled clean while the exact same code warned in a real user's project —
+       which is how hard-coded colours and inert modifiers reached the published guides.
+       Wire the customer-facing bundle in explicitly so snippets are held to the same
+       bar as the code we tell people to write. -->
+  <ItemGroup>
+    <ProjectReference Include="$(MSBuildThisFileDirectory)..\..\..\src\Reactor.Analyzers\Reactor.Analyzers.csproj"
+                      OutputItemType="Analyzer"
+                      ReferenceOutputAssembly="false" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(Configuration)' == 'Debug'">
     <RuntimeHostConfigurationOption Include="Reactor.DevtoolsSupport"
                                     Value="true"

--- a/docs/_pipeline/apps/DocApps.proj
+++ b/docs/_pipeline/apps/DocApps.proj
@@ -1,0 +1,56 @@
+<!--
+  Builds every doc app under docs/_pipeline/apps/ in one pass.
+
+  Doc apps are the source of truth for every `snippet=` block in docs/guide/, but
+  only one of them (win2d-canvas) was ever listed in Reactor.slnx, so the other 52
+  were never compiled by CI. Combined with the fact that a ProjectReference to
+  src/Reactor does not flow the packed Reactor.Analyzers bundle (it is a
+  <None Pack="true"> item), a snippet could ship hard-coded colours, inert
+  modifiers, or conditional hook calls and still look green to everyone working on
+  the guides. Directory.Build.props next to this file wires the analyzers in; this
+  project is what gives CI a single thing to build.
+
+  Plain MSBuild rather than Microsoft.Build.Traversal: the repo does not already
+  depend on that SDK, and a doc-only gate is not worth a new package pin.
+
+  The glob is deliberate. A hand-maintained project list would reproduce the very
+  defect this gate exists to close, letting the *next* new doc app escape unbuilt,
+  so DocAppGateWiringTests floors the matched count against the directory count,
+  making a glob that silently stops matching a test failure in its own right.
+-->
+<Project DefaultTargets="Build">
+
+  <PropertyGroup>
+    <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
+    <Platform Condition="'$(Platform)' == ''">x64</Platform>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <DocApp Include="$(MSBuildThisFileDirectory)*\*.csproj" />
+  </ItemGroup>
+
+  <Target Name="Build">
+    <Message Importance="high" Text="Building doc apps ($(Configuration)|$(Platform))" />
+    <MSBuild Projects="@(DocApp)"
+             BuildInParallel="true"
+             Properties="Configuration=$(Configuration);Platform=$(Platform)" />
+  </Target>
+
+  <Target Name="Restore">
+    <MSBuild Projects="@(DocApp)"
+             Targets="Restore"
+             BuildInParallel="true"
+             Properties="Configuration=$(Configuration);Platform=$(Platform)" />
+  </Target>
+
+  <!-- CI always builds a fresh checkout, so Build re-runs the analyzers there. Locally the
+       incremental build is up-to-date and csc never re-runs, which reports zero diagnostics for
+       an app that is still dirty. Verifying a fix locally therefore has to go through Rebuild. -->
+  <Target Name="Rebuild">
+    <MSBuild Projects="@(DocApp)"
+             Targets="Rebuild"
+             BuildInParallel="true"
+             Properties="Configuration=$(Configuration);Platform=$(Platform)" />
+  </Target>
+
+</Project>

--- a/docs/_pipeline/apps/DocApps.proj
+++ b/docs/_pipeline/apps/DocApps.proj
@@ -36,10 +36,16 @@
              Properties="Configuration=$(Configuration);Platform=$(Platform)" />
   </Target>
 
+  <!-- Restore runs serially on purpose. All 53 doc apps ProjectReference the same framework
+       projects, so restoring them in parallel has NuGet writing the shared assets/nuget.g.props
+       files from several processes at once — which failed on the CI runner with
+       "NuGet.targets(198,5): error : Cannot create a file when that file already exists."
+       Restore is cheap and idempotent, so serialising it costs little; Build below stays parallel
+       because MSBuild dedupes a shared project reference within one build session. -->
   <Target Name="Restore">
     <MSBuild Projects="@(DocApp)"
              Targets="Restore"
-             BuildInParallel="true"
+             BuildInParallel="false"
              Properties="Configuration=$(Configuration);Platform=$(Platform)" />
   </Target>
 

--- a/docs/_pipeline/apps/DocApps.proj
+++ b/docs/_pipeline/apps/DocApps.proj
@@ -29,19 +29,24 @@
     <DocApp Include="$(MSBuildThisFileDirectory)*\*.csproj" />
   </ItemGroup>
 
+  <!-- Every target runs serially, and that costs almost nothing: a measured Rebuild of all 53
+       apps takes 45s serial vs 43s parallel, because the real work is the shared framework
+       projects, which are built once either way. Each doc app is a small compile on top.
+
+       Parallelism is what it buys us trouble for. All 53 apps ProjectReference the same framework
+       projects, so building or restoring them concurrently has several processes writing the same
+       obj/bin and NuGet assets. Restore failed exactly that way on the first CI run
+       ("NuGet.targets(198,5): error : Cannot create a file when that file already exists"), and
+       AGENTS.md documents the matching build-side hazard (`CSC error CS2012 ... used by another
+       process` under parallel WinUI builds). A gate that fails intermittently gets switched off,
+       so this one trades two seconds for determinism. -->
   <Target Name="Build">
     <Message Importance="high" Text="Building doc apps ($(Configuration)|$(Platform))" />
     <MSBuild Projects="@(DocApp)"
-             BuildInParallel="true"
+             BuildInParallel="false"
              Properties="Configuration=$(Configuration);Platform=$(Platform)" />
   </Target>
 
-  <!-- Restore runs serially on purpose. All 53 doc apps ProjectReference the same framework
-       projects, so restoring them in parallel has NuGet writing the shared assets/nuget.g.props
-       files from several processes at once — which failed on the CI runner with
-       "NuGet.targets(198,5): error : Cannot create a file when that file already exists."
-       Restore is cheap and idempotent, so serialising it costs little; Build below stays parallel
-       because MSBuild dedupes a shared project reference within one build session. -->
   <Target Name="Restore">
     <MSBuild Projects="@(DocApp)"
              Targets="Restore"
@@ -55,7 +60,7 @@
   <Target Name="Rebuild">
     <MSBuild Projects="@(DocApp)"
              Targets="Rebuild"
-             BuildInParallel="true"
+             BuildInParallel="false"
              Properties="Configuration=$(Configuration);Platform=$(Platform)" />
   </Target>
 

--- a/docs/_pipeline/apps/accessibility/App.cs
+++ b/docs/_pipeline/apps/accessibility/App.cs
@@ -49,7 +49,7 @@ class Tier2Demo : Component
             ).FullDescription(
                 "Bar chart showing Q1 revenue: East $4.2M, " +
                 "West $3.8M, Central $2.1M")
-             .Padding(16).Background("#f5f5f5").CornerRadius(8),
+             .Padding(16).Background(Theme.CardBackground).CornerRadius(8),
             TextBlock("Decorative divider")
                 .Opacity(0.2)
                 .AccessibilityHidden()
@@ -151,21 +151,21 @@ class FocusTrapDemo : Component
         return VStack(12,
             SubHeading("Focus Trapping"),
             Button("Open Modal", () => setShowModal(true)),
-            When(showModal, () =>
-                Border(
-                    VStack(12,
-                        TextBlock("Modal Dialog").FontSize(18).Bold(),
-                        TextBlock("Tab/Shift+Tab stays inside this panel."),
-                        TextBox("", _ => { }, placeholderText: "Name")
-                            .TabIndex(0),
-                        Button("Close", () => setShowModal(false))
-                            .TabIndex(1)
-                    ).Padding(24)
-                ).WithBorder("#888", 1)
-                 .CornerRadius(8)
-                 .Background("#ffffff")
-                 .FocusTrap(trap)
-            )
+            Border(
+                VStack(12,
+                    TextBlock("Modal Dialog").FontSize(18).Bold(),
+                    TextBlock("Tab/Shift+Tab stays inside this panel."),
+                    TextBox("", _ => { }, placeholderText: "Name")
+                        .AutomationName("Name")
+                        .TabIndex(0),
+                    Button("Close", () => setShowModal(false))
+                        .TabIndex(1)
+                ).Padding(24)
+            ).WithBorder(Theme.CardStroke, 1)
+             .CornerRadius(8)
+             .Background(Theme.SolidBackground)
+             .FocusTrap(trap)
+             .IsVisible(showModal)
         ).Padding(24);
     }
 }
@@ -210,6 +210,8 @@ class SemanticPanelDemo : Component
                 Button(i <= rating ? "\u2605" : "\u2606",
                     () => setRating(i))
                     .AutomationName($"{i} star{(i == 1 ? "" : "s")}")
+                    .AccessibilityHidden()
+                    .WithKey($"star-{i}")
             ).ToArray())
             .Semantics(
                 role: "slider",

--- a/docs/_pipeline/apps/advanced/App.cs
+++ b/docs/_pipeline/apps/advanced/App.cs
@@ -159,8 +159,11 @@ class ObservableTreeDemo : Component
 // <snippet:observable-collection>
 class ObservableCollectionDemo : Component
 {
-    private static readonly ObservableCollection<string> _tasks = new()
-        { "Review pull request", "Update documentation" };
+    private record TaskItem(int Id, string Title);
+
+    private static int _nextId = 3;
+    private static readonly ObservableCollection<TaskItem> _tasks = new()
+        { new TaskItem(1, "Review pull request"), new TaskItem(2, "Update documentation") };
 
     public override Element Render()
     {
@@ -175,15 +178,17 @@ class ObservableCollectionDemo : Component
                     .Width(200),
                 Button("Add", () => {
                     if (!string.IsNullOrWhiteSpace(input))
-                    { _tasks.Add(input.Trim()); setInput(""); }
+                    { _tasks.Add(new TaskItem(_nextId++, input.Trim())); setInput(""); }
                 })
             ),
             TextBlock($"{tasks.Count} tasks:").SemiBold(),
             VStack(4, tasks.Select((task, i) =>
                 HStack(8,
-                    TextBlock($"{i + 1}. {task}"),
-                    Button("Remove", () => _tasks.RemoveAt(i))
-                ).WithKey($"task-{i}-{task}")
+                    // The index is fine for display; it must not become the key.
+                    TextBlock($"{i + 1}. {task.Title}"),
+                    Button("Remove", () => _tasks.Remove(task))
+                        .AutomationName($"Remove {task.Title}")
+                ).WithKey(task.Id.ToString())   // stable identity survives removal
             ).ToArray())
         ).Padding(24);
     }

--- a/docs/_pipeline/apps/advanced/App.cs
+++ b/docs/_pipeline/apps/advanced/App.cs
@@ -26,10 +26,10 @@ class ErrorBoundaryDemo : Component
                 Component<BuggyComponent>(),
                 (Exception ex) => VStack(8,
                     TextBlock("Something went wrong").Bold()
-                        .Foreground("#d13438"),
+                        .Foreground(Theme.SystemCritical),
                     TextBlock(ex.Message).FontSize(12).Opacity(0.7)
                 ).Padding(12)
-                 .Background("#fde7e9")
+                 .Background(Theme.SystemCriticalBackground)
                  .CornerRadius(8)
             )
         ).Padding(24);
@@ -68,7 +68,7 @@ class MemoSubtreeDemo : Component
                         TextBlock("Skips re-render when deps unchanged")
                             .FontSize(12).Opacity(0.6)
                     ).Padding(12)
-                ).Background("#f0f0f0").CornerRadius(8);
+                ).Background(Theme.CardBackground).CornerRadius(8);
             }, label)
         ).Padding(24);
     }
@@ -147,7 +147,8 @@ class ObservableTreeDemo : Component
                 header: "User Name"),
             ToggleSwitch(vm.DarkMode, v => vm.DarkMode = v,
                 header: "Dark Mode"),
-            Slider(vm.FontSize, 10, 32, v => vm.FontSize = (int)v),
+            Slider(vm.FontSize, 10, 32, v => vm.FontSize = (int)v)
+                .AutomationName("Font size"),
             TextBlock($"Preview: {vm.UserName}")
                 .FontSize(vm.FontSize).Bold()
         ).Padding(24);
@@ -170,6 +171,7 @@ class ObservableCollectionDemo : Component
             SubHeading("UseCollection"),
             HStack(8,
                 TextBox(input, setInput, placeholderText: "New task")
+                    .AutomationName("New task")
                     .Width(200),
                 Button("Add", () => {
                     if (!string.IsNullOrWhiteSpace(input))
@@ -198,7 +200,9 @@ class ElementRefFocusDemo : Component
 
         return VStack(12,
             SubHeading("Imperative focus via ElementRef<T>"),
-            TextBox(name, setName, placeholderText: "Name").Ref(fieldRef),
+            TextBox(name, setName, placeholderText: "Name")
+                .AutomationName("Name")
+                .Ref(fieldRef),
             Button("Focus the field", () =>
                 fieldRef.Current?.Focus(FocusState.Programmatic))
         ).Padding(24);
@@ -226,9 +230,10 @@ class CustomHookDemo : Component
         var (isOn, toggle) = ctx.UseToggler();
         return VStack(8,
             SubHeading("Custom hook: UseToggler"),
-            Button(isOn ? "On" : "Off", toggle),
+            Button(isOn ? "On" : "Off", toggle)
+                .AutomationName("Toggle state"),
             TextBlock(isOn ? "State is on." : "State is off.")
-                .Foreground(isOn ? "#107c10" : "#666666")
+                .Foreground(isOn ? Theme.SystemSuccess : Theme.SecondaryText)
         ).Padding(24);
     });
 }
@@ -246,12 +251,12 @@ class ErrorBoundaryRetryDemo : Component
             ErrorBoundary(
                 Component<FlakyComponent>().WithKey($"flaky-{resetKey}"),
                 ex => VStack(8,
-                    TextBlock("Couldn't load.").Bold().Foreground("#d13438"),
+                    TextBlock("Couldn't load.").Bold().Foreground(Theme.SystemCritical),
                     TextBlock(ex.Message).FontSize(12).Opacity(0.7),
                     // Bumping resetKey reassigns identity to the child, so the
                     // ErrorBoundary mounts a fresh subtree on the next render.
                     Button("Retry", () => setResetKey(resetKey + 1))
-                ).Padding(12).Background("#fde7e9").CornerRadius(8)
+                ).Padding(12).Background(Theme.SystemCriticalBackground).CornerRadius(8)
             )
         ).Padding(24);
     }
@@ -263,7 +268,7 @@ class FlakyComponent : Component
     {
         var (attempt, _) = UseState(Random.Shared.Next(0, 3));
         if (attempt == 0) throw new InvalidOperationException("Service unavailable");
-        return TextBlock("Loaded.").Foreground("#107c10");
+        return TextBlock("Loaded.").Foreground(Theme.SystemSuccess);
     }
 }
 // </snippet:error-boundary-retry>
@@ -373,8 +378,12 @@ class MemoCellsDemo : Component
 // current when the closure was created.
 class WrongThisCaptureDemo : Component
 {
-    public override Element Render() =>
-        Button("Load").Set(b => b.Loaded += (s, e) => this.OnChildLoaded());
+    public override Element Render()
+    {
+        // Don't do this:
+        // return Button("Load").Set(b => b.Loaded += (s, e) => this.OnChildLoaded());
+        return Button("Load");
+    }
 
     void OnChildLoaded() { }
 }

--- a/docs/_pipeline/apps/animation/App.cs
+++ b/docs/_pipeline/apps/animation/App.cs
@@ -17,7 +17,8 @@ class OpacityDemo : Component
         return VStack(12,
             SubHeading("Opacity Transition"),
             Button(visible ? "Fade Out" : "Fade In",
-                () => setVisible(!visible)),
+                () => setVisible(!visible))
+                .AutomationName(visible ? "Fade out text" : "Fade in text"),
             TextBlock("This text fades in and out")
                 .FontSize(18).Bold()
                 .Opacity(visible ? 1.0 : 0.0)
@@ -37,12 +38,13 @@ class ScaleDemo : Component
         return VStack(12,
             SubHeading("Scale Transition"),
             Button(enlarged ? "Shrink" : "Enlarge",
-                () => setEnlarged(!enlarged)),
+                () => setEnlarged(!enlarged))
+                .AutomationName(enlarged ? "Shrink sample" : "Enlarge sample"),
             Border(
                 TextBlock("Scales up and down").FontSize(18).Bold()
             ).Padding(12)
              .CornerRadius(8)
-             .Background("#e8e8e8")
+             .Background(Theme.CardBackground)
              .Scale(enlarged ? 1.5f : 1.0f)
              .ScaleTransition()
         ).Padding(24);
@@ -60,7 +62,8 @@ class TranslationDemo : Component
         return VStack(12,
             SubHeading("Translation Transition"),
             Button(moved ? "Slide Back" : "Slide Right",
-                () => setMoved(!moved)),
+                () => setMoved(!moved))
+                .AutomationName(moved ? "Slide sample back" : "Slide sample right"),
             TextBlock("Slides horizontally")
                 .FontSize(18).Bold()
                 .Translation(moved ? 120f : 0f, 0f, 0f)
@@ -80,13 +83,14 @@ class BackgroundDemo : Component
         return VStack(12,
             SubHeading("Background Transition"),
             Button(warm ? "Cool Colors" : "Warm Colors",
-                () => setWarm(!warm)),
+                () => setWarm(!warm))
+                .AutomationName(warm ? "Switch to cool colors" : "Switch to warm colors"),
             VStack(8,
                 TextBlock("Background animates between colors")
-                    .Foreground("#ffffff").Bold()
+                    .Foreground(Theme.AccentText).Bold()
             ).Padding(16)
              .CornerRadius(8)
-             .Background(warm ? "#da3b01" : "#0078d4")
+             .Background(warm ? Theme.SystemCaution : Theme.Accent)
              .BackgroundTransition(TimeSpan.FromMilliseconds(600))
         ).Padding(24);
     }
@@ -103,13 +107,14 @@ class CombinedDemo : Component
         return VStack(12,
             SubHeading("Combined Transitions"),
             Button(active ? "Reset" : "Animate",
-                () => setActive(!active)),
+                () => setActive(!active))
+                .AutomationName(active ? "Reset combined transitions" : "Run combined transitions"),
             Border(
                 TextBlock("All at once").FontSize(16).Bold()
-                    .Foreground("#ffffff")
+                    .Foreground(Theme.AccentText)
             ).Padding(16)
              .CornerRadius(8)
-             .Background("#7b2ab5")
+             .Background(Theme.Accent)
              .Opacity(active ? 1.0 : 0.4)
              .Scale(active ? 1.2f : 1.0f)
              .Translation(active ? 40f : 0f, 0f, 0f)
@@ -137,14 +142,16 @@ class LayoutAnimationDemo : Component
                 {
                     nextId.Current++;
                     updateItems(l => [$"Item {nextId.Current}", .. l]);
-                }),
+                }).AutomationName("Add layout animation item"),
                 Button("Remove First", () =>
                     updateItems(l => l.Count > 0 ? l[1..] : l))
+                    .AutomationName("Remove first layout animation item")
             ),
             VStack(4, items.Select(item =>
-                TextBlock(item)
-                    .Padding(horizontal: 8, vertical: 12)
-                    .Background("#f0f0f0")
+                Border(
+                    TextBlock(item)
+                ).Padding(horizontal: 8, vertical: 12)
+                    .Background(Theme.CardBackground)
                     .CornerRadius(4)
                     .LayoutAnimation()
                     .WithKey($"item-{item}")
@@ -163,7 +170,8 @@ class ConnectedAnimationDemo : Component
 
         if (selected is not null)
             return VStack(12,
-                Button("Back to list", () => setSelected(null)),
+                Button("Back to list", () => setSelected(null))
+                    .AutomationName("Return to animation list"),
                 TextBlock(selected)
                     .FontSize(28).Bold()
                     .ConnectedAnimation($"title-{selected}")
@@ -175,7 +183,9 @@ class ConnectedAnimationDemo : Component
             VStack(4,
                 items.Select(item =>
                     Button(item, () => setSelected(item))
+                        .AutomationName($"Open {item}")
                         .ConnectedAnimation($"title-{item}")
+                        .WithKey($"source-{item}")
                 ).ToArray()
             )
         ).Padding(24);
@@ -199,7 +209,7 @@ class WithAnimationDemo : Component
                     {
                         setOpacity(opacity > 0.5 ? 0.2 : 1.0);
                     });
-            }),
+            }).AutomationName(opacity > 0.5 ? "Fade out with animation" : "Fade in with animation"),
             TextBlock("Compositor-animated via WithAnimation scope")
                 .FontSize(18).Bold()
                 .Opacity(opacity)
@@ -217,10 +227,11 @@ class AnimateDemo : Component
 
         return VStack(12,
             SubHeading(".Animate() Modifier"),
-            Button(active ? "Reset" : "Animate", () => setActive(!active)),
+            Button(active ? "Reset" : "Animate", () => setActive(!active))
+                .AutomationName(active ? "Reset animate modifier" : "Run animate modifier"),
             Border(
                 TextBlock("Spring-animated").FontSize(18).Bold()
-            ).Padding(12).CornerRadius(8).Background("#e8e8e8")
+            ).Padding(12).CornerRadius(8).Background(Theme.CardBackground)
              .Opacity(active ? 0.5 : 1.0)
              .Animate(Microsoft.UI.Reactor.Animation.Curve.Spring(0.65f))
         ).Padding(24);
@@ -240,14 +251,14 @@ class InteractionStatesDemo : Component
                 Border(
                     TextBlock("Hover me").FontSize(16).Bold()
                         .HAlign(HorizontalAlignment.Center).VAlign(VerticalAlignment.Center)
-                ).Padding(16).CornerRadius(8).Size(150, 60).Background("#50C878")
+                ).Padding(16).CornerRadius(8).Size(150, 60).Background(Theme.SystemSuccess)
                  .InteractionStates(s => s
                     .PointerOver(opacity: 0.85f, scale: 1.05f)
                     .Pressed(scale: 0.95f, opacity: 0.7f)),
                 Border(
                     TextBlock("Press me").FontSize(16).Bold()
                         .HAlign(HorizontalAlignment.Center).VAlign(VerticalAlignment.Center)
-                ).Padding(16).CornerRadius(8).Size(150, 60).Background("#9B59B6")
+                ).Padding(16).CornerRadius(8).Size(150, 60).Background(Theme.AccentSecondary)
                  .InteractionStates(s => s
                     .PointerOver(scale: 1.03f)
                     .Pressed(scale: 0.97f, opacity: 0.8f),
@@ -267,12 +278,13 @@ class TransitionDemo : Component
 
         return VStack(12,
             SubHeading("Enter/Exit Transition"),
-            Button(visible ? "Hide" : "Show", () => setVisible(!visible)),
+            Button(visible ? "Hide" : "Show", () => setVisible(!visible))
+                .AutomationName(visible ? "Hide transition sample" : "Show transition sample"),
             visible
                 ? Border(
                     TextBlock("Fade + Slide").FontSize(16).Bold()
                         .HAlign(HorizontalAlignment.Center).VAlign(VerticalAlignment.Center)
-                ).Padding(12).CornerRadius(8).Size(200, 60).Background("#E74C3C")
+                ).Padding(12).CornerRadius(8).Size(200, 60).Background(Theme.SystemCritical)
                  .Transition(Microsoft.UI.Reactor.Animation.Transition.Fade + Microsoft.UI.Reactor.Animation.Transition.Slide(Microsoft.UI.Reactor.Animation.Edge.Bottom))
                 : (Element)TextBlock("(removed from tree)")
         ).Padding(24);
@@ -285,13 +297,15 @@ class StaggerDemo : Component
 {
     public override Element Render()
     {
-        var (items, setItems) = UseState(new[] { "One", "Two", "Three", "Four", "Five" });
+        var initialItems = UseMemo(() => new[] { "One", "Two", "Three", "Four", "Five" });
+        var (items, setItems) = UseState(initialItems);
 
         return VStack(12,
             SubHeading("Staggered Animation"),
-            Button("Shuffle", () => setItems(items.OrderBy(_ => Random.Shared.Next()).ToArray())),
+            Button("Shuffle", () => setItems(items.OrderBy(_ => Random.Shared.Next()).ToArray()))
+                .AutomationName("Shuffle staggered items"),
             VStack(4, items.Select(item =>
-                TextBlock(item).Padding(horizontal: 8, vertical: 12).Background("#f0f0f0")
+                Border(TextBlock(item)).Padding(horizontal: 8, vertical: 12).Background(Theme.CardBackground)
                     .CornerRadius(4).LayoutAnimation()
                     .WithKey(item)
             ).ToArray()).Stagger(TimeSpan.FromMilliseconds(40))
@@ -309,11 +323,12 @@ class KeyframeDemo : Component
 
         return VStack(12,
             SubHeading("Keyframe Animation"),
-            Button("Pulse!", () => setCount(count + 1)),
+            Button("Pulse!", () => setCount(count + 1))
+                .AutomationName("Run pulse keyframe animation"),
             Border(
                 TextBlock("Pulse target").FontSize(16).Bold()
                     .HAlign(HorizontalAlignment.Center).VAlign(VerticalAlignment.Center)
-            ).Padding(12).CornerRadius(8).Size(200, 60).Background("#9B59B6")
+            ).Padding(12).CornerRadius(8).Size(200, 60).Background(Theme.AccentSecondary)
              .Keyframes("pulse", count, kf => kf
                 .Duration(600)
                 .At(0.0f, scale: global::System.Numerics.Vector3.One)
@@ -340,7 +355,7 @@ class ChoreographyDemo : Component
                     Microsoft.UI.Reactor.Animation.Curve.Ease(200), () => setPhase(1));
                 await Microsoft.UI.Reactor.Animation.AnimationScope.WithAnimationAsync(
                     Microsoft.UI.Reactor.Animation.Curve.Spring(0.7f), () => setPhase(2));
-            }),
+            }).AutomationName("Run choreography sequence"),
             TextBlock($"Phase: {phase}").FontSize(18).Bold()
                 .Opacity(phase == 0 ? 1.0 : phase == 1 ? 0.3 : 1.0)
         ).Padding(24);
@@ -361,8 +376,9 @@ class TransactionalAnimateDemo : Component
 {
     public override Element Render()
     {
-        var (items, setItems) = UseState<IReadOnlyList<Todo>>(
+        var initialItems = UseMemo<IReadOnlyList<Todo>>(() =>
             [new Todo("seed-1", "First"), new Todo("seed-2", "Second")]);
+        var (items, setItems) = UseState(initialItems);
 
         return VStack(12,
             SubHeading("Animations.Animate — structural changes"),
@@ -371,7 +387,8 @@ class TransactionalAnimateDemo : Component
             // with a spring. No per-element modifier needed.
             Button("Add", () =>
                 Animations.Animate(AnimationKind.Spring, () =>
-                    setItems([.. items, new Todo(Guid.NewGuid().ToString(), "New")]))),
+                    setItems([.. items, new Todo(Guid.NewGuid().ToString(), "New")])))
+                .AutomationName("Add animated todo"),
 
             ListView<Todo>(items, (t, _) => TextBlock(t.Title).Padding(8))
                 .Height(200)

--- a/docs/_pipeline/apps/async-resources-cookbook/App.cs
+++ b/docs/_pipeline/apps/async-resources-cookbook/App.cs
@@ -134,20 +134,21 @@ class InfiniteScrollExample : Component
             },
             deps: new object[] { "repo-main" });
 
-        // With a real virtualizer, drive fetches from ItemAt inside VirtualList's
-        // renderItem. The important bit: null return = placeholder row.
         return VStack(4,
             Heading($"Commits ({commits.TotalCount ?? 0})").FontSize(14),
-            VStack(2,
-                Enumerable.Range(0, Math.Min(commits.Items.Count, 6))
-                    .Select(i =>
-                    {
-                        var commit = commits.ItemAt(i);
-                        return commit is null
-                            ? TextBlock("…").Opacity(0.4).Padding(4)
-                            : TextBlock($"{commit.Sha} — {commit.Message}").Padding(4);
-                    })
-                    .ToArray())
+            VirtualList(
+                itemCount: commits.TotalCount ?? Math.Max(commits.Items.Count, 20),
+                renderItem: i =>
+                {
+                    var commit = commits.ItemAt(i);
+                    return commit is null
+                        ? TextBlock("…").Opacity(0.4).Padding(4)
+                        : TextBlock($"{commit.Sha} — {commit.Message}").Padding(4);
+                },
+                getItemKey: i => commits.ItemAt(i)?.Sha ?? $"placeholder-{i}",
+                itemHeight: 32,
+                onVisibleRangeChanged: (first, last) => commits.EnsureRange(first, last))
+                .Height(200)
         ).Padding(24);
     }
 }
@@ -175,7 +176,8 @@ class UseMutationExample : Component
             Heading($"Todos ({todos.Count})").FontSize(14),
             VStack(2, todos.Select(t =>
                 TextBlock(t.Title + (t.IsTemporary ? " (saving…)" : ""))
-                    .Opacity(t.IsTemporary ? 0.5 : 1.0)).ToArray()),
+                    .Opacity(t.IsTemporary ? 0.5 : 1.0)
+                    .WithKey(t.Title)).ToArray()),
             Button("Add Todo",
                 () => _ = mutation.RunAsync(new DemoApi.TodoInput($"Item {todos.Count + 1}")))
         ).Padding(24);

--- a/docs/_pipeline/apps/calculator/App.cs
+++ b/docs/_pipeline/apps/calculator/App.cs
@@ -68,10 +68,19 @@ class CalculatorApp : Component
 
         Element NumButton(string digit) =>
             Button(digit, () => PressDigit(digit))
+                .AutomationName($"Digit {digit}")
                 .Width(60).Height(48);
 
         Element OpButton(string label, string opCode) =>
             Button(label, () => PressOp(opCode))
+                .AutomationName(opCode switch
+                {
+                    "+" => "Add",
+                    "-" => "Subtract",
+                    "*" => "Multiply",
+                    "/" => "Divide",
+                    _ => $"Operator {label}"
+                })
                 .Width(60).Height(48);
 
         return VStack(4,
@@ -90,7 +99,9 @@ class CalculatorApp : Component
                        NumButton("1"), NumButton("2"), NumButton("3")),
             HStack(4, OpButton("-", "-"),
                        NumButton("0"), OpButton("+", "+"),
-                       Button("=", PressEquals).Width(60).Height(48))
+                       Button("=", PressEquals)
+                          .AutomationName("Equals")
+                          .Width(60).Height(48))
         ).Padding(16);
     }
 

--- a/docs/_pipeline/apps/charting/App.cs
+++ b/docs/_pipeline/apps/charting/App.cs
@@ -16,19 +16,19 @@ record CategoryData(string Name, double Value);
 // <snippet:line-chart>
 class LineChartDemo : Component
 {
+    private static readonly SalesPoint[] Data =
+    [
+        new(1, 120), new(2, 180), new(3, 150),
+        new(4, 220), new(5, 310), new(6, 280),
+        new(7, 350), new(8, 400), new(9, 380),
+        new(10, 420), new(11, 460), new(12, 510)
+    ];
+
     public override Element Render()
     {
-        var data = new SalesPoint[]
-        {
-            new(1, 120), new(2, 180), new(3, 150),
-            new(4, 220), new(5, 310), new(6, 280),
-            new(7, 350), new(8, 400), new(9, 380),
-            new(10, 420), new(11, 460), new(12, 510)
-        };
-
         return VStack(12,
             SubHeading("Line Chart"),
-            LineChart(data, d => d.Month, d => d.Revenue)
+            LineChart(Data, d => d.Month, d => d.Revenue)
                 .Title("Monthly Revenue — Line")
                 .SeriesName("Revenue")
                 .Units("months", "USD")
@@ -45,16 +45,16 @@ class LineChartDemo : Component
 // <snippet:bar-chart>
 class BarChartDemo : Component
 {
+    private static readonly SalesPoint[] Data =
+    [
+        new(1, 340), new(2, 420), new(3, 510), new(4, 380)
+    ];
+
     public override Element Render()
     {
-        var data = new SalesPoint[]
-        {
-            new(1, 340), new(2, 420), new(3, 510), new(4, 380)
-        };
-
         return VStack(12,
             SubHeading("Bar Chart"),
-            BarChart(data, d => d.Month, d => d.Revenue)
+            BarChart(Data, d => d.Month, d => d.Revenue)
                 .Title("Quarterly Revenue — Bar")
                 .SeriesName("Revenue")
                 .Units("quarters", "USD")
@@ -71,19 +71,19 @@ class BarChartDemo : Component
 // <snippet:area-chart>
 class AreaChartDemo : Component
 {
+    private static readonly SalesPoint[] Data =
+    [
+        new(1, 50), new(2, 120), new(3, 200),
+        new(4, 350), new(5, 480), new(6, 600),
+        new(7, 720), new(8, 850), new(9, 1020),
+        new(10, 1150), new(11, 1300), new(12, 1500)
+    ];
+
     public override Element Render()
     {
-        var data = new SalesPoint[]
-        {
-            new(1, 50), new(2, 120), new(3, 200),
-            new(4, 350), new(5, 480), new(6, 600),
-            new(7, 720), new(8, 850), new(9, 1020),
-            new(10, 1150), new(11, 1300), new(12, 1500)
-        };
-
         return VStack(12,
             SubHeading("Area Chart"),
-            AreaChart(data, d => d.Month, d => d.Revenue)
+            AreaChart(Data, d => d.Month, d => d.Revenue)
                 .Title("Monthly Revenue — Area")
                 .SeriesName("Revenue")
                 .Units("months", "USD")
@@ -101,19 +101,19 @@ class AreaChartDemo : Component
 // <snippet:pie-chart>
 class PieChartDemo : Component
 {
+    private static readonly CategoryData[] Data =
+    [
+        new("Engineering", 42),
+        new("Marketing", 18),
+        new("Sales", 25),
+        new("Support", 15)
+    ];
+
     public override Element Render()
     {
-        var data = new CategoryData[]
-        {
-            new("Engineering", 42),
-            new("Marketing", 18),
-            new("Sales", 25),
-            new("Support", 15)
-        };
-
         return VStack(12,
             SubHeading("Pie Chart"),
-            PieChart(data, d => d.Value, d => d.Name)
+            PieChart(Data, d => d.Value, d => d.Name)
                 .Title("Team Distribution")
                 .Description("Pie chart showing team size across Engineering, Marketing, Sales, and Support.")
                 .Width(300).Height(300)
@@ -127,27 +127,28 @@ class PieChartDemo : Component
 // <snippet:combined-chart>
 class CombinedChartDemo : Component
 {
+    private static readonly SalesPoint[] Data2024 =
+    [
+        new(1, 100), new(2, 140), new(3, 180),
+        new(4, 200), new(5, 260), new(6, 300)
+    ];
+
+    private static readonly SalesPoint[] Data2025 =
+    [
+        new(1, 160), new(2, 220), new(3, 280),
+        new(4, 320), new(5, 390), new(6, 450)
+    ];
+
+    private static readonly string[] Years = ["2024", "2025"];
+
     public override Element Render()
     {
         var (year, setYear) = UseState(0);
-        var years = new[] { "2024", "2025" };
-
-        var data2024 = new SalesPoint[]
-        {
-            new(1, 100), new(2, 140), new(3, 180),
-            new(4, 200), new(5, 260), new(6, 300)
-        };
-        var data2025 = new SalesPoint[]
-        {
-            new(1, 160), new(2, 220), new(3, 280),
-            new(4, 320), new(5, 390), new(6, 450)
-        };
-
-        var data = year == 0 ? data2024 : data2025;
+        var data = year == 0 ? Data2024 : Data2025;
 
         return VStack(12,
             SubHeading("Interactive Chart"),
-            ComboBox(years, year, setYear),
+            ComboBox(Years, year, setYear),
             AreaChart(data, d => d.Month, d => d.Revenue)
                 .Title("Revenue by Year")
                 .SeriesName("Revenue")
@@ -165,12 +166,14 @@ class CombinedChartDemo : Component
 // <snippet:dynamic-data>
 class DynamicDataDemo : Component
 {
+    private static readonly List<SalesPoint> InitialPoints =
+        Enumerable.Range(1, 8)
+            .Select(i => new SalesPoint(i, Random.Shared.Next(50, 500)))
+            .ToList();
+
     public override Element Render()
     {
-        var (points, updatePoints) = UseReducer(
-            Enumerable.Range(1, 8)
-                .Select(i => new SalesPoint(i, Random.Shared.Next(50, 500)))
-                .ToList());
+        var (points, updatePoints) = UseReducer(InitialPoints);
 
         return VStack(12,
             SubHeading("Dynamic Data"),
@@ -197,26 +200,26 @@ class DynamicDataDemo : Component
 /// </summary>
 class PieLabelViewDemo : Component
 {
+    private static readonly CategoryData[] Data =
+    [
+        new("Engineering", 42), new("Sales", 25),
+        new("Marketing", 18),   new("Support", 15)
+    ];
+
     public override Element Render()
     {
-        var data = new CategoryData[]
-        {
-            new("Engineering", 42), new("Sales", 25),
-            new("Marketing", 18),   new("Support", 15)
-        };
-
         return VStack(12,
             SubHeading("Pie LabelView"),
             // <snippet:pie-label-view>
             // Percent rendered inside the slice. The string label accessor
             // is still passed so screen readers describe the slice.
-            PieChart(data, d => d.Value, d => d.Name)
+            PieChart(Data, d => d.Value, d => d.Name)
                 .Title("Team Distribution")
                 .Width(300).Height(300)
                 .InnerRadius(50).PadAngle(0.02)
                 .LabelView((d, layout) =>
                     TextBlock($"{layout.Fraction:P0}")
-                        .FontSize(12).Bold().Foreground("White"))
+                        .FontSize(12).Bold().Foreground(Theme.AccentText))
             // </snippet:pie-label-view>
         ).Padding(24);
     }
@@ -228,28 +231,28 @@ class PieLabelViewDemo : Component
 /// </summary>
 class AxisTickViewDemo : Component
 {
+    private static readonly SalesPoint[] Data =
+    [
+        new(1, 120), new(2, 180), new(3, 150),
+        new(4, 220), new(5, 310), new(6, 280)
+    ];
+
+    private static readonly string[] Months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun"];
+
     public override Element Render()
     {
-        var data = new SalesPoint[]
-        {
-            new(1, 120), new(2, 180), new(3, 150),
-            new(4, 220), new(5, 310), new(6, 280)
-        };
-
-        string[] months = { "Jan", "Feb", "Mar", "Apr", "May", "Jun" };
-
         return VStack(12,
             SubHeading("Axis XTickLabelView"),
             // <snippet:axis-tick-view>
             // X axis ticks: render month name plus a caption per tick.
-            LineChart(data, d => d.Month, d => d.Revenue)
+            LineChart(Data, d => d.Month, d => d.Revenue)
                 .Title("Revenue by Month")
                 .SeriesName("Revenue")
                 .Width(600).Height(220)
                 .Stroke("#0078D4").StrokeWidth(2.5)
                 .ShowGrid(true).ShowAxes(true)
                 .XTickLabelView(t => VStack(2,
-                    TextBlock(months[Math.Clamp((int)t - 1, 0, months.Length - 1)])
+                    TextBlock(Months[Math.Clamp((int)t - 1, 0, Months.Length - 1)])
                         .FontSize(11).SemiBold(),
                     TextBlock("month").FontSize(8).Opacity(0.6)))
             // </snippet:axis-tick-view>
@@ -266,19 +269,19 @@ class AxisTickViewDemo : Component
 /// </summary>
 class AccessibleChartDemo : Component
 {
+    private static readonly SalesPoint[] Data =
+    [
+        new(1, 120), new(2, 180), new(3, 150),
+        new(4, 220), new(5, 310), new(6, 280)
+    ];
+
     public override Element Render()
     {
-        var data = new SalesPoint[]
-        {
-            new(1, 120), new(2, 180), new(3, 150),
-            new(4, 220), new(5, 310), new(6, 280)
-        };
-
         return VStack(12,
             SubHeading("Accessible Chart"),
 
             // Static accessible chart: Title + SeriesName + Units
-            LineChart(data, d => d.Month, d => d.Revenue)
+            LineChart(Data, d => d.Month, d => d.Revenue)
                 .Title("Monthly Revenue 2024")
                 .SeriesName("Revenue")
                 .Units("months", "USD")
@@ -289,7 +292,7 @@ class AccessibleChartDemo : Component
                 .ShowGrid(true).ShowAxes(true),
 
             // Interactive accessible chart: adds keyboard nav and point invocation
-            BarChart(data, d => d.Month, d => d.Revenue)
+            BarChart(Data, d => d.Month, d => d.Revenue)
                 .Title("Monthly Revenue — Interactive")
                 .SeriesName("Revenue")
                 .Units("months", "USD")

--- a/docs/_pipeline/apps/cheat-sheet/App.cs
+++ b/docs/_pipeline/apps/cheat-sheet/App.cs
@@ -29,7 +29,8 @@ class StateVignette : Component
     public override Element Render()
     {
         var (count, setCount) = UseState(0);
-        return Button($"clicked {count}×", () => setCount(count + 1));
+        return Button($"clicked {count}×", () => setCount(count + 1))
+            .AutomationName($"Increment counter; clicked {count} times");
     }
 }
 // </snippet:state-vignette>
@@ -39,14 +40,14 @@ class EffectVignette : Component
 {
     public override Element Render()
     {
-        var (tick, setTick) = UseState(0);
+        var (tick, incrementTick) = UseReducer(0, threadSafe: true);
         UseEffect(() =>
         {
             var timer = new System.Timers.Timer(1000);
-            timer.Elapsed += (_, _) => setTick(tick + 1);
+            timer.Elapsed += (_, _) => incrementTick(t => t + 1);
             timer.Start();
             return () => timer.Dispose();
-        });
+        }, []);
         return TextBlock($"Tick: {tick}");
     }
 }

--- a/docs/_pipeline/apps/collections/App.cs
+++ b/docs/_pipeline/apps/collections/App.cs
@@ -84,7 +84,7 @@ class GridViewDemo : Component
                         TextBlock(contact.Name).Bold(),
                         TextBlock(contact.Email).FontSize(12).Opacity(0.6)
                     ).Padding(12)
-                     .Background("#f5f5f5")
+                     .Background(Theme.CardBackground)
                      .CornerRadius(8)
                      .Width(160).Height(80)
             ).Height(300)
@@ -128,7 +128,8 @@ class VirtualListRefDemo : Component
             SubHeading("VirtualListRef — Imperative Scroll"),
             HStack(8,
                 TextBox(targetIndex, setTargetIndex,
-                    placeholderText: "Index"),
+                    placeholderText: "Index")
+                    .AutomationName("Target index"),
                 Button("Scroll To", () =>
                 {
                     if (int.TryParse(targetIndex, out var idx))
@@ -155,17 +156,19 @@ class ForEachDemo : Component
     {
         var colors = new[]
         {
-            ("Red", "#ff4444"), ("Green", "#44ff44"),
-            ("Blue", "#4444ff"), ("Yellow", "#ffff44")
+            ("Primary", Theme.Accent), ("Secondary", Theme.AccentSecondary),
+            ("Tertiary", Theme.AccentTertiary), ("Subtle", Theme.SubtleFill)
         };
 
         return VStack(12,
             SubHeading("ForEach (non-virtualized)"),
             HStack(8,
-                ForEach(colors, ((string Name, string Hex) color) =>
-                    TextBlock(color.Name)
-                        .Padding(horizontal: 8, vertical: 16)
-                        .Background(color.Hex)
+                ForEach(colors, ((string Name, ThemeRef Brush) color) =>
+                    Border(
+                        TextBlock(color.Name)
+                            .Padding(horizontal: 8, vertical: 16)
+                    )
+                        .Background(color.Brush)
                         .CornerRadius(4)
                         .WithKey(color.Name)
                 )
@@ -181,7 +184,8 @@ class MultiSelectDemo : Component
     public override Element Render()
     {
         var contacts = SampleData.Contacts.Take(10).ToList();
-        var (selectedIds, setSelectedIds) = UseState(new List<string>());
+        var initialSelectedIds = UseMemo(() => new List<string>());
+        var (selectedIds, setSelectedIds) = UseState(initialSelectedIds);
 
         return VStack(12,
             SubHeading($"{selectedIds.Count} selected"),
@@ -207,29 +211,42 @@ class MultiSelectDemo : Component
 // <snippet:withkey>
 class WithKeyDemo : Component
 {
+    record FruitItem(string Id, string Name);
+
     public override Element Render()
     {
+        var initialItems = UseMemo(() => new List<FruitItem>
+        {
+            new("fruit-1", "Apple"),
+            new("fruit-2", "Banana"),
+            new("fruit-3", "Cherry")
+        });
         var (items, updateItems) = UseReducer(
-            new List<string> { "Apple", "Banana", "Cherry" });
+            initialItems);
         var (newItem, setNewItem) = UseState("");
+        var (nextId, setNextId) = UseState(4);
 
         return VStack(12,
             SubHeading("Stable Identity with WithKey"),
             HStack(8,
-                TextBox(newItem, setNewItem, placeholderText: "New item"),
+                TextBox(newItem, setNewItem, placeholderText: "New item")
+                    .AutomationName("New item"),
                 Button("Add", () => {
                     if (!string.IsNullOrWhiteSpace(newItem)) {
-                        updateItems(l => [.. l, newItem.Trim()]);
+                        var name = newItem.Trim();
+                        updateItems(l => [.. l, new FruitItem($"fruit-{nextId}", name)]);
+                        setNextId(nextId + 1);
                         setNewItem("");
                     }
                 })
             ),
-            VStack(4, items.Select((item, i) =>
+            VStack(4, items.Select((item, _) =>
                 HStack(8,
-                    TextBlock(item),
+                    TextBlock(item.Name),
                     Button("Remove", () => updateItems(
-                        l => l.Where((_, idx) => idx != i).ToList()))
-                ).WithKey($"item-{item}-{i}")
+                        l => l.Where(x => x.Id != item.Id).ToList()))
+                        .AutomationName($"Remove {item.Name}")
+                ).WithKey(item.Id)
             ).ToArray())
         ).Padding(24);
     }
@@ -278,15 +295,15 @@ class DragReorderDemo : Component
 {
     public override Element Render()
     {
-        var (items, setItems) = UseState(
-            new List<string> { "Alpha", "Bravo", "Charlie",
-                "Delta", "Echo", "Foxtrot" });
+        var initialItems = UseMemo(() => new List<string> { "Alpha", "Bravo", "Charlie",
+            "Delta", "Echo", "Foxtrot" });
+        var (items, setItems) = UseState(initialItems);
 
         // Reactor surfaces drag-reorder through the underlying WinUI
         // ListView's CanReorderItems / AllowDrop / CanDragItems. The
         // .Set passthrough is the supported escape hatch until a
-        // first-class fluent ships. The user's reorder is mirrored
-        // back into state via the ListView's reorder event.
+        // first-class fluent ships. The recipe linked below shows
+        // how to mirror a drop back into app state.
         return VStack(8,
             SubHeading("Drag to reorder"),
             ListView<string>(
@@ -398,6 +415,7 @@ class NoteEditor : Component<Note>
         return HStack(8,
             TextBlock(Props.Title).SemiBold(),
             Button(dirty ? "Dirty" : "Clean", () => setDirty(!dirty))
+                .AutomationName($"Mark {Props.Title} {(dirty ? "clean" : "dirty")}")
         );
     }
 }
@@ -516,7 +534,7 @@ class LetterJump : Component<IReadOnlyList<Person>>
                     {
                         if (groupStarts.TryGetValue(letter, out var start))
                             listRef.Current?.ScrollToIndex(start);
-                    })))
+                    }).AutomationName($"Jump to {letter}")))
         );
     }
 }

--- a/docs/_pipeline/apps/commanding/App.cs
+++ b/docs/_pipeline/apps/commanding/App.cs
@@ -27,7 +27,7 @@ class BasicCommandExample : Component
         };
 
         return VStack(12,
-            TextBox(text, v => { setText(v); setSaved(false); })
+            TextBox(text, v => { setText(v); setSaved(false); }, header: "Document")
                 .Width(400),
             HStack(8,
                 Button(saveCmd),
@@ -113,7 +113,7 @@ class CommandBarExample : Component
                 secondaryCommands: new[] {
                     AppBarButton(delete) }
             ),
-            TextBox(text, setText).Margin(16)
+            TextBox(text, setText, header: "Document").Margin(16)
         );
     }
 }
@@ -181,7 +181,7 @@ class ParameterizedCommandExample : Component
     public override Element Render()
     {
         var (items, setItems) = UseState<IReadOnlyList<TodoItem>>(
-            new[] { new TodoItem(1, "Buy milk"), new TodoItem(2, "Walk dog"), new TodoItem(3, "Ship doc") });
+            UseMemo(() => new[] { new TodoItem(1, "Buy milk"), new TodoItem(2, "Walk dog"), new TodoItem(3, "Ship doc") }, []));
 
         // One Command<TodoItem> drives every row.
         var delete = new Command<TodoItem>
@@ -198,6 +198,7 @@ class ParameterizedCommandExample : Component
                     // Inline button — Command<T> doesn't have a Button(cmd, arg) overload
                     // by design, so call .Execute(arg) directly from the click handler.
                     Button(delete.Label, () => delete.Execute?.Invoke(item))
+                        .AutomationName($"Delete {item.Title}")
                         .IsEnabled(delete.IsEnabled)))
         ).Padding(24);
     }
@@ -433,7 +434,7 @@ class CanExecuteDontExample : Component
             Execute = () => { if (text.Length > 0) Save(); },
         };
 
-        return VStack(12, TextBox(text, setText).Width(300), Button(save))
+        return VStack(12, TextBox(text, setText, header: "Document").Width(300), Button(save))
             .Padding(24);
 
         void Save() { }
@@ -457,7 +458,7 @@ class CanExecuteDoExample : Component
             CanExecute = text.Length > 0,
         };
 
-        return VStack(12, TextBox(text, setText).Width(300), Button(save))
+        return VStack(12, TextBox(text, setText, header: "Document").Width(300), Button(save))
             .Padding(24);
 
         void Save() { }

--- a/docs/_pipeline/apps/components/App.cs
+++ b/docs/_pipeline/apps/components/App.cs
@@ -16,6 +16,7 @@ class Greeting : Component
         return VStack(12,
             TextBlock($"Hello, {name}!").FontSize(20).Bold(),
             TextBox(name, setName, placeholderText: "Your name")
+                .AutomationName("Name")
                 .Width(200)
         ).Padding(16);
     }
@@ -33,9 +34,9 @@ class Alert : Component<AlertProps>
     {
         var bg = Props.Severity switch
         {
-            "error" => "#FDE7E9",
-            "warning" => "#FFF4CE",
-            _ => "#DFF6DD"
+            "error" => Theme.SystemCriticalBackground,
+            "warning" => Theme.SystemCautionBackground,
+            _ => Theme.SystemSuccessBackground
         };
 
         return Border(

--- a/docs/_pipeline/apps/context/App.cs
+++ b/docs/_pipeline/apps/context/App.cs
@@ -145,9 +145,11 @@ static class AppContexts
 
 class UserContextExample : Component
 {
+    private static readonly CurrentUser InitialUser = new("u1", "Alice", IsAdmin: true);
+
     public override Element Render()
     {
-        var (user, setUser) = UseState(new CurrentUser("u1", "Alice", IsAdmin: true));
+        var (user, setUser) = UseState(InitialUser);
 
         return VStack(12,
             HStack(8,

--- a/docs/_pipeline/apps/controls/App.cs
+++ b/docs/_pipeline/apps/controls/App.cs
@@ -38,7 +38,7 @@ class FormsGroup : Component
         var (volume, setVolume) = UseState(60.0);
 
         return VStack(8,
-            TextBox(name, setName, placeholderText: "Name").Width(200),
+            TextBox(name, setName, placeholderText: "Name", header: "Name").Width(200),
             CheckBox(agree, setAgree, label: "I agree"),
             Slider(volume, 0, 100, setVolume).Width(200),
             Button("Submit", () => { })

--- a/docs/_pipeline/apps/data-system/App.cs
+++ b/docs/_pipeline/apps/data-system/App.cs
@@ -104,8 +104,8 @@ class SelectionDemo : Component
 {
     public override Element Render()
     {
-        var (selected, setSelected) = UseState<IReadOnlySet<RowKey>>(
-            new HashSet<RowKey>());
+        var initialSelection = UseMemo<IReadOnlySet<RowKey>>(() => new HashSet<RowKey>());
+        var (selected, setSelected) = UseState(initialSelection);
 
         var source = UseMemo(() => new ListDataSource<Product>(
             SampleProducts.Items, p => (RowKey)p.Id));
@@ -213,7 +213,7 @@ class RowDetailsDemo : Component
                     TextBlock($"Full details for {product.Name}"),
                     TextBlock($"Category: {product.Category}"),
                     TextBlock($"Unit price: {product.Price:C2}, Stock: {product.Stock}")
-                ).Padding(16).Background("#f5f5f5")
+                ).Padding(16).Background(Theme.CardBackground)
         ).Height(400);
     }
 }

--- a/docs/_pipeline/apps/dev-tooling/App.cs
+++ b/docs/_pipeline/apps/dev-tooling/App.cs
@@ -22,7 +22,8 @@ class DevToolingApp : Component
                 Button("Click me", () => setCount(count + 1)),
                 TextBlock($"Clicked {count} times").SemiBold()
             ),
-            TextBox(message, setMessage, placeholderText: "Type something")
+            TextBox(message, setMessage, placeholderText: "Type something",
+                header: "Message")
                 .Width(300)
         ).Padding(24);
     }
@@ -64,7 +65,8 @@ class IterationDemo : Component
             Heading("Iteration Cycle Demo"),
             TextBlock("Add items, then edit this code and save to see hot reload."),
             HStack(8,
-                TextBox(input, setInput, placeholderText: "New item")
+                TextBox(input, setInput, placeholderText: "New item",
+                    header: "New item")
                     .Width(200),
                 Button("Add", () =>
                 {

--- a/docs/_pipeline/apps/dialogs-and-flyouts/App.cs
+++ b/docs/_pipeline/apps/dialogs-and-flyouts/App.cs
@@ -79,8 +79,7 @@ class DialogGatedPrimaryDemo : Component
             ContentDialog(
                 "Rename file",
                 VStack(8,
-                    TextBlock("New filename:"),
-                    TextBox(name, setName, placeholderText: "untitled.txt")
+                    TextBox(name, setName, placeholderText: "untitled.txt", header: "New filename")
                         .Width(280)),
                 primaryButtonText: "Rename") with
             {
@@ -166,12 +165,13 @@ class PopupDemo : Component
                 TextBlock("This is a Popup.").Bold(),
                 TextBlock("Click outside to dismiss.")
             ).Padding(12)
-        ).Background("#FFFFFF").WithBorder("#888888").CornerRadius(6);
+        ).Background(Theme.SolidBackground).WithBorder(Theme.ControlStroke).CornerRadius(6);
 
         return VStack(8,
             SubHeading("Popup"),
             Button(open ? "Hide popup" : "Show popup",
-                () => setOpen(!open)),
+                () => setOpen(!open))
+                .AutomationName(open ? "Hide popup" : "Show popup"),
             Popup(popupContent, isOpen: open,
                 onClosed: () => setOpen(false))
                 .IsLightDismissEnabled()
@@ -265,7 +265,8 @@ class ModalPopupDemo : Component
                         TextBlock("Focus stays inside this popup."),
                         Button("Close", () => setOpen(false))
                     ).Padding(16)
-                ).FocusTrap(trap),
+                ).FocusTrap(trap)
+                 .Semantics(role: "dialog"),
                 isOpen: open,
                 onClosed: () => setOpen(false))
         ).Padding(24);

--- a/docs/_pipeline/apps/effects/App.cs
+++ b/docs/_pipeline/apps/effects/App.cs
@@ -43,7 +43,7 @@ class DependencyEffectExample : Component
         }, query);
 
         return VStack(12,
-            TextBox(query, setQuery, placeholderText: "Search...").Width(300),
+            TextBox(query, setQuery, placeholderText: "Search...", header: "Search query").Width(300),
             TextBlock(results).Foreground(Theme.SecondaryText)
         ).Padding(24);
     }
@@ -79,7 +79,8 @@ class TimerCleanupExample : Component
         return VStack(12,
             TextBlock($"Elapsed: {seconds}s").FontSize(24).Bold(),
             HStack(8,
-                Button(isRunning ? "Stop" : "Start", () => setIsRunning(!isRunning)),
+                Button(isRunning ? "Stop" : "Start", () => setIsRunning(!isRunning))
+                    .AutomationName(isRunning ? "Stop timer" : "Start timer"),
                 Button("Reset", () => updateSeconds(_ => 0))
             )
         ).Padding(24);
@@ -108,7 +109,7 @@ class AsyncLoadingExample : Component
 
         return VStack(8,
             Heading("Loaded Users"),
-            VStack(4, items.Select(name => TextBlock(name)).ToArray())
+            VStack(4, items.Select(name => TextBlock(name).WithKey(name)).ToArray())
         ).Padding(24);
     }
 }
@@ -162,7 +163,7 @@ class FetchCancellationExample : Component
         }, query);
 
         return VStack(8,
-            TextBox(query, setQuery).Width(250),
+            TextBox(query, setQuery, header: "Search query").Width(250),
             ForEach(items, i => TextBlock(i))
         ).Padding(24);
     }
@@ -213,7 +214,7 @@ class DepsLiteralDontExample : Component
         var options = new { Url = url, Limit = 10 };
         UseEffect(() => FetchAsync(options), options);
 
-        return TextBox(url, setUrl).Width(250).Padding(24);
+        return TextBox(url, setUrl, header: "Request URL").Width(250).Padding(24);
     }
 }
 // </snippet:deps-literal-dont>
@@ -230,7 +231,7 @@ class DepsLiteralDoExample : Component
         // Do — pass the primitives, which compare by value.
         UseEffect(() => FetchAsync(url, 10), url);
 
-        return TextBox(url, setUrl).Width(250).Padding(24);
+        return TextBox(url, setUrl, header: "Request URL").Width(250).Padding(24);
     }
 }
 // </snippet:deps-literal-do>
@@ -243,15 +244,15 @@ class MissingCleanupDontExample : Component
         var (tick, updateTick) = UseReducer(0);
 
         // Don't — no cleanup, so the timer fires forever after unmount.
-        UseEffect(() =>
-        {
-            var timer = new PeriodicTimer(TimeSpan.FromSeconds(1));
-            _ = Task.Run(async () =>
-            {
-                while (await timer.WaitForNextTickAsync())
-                    updateTick(t => t + 1);
-            });
-        }, Array.Empty<object>());
+        // UseEffect(() =>
+        // {
+        //     var timer = new PeriodicTimer(TimeSpan.FromSeconds(1));
+        //     _ = Task.Run(async () =>
+        //     {
+        //         while (await timer.WaitForNextTickAsync())
+        //             updateTick(t => t + 1);
+        //     });
+        // }, Array.Empty<object>());
 
         return TextBlock($"Ticks: {tick}").Padding(24);
     }
@@ -306,8 +307,8 @@ class EffectVsMemoDontExample : Component
         UseEffect(() => setFull($"{first} {last}"), first, last);
 
         return VStack(8,
-            TextBox(first, setFirst).Width(150),
-            TextBox(last, setLast).Width(150),
+            TextBox(first, setFirst, header: "First name").Width(150),
+            TextBox(last, setLast, header: "Last name").Width(150),
             TextBlock(full)
         ).Padding(24);
     }
@@ -328,8 +329,8 @@ class EffectVsMemoDoExample : Component
         var stats = UseMemo(() => Compute(full), full);      // memoized when expensive
 
         return VStack(8,
-            TextBox(first, setFirst).Width(150),
-            TextBox(last, setLast).Width(150),
+            TextBox(first, setFirst, header: "First name").Width(150),
+            TextBox(last, setLast, header: "Last name").Width(150),
             TextBlock(full),
             TextBlock(stats)
         ).Padding(24);

--- a/docs/_pipeline/apps/extending-reactor-controls/App.cs
+++ b/docs/_pipeline/apps/extending-reactor-controls/App.cs
@@ -129,7 +129,7 @@ public static class StarMeter
         int maxRating = 5,
         string? caption = null,
         bool isClearEnabled = true) =>
-        Of(value, onValueChanged, maxRating, caption, isClearEnabled);
+        Of(Optional<double>.Of(value), onValueChanged, maxRating, caption, isClearEnabled);
 
     public static StarMeterElement Of(
         Optional<double> value,
@@ -176,4 +176,3 @@ class ExtendingApp : Component
     }
 }
 // </snippet:star-meter-usage>
-

--- a/docs/_pipeline/apps/flex-layout/App.cs
+++ b/docs/_pipeline/apps/flex-layout/App.cs
@@ -15,16 +15,16 @@ class FlexDirectionDemo : Component
         return VStack(16,
             SubHeading("Row (default)"),
             FlexRow(
-                TextBlock("A").Padding(12).Background("#e0e0ff"),
-                TextBlock("B").Padding(12).Background("#ffe0e0"),
-                TextBlock("C").Padding(12).Background("#e0ffe0")
+                Border("A").Padding(12).Background(Theme.AccentTertiary),
+                Border("B").Padding(12).Background(Theme.SystemCriticalBackground),
+                Border("C").Padding(12).Background(Theme.SystemSuccessBackground)
             ) with { ColumnGap = 8 },
 
             SubHeading("Column"),
             FlexColumn(
-                TextBlock("A").Padding(12).Background("#e0e0ff"),
-                TextBlock("B").Padding(12).Background("#ffe0e0"),
-                TextBlock("C").Padding(12).Background("#e0ffe0")
+                Border("A").Padding(12).Background(Theme.AccentTertiary),
+                Border("B").Padding(12).Background(Theme.SystemCriticalBackground),
+                Border("C").Padding(12).Background(Theme.SystemSuccessBackground)
             ) with { RowGap = 8 }
         ).Padding(24);
     }
@@ -39,16 +39,16 @@ class JustifyAlignDemo : Component
         return VStack(16,
             SubHeading("JustifyContent: SpaceBetween"),
             FlexRow(
-                TextBlock("Left").Padding(8).Background("#e0e0ff"),
-                TextBlock("Center").Padding(8).Background("#ffe0e0"),
-                TextBlock("Right").Padding(8).Background("#e0ffe0")
+                Border("Left").Padding(8).Background(Theme.AccentTertiary),
+                Border("Center").Padding(8).Background(Theme.SystemCriticalBackground),
+                Border("Right").Padding(8).Background(Theme.SystemSuccessBackground)
             ) with { JustifyContent = FlexJustify.SpaceBetween },
 
             SubHeading("AlignItems: Center"),
             FlexRow(
-                TextBlock("Short").Padding(8).Background("#e0e0ff"),
-                TextBlock("Tall\nItem").Padding(8).Background("#ffe0e0"),
-                TextBlock("Med").Padding(8).Background("#e0ffe0")
+                Border("Short").Padding(8).Background(Theme.AccentTertiary),
+                Border("Tall\nItem").Padding(8).Background(Theme.SystemCriticalBackground),
+                Border("Med").Padding(8).Background(Theme.SystemSuccessBackground)
             ) with {
                 AlignItems = FlexAlign.Center,
                 ColumnGap = 8
@@ -72,10 +72,11 @@ class WrapGapDemo : Component
             SubHeading("Wrapping Tags"),
             FlexRow(
                 tags.Select(tag =>
-                    TextBlock(tag)
+                    Border(tag)
                         .Padding(horizontal: 6, vertical: 12)
-                        .Background("#e8e8e8")
+                        .Background(Theme.ControlFillSecondary)
                         .CornerRadius(12)
+                        .WithKey(tag)
                 ).ToArray()
             ) with {
                 Wrap = FlexWrap.Wrap,
@@ -95,19 +96,19 @@ class GrowShrinkDemo : Component
         return VStack(16,
             SubHeading("Grow: sidebar + content"),
             FlexRow(
-                TextBlock("Sidebar")
-                    .Padding(16).Background("#e0e0ff")
+                Border("Sidebar")
+                    .Padding(16).Background(Theme.AccentTertiary)
                     .Flex(basis: 200, shrink: 0),
-                TextBlock("Main content area")
-                    .Padding(16).Background("#f0f0f0")
+                Border("Main content area")
+                    .Padding(16).Background(Theme.CardBackground)
                     .Flex(grow: 1)
             ) with { ColumnGap = 8 },
 
             SubHeading("Equal columns"),
             FlexRow(
-                TextBlock("Column 1").Padding(16).Background("#ffe0e0").Flex(grow: 1),
-                TextBlock("Column 2").Padding(16).Background("#e0ffe0").Flex(grow: 1),
-                TextBlock("Column 3").Padding(16).Background("#e0e0ff").Flex(grow: 1)
+                Border("Column 1").Padding(16).Background(Theme.SystemCriticalBackground).Flex(grow: 1),
+                Border("Column 2").Padding(16).Background(Theme.SystemSuccessBackground).Flex(grow: 1),
+                Border("Column 3").Padding(16).Background(Theme.AccentTertiary).Flex(grow: 1)
             ) with { ColumnGap = 8 }
         ).Padding(24);
     }
@@ -174,7 +175,7 @@ class AppShellDemo : Component
                 TextBlock("Inbox").Padding(8),
                 TextBlock("Drafts").Padding(8),
                 TextBlock("Sent").Padding(8)
-            ).Background("#f3f3f3")
+            ).Background(Theme.CardBackground)
              .Flex(basis: 220, shrink: 0),
 
             // Content — explicit basis: 0 + grow: 1 gives a single distribution
@@ -197,13 +198,13 @@ class ResponsiveNavDemo : Component
         // Wrap kicks in when the narrow viewport can no longer fit one row.
         // RowGap and ColumnGap apply between wrapped lines too — no manual margin.
         return FlexRow(
-            TextBlock("Home").Padding(8).Background("#e0e0ff"),
-            TextBlock("Catalog").Padding(8).Background("#e0e0ff"),
-            TextBlock("Pricing").Padding(8).Background("#e0e0ff"),
-            TextBlock("Docs").Padding(8).Background("#e0e0ff"),
-            TextBlock("About").Padding(8).Background("#e0e0ff"),
-            TextBlock("Contact").Padding(8).Background("#e0e0ff"),
-            TextBlock("Status").Padding(8).Background("#e0e0ff")
+            Border("Home").Padding(8).Background(Theme.AccentTertiary),
+            Border("Catalog").Padding(8).Background(Theme.AccentTertiary),
+            Border("Pricing").Padding(8).Background(Theme.AccentTertiary),
+            Border("Docs").Padding(8).Background(Theme.AccentTertiary),
+            Border("About").Padding(8).Background(Theme.AccentTertiary),
+            Border("Contact").Padding(8).Background(Theme.AccentTertiary),
+            Border("Status").Padding(8).Background(Theme.AccentTertiary)
         ) with {
             Wrap = FlexWrap.Wrap,
             ColumnGap = 8,
@@ -223,10 +224,10 @@ class WidthVsGrowWrong : Component
         // child sizing is governed by Flex(basis/grow/shrink). The 200 is
         // silently ignored when grow > 0 fills available space.
         return FlexRow(
-            TextBlock("Stays 200?")
+            Border("Stays 200?")
                 .Width(200)              // ignored — grow wins
                 .Flex(grow: 1)
-                .Background("#ffe0e0")
+                .Background(Theme.SystemCriticalBackground)
         ) with { ColumnGap = 8 };
     }
 }
@@ -240,9 +241,9 @@ class WidthVsGrowRight : Component
         // Do: encode the intended size as basis with shrink: 0 — Flex
         // owns the sizing math, so no surprise overrides.
         return FlexRow(
-            TextBlock("Exactly 200")
+            Border("Exactly 200")
                 .Flex(basis: 200, shrink: 0)
-                .Background("#e0ffe0")
+                .Background(Theme.SystemSuccessBackground)
                 .Padding(8)
         ) with { ColumnGap = 8 };
     }
@@ -256,23 +257,23 @@ class MinSizingDemo : Component
         SubHeading("Default — items keep their min-content size"),
         FlexRow(
             Border("Long text that won't truncate").Flex(shrink: 1)
-                .Background("#e0e0ff").Padding(8),
+                .Background(Theme.AccentTertiary).Padding(8),
             Border("Short").Flex(shrink: 1)
-                .Background("#ffe0e0").Padding(8)
+                .Background(Theme.SystemCriticalBackground).Padding(8)
         ) with { ColumnGap = 8 },
 
         SubHeading("Opt out — minWidth: 0 lets items shrink below content"),
         FlexRow(
             Border("Long text that may be clipped").Flex(shrink: 1, minWidth: 0)
-                .Background("#e0e0ff").Padding(8),
+                .Background(Theme.AccentTertiary).Padding(8),
             Border("Short").Flex(shrink: 1, minWidth: 0)
-                .Background("#ffe0e0").Padding(8)
+                .Background(Theme.SystemCriticalBackground).Padding(8)
         ) with { ColumnGap = 8 },
 
         SubHeading("Explicit floor — never below 80px regardless of content"),
         FlexRow(
             Border("Hard floor").Flex(shrink: 1, minWidth: 80)
-                .Background("#e0ffe0").Padding(8)
+                .Background(Theme.SystemSuccessBackground).Padding(8)
         ) with { ColumnGap = 8 }
     ).Width(360);
 }

--- a/docs/_pipeline/apps/forms/App.cs
+++ b/docs/_pipeline/apps/forms/App.cs
@@ -19,7 +19,8 @@ class ControlledInputDemo : Component
 
         return VStack(12,
             SubHeading("Controlled Input"),
-            TextBox(name, setName, placeholderText: "Type your name"),
+            TextBox(name, setName, placeholderText: "Type your name",
+                header: "Name"),
             TextBlock($"You typed: {name}").Opacity(0.6)
         ).Padding(24);
     }
@@ -44,16 +45,18 @@ class InputTypesDemo : Component
             TextBox(text, setText, placeholderText: "Email",
                 header: "Email"),
             PasswordBox(password, setPassword,
-                placeholderText: "Enter password"),
-            Slider(volume, 0, 100, setVolume),
+                placeholderText: "Enter password")
+                .Header("Password")
+                .AutomationName("Password"),
+            Slider(volume, 0, 100, setVolume).Header("Volume"),
             NumberBox(count, setCount, header: "Quantity"),
             CheckBox(agree, setAgree, label: "I agree to the terms"),
             ToggleSwitch(notify, setNotify,
                 header: "Notifications"),
             ComboBox(["Admin", "Editor", "Viewer"],
                 role, setRole).Header("Role"),
-            RadioButtons(["Low", "Medium", "High"],
-                priority, setPriority)
+            (RadioButtons(["Low", "Medium", "High"],
+                priority, setPriority) with { Header = "Priority" })
         ).Padding(24);
     }
 }
@@ -149,6 +152,8 @@ class ValidationContextDemo : Component
                     .Foreground(Theme.SystemCritical).FontSize(12)),
             PasswordBox(password, v => { setPassword(v); ctx.NotifyValueChanged("password", v); },
                 placeholderText: "Min 8 characters")
+                .Header("Password")
+                .AutomationName("Password")
                 .Validate("password", password,
                     Validate.Required(),
                     Validate.MinLength(8)),
@@ -181,12 +186,14 @@ class FormFieldDemo : Component
             SubHeading("FormField Helper"),
             FormField(
                 TextBox(name, v => { setName(v); ctx.NotifyValueChanged("name", v); })
+                    .AutomationName("Full Name")
                     .Validate("name", name, Validate.Required()),
                 label: "Full Name",
                 required: true,
                 description: "As it appears on your ID"),
             FormField(
                 TextBox(email, v => { setEmail(v); ctx.NotifyValueChanged("email", v); })
+                    .AutomationName("Email Address")
                     .Validate("email", email,
                         Validate.Required(), Validate.Email()),
                 label: "Email Address",
@@ -264,7 +271,8 @@ class TextBoxConfigDemo : Component
                 .UrlInput(),
             TextBox(phone, setPhone, header: "Phone")
                 .PhoneInput(),
-            TextBox(search, setSearch, placeholderText: "Search…")
+            TextBox(search, setSearch, placeholderText: "Search…",
+                header: "Search")
                 .SearchInput(),
             TextBox(note, setNote, header: "Reference code")
                 .MaxLength(8)
@@ -301,6 +309,7 @@ class AutoSuggestDemo : Component
             AutoSuggestBox(text, setText,
                 onQuerySubmitted: q => setText(q))
                 .Header("Animal")
+                .AutomationName("Animal")
                 .QueryIcon(SymbolIcon("Find"))
                 .Width(280),
             // Suggestion list — bind to AutoSuggestBox.ItemsSource via .Set
@@ -310,7 +319,7 @@ class AutoSuggestDemo : Component
                 VStack(2,
                     ForEach(matches, m =>
                         TextBlock(m).Padding(8, 4))
-                ).Background("#F5F5F5").Width(280))
+                ).Background(Theme.CardBackground).Width(280))
         ).Padding(24);
     }
 }
@@ -396,12 +405,9 @@ class ColorPickerDemo : Component
                 .HexInputVisible(true)
                 .ColorSpectrumShape(
                     Microsoft.UI.Xaml.Controls.ColorSpectrumShape.Ring),
-            // Preview swatch driven by the picker.
-            Border(Empty())
-                .Background(
-                    new Microsoft.UI.Xaml.Media.SolidColorBrush(color))
-                .Width(80).Height(40)
-                .WithBorder("#888888")
+            TextBlock($"Selected: #{color.A:X2}{color.R:X2}{color.G:X2}{color.B:X2}")
+                .FontSize(12)
+                .Foreground(Theme.SecondaryText)
         ).Padding(24);
     }
 }

--- a/docs/_pipeline/apps/forms/App.cs
+++ b/docs/_pipeline/apps/forms/App.cs
@@ -46,8 +46,7 @@ class InputTypesDemo : Component
                 header: "Email"),
             PasswordBox(password, setPassword,
                 placeholderText: "Enter password")
-                .Header("Password")
-                .AutomationName("Password"),
+                .Header("Password"),
             Slider(volume, 0, 100, setVolume).Header("Volume"),
             NumberBox(count, setCount, header: "Quantity"),
             CheckBox(agree, setAgree, label: "I agree to the terms"),
@@ -153,7 +152,6 @@ class ValidationContextDemo : Component
             PasswordBox(password, v => { setPassword(v); ctx.NotifyValueChanged("password", v); },
                 placeholderText: "Min 8 characters")
                 .Header("Password")
-                .AutomationName("Password")
                 .Validate("password", password,
                     Validate.Required(),
                     Validate.MinLength(8)),
@@ -309,7 +307,6 @@ class AutoSuggestDemo : Component
             AutoSuggestBox(text, setText,
                 onQuerySubmitted: q => setText(q))
                 .Header("Animal")
-                .AutomationName("Animal")
                 .QueryIcon(SymbolIcon("Find"))
                 .Width(280),
             // Suggestion list — bind to AutoSuggestBox.ItemsSource via .Set

--- a/docs/_pipeline/apps/getting-started/App.cs
+++ b/docs/_pipeline/apps/getting-started/App.cs
@@ -14,7 +14,9 @@ class GettingStartedApp : Component
 
         return VStack(16,
             TextBlock($"Hello, {name}!").FontSize(24).Bold(),
-            TextBox(name, setName, placeholderText: "Enter your name").Width(250)
+            TextBox(name, setName, placeholderText: "Enter your name")
+                .AutomationName("Name")
+                .Width(250)
         ).Padding(24);
     }
 }
@@ -101,8 +103,12 @@ class MultipleStateExample : Component
 
         return VStack(12,
             TextBlock($"Hello, {fullName}!").FontSize(fontSize).Bold(),
-            TextBox(firstName, setFirstName, placeholderText: "First name").Width(200),
-            TextBox(lastName, setLastName, placeholderText: "Last name").Width(200),
+            TextBox(firstName, setFirstName, placeholderText: "First name")
+                .AutomationName("First name")
+                .Width(200),
+            TextBox(lastName, setLastName, placeholderText: "Last name")
+                .AutomationName("Last name")
+                .Width(200),
             HStack(8,
                 TextBlock("Font size:"),
                 Slider(fontSize, 10, 40, setFontSize).Width(200),

--- a/docs/_pipeline/apps/hooks/App.cs
+++ b/docs/_pipeline/apps/hooks/App.cs
@@ -18,10 +18,13 @@ class StateDemo : Component
             SubHeading("UseState"),
             TextBlock("Sample text").FontSize(size).Foreground(color),
             TextBox(color, setColor, placeholderText: "#hex color")
+                .AutomationName("Sample text color")
                 .Width(150),
             HStack(8,
                 TextBlock("Size:"),
-                Slider(size, 10, 48, setSize).Width(200)
+                Slider(size, 10, 48, setSize)
+                    .AutomationName("Sample text size")
+                    .Width(200)
             )
         );
     }
@@ -40,6 +43,7 @@ class ReducerDemo : Component
             SubHeading("UseReducer"),
             HStack(8,
                 TextBox(input, setInput, placeholderText: "Add item")
+                    .AutomationName("Item text")
                     .Width(180),
                 Button("Add", () =>
                 {
@@ -79,9 +83,11 @@ class ReduxReducerDemo : Component
             TextBlock($"Count: {state.Count}  (last: {state.LastAction})")
                 .FontSize(18).Bold(),
             HStack(8,
-                Button("-", () => dispatch(new Decrement())),
+                Button("-", () => dispatch(new Decrement()))
+                    .AutomationName("Decrement count"),
                 Button("Reset", () => dispatch(new Reset())),
                 Button("+", () => dispatch(new Increment()))
+                    .AutomationName("Increment count")
             )
         );
     }
@@ -118,7 +124,8 @@ class EffectDemo : Component
             SubHeading("UseEffect"),
             TextBlock($"Elapsed: {seconds}s").FontSize(18),
             HStack(8,
-                Button(running ? "Stop" : "Start", () => setRunning(!running)),
+                Button(running ? "Stop" : "Start", () => setRunning(!running))
+                    .AutomationName(running ? "Stop timer" : "Start timer"),
                 Button("Reset", () => updateSeconds(_ => 0))
             )
         );
@@ -143,7 +150,9 @@ class MemoDemo : Component
 
         return VStack(8,
             SubHeading("UseMemo"),
-            TextBox(input, setInput).Width(250),
+            TextBox(input, setInput)
+                .AutomationName("Text to analyze")
+                .Width(250),
             TextBlock($"Characters: {stats.Chars}, Words: {stats.Words}"),
             Caption($"Uppercased: {stats.Upper}")
         );
@@ -164,6 +173,7 @@ class RefDemo : Component
             SubHeading("UseRef"),
             TextBlock($"Render count: {renderCount.Current}").SemiBold(),
             TextBox(value, setValue, placeholderText: "Type to trigger renders")
+                .AutomationName("Render trigger text")
                 .Width(250),
             Caption("UseRef persists across renders without causing them")
         );
@@ -186,8 +196,10 @@ class CallbackDemo : Component
             SubHeading("UseCallback"),
             TextBlock($"Count: {count}").FontSize(18),
             TextBox(label, setLabel, placeholderText: "Button label")
+                .AutomationName("Button label")
                 .Width(200),
-            Button(label, stableIncrement),
+            Button(label, stableIncrement)
+                .AutomationName("Increment count"),
             Caption("The callback identity stays stable across renders")
         );
     }
@@ -275,7 +287,9 @@ class CustomHookDemo : Component
         var (debounced, setText) = ctx.UseDebouncedText("", 300);
         return VStack(8,
             SubHeading("Custom hook: UseDebouncedText"),
-            TextBox(debounced, setText, placeholderText: "Type…").Width(250),
+            TextBox(debounced, setText, placeholderText: "Type…")
+                .AutomationName("Text to debounce")
+                .Width(250),
             Caption($"Debounced: {debounced}")
         );
     });

--- a/docs/_pipeline/apps/input-and-gestures/App.cs
+++ b/docs/_pipeline/apps/input-and-gestures/App.cs
@@ -25,11 +25,17 @@ class PointerModifiersExample : Component
             Border(TextBlock(hover ? "hovered" : "hover me")
                 .HAlign(HorizontalAlignment.Center).VAlign(VerticalAlignment.Center))
                 .Width(240).Height(120)
-                .Background(hover ? "#BFE3FF" : "#E5F1FB")
+                .Background(hover ? Theme.AccentTertiary : Theme.ControlFillSecondary)
                 .CornerRadius(8)
+                .IsTabStop(true)
                 .OnPointerEntered((_, _) => setHover(true))
                 .OnPointerExited((_, _) => setHover(false))
                 .OnTapped((_, _) => setTapCount(tapCount + 1))
+                .OnKeyDown((_, e) =>
+                {
+                    if (e.Key is VirtualKey.Enter or VirtualKey.Space)
+                        setTapCount(tapCount + 1);
+                })
                 .OnDoubleTap(() => setTapCount(0)),
 
             TextBlock($"Tapped {tapCount} time(s) — double-tap to reset")
@@ -48,6 +54,7 @@ class KeyboardEventsExample : Component
 
         return VStack(12,
             TextBox(value, setValue, placeholderText: "type here").Width(280)
+                .AutomationName("Text to submit")
                 // Tunnels first — the right spot to intercept before bubbling.
                 .OnPreviewKeyDown((_, _) => setLog("preview"))
                 // Bubbles — fires after the preview pair.
@@ -74,6 +81,7 @@ class FocusEventsExample : Component
 
         return VStack(12,
             TextBox(value, setValue, placeholderText: "email").Width(280)
+                .AutomationName("Email")
                 .OnGotFocus((_, _) => setHint("We never share your address."))
                 .OnLostFocus((_, _) => setHint("")),
 
@@ -129,7 +137,9 @@ class SearchBoxExample : Component
 
         return VStack(12,
             TextBlock("Text is pre-selected on mount via UseElementRef<TextBox>()."),
-            TextBox(query, setQuery).Width(280).Ref(inputRef)
+            TextBox(query, setQuery).Width(280)
+                .AutomationName("Search query")
+                .Ref(inputRef)
         ).Padding(24);
     }
 }
@@ -163,10 +173,10 @@ class PanGestureExample : Component
         return VStack(8,
             Border(
                 Border(TextBlock("drag me")
-                    .HAlign(HorizontalAlignment.Center).VAlign(VerticalAlignment.Center))
+                    .HAlign(HorizontalAlignment.Center).VAlign(VerticalAlignment.Center)
+                    .Foreground(Theme.AccentText))
                     .Width(120).Height(120)
-                    .Background("#3A7BD5")
-                    .Foreground("#ffffff")
+                    .Background(Theme.Accent)
                     .CornerRadius(8)
                     .Translation(offset.X, offset.Y, 0)
                     .OnMount(fe => cardRef.Current = fe)
@@ -184,7 +194,7 @@ class PanGestureExample : Component
                             setOffset(committedRef.Current);
                         },
                         withInertia: true)
-            ).Height(260).Background("#f3f3f3").CornerRadius(8).Padding(16),
+            ).Height(260).Background(Theme.CardBackground).CornerRadius(8).Padding(16),
 
             Button("Reset position", Reset)
         );
@@ -202,7 +212,7 @@ class LongPressExample : Component
         return VStack(12,
             Border(TextBlock("Hold me")
                 .HAlign(HorizontalAlignment.Center).VAlign(VerticalAlignment.Center))
-                .Height(80).Background("#FFF4CE").CornerRadius(6).Padding(12)
+                .Height(80).Background(Theme.SystemCautionBackground).CornerRadius(6).Padding(12)
                 .OnLongPress(
                     g => setLog($"long-press after {g.Duration.TotalMilliseconds:F0}ms"),
                     enableMouseEmulation: true),
@@ -224,7 +234,9 @@ class UseElementFocusExample : Component
 
         return VStack(12,
             TextBlock("The field below auto-focuses on mount via UseElementFocus()."),
-            TextBox(name, setName, placeholderText: "name").Width(280).Ref(inputRef)
+            TextBox(name, setName, placeholderText: "name").Width(280)
+                .AutomationName("Name")
+                .Ref(inputRef)
         ).Padding(24);
     }
 }
@@ -237,11 +249,12 @@ class KanbanDndExample : Component
 {
     public override Element Render()
     {
-        var (todo, setTodo) = UseState<IReadOnlyList<KanbanCard>>(new KanbanCard[]
+        var initialTodo = UseMemo(() => new KanbanCard[]
         {
             new("k1", "Write docs"),
             new("k2", "Ship feature"),
-        });
+        }, Array.Empty<object>());
+        var (todo, setTodo) = UseState<IReadOnlyList<KanbanCard>>(initialTodo);
         var (done, setDone) = UseState<IReadOnlyList<KanbanCard>>(Array.Empty<KanbanCard>());
 
         Element Column(string label,
@@ -253,8 +266,8 @@ class KanbanDndExample : Component
             {
                 var captured = card;
                 children.Add(
-                    Border(TextBlock(captured.Title).Foreground("#ffffff"))
-                        .Background("#4B7BEC").CornerRadius(6).Padding(10)
+                    Border(TextBlock(captured.Title).Foreground(Theme.AccentText))
+                        .Background(Theme.Accent).CornerRadius(6).Padding(10)
                         .OnDragStart<BorderElement, KanbanCard>(
                             getPayload: () => captured,
                             allowedOperations: DragOperations.Move,
@@ -276,9 +289,9 @@ class KanbanDndExample : Component
 
         return HStack(12,
             Border(Column("Todo", todo, setTodo))
-                .Width(240).Background("#F7F7F7").CornerRadius(6).Padding(10),
+                .Width(240).Background(Theme.CardBackground).CornerRadius(6).Padding(10),
             Border(Column("Done", done, setDone))
-                .Width(240).Background("#F1FFF4").CornerRadius(6).Padding(10)
+                .Width(240).Background(Theme.SystemSuccessBackground).CornerRadius(6).Padding(10)
         ).Padding(24);
     }
 }

--- a/docs/_pipeline/apps/layout/App.cs
+++ b/docs/_pipeline/apps/layout/App.cs
@@ -38,10 +38,11 @@ class GridDemo : Component
                 rows: [GridSize.Auto, GridSize.Auto],
                 TextBlock("Label").Bold().Grid(row: 0, column: 0),
                 TextBox("", _ => { }, placeholderText: "Input...")
+                    .AutomationName("Input")
                     .Grid(row: 0, column: 1),
                 Button("Go").Grid(row: 0, column: 2),
                 TextBlock("Status").Grid(row: 1, column: 0),
-                TextBlock("Ready").Foreground("#0078D4")
+                TextBlock("Ready").Foreground(Theme.Accent)
                     .Grid(row: 1, column: 1, columnSpan: 2)
             ).Height(80)
         );
@@ -99,7 +100,7 @@ class ScrollBorderDemo : Component
                             i => TextBlock($"Scrollable item {i}"))
                     ).Padding(8)
                 ).Height(120)
-            ).CornerRadius(4).Background("#F5F5F5")
+            ).CornerRadius(4).Background(Theme.CardBackground)
         );
     }
 }
@@ -128,7 +129,7 @@ class ExpanderCanvasDemo : Component
                         Microsoft.UI.Xaml.Controls.Canvas.SetTop((UIElement)c, 40);
                     })
                 ).Height(90).Width(300)
-            ).Background("#F5F5F5").CornerRadius(4)
+            ).Background(Theme.CardBackground).CornerRadius(4)
         );
     }
 }
@@ -144,11 +145,11 @@ class ResponsiveDemo : Component
         var content = new Element[]
         {
             Border(TextBlock("Panel A").Padding(16))
-                .Background("#E3F2FD").CornerRadius(4),
+                .Background(Theme.SystemNeutralBackground).CornerRadius(4),
             Border(TextBlock("Panel B").Padding(16))
-                .Background("#FFF3E0").CornerRadius(4),
+                .Background(Theme.SystemCautionBackground).CornerRadius(4),
             Border(TextBlock("Panel C").Padding(16))
-                .Background("#E8F5E9").CornerRadius(4),
+                .Background(Theme.SystemSuccessBackground).CornerRadius(4),
         };
 
         return VStack(8,
@@ -210,15 +211,17 @@ class AutoGridExample : Component
 {
     public override Element Render()
     {
-        return WrapGrid(maxRowsOrColumns: 4,
-            children: Enumerable.Range(1, 11)
-                .Select(i =>
-                    Border(TextBlock($"Tile {i}").Padding(12))
-                        .Background(Theme.CardBackground)
-                        .CornerRadius(6)
-                        .Width(110).Height(60))
-                .Cast<Element?>()
-                .ToArray()
+        return Border(
+            WrapGrid(maxRowsOrColumns: 4,
+                children: Enumerable.Range(1, 11)
+                    .Select(i =>
+                        Border(TextBlock($"Tile {i}").Padding(12))
+                            .Background(Theme.CardBackground)
+                            .CornerRadius(6)
+                            .Width(110).Height(60))
+                    .Cast<Element?>()
+                    .ToArray()
+            )
         ).Padding(24);
     }
 }
@@ -304,12 +307,14 @@ class AlignmentSizingDemo : Component
         SubHeading("Alignment and sizing"),
 
         TextBlock("Centered").HAlign(HorizontalAlignment.Center),
-        TextBlock("Fixed width").Width(200).Height(40).Background("#E5F1FB"),
+        Border(TextBlock("Fixed width"))
+            .Width(200).Height(40)
+            .Background(Theme.ControlFillSecondary),
 
         VStack(8,
             TextBlock("Item A"),
             TextBlock("Item B")
-        ).Margin(24).Padding(16).Background("#F3F3F3")
+        ).Margin(24).Padding(16).Background(Theme.ControlFillSecondary)
     );
 }
 // </snippet:alignment-sizing>
@@ -324,6 +329,7 @@ class ContentAlignmentDemo : Component
         // stretches too — without HorizontalContentAlignment the label
         // would stay centered in an otherwise full-width button.
         Button(TextBlock("Open"), () => { })
+            .AutomationName("Open")
             .HAlign(HorizontalAlignment.Stretch)
             .HorizontalContentAlignment(HorizontalAlignment.Stretch)
     ).Width(320);

--- a/docs/_pipeline/apps/localization/App.cs
+++ b/docs/_pipeline/apps/localization/App.cs
@@ -13,16 +13,16 @@ class DemoResourceProvider : IStringResourceProvider
     private readonly Dictionary<string, Dictionary<string, string>> _strings = new()
     {
         ["en-US"] = new() {
-            ["App.title"] = "My Application",
-            ["App.greeting"] = "Hello, {name}!",
+            ["App.Title"] = "My Application",
+            ["App.Greeting"] = "Hello, {name}!",
         },
         ["fr-FR"] = new() {
-            ["App.title"] = "Mon Application",
-            ["App.greeting"] = "Bonjour, {name} !",
+            ["App.Title"] = "Mon Application",
+            ["App.Greeting"] = "Bonjour, {name} !",
         },
         ["ar-SA"] = new() {
-            ["App.title"] = "\u062a\u0637\u0628\u064a\u0642\u064a",
-            ["App.greeting"] = "\u0645\u0631\u062d\u0628\u0627\u060c {name}!",
+            ["App.Title"] = "\u062a\u0637\u0628\u064a\u0642\u064a",
+            ["App.Greeting"] = "\u0645\u0631\u062d\u0628\u0627\u060c {name}!",
         }
     };
 
@@ -47,7 +47,8 @@ class LocaleSwitcher : Component
 
         return VStack(16,
             ComboBox(["English (US)", "Fran\u00e7ais", "\u0627\u0644\u0639\u0631\u0628\u064a\u0629"],
-                localeIndex, setLocaleIndex),
+                localeIndex, setLocaleIndex)
+                .Header("Locale"),
             LocaleProvider(locale,
                 Component<LocalizedContent>(),
                 resourceProvider: provider,
@@ -63,9 +64,9 @@ class LocalizedContent : Component
     public override Element Render()
     {
         var intl = UseIntl();
-        var title = intl.Message(new MessageKey("App", "title"));
+        var title = intl.Message(new MessageKey("App", "Title"));
         var greeting = intl.Message(
-            new MessageKey("App", "greeting"),
+            new MessageKey("App", "Greeting"),
             ("name", "Alice"));
 
         return VStack(12,
@@ -122,13 +123,14 @@ class RtlDemo : Component
                         TextBlock(RtlHelper.IsRtlLocale(loc) ? "RTL" : "LTR")
                             .Bold()
                             .Foreground(RtlHelper.IsRtlLocale(loc)
-                                ? "#d13438" : "#107c10")
+                                ? Theme.SystemCritical : Theme.SystemSuccess)
                     )
+                    .WithKey(loc)
                 ).ToArray()
             ),
             When(intl.IsRtl, () =>
                 TextBlock("Current layout is right-to-left")
-                    .Foreground("#d13438").SemiBold())
+                    .Foreground(Theme.SystemCritical).SemiBold())
         ).Padding(24);
     }
 }
@@ -150,9 +152,9 @@ class PseudoLocDemo : Component
                 RenderEachTime(ctx =>
                 {
                     var intl = ctx.UseIntl();
-                    var title = intl.Message(new MessageKey("App", "title"));
+                    var title = intl.Message(new MessageKey("App", "Title"));
                     var greeting = intl.Message(
-                        new MessageKey("App", "greeting"),
+                        new MessageKey("App", "Greeting"),
                         ("name", "World"));
                     return VStack(4,
                         TextBlock(title).FontSize(18).Bold(),

--- a/docs/_pipeline/apps/navigation/App.cs
+++ b/docs/_pipeline/apps/navigation/App.cs
@@ -120,20 +120,20 @@ class LifecyclePage : Component
         UseNavigationLifecycle(
             onNavigatedTo: ctx =>
                 updateLog(l => [.. l,
-                    $"Arrived from {ctx.PreviousRoute}"]),
+                    $"{l.Count + 1}: Arrived from {ctx.PreviousRoute}"]),
             onNavigatingFrom: ctx =>
                 updateLog(l => [.. l,
-                    $"Leaving to {ctx.TargetRoute}"]),
+                    $"{l.Count + 1}: Leaving to {ctx.TargetRoute}"]),
             onNavigatedFrom: ctx =>
                 updateLog(l => [.. l,
-                    $"Left for {ctx.TargetRoute}"])
+                    $"{l.Count + 1}: Left for {ctx.TargetRoute}"])
         );
 
         return VStack(8,
             SubHeading("Lifecycle Events"),
             VStack(4,
                 log.TakeLast(5).Select(entry =>
-                    TextBlock(entry).FontSize(12).Opacity(0.7)
+                    TextBlock(entry).FontSize(12).Opacity(0.7).WithKey(entry)
                 ).ToArray()
             )
         ).Padding(16);
@@ -161,7 +161,7 @@ class PageTransitionsDemo : Component
             {
                 Route.Home => VStack(8,
                     TextBlock("Home").FontSize(24).Bold(),
-                    TextBlock("Slide transition on navigate")).Padding(16),
+                    TextBlock("DrillIn transition on navigate")).Padding(16),
                 Route.Settings => VStack(8,
                     TextBlock("Settings").FontSize(24).Bold(),
                     TextBlock("DrillIn transition to detail")).Padding(16),
@@ -284,9 +284,9 @@ class DiagnosticsDemo : Component
         UseEffect(() =>
         {
             EventHandler<NavigationDiagnosticEvent> onRequested =
-                (_, e) => updateLog(l => [.. l, $"Requested: {e.From} → {e.To}"]);
+                (_, e) => updateLog(l => [.. l, $"{l.Count + 1}: Requested {e.From} → {e.To}"]);
             EventHandler<NavigationDiagnosticEvent> onCompleted =
-                (_, e) => updateLog(l => [.. l, $"Completed: {e.To}"]);
+                (_, e) => updateLog(l => [.. l, $"{l.Count + 1}: Completed {e.To}"]);
 
             NavigationDiagnostics.NavigationRequested += onRequested;
             NavigationDiagnostics.NavigationCompleted += onCompleted;
@@ -304,7 +304,7 @@ class DiagnosticsDemo : Component
                 Button("Settings", () => nav.Navigate(Route.Settings))
             ),
             VStack(4, log.TakeLast(6).Select(
-                entry => TextBlock(entry).FontSize(11).Opacity(0.6)
+                entry => TextBlock(entry).FontSize(11).Opacity(0.6).WithKey(entry)
             ).ToArray()),
             NavigationHost(nav, route =>
                 TextBlock($"Page: {route}").Padding(16))
@@ -346,6 +346,7 @@ class PageCachingDemo : Component
         VStack(8,
             TextBlock(name).FontSize(20).Bold(),
             TextBox("", _ => { }, placeholderText: "Type here — state persists")
+                .AutomationName($"{name} page note")
         ).Padding(16);
 }
 // </snippet:page-caching>
@@ -423,6 +424,7 @@ class PaneOpenChangedDemo : Component
                 TextBlock(isPaneOpen ? "Pane is open" : "Pane is closed").Opacity(0.6),
                 Button(isPaneOpen ? "Close pane" : "Open pane",
                     () => setIsPaneOpen(!isPaneOpen))
+                    .AutomationName(isPaneOpen ? "Close pane" : "Open pane")
             ).Padding(24)
         ) with
         {
@@ -449,7 +451,9 @@ class ControlledPaneDemo : Component
                 NavItem("Settings", icon: "Setting", tag: "Settings")
             ],
             content: Button(isPaneOpen ? "Close pane" : "Open pane",
-                () => setIsPaneOpen(!isPaneOpen)).Padding(24)
+                () => setIsPaneOpen(!isPaneOpen))
+                .AutomationName(isPaneOpen ? "Close pane" : "Open pane")
+                .Padding(24)
         )
         // One call sets the pane state and wires the change handler, so the two
         // cannot drift apart.
@@ -530,14 +534,14 @@ class FrameEventsDemo : Component
             SubHeading("Frame events"),
             Frame(sourcePageType: typeof(DocsFrameDemoPage))
                 .Navigating(target =>
-                    updateLog(l => [.. l, $"Navigating to {target.Name}"]))
+                    updateLog(l => [.. l, $"{l.Count + 1}: Navigating to {target.Name}"]))
                 .Navigated(target =>
-                    updateLog(l => [.. l, $"Arrived at {target.Name}"]))
+                    updateLog(l => [.. l, $"{l.Count + 1}: Arrived at {target.Name}"]))
                 .NavigationFailed((target, ex) =>
-                    updateLog(l => [.. l, $"Failed {target.Name}: {ex.Message}"]))
+                    updateLog(l => [.. l, $"{l.Count + 1}: Failed {target.Name}: {ex.Message}"]))
                 .Height(300),
             VStack(4, log.TakeLast(6).Select(
-                entry => TextBlock(entry).FontSize(11).Opacity(0.6)
+                entry => TextBlock(entry).FontSize(11).Opacity(0.6).WithKey(entry)
             ).ToArray())
         ).Padding(24);
     }

--- a/docs/_pipeline/apps/persistence/App.cs
+++ b/docs/_pipeline/apps/persistence/App.cs
@@ -33,7 +33,9 @@ class NotesEditor : Component
 
         return VStack(8,
             SubHeading("Notes"),
-            TextBox(text, setText, placeholderText: "Start typing…").Width(380),
+            TextBox(text, setText, placeholderText: "Start typing…")
+                .AutomationName("Notes body")
+                .Width(380),
             TextBlock($"{text.Length} characters").Opacity(0.6)
         ).Padding(16);
     }
@@ -51,16 +53,19 @@ class VersionedNotesEditor : Component
 {
     public override Element Render()
     {
+        var initialState = UseMemo(
+            () => new NotesStateV2("", DateTimeOffset.Now, ""),
+            Array.Empty<object>());
         var (state, setState) = UsePersisted(
             "notes/state-v2",
-            initialValue: new NotesStateV2("", DateTimeOffset.Now, ""),
+            initialValue: initialState,
             scope: PersistedScope.Application);
 
         return VStack(8,
             TextBox(state.Title, t => setState(state with { Title = t }),
-                placeholderText: "Title"),
+                placeholderText: "Title", header: "Title"),
             TextBox(state.Body, b => setState(state with { Body = b, LastEdit = DateTimeOffset.Now }),
-                placeholderText: "Body")
+                placeholderText: "Body", header: "Body")
         );
     }
 
@@ -142,7 +147,8 @@ class ScopedStateDemo : Component
         // </snippet:scopes>
 
         return VStack(8,
-            TextBox(filter, setFilter, placeholderText: "Filter"),
+            TextBox(filter, setFilter, placeholderText: "Filter")
+                .AutomationName("List filter"),
             TextBlock(token.Length == 0 ? "(signed out)" : "(signed in)"));
     }
 }

--- a/docs/_pipeline/apps/reactor-vs-xaml/App.cs
+++ b/docs/_pipeline/apps/reactor-vs-xaml/App.cs
@@ -37,11 +37,12 @@ class ReactorVsXamlApp : Component
 
     // <snippet:style-as-composition>
     // A XAML `Style` is a keyed bag of setters matched by TargetType. The
-    // Reactor analogue is a plain method that applies modifiers — no static
-    // registration, no runtime TargetType check, just composition.
+    // Reactor analogue is a plain method that composes a wrapper element — no
+    // static registration, no runtime TargetType check, just composition.
     static Element CardSurface(Element child) =>
-        child.Background(Theme.CardBackground)
-             .CornerRadius(8)
-             .Padding(16);
+        Border(child)
+            .Background(Theme.CardBackground)
+            .CornerRadius(8)
+            .Padding(16);
     // </snippet:style-as-composition>
 }

--- a/docs/_pipeline/apps/readme/App.cs
+++ b/docs/_pipeline/apps/readme/App.cs
@@ -45,7 +45,7 @@ class StyledText : Component
             Heading("Heading element"),
             SubHeading("SubHeading element"),
             TextBlock("Regular text with modifiers")
-                .FontSize(14).Foreground("#0078D4"),
+                .FontSize(14).Foreground(Theme.Accent),
             Caption("Caption for fine print")
         ).Padding(24);
     }
@@ -68,6 +68,7 @@ class ReadmeShowcase : Component
                         SubHeading("Interactive greeting"),
                         TextBlock($"Hello, {name}!").FontSize(18),
                         TextBox(name, setName, placeholderText: "Your name")
+                            .AutomationName("Your name")
                             .Width(250)
                     );
                 }),

--- a/docs/_pipeline/apps/recipe-command-palette/App.cs
+++ b/docs/_pipeline/apps/recipe-command-palette/App.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using Microsoft.UI.Reactor;
 using Microsoft.UI.Reactor.Core;
+using Microsoft.UI.Reactor.Hooks;
 using Windows.System;
 using static Microsoft.UI.Reactor.Factories;
 
@@ -40,11 +41,13 @@ class CommandPalette : Component
     {
         // <snippet:state>
         // Three pieces of state run the palette: whether it's open, the
-        // typed query, and the highlighted row in the filtered list.
+        // typed query, and the highlighted row in the filtered list. The
+        // focus helper is separate; it moves focus into the query box on open.
         var (open, setOpen) = UseState(false);
         var (query, setQuery) = UseState("");
         var (index, setIndex) = UseState(0);
         var (last, setLast) = UseState<string?>(null);
+        var (queryRef, requestQueryFocus) = this.UseElementFocus();
         // </snippet:state>
 
         // <snippet:filter>
@@ -113,21 +116,32 @@ class CommandPalette : Component
                 : TextBlock($"Last command: {last}").Opacity(0.6)
         ).Padding(24);
 
+        UseEffect(() =>
+        {
+            if (open)
+                requestQueryFocus();
+            return () => { };
+        }, open);
+
         Element palette = Border(
             VStack(0,
                 TextBox(query, v => { setQuery(v); setIndex(0); },
-                    placeholderText: "Type a command…").Width(420),
+                    placeholderText: "Type a command…")
+                    .AutomationName("Command search")
+                    .Width(420)
+                    .Ref(queryRef),
                 matches.Length == 0
-                    ? TextBlock("No commands match.").Padding(12).Opacity(0.6)
+                    ? (Element)TextBlock("No commands match.").Padding(12).Opacity(0.6)
                     : VStack(0,
                         matches.Select((c, i) =>
-                            TextBlock(c.Label)
-                                .Padding(10)
-                                .Background(i == safeIndex ? "#E5F1FB" : "#FFFFFF")
+                            Border(
+                                TextBlock(c.Label).Padding(10)
+                            ).Background(i == safeIndex ? Theme.AccentTertiary : Theme.CardBackground)
+                             .WithKey(c.Label)
                         ).ToArray<Element>()
                     )
-            ).Background("#FFFFFF").CornerRadius(8).Width(440)
-        ).Background("#80000000").Padding(60)
+            ).Background(Theme.CardBackground).CornerRadius(8).Width(440)
+        ).Background(Theme.SmokeFill).Padding(60)
          .OnPreviewKeyDown(OnPaletteKey);
 
         var root = (open ? Group(page, palette) : page)

--- a/docs/_pipeline/apps/recipe-drag-reorder/App.cs
+++ b/docs/_pipeline/apps/recipe-drag-reorder/App.cs
@@ -114,8 +114,8 @@ class TaskList : Component
                     TextBlock(item.Title)
                 )
                 .Padding(10)
-                .Background(isFocused ? "#EEF4FB" : "#FFFFFF")
-                .WithBorder(isHover ? "#0078D4" : "#E1E1E1", isHover ? 2 : 1)
+                .Background(isFocused ? Theme.SubtleFill : Theme.CardBackground)
+                .WithBorder(isHover ? Theme.Accent : Theme.ControlStroke, isHover ? 2 : 1)
                 .Opacity(isDragging ? 0.4 : 1.0)
                 .IsTabStop(true)
                 .OnGotFocus((_, _) => setFocusedId(item.Id))
@@ -128,6 +128,11 @@ class TaskList : Component
                 {
                     if (args.Data.TryGetTypedPayload<int>(out var srcId) && srcId != item.Id)
                         setHoverId(item.Id);
+                })
+                .OnDragLeave(_ =>
+                {
+                    if (hoverId == item.Id)
+                        setHoverId(null);
                 })
                 .OnDrop<StackElement, int>(srcId =>
                 {
@@ -142,7 +147,7 @@ class TaskList : Component
             TextBlock("Drag a row, or focus one and press Alt+Up / Alt+Down.")
                 .Opacity(0.7),
             VStack(4,
-                items.Select(Row).ToArray()
+                items.Select(item => Row(item).WithKey(item.Id.ToString())).ToArray()
             )
         ).Padding(16).Width(320);
         // </snippet:render>

--- a/docs/_pipeline/apps/recipe-login/App.cs
+++ b/docs/_pipeline/apps/recipe-login/App.cs
@@ -67,14 +67,16 @@ class LoginForm : Component
             Heading("Sign in"),
             TextBox(email, setEmail, placeholderText: "you@example.com",
                 header: "Email").Width(280),
-            PasswordBox(pwd, setPwd, placeholderText: "8+ characters"),
+            PasswordBox(pwd, setPwd, placeholderText: "8+ characters")
+                .AutomationName("Password"),
             signIn.Error is null
                 ? Empty()
-                : TextBlock(signIn.Error.Message).Foreground("#C42B1C"),
+                : TextBlock(signIn.Error.Message).Foreground(Theme.SystemCritical),
             // SubmitAsync swallows the fault above, so this discard cannot
             // leave anything unobserved.
             Button(signIn.IsPending ? "Signing in…" : "Sign in",
                     () => _ = SubmitAsync())
+                .AutomationName("Sign in")
                 .IsEnabled(canSubmit)
         ).Padding(20).Width(320);
         // </snippet:render>

--- a/docs/_pipeline/apps/recipe-master-detail/App.cs
+++ b/docs/_pipeline/apps/recipe-master-detail/App.cs
@@ -40,7 +40,7 @@ class NoteBrowser : Component
                     .WithKey(n.Id.ToString())
                     .AutomationName(n.Title)
                     .HAlign(Microsoft.UI.Xaml.HorizontalAlignment.Stretch)
-                    .Background(n.Id == selectedId ? "#E5F1FB" : "#FFFFFF")
+                    .Background(n.Id == selectedId ? Theme.SubtleFill : Theme.SolidBackground)
             ).ToArray()
         ).Width(200).Padding(8);
 

--- a/docs/_pipeline/apps/recipe-master-detail/App.cs
+++ b/docs/_pipeline/apps/recipe-master-detail/App.cs
@@ -37,6 +37,8 @@ class NoteBrowser : Component
         var list = VStack(2,
             Notes.Select(n =>
                 Button(n.Title, () => setSelectedId(n.Id))
+                    .WithKey(n.Id.ToString())
+                    .AutomationName(n.Title)
                     .HAlign(Microsoft.UI.Xaml.HorizontalAlignment.Stretch)
                     .Background(n.Id == selectedId ? "#E5F1FB" : "#FFFFFF")
             ).ToArray()

--- a/docs/_pipeline/apps/recipe-modal-dialog/App.cs
+++ b/docs/_pipeline/apps/recipe-modal-dialog/App.cs
@@ -30,8 +30,7 @@ class DeleteConfirmation : Component
 
         // <snippet:modal>
         // Pair the dialog with a scrim (SmokeFill) so clicks outside the
-        // dialog don't reach the page underneath. The focus trap lives on
-        // the modal Border.
+        // dialog don't reach the page underneath.
         Element modal = Border(
             VStack(16,
                 Heading("Delete this item?"),
@@ -40,8 +39,8 @@ class DeleteConfirmation : Component
                     Button("Cancel", () => setOpen(false)),
                     Button("Delete", () => { setDeleted(true); setOpen(false); })
                 ).HAlign(Microsoft.UI.Xaml.HorizontalAlignment.Right)
-            ).Padding(20).Background("#FFFFFF").CornerRadius(8)
-        ).Background("#80000000").Padding(40);
+            ).Padding(20).Background(Theme.CardBackground).CornerRadius(8)
+        ).Background(Theme.SmokeFill).Padding(40);
         // </snippet:modal>
 
         return open ? Group(page, modal) : page;

--- a/docs/_pipeline/apps/recipe-multi-step-form/App.cs
+++ b/docs/_pipeline/apps/recipe-multi-step-form/App.cs
@@ -86,7 +86,9 @@ class Wizard : Component
             HStack(8,
                 Button("Back", () => setStep(step - 1)).IsEnabled(step != 0),
                 Button(step == 2 ? "Submit" : "Next",
-                    () => setStep(step + 1)).IsEnabled(canAdvance && step != 2)
+                    () => setStep(step + 1))
+                    .AutomationName(step == 2 ? "Submit form" : "Next step")
+                    .IsEnabled(canAdvance && step != 2)
             )
         ).Padding(20).Width(380);
         // </snippet:render>

--- a/docs/_pipeline/apps/recipe-paginated-list/App.cs
+++ b/docs/_pipeline/apps/recipe-paginated-list/App.cs
@@ -78,7 +78,7 @@ class CommitFeed : Component
         {
             body = VStack(8,
                 TextBlock($"Couldn't load commits: {error.Exception.Message}")
-                    .Foreground("#C42B1C"),
+                    .Foreground(Theme.SystemCritical),
                 Button("Retry", () => commits.Retry())
             ).Padding(20);
         }
@@ -94,6 +94,7 @@ class CommitFeed : Component
                         TextBlock(c.Sha).Opacity(0.5).Width(72),
                         TextBlock(c.Message)
                     ).Padding(6)
+                     .WithKey(c.Sha)
                 ).ToArray()
             );
         }
@@ -103,11 +104,16 @@ class CommitFeed : Component
         Element footer = atEnd
             ? TextBlock("— end of list —").Opacity(0.5).Padding(12)
             : error is not null && loadedItems.Length > 0
-                ? Button($"Retry — {error.Exception.Message}", () => commits.Retry()).Padding(8)
+                ? Button($"Retry — {error.Exception.Message}", () => commits.Retry())
+                    .AutomationName("Retry loading the next page")
+                    .Padding(8)
                 : Button(
                     loadingMore ? "Loading more…" : $"Load more ({commits.EstimatedRemaining} remaining)",
                     () => commits.FetchNext()
-                  ).IsEnabled(!loadingMore).Padding(8);
+                  )
+                    .AutomationName(loadingMore ? "Loading more commits" : "Load more commits")
+                    .IsEnabled(!loadingMore)
+                    .Padding(8);
 
         return VStack(0,
             Heading($"Commits ({commits.TotalCount ?? loadedItems.Length})").Padding(20),

--- a/docs/_pipeline/apps/recipe-search-with-suggestions/App.cs
+++ b/docs/_pipeline/apps/recipe-search-with-suggestions/App.cs
@@ -42,15 +42,17 @@ class SearchBox : Component
 
         // <snippet:render>
         return VStack(8,
-            TextBox(query, setQuery, placeholderText: "Search topics…").Width(300),
+            TextBox(query, setQuery, placeholderText: "Search topics…")
+                .AutomationName("Search topics")
+                .Width(300),
             suggestions.Length == 0
                 ? Empty()
                 : Border(
                     VStack(2,
                         suggestions.Select(s =>
-                            TextBlock(s).Padding(8)).ToArray()
-                    ).Background("#FFFFFF")
-                ).WithBorder("#E0E0E0").Width(300)
+                            TextBlock(s).Padding(8).WithKey(s)).ToArray()
+                    ).Background(Theme.SolidBackground)
+                ).WithBorder(Theme.ControlStroke).Width(300)
         ).Padding(20);
         // </snippet:render>
     }

--- a/docs/_pipeline/apps/recipe-settings-page/App.cs
+++ b/docs/_pipeline/apps/recipe-settings-page/App.cs
@@ -46,7 +46,7 @@ class SettingsPage : Component
     private static Element SettingsRow(string label, Element control) =>
         HStack(16,
             TextBlock(label).Width(120),
-            control
+            control.AutomationName(label)
         );
     // </snippet:row-helper>
 }

--- a/docs/_pipeline/apps/recipes-index/App.cs
+++ b/docs/_pipeline/apps/recipes-index/App.cs
@@ -12,13 +12,21 @@ class RecipesIndexApp : Component
         Heading("Recipes"),
         TextBlock("Real-world compositions made of Reactor primitives.")
             .Opacity(0.7),
-        HStack(8,
-            Tile("Login", "Validation + async submit"),
-            Tile("Master-detail", "Selection-driven layout"),
-            Tile("Settings", "Persisted preferences")
+        VStack(8,
+            HStack(8,
+                Tile("Login", "Validation + async submit"),
+                Tile("Master-detail", "Selection-driven layout"),
+                Tile("Settings", "Persisted preferences")),
+            HStack(8,
+                Tile("Paginated list", "Loading + empty + error states"),
+                Tile("Modal dialog", "Scrim + confirmation flow"),
+                Tile("Multi-step form", "Wizard validation")),
+            HStack(8,
+                Tile("Search", "Memoized suggestions"),
+                Tile("Command palette", "Keyboard-opened overlay"),
+                Tile("Drag-reorder", "Keyed list reordering"))
         )
     ).Padding(20);
-// </snippet:app>
 
     // <snippet:tile>
     private static Element Tile(string title, string sub) => VStack(4,
@@ -27,6 +35,7 @@ class RecipesIndexApp : Component
     ).Padding(12);
     // </snippet:tile>
 }
+// </snippet:app>
 
 // <snippet:rendering-shape>
 // Every recipe page in this folder pulls a tiny dedicated doc app under

--- a/docs/_pipeline/apps/rules-of-reactor/App.cs
+++ b/docs/_pipeline/apps/rules-of-reactor/App.cs
@@ -4,9 +4,8 @@ using static Microsoft.UI.Reactor.Factories;
 
 // Doc app for `rules-of-reactor.md`. Each snippet is a "before / after"
 // pair — the bad shape and the corrected shape — so the page can show
-// the analyzer's catch and the fix side by side. Analyzers are
-// suppressed in the csproj because these examples deliberately violate
-// the rules (the comment in each snippet names the analyzer code).
+// the analyzer's catch and the fix side by side. Deliberate
+// counterexamples name the analyzer code in their comments.
 ReactorApp.Run<RulesApp>("Rules of Reactor", width: 360, height: 220
 );
 
@@ -106,9 +105,16 @@ class TodoListBad : Component
     public override Element Render() => VStack(4,
         Items.Select(i =>
             // No .WithKey — reorder is destructive.
-            TextBox(i.Title, _ => { }, header: i.Id.ToString())
+            TextBox(i.Title, title => Rename(i, title), header: i.Id.ToString())
         ).ToArray()
     );
+
+    void Rename(TodoItem item, string title)
+    {
+        var index = System.Array.IndexOf(Items, item);
+        if (index >= 0)
+            Items[index] = item with { Title = title };
+    }
 }
 public record TodoItem(int Id, string Title);
 // </snippet:keys-bad>
@@ -120,10 +126,17 @@ class TodoListGood : Component
 
     public override Element Render() => VStack(4,
         Items.Select(i =>
-            TextBox(i.Title, _ => { }, header: i.Id.ToString())
+            TextBox(i.Title, title => Rename(i, title), header: i.Id.ToString())
                 .WithKey(i.Id.ToString())                  // stable identity
         ).ToArray()
     );
+
+    void Rename(TodoItem item, string title)
+    {
+        var index = System.Array.IndexOf(Items, item);
+        if (index >= 0)
+            Items[index] = item with { Title = title };
+    }
 }
 // </snippet:keys-good>
 

--- a/docs/_pipeline/apps/rules-of-reactor/rules-of-reactor.csproj
+++ b/docs/_pipeline/apps/rules-of-reactor/rules-of-reactor.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
     <UseWinUI>true</UseWinUI>
     <WindowsPackageType>None</WindowsPackageType>
-    <NoWarn>$(NoWarn);REACTOR_HOOKS_001;REACTOR_HOOKS_004;REACTOR_HOOKS_005;REACTOR_THEME_001;CS0169;CS0414;CS0649</NoWarn>
+    <NoWarn>$(NoWarn);REACTOR_HOOKS_001;REACTOR_HOOKS_004;REACTOR_HOOKS_005;REACTOR_DSL_001;CS0169;CS0414;CS0649</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\src\Reactor\Reactor.csproj" />

--- a/docs/_pipeline/apps/status-and-info/App.cs
+++ b/docs/_pipeline/apps/status-and-info/App.cs
@@ -1,5 +1,6 @@
 using Microsoft.UI.Reactor;
 using Microsoft.UI.Reactor.Core;
+using Microsoft.UI.Reactor.Hooks;
 using static Microsoft.UI.Reactor.Factories;
 using Microsoft.UI.Xaml;
 
@@ -101,7 +102,7 @@ class ProgressRingDemo : Component
     public override Element Render() => VStack(12,
         SubHeading("ProgressRing"),
         // Determinate ring at 60%.
-        ProgressRing(0.6).Width(48).Height(48),
+        ProgressRing(60).Width(48).Height(48),
         // Indeterminate spinner.
         ProgressRing().IsActive().Width(48).Height(48)
     ).Padding(24);
@@ -114,12 +115,14 @@ class TeachingTipDemo : Component
     public override Element Render()
     {
         var (show, setShow) = UseState(false);
+        var target = this.UseElementRef<FrameworkElement>();
 
         return VStack(12,
             SubHeading("TeachingTip"),
-            Button("Show tip", () => setShow(true)),
+            Button("Show tip", () => setShow(true)).Ref(target),
             TeachingTip("Try the new sort menu",
-                "Sort across multiple columns by holding Shift.") with
+                "Sort across multiple columns by holding Shift.",
+                target: target) with
             {
                 IsOpen = show,
                 OnClosed = () => setShow(false),

--- a/docs/_pipeline/apps/styling/App.cs
+++ b/docs/_pipeline/apps/styling/App.cs
@@ -15,11 +15,12 @@ class ThemeTokensExample : Component
             TextBlock("Primary Text").Foreground(Theme.PrimaryText),
             TextBlock("Secondary Text").Foreground(Theme.SecondaryText),
             TextBlock("Accent Text").Foreground(Theme.AccentText).SemiBold(),
-            TextBlock("On Accent Background")
-                .Foreground("#FFFFFF")
-                .Padding(horizontal: 8, vertical: 4)
-                .Background(Theme.Accent)
-                .CornerRadius(4)
+            Border(
+                TextBlock("On Accent Background")
+                    .Foreground(Theme.AccentText)
+                    .Padding(horizontal: 8, vertical: 4)
+            ).Background(Theme.Accent)
+             .CornerRadius(4)
         ).Padding(24);
     }
 }
@@ -59,10 +60,14 @@ class ColorModifiersExample : Component
     public override Element Render()
     {
         return VStack(8,
-            TextBlock("Theme token").Background(Theme.SubtleFill).Padding(8),
-            TextBlock("Hex string").Background("#E8F5E9").Padding(8),
-            TextBlock("Mixed").Foreground(Theme.PrimaryText)
-                .Background("#1E1E2E").Padding(8)
+            Border(TextBlock("Typed token").Padding(8))
+                .Background(Theme.SubtleFill),
+            Border(TextBlock("Theme.Ref token").Padding(8))
+                .Background(Theme.Ref("AcrylicBackgroundFillColorDefaultBrush")),
+            Border(TextBlock("Token foreground + token background")
+                .Foreground(Theme.PrimaryText)
+                .Padding(8))
+                .Background(Theme.ControlFill)
         ).Padding(24);
     }
 }
@@ -82,12 +87,13 @@ class SignalColorsExample : Component
     }
 
     static Element Badge(string label, ThemeRef color) =>
-        TextBlock(label)
-            .FontSize(12).SemiBold()
-            .Foreground(color)
-            .Padding(horizontal: 8, vertical: 4)
-            .Background(Theme.SubtleFill)
-            .CornerRadius(4);
+        Border(
+            TextBlock(label)
+                .FontSize(12).SemiBold()
+                .Foreground(color)
+                .Padding(horizontal: 8, vertical: 4)
+        ).Background(Theme.SubtleFill)
+         .CornerRadius(4);
 }
 // </snippet:signal-colors>
 

--- a/docs/_pipeline/apps/testing/App.cs
+++ b/docs/_pipeline/apps/testing/App.cs
@@ -45,7 +45,8 @@ class EffectfulCounter : Component
             Log.Add($"effect:{count}");
             return () => Log.Add($"cleanup:{count}");
         }, count);
-        return Button($"count={count}", () => setCount(count + 1));
+        return Button($"count={count}", () => setCount(count + 1))
+            .AutomationName($"Counter is {count}");
     }
 }
 // </snippet:effectful>
@@ -57,7 +58,7 @@ class EffectfulCounter : Component
 class IconOnlyButton : Component
 {
     public override Element Render() =>
-        Button(TextBlock("🔍"), null);      // icon content, no accessible name
+        Button(TextBlock("🔍"));            // icon content, no accessible name
 }
 
 class NamedButton : Component

--- a/docs/_pipeline/apps/text-and-media/App.cs
+++ b/docs/_pipeline/apps/text-and-media/App.cs
@@ -111,6 +111,8 @@ class ImageDemo : Component
         // Resource Uri — ms-appx:// for packaged assets, file:// for disk,
         // https:// for remote.
         Image("ms-appx:///Assets/StoreLogo.png")
+            .AutomationName("Reactor app logo")
+            .Set(img => img.Stretch = Microsoft.UI.Xaml.Media.Stretch.UniformToFill)
             .Width(96).Height(96),
         TextBlock("Stretch.UniformToFill for cover art; " +
                   "ImageFailed to detect missing assets.").Opacity(0.6)
@@ -124,8 +126,7 @@ class MediaPlayerDemo : Component
     public override Element Render() => VStack(8,
         SubHeading("MediaPlayerElement"),
         MediaPlayerElement(
-            "https://learn.microsoft.com/en-us/windows/apps/design/" +
-            "controls/images/ic_fluent_play_24_regular.svg")
+            "https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.mp4")
             .Width(420).Height(240)
             .Set(m =>
             {

--- a/docs/_pipeline/apps/theming-tokens/App.cs
+++ b/docs/_pipeline/apps/theming-tokens/App.cs
@@ -75,14 +75,14 @@ class SwatchGrid : Component
     private static Element SwatchSection(string title, (string Name, ThemeRef Ref)[] tokens) =>
         VStack(8,
             SubHeading(title),
-            VStack(4, tokens.Select(t => Row(t.Name, t.Ref)).ToArray())
+            VStack(4, tokens.Select(t => Row(t.Name, t.Ref).WithKey(t.Name)).ToArray())
         );
 
     private static Element Row(string name, ThemeRef token) => HStack(12,
         new BorderElement(Empty())
             .Background(token)
             .Size(40, 24)
-            .WithBorder("#DDDDDD"),
+            .WithBorder(Theme.ControlStroke),
         TextBlock(name).Width(220),
         TextBlock(token.ResourceKey).Opacity(0.6)
     );
@@ -94,10 +94,13 @@ class SwatchGrid : Component
 // aware modifiers like .Background / .Foreground. Use Theme.* tokens (or
 // Theme.Ref("...") for a custom XAML resource key) so the value follows the
 // theme switch.
+//
+// Don't:
+// Button("Click me", () => { }).Background("#0066CC");
 class HardcodedColorBad : Component
 {
     public override Element Render() =>
-        Button("Click me", () => { }).Background("#0066CC");   // REACTOR_THEME_001
+        Button("Click me", () => { }).Background(Theme.Accent);
 }
 // </snippet:bad-hardcoded>
 

--- a/docs/_pipeline/apps/todo-app/App.cs
+++ b/docs/_pipeline/apps/todo-app/App.cs
@@ -10,13 +10,15 @@ class TodoApp : Component
 {
     public override Element Render()
     {
-        var (items, updateItems) = UseReducer(new List<TodoItem>
+        var initialItems = UseMemo(() => new List<TodoItem>
         {
-            new("Learn Reactor basics", true),
-            new("Build a todo app", false),
-            new("Explore hooks", false),
+            new("todo-1", "Learn Reactor basics", true),
+            new("todo-2", "Build a todo app", false),
+            new("todo-3", "Explore hooks", false),
         });
+        var (items, updateItems) = UseReducer(initialItems);
         var (newText, setNewText) = UseState("");
+        var (nextId, setNextId) = UseState(4);
 
         var doneCount = items.Count(i => i.Done);
 
@@ -27,12 +29,15 @@ class TodoApp : Component
             // Input row
             HStack(8,
                 TextBox(newText, setNewText, placeholderText: "What needs to be done?")
+                    .AutomationName("New todo")
                     .Width(300),
                 Button("Add", () =>
                 {
                     if (!string.IsNullOrWhiteSpace(newText))
                     {
-                        updateItems(list => [.. list, new TodoItem(newText.Trim(), false)]);
+                        var text = newText.Trim();
+                        updateItems(list => [.. list, new TodoItem($"todo-{nextId}", text, false)]);
+                        setNextId(nextId + 1);
                         setNewText("");
                     }
                 }).IsEnabled(!(string.IsNullOrWhiteSpace(newText)))
@@ -40,13 +45,15 @@ class TodoApp : Component
 
             // Item list
             VStack(4,
-                items.Select((item, index) =>
+                items.Select((item, _) =>
                     HStack(8,
                         CheckBox(item.Done, done =>
                             updateItems(list =>
                             {
                                 var copy = new List<TodoItem>(list);
-                                copy[index] = item with { Done = done };
+                                var itemIndex = copy.FindIndex(i => i.Id == item.Id);
+                                if (itemIndex >= 0)
+                                    copy[itemIndex] = item with { Done = done };
                                 return copy;
                             }),
                             label: item.Text
@@ -55,11 +62,11 @@ class TodoApp : Component
                             updateItems(list =>
                             {
                                 var copy = new List<TodoItem>(list);
-                                copy.RemoveAt(index);
+                                copy.RemoveAll(i => i.Id == item.Id);
                                 return copy;
                             })
-                        )
-                    ).WithKey($"todo-{index}")
+                        ).AutomationName($"Remove {item.Text}")
+                    ).WithKey(item.Id)
                 ).ToArray()
             ),
 
@@ -67,7 +74,7 @@ class TodoApp : Component
             When(doneCount > 0, () =>
                 Button($"Clear completed ({doneCount})", () =>
                     updateItems(list => list.Where(i => !i.Done).ToList())
-                )
+                ).AutomationName("Clear completed todos")
             )
         ).Padding(24);
     }
@@ -75,5 +82,5 @@ class TodoApp : Component
 // </snippet:todo-app>
 
 // <snippet:todo-record>
-record TodoItem(string Text, bool Done);
+record TodoItem(string Id, string Text, bool Done);
 // </snippet:todo-record>

--- a/docs/_pipeline/apps/win2d-canvas/App.cs
+++ b/docs/_pipeline/apps/win2d-canvas/App.cs
@@ -21,7 +21,8 @@ class ManualCanvasDemo : Component
 
         return VStack(12,
             SubHeading("Manual canvas"),
-            Button($"Redraw with count {count}", () => setCount(count + 1)),
+            Button($"Redraw with count {count}", () => setCount(count + 1))
+                .AutomationName("Redraw manual canvas"),
             Win2DCanvas((session, _) =>
             {
                 session.Clear(Colors.White);
@@ -242,7 +243,8 @@ class DrawCommandDemo : Component
                 deps: [count]);
 
             return VStack(12,
-                Button($"Redraw with count {count}", () => setCount(count + 1)),
+                Button($"Redraw with count {count}", () => setCount(count + 1))
+                    .AutomationName("Redraw draw command canvas"),
                 Win2DCanvas(draw, redrawKey: count)
                     .ClearColor(Colors.White)
                     .Width(240)

--- a/docs/_pipeline/apps/windows/App.cs
+++ b/docs/_pipeline/apps/windows/App.cs
@@ -80,6 +80,7 @@ class NotePadWindow : Component
                 ? "(no owning window)"
                 : $"id={window.Id}  state={state}  dpi={window.Dpi}"),
             TextBox(text, setText, placeholderText: "Type something...")
+                .AutomationName("Document text")
                 .Width(360),
             Button("Close", () => window?.Close())
         ).Padding(16);
@@ -299,7 +300,9 @@ class TitleBarContentWindow : Component
         (TitleBar("Gallery") with
         {
             Content = HStack(8,
-                AutoSuggestBox("", _ => {}).Width(200),
+                AutoSuggestBox("", _ => {})
+                    .AutomationName("Search gallery")
+                    .Width(200),
                 Button(Icon(FontIcon("\uE713", fontSize: 16)), OnSettings)
                     .AutomationName("Settings").IsDragRegion(false)),
         }).AutoRefreshDragRegions();
@@ -430,21 +433,24 @@ class DisplayDemo : Component
 
 class PickerDemo : Component
 {
-    // <snippet:pickers>
-    // Both helpers return null when the user cancels the dialog.
-    async Task OpenAsync()
+    public override Element Render()
     {
-        var file = await UseFilePickerAsync(new FilePickerOptions(
-            FileTypeFilter: [".txt", ".md"]));
-        if (file is null) return;
+        // <snippet:pickers>
+        // Both helpers return null when the user cancels the dialog.
+        var pickFile = UseFilePickerAsync;
+        var pickFolder = UseFolderPickerAsync;
 
-        var folder = await UseFolderPickerAsync(new FolderPickerOptions());
-        if (folder is null) return;
+        return Button("Open...", async () =>
+        {
+            var file = await pickFile(new FilePickerOptions(
+                FileTypeFilter: [".txt", ".md"]));
+            if (file is null) return;
+
+            var folder = await pickFolder(new FolderPickerOptions());
+            if (folder is null) return;
+        });
+        // </snippet:pickers>
     }
-    // </snippet:pickers>
-
-    public override Element Render() =>
-        Button("Open...", () => _ = OpenAsync());
 }
 
 static class WindowRegistry

--- a/docs/_pipeline/apps/winforms-interop/App.cs
+++ b/docs/_pipeline/apps/winforms-interop/App.cs
@@ -70,7 +70,7 @@ class KeyboardDemo : Component
         // Tab/Shift+Tab cycles through Reactor controls normally.
         // Tab out of the last Reactor control returns focus to WinForms.
         return VStack(12,
-            TextBox(text, setText, placeholderText: "Type here...")
+            TextBox(text, setText, placeholderText: "Type here...", header: "Message")
                 .TabIndex(0),
             Button("Submit", () => { })
                 .TabIndex(1)
@@ -115,11 +115,13 @@ class BackgroundDemo : Component
         // Always set an explicit background on root content.
         // XAML Islands have no default background — without this,
         // content renders on a transparent surface.
-        return VStack(12,
-            TextBlock("Theme-aware background").Bold(),
-            TextBlock($"Count: {count}"),
-            Button("Increment", () => setCount(count + 1))
-        ).Padding(24).Background(SolidBackground);
+        return Grid([GridSize.Star()], [GridSize.Star()],
+            VStack(12,
+                TextBlock("Theme-aware background").Bold(),
+                TextBlock($"Count: {count}"),
+                Button("Increment", () => setCount(count + 1))
+            ).Padding(24)
+        ).Background(SolidBackground);
     }
 }
 // </snippet:background>

--- a/docs/_pipeline/apps/xaml-developers/App.cs
+++ b/docs/_pipeline/apps/xaml-developers/App.cs
@@ -64,9 +64,9 @@ class GridTranslationPage : Component
             columns: [GridSize.Auto, GridSize.Star()],
             rows: [GridSize.Auto, GridSize.Auto],
             TextBlock("First name").Bold().Grid(row: 0, column: 0),
-            TextBox("", _ => { }).Grid(row: 0, column: 1),
+            TextBox("", _ => { }).AutomationName("First name").Grid(row: 0, column: 1),
             TextBlock("Last name").Bold().Grid(row: 1, column: 0),
-            TextBox("", _ => { }).Grid(row: 1, column: 1)
+            TextBox("", _ => { }).AutomationName("Last name").Grid(row: 1, column: 1)
         ) with
         {
             ColumnSpacing = 12,

--- a/docs/_pipeline/templates/advanced.md.dt
+++ b/docs/_pipeline/templates/advanced.md.dt
@@ -463,13 +463,14 @@ handler that explicitly transitions the parent. See
 ```csharp snippet="advanced/wrong-this-capture"
 ```
 
-`.Set(control => ...)` runs on every mount and update — every event
-subscription accumulates. The `this` inside the lambda is the parent
-component, captured at the lambda's closure site, which keeps a strong
-reference to a stale render's component instance after the parent has
-re-rendered. Two fixes: lift the handler to a stable `UseCallback`
-in the parent and pass it via [props](components.md), or use
-`.OnMount(...)` for a one-shot subscription with explicit cleanup.
+The commented `.Set(control => ...)` line is the bug: `.Set` runs on
+every mount and update, so every render would add another event
+subscription. The `this` inside the lambda is the parent component,
+captured at the lambda's closure site, which keeps a strong reference
+to a stale render's component instance after the parent has re-rendered.
+Two fixes: lift the handler to a stable `UseCallback` in the parent and
+pass it via [props](components.md), or use `.OnMount(...)` for a one-shot
+subscription with explicit cleanup.
 
 (`.Set` is generated per control-backed element — `ButtonElement.Set(Action<Button>)`,
 `TextBoxElement.Set(Action<TextBox>)`, and so on. Component elements returned by

--- a/docs/_pipeline/templates/analyzer-architecture.md.dt
+++ b/docs/_pipeline/templates/analyzer-architecture.md.dt
@@ -204,9 +204,15 @@ correct.
 ```
 
 [`REACTOR_THEME_001`](theming-tokens.md) is a counterpoint: the rule
-needs to read the string literal that follows
-`.Background("...")` / `.Foreground("...")` / `.WithBorder("...")` and
-map it to a suggested theme token. The descriptor message format has a
+needs to read the string literals an argument to
+`.Background("...")` / `.Foreground("...")` / `.WithBorder("...")` can
+evaluate to, and map each one to a suggested theme token. It walks the
+value-*selecting* shapes — a conditional, switch, null-coalesce, or
+parenthesis — rather than only accepting a bare literal, because
+`.Background(isSelected ? "#E5F1FB" : "#FFFFFF")` is still two
+hard-coded colours. It deliberately does not walk into nested calls,
+where a string is not necessarily a colour at all. The descriptor
+message format has a
 `{0}` slot for the suggested token, which the analyzer looks up in
 `ColorToThemeToken` after the syntactic match. The diagnostic flows
 through to a paired `CodeFixProvider` that rewrites the literal to the

--- a/docs/_pipeline/templates/cheat-sheet.md.dt
+++ b/docs/_pipeline/templates/cheat-sheet.md.dt
@@ -138,8 +138,8 @@ Full token catalog on [Theming Tokens](theming-tokens.md).
 **Controlled input.** `var (v, set) = UseState("")` →
 `TextBox(v, set)`.
 
-**Effect with cleanup.** Return a `Func<void>` from the effect lambda;
-Reactor calls it before the next run and on unmount.
+**Effect with cleanup.** Return a cleanup lambda from the effect lambda;
+Reactor calls it before the next run (when deps change) and on unmount.
 
 **Conditional render.** `cond ? Element1 : Empty()` keeps the element
 out of the tree when `cond` is false — see the

--- a/docs/_pipeline/templates/collections.md.dt
+++ b/docs/_pipeline/templates/collections.md.dt
@@ -379,10 +379,10 @@ travel with the items.
 WinUI `ListView` and `GridView` ship drag-reorder, and Reactor exposes
 the relevant properties through the `.Set` passthrough until a
 first-class fluent ships. Three properties switch the surface on —
-`CanReorderItems`, `AllowDrop`, and `CanDragItems` — and the list
-mutates its internal `ItemsSource` order on drop. Mirror the new order
-back into your state via the underlying `ItemsSource` collection or a
-`DragItemsCompleted` handler:
+`CanReorderItems`, `AllowDrop`, and `CanDragItems`. The compact snippet
+below shows those WinUI switches; for a state-backed list, mirror the
+new order back into your state via the underlying `ItemsSource`
+collection or a `DragItemsCompleted` handler:
 
 ```csharp snippet="collections/drag-reorder"
 ```

--- a/docs/_pipeline/templates/dialogs-and-flyouts.md.dt
+++ b/docs/_pipeline/templates/dialogs-and-flyouts.md.dt
@@ -309,9 +309,10 @@ close.
 
 The exception is `Popup`. The popup has none of the above; it is a
 positioning primitive. For a popup that should behave like a modal,
-wrap its content with `UseFocusTrap` and apply the dialog role
-explicitly. `UseFocusTrap(bool isActive)` takes the active flag, and the
-handle attaches with the `.FocusTrap(handle)` element modifier — inside a
+wrap its content with `UseFocusTrap` and apply dialog semantics
+explicitly. `UseFocusTrap(bool isActive)` takes the active flag, the
+handle attaches with the `.FocusTrap(handle)` element modifier, and
+`.Semantics(role: "dialog")` supplies the screen-reader role — inside a
 `Component`, call the hook as `this.UseFocusTrap(...)` because it is an
 extension method:
 

--- a/docs/_pipeline/templates/docking.md.dt
+++ b/docs/_pipeline/templates/docking.md.dt
@@ -62,7 +62,8 @@ matches panes by `Key` and preserves the element subtree (and its
 `UseState` slots) across tree rebuilds. There is no implicit
 `Title`-as-key fallback; always supply one.
 
-The `DockNode` algebra has three node kinds (all immutable records):
+The `DockNode` algebra has three core node families (all immutable
+records), plus the document/tool leaf specializations:
 
 | Type | Purpose |
 |------|---------|

--- a/docs/_pipeline/templates/effects.md.dt
+++ b/docs/_pipeline/templates/effects.md.dt
@@ -78,7 +78,7 @@ change:
 ```csharp snippet="effects/dependency-effect"
 ```
 
-![Search with debounced query](screenshot://effects/dependency-effect)
+![Search reacting to query changes](screenshot://effects/dependency-effect)
 
 Every time `query` changes, the effect runs again. Reactor compares the current
 dependencies to the previous ones using structural equality. If nothing
@@ -221,10 +221,10 @@ stable across renders.
 ```csharp snippet="effects/missing-cleanup-dont"
 ```
 
-The component unmounts, the timer keeps firing, the setter is called on a
-dead [`RenderContext`](hooks-internals.md), and the setter throws (or worse,
-silently leaks the closure tree the timer captured). Always return a
-cleanup that cancels the producer:
+If you leave the commented effect active, the component unmounts, the timer
+keeps firing, the setter is called on a dead [`RenderContext`](hooks-internals.md),
+and the setter throws (or worse, silently leaks the closure tree the timer
+captured). Always return a cleanup that cancels the producer:
 
 ```csharp snippet="effects/missing-cleanup-do"
 ```

--- a/docs/_pipeline/templates/flex-layout.md.dt
+++ b/docs/_pipeline/templates/flex-layout.md.dt
@@ -336,7 +336,7 @@ container when total child width exceeds available space. Set
 vary. The cost is zero on rows that don't actually need to wrap — Yoga
 short-circuits when one line fits.
 
-### Reaching for `FlexPadding` when you wanted `.Padding`
+### Using `.Padding` when you wanted `FlexPadding`
 
 `FlexPadding` is a property on the FlexPanel itself, measured by Yoga
 inside the same algorithm that distributes children. The `.Padding(...)`

--- a/docs/_pipeline/templates/input-and-gestures.md.dt
+++ b/docs/_pipeline/templates/input-and-gestures.md.dt
@@ -163,6 +163,7 @@ lifts.
 
 ```csharp
 Image(imageUrl)
+    .AutomationName("Photo preview")
     .OnPinch(
         onChanged: g => Scale(g.Scale),
         withInertia: true)
@@ -346,7 +347,7 @@ visibility via `DragTargetArgs.UIOverride` — Reactor writes the changes back
 onto WinUI's `DragUIOverride` after your callback returns.
 
 ```csharp
-VStack(children)
+VStack(children.ToArray())
     .OnDragOver(args =>
     {
         args.UIOverride.Caption = "Move to Inbox";
@@ -439,9 +440,8 @@ see [recipes/drag-reorder](recipes/drag-reorder.md).
 
 ### Pinch-to-zoom on an image
 
-Combine `.OnPinch` with a `Translation` scale modifier driven from
-state. Scale is cumulative since `Began` — apply it directly to the
-element's `Scale` compositor property in `onChanged` for 60 Hz
+Combine `.OnPinch` with the element's `Scale` compositor property driven from
+state. Scale is cumulative since `Began` — apply it directly in `onChanged` for 60 Hz
 behavior (same pattern as pan above), then commit to `UseState` in
 `onEnded`. The reconciler unions `ManipulationModes` so adding
 `.OnRotate` on the same element is free.

--- a/docs/_pipeline/templates/localization.md.dt
+++ b/docs/_pipeline/templates/localization.md.dt
@@ -70,6 +70,11 @@ shape supported by the tuple-params overload:
 file name (e.g., `"App"` for `App.resw`). The accessor also exposes the
 current `Locale`, `Direction`, and `IsRtl` flag.
 
+In `.resw`-backed apps, `Reactor.Localization.Generator` reads the default
+locale's files at build time and emits the same keys as generated fields
+(for example, `Loc.App.Title`). These self-contained snippets spell out
+`new MessageKey(...)` so the in-memory provider remains visible.
+
 ## Formatting Numbers and Dates
 
 `IntlAccessor` provides locale-aware formatting for numbers, dates, and

--- a/docs/_pipeline/templates/navigation.md.dt
+++ b/docs/_pipeline/templates/navigation.md.dt
@@ -211,9 +211,9 @@ even after deep-linked entry.
 ```csharp snippet="navigation/deep-link-query"
 ```
 
-This example shows query parameters and optional path segments. The resolver
-parses `/users/42/posts?sort=date&page=2` into typed values you can use
-directly in route constructors.
+This example shows typed path parameters and query values. The resolver
+parses `/users/42/posts/7?sort=date` into typed values you can use directly
+in route constructors.
 
 ## Page Caching
 

--- a/docs/_pipeline/templates/reactor-vs-xaml.md.dt
+++ b/docs/_pipeline/templates/reactor-vs-xaml.md.dt
@@ -158,13 +158,13 @@ that matches a `TargetType` (or carries the style key). The bag is
 keyed by DP, and `BasedOn` chains styles through inheritance.
 
 Reactor has two analogues. The most common is a plain method that
-takes an element and applies modifiers:
+composes elements and modifiers:
 
 ```csharp snippet="reactor-vs-xaml/style-as-composition"
 ```
 
-Calling `CardSurface(TextBlock("hi"))` returns the modified element. This
-is just composition — no framework involvement, no static
+Calling `CardSurface(TextBlock("hi"))` returns a `Border` around the child
+with the card modifiers applied. This is just composition — no framework involvement, no static
 registration, no `Style.TargetType` check at runtime.
 
 For the handful of canonical WinUI named styles, the [styling](styling.md)

--- a/docs/_pipeline/templates/recipes/command-palette.md.dt
+++ b/docs/_pipeline/templates/recipes/command-palette.md.dt
@@ -28,6 +28,7 @@ overlay, layered over the page the same way the
 | Open / query / selection state | `UseState<bool>` / `UseState<string>` / `UseState<int>` |
 | Command catalog | [`Command`](../commanding.md) records — same shape used by `Button`, `MenuItem`, `AppBarButton` |
 | Filter | LINQ `Where(...Contains(query, OrdinalIgnoreCase))` |
+| Open focus | `UseElementFocus()` + `UseEffect` when `open` changes |
 | Open accelerator | [`.OnKeyDown`](../input-and-gestures.md) on the root surface |
 | List navigation | [`.OnPreviewKeyDown`](../input-and-gestures.md) on the palette container |
 | Overlay composition | `Group(page, palette)` — same shape as [Recipe: Modal dialog](modal-dialog.md) |
@@ -48,10 +49,12 @@ same record with a toolbar button or a context menu entry.
 ```csharp snippet="recipe-command-palette/state"
 ```
 
-Three hooks own the palette: `open` toggles the overlay, `query`
+Three state hooks own the palette: `open` toggles the overlay, `query`
 drives the filter, and `index` is the highlighted row. A fourth
 `last` hook just echoes the most recently executed command for the
-demo — it's not part of the palette pattern.
+demo — it's not part of the palette pattern. The focus helper is
+separate from palette state; it moves focus into the query box when
+the overlay opens.
 
 ### Filter
 
@@ -88,7 +91,7 @@ covers the preview-vs-bubble pairing in detail.
 
 The page renders normally; the palette is a `Border` wrapping a
 `VStack` returned alongside it in a `Group(page, palette)`. The
-scrim background `#80000000` dims the page underneath. The root
+theme smoke-fill scrim dims the page underneath. The root
 surface's `.OnKeyDown` watches for Ctrl+K and toggles `open`, which
 is the cheapest "global accelerator" that works from any focus state
 on the page.

--- a/docs/_pipeline/templates/recipes/index.md.dt
+++ b/docs/_pipeline/templates/recipes/index.md.dt
@@ -19,24 +19,6 @@ palette, drag-to-reorder. The recipes here are not exhaustive apps;
 each is a single screen showing the pattern, and each ships a tiny
 doc app you can clone and adapt.
 
-```csharp snippet="recipes-index/app"
-```
-
-![Recipes gallery preview](screenshot://recipes-index/gallery)
-
-The gallery uses the same primitives every recipe page does — a
-`VStack` for the column layout, `TextBlock` for descriptions, `HStack`
-for the tile row. The tile helper is a private static method, not a
-component, so it has no hook scope:
-
-```csharp snippet="recipes-index/tile"
-```
-
-Every page in this folder follows the same shape:
-
-```csharp snippet="recipes-index/rendering-shape"
-```
-
 ## Gallery
 
 | Recipe | What it shows |
@@ -50,6 +32,26 @@ Every page in this folder follows the same shape:
 | [Search with suggestions](search-with-suggestions.md) | `UseMemo`-filtered suggestion list against a static catalog. |
 | [Command palette](command-palette.md) | Keyboard accelerator opening an overlay with a filtered command list. |
 | [Drag-reorder](drag-reorder.md) | Identity-preserving reorder of a keyed list, with a keyboard path. |
+
+## The gallery app
+
+```csharp snippet="recipes-index/app"
+```
+
+![Recipes gallery preview](screenshot://recipes-index/gallery)
+
+The gallery uses the same primitives every recipe page does — a
+`VStack` for the column layout, `TextBlock` for descriptions, and
+`HStack` for each tile row. The tile helper is a private static method, not a
+component, so it has no hook scope:
+
+```csharp snippet="recipes-index/tile"
+```
+
+Every page in this folder follows the same shape:
+
+```csharp snippet="recipes-index/rendering-shape"
+```
 
 ## How to read a recipe
 

--- a/docs/_pipeline/templates/recipes/login.md.dt
+++ b/docs/_pipeline/templates/recipes/login.md.dt
@@ -83,10 +83,9 @@ disabling the button is enough; an analyzer-flagged guard inside the
 mutator would double-fire on a re-render race. `signIn.IsPending` owns
 both the spinner label ("Signing in…") and the disabled state, so an
 in-flight submit can't be re-triggered by an Enter press.
-`() => _ = signIn.RunAsync((email, pwd))` is the standard fire-and-
-forget shape: the returned task carries the same fault that
-`signIn.Error` already holds, so the UI reads the handle rather than
-awaiting.
+`SubmitAsync` observes the task returned by `signIn.RunAsync((email, pwd))`
+while letting the mutation own the rendered error state, so the UI reads the
+handle instead of duplicating error flags.
 
 ## Tips
 

--- a/docs/_pipeline/templates/recipes/master-detail.md.dt
+++ b/docs/_pipeline/templates/recipes/master-detail.md.dt
@@ -21,7 +21,7 @@ is one `UseState` for the selected id and two slots in an `HStack`.
 | Slot | API |
 |---|---|
 | Selection state | `UseState<int?>` |
-| List render | `VStack` + `Select(...).ToArray()` |
+| List render | `VStack` + keyed `Select(...).ToArray()` |
 | Selected highlight | Per-row `.Background(...)` |
 | Detail branch | `Element` typed local for null case |
 | Layout split | `HStack(0, list, detail)` |
@@ -50,7 +50,7 @@ the selection actually changes.
 
 ![Master-detail layout](screenshot://recipe-master-detail/layout)
 
-The list is a `VStack` of full-width buttons; the selected row gets a
+The list is a keyed `VStack` of full-width buttons; the selected row gets a
 distinct background. The detail pane is conditional — `selected is null`
 renders the empty state, otherwise the title + body. Both sides are
 plain elements; no intermediate component is needed.

--- a/docs/_pipeline/templates/recipes/modal-dialog.md.dt
+++ b/docs/_pipeline/templates/recipes/modal-dialog.md.dt
@@ -5,7 +5,7 @@ order: 22.5
 audience: intermediate
 goal: |
   Confirmation-modal recipe: a scrim panel rendered conditionally,
-  a focus-trapped Border, and two button branches that flip the
+  a modal Border, and two button branches that flip the
   underlying state. Idiomatic conditional render — the modal is just
   another element in the tree.
 tier: solid

--- a/docs/_pipeline/templates/recipes/settings-page.md.dt
+++ b/docs/_pipeline/templates/recipes/settings-page.md.dt
@@ -33,9 +33,9 @@ moves. The row layout is a single helper.
 ```csharp snippet="recipe-settings-page/persisted-state"
 ```
 
-Three preferences, three keys. Each pref renders + persists
-independently, so adding a fourth is one line in `Render()` + one
-matching control. The `PersistedScope.Window` scope keeps the values
+Three preferences, three keys. Each pref persists independently, so
+adding a fourth is one line in `Render()` + one matching control. The
+`PersistedScope.Window` scope keeps the values
 inside the host window — flip to `PersistedScope.Application` for
 process-wide preferences (auth, locale, theme) per the
 [persistence](../persistence.md) page.
@@ -47,18 +47,20 @@ process-wide preferences (auth, locale, theme) per the
 
 ![Settings page](screenshot://recipe-settings-page/settings)
 
-A `VStack` of `SettingsRow`s; each row is a label + control. Reactor
-re-renders only the row whose state changed — the slider doesn't
-re-mount when you toggle notifications.
+A `VStack` of `SettingsRow`s; each row is a label + control. The page
+re-renders from the changed hook state, and the reconciler patches the
+existing controls in place — the slider doesn't re-mount when you toggle
+notifications.
 
 ### Row helper
 
 ```csharp snippet="recipe-settings-page/row-helper"
 ```
 
-A fixed-width label keeps the controls aligned across rows. The helper
-is a private static method, not a `Component` — it has no state, so a
-function returning an `Element` is the right shape.
+A fixed-width label keeps the controls aligned across rows, and the
+control receives the same text as its automation name. The helper is a
+private static method, not a `Component` — it has no state, so a function
+returning an `Element` is the right shape.
 
 ## Tips
 

--- a/docs/_pipeline/templates/status-and-info.md.dt
+++ b/docs/_pipeline/templates/status-and-info.md.dt
@@ -100,8 +100,8 @@ pick the ring for unknown-duration spinners next to a label
 ```
 
 <!-- phantom:skip "ProgressBar" -->
-The `value` argument is 0–100 for `Progress(double)` and 0–1 for
-`ProgressRing(double)` — same convention as the underlying WinUI
+The `value` argument is 0–100 for both `Progress(double)` and
+`ProgressRing(double)` — the same convention as the underlying WinUI
 controls. There is no `ProgressBar(...)` factory: the linear bar is
 reached through `Progress` / `ProgressIndeterminate`, which is what the
 element record `ProgressElement` binds to (spec 039 §5).

--- a/docs/_pipeline/templates/styling.md.dt
+++ b/docs/_pipeline/templates/styling.md.dt
@@ -48,7 +48,7 @@ of mode.
 |---|---|---|
 | `Theme.Accent`, `Theme.PrimaryText`, etc. | Typed token | Always — these are the canonical brush references. |
 | `Theme.Ref("AnyResourceKey")` | String token | The brush isn't surfaced as a typed accessor (rare). |
-| `.Background(token)` / `.Foreground(token)` | Color modifier | Apply a token to any element. |
+| `.Background(token)` / `.Foreground(token)` | Color modifier | Apply a token to elements that expose that property (for example `Border` for backgrounds, `TextBlock` for foregrounds). |
 | `.Background("#RRGGBB")` | Color modifier | Brand colors that must stay constant across themes. |
 | `.AccentButton()`, `.SubtleButton()`, `.TextLink()` | Named-style fluent | The four canonical button shapes. No `.Resources` needed. |
 | `.Informational()` / `.Success()` / `.Warning()` / `.Error()` | Named-style fluent | InfoBar severity. |
@@ -89,7 +89,8 @@ that looks native in both light and dark mode.
 
 ## Color modifiers
 
-`.Background()` and `.Foreground()` accept three input shapes:
+`.Background()` and `.Foreground()` accept typed tokens and `Theme.Ref`
+tokens for theme-aware colors:
 
 ```csharp snippet="styling/color-modifiers"
 ```
@@ -98,10 +99,10 @@ that looks native in both light and dark mode.
 |---|---|---|
 | Typed token | `.Background(Theme.Accent)` | yes |
 | `Theme.Ref` | `.Background(Theme.Ref("MyCustomBrush"))` | yes |
-| Hex string | `.Background("#FF5733")` | no — frozen |
-| `Windows.UI.Color` | `.Background(Colors.Blue)` | no — frozen |
+| Hex string | `.Background("#FF5733")` | no — frozen; reserve for brand colors |
+| `Brush` | `.Background(new SolidColorBrush(...))` | no — frozen; avoid unless the color must not follow theme |
 
-Tokens are the right default. Reserve hex and `Color` for brand colors
+Tokens are the right default. Reserve hex and `Brush` for brand colors
 that should stay constant regardless of mode.
 
 ## Signal colors

--- a/docs/_pipeline/templates/testing.md.dt
+++ b/docs/_pipeline/templates/testing.md.dt
@@ -39,13 +39,26 @@ pipeline which compiles every published sample:
 | Self-test | `tests/Reactor.SelfTests/` (fixtures in `Reactor.AppTests.Host`) | MSTest wrapping a TAP subprocess | Component renders into a real WinUI tree; assertions via `VisualTreeHelper`. |
 | App E2E | `tests/Reactor.AppTests/` | MSTest + winapp ui | Real user input, UIA properties as seen by assistive tech, cross-process behavior. |
 
-One command per suite — there are no filters to remember:
+Every suite runs on **Microsoft.Testing.Platform**. Full-suite commands are
+plain:
 
 <!-- ai:lock -->
 ```
 dotnet test tests/Reactor.Tests -p:Platform=x64
 dotnet test tests/Reactor.SelfTests
 dotnet test tests/Reactor.AppTests
+```
+<!-- /ai:lock -->
+
+For targeted runs, use the runner's current filter syntax: xUnit suites
+prefer MTP's `--filter-class` / `--filter-method` family, while the MSTest
+self-test and E2E suites keep VSTest-style `--filter` expressions:
+
+<!-- ai:lock -->
+```
+dotnet test tests/Reactor.Tests --filter-class "*ReconcilerMountUpdateTests*"
+dotnet test tests/Reactor.SelfTests --filter "ClassName~SkipReportingTests"
+dotnet test tests/Reactor.AppTests --filter "ClassName=Microsoft.UI.Reactor.AppTests.Tests.AccessibilityTests"
 ```
 <!-- /ai:lock -->
 

--- a/docs/_pipeline/templates/text-and-media.md.dt
+++ b/docs/_pipeline/templates/text-and-media.md.dt
@@ -15,16 +15,16 @@ tier: comprehensive
 winui-ref: https://learn.microsoft.com/en-us/windows/apps/design/controls/text-controls
 ---
 
-Text and media controls are the read-only-display half of the Microsoft.UI.Reactor (Reactor)
+Text and media controls are the display, rich-text, and media half of the Microsoft.UI.Reactor (Reactor)
 catalog: surfaces that show content the user is reading, watching, or
-inspecting rather than editing. Most of them are thin wrappers over the
+inspecting, plus `RichEditBox` for rich-text editing. Most of them are thin wrappers over the
 WinUI text and media surface, so the modifier names and accessibility
 behavior match what a WinUI developer already knows. The two outliers are
 [`Markdown(string)`](#markdown-reactor-original) — a Reactor-original
 renderer that parses GFM-style Markdown into the same element tree the
 rest of your UI uses, no WebView round trip — and the semantic text
-variants [`Heading`](#text-variants) / [`SubHeading`](#text-variants) /
-[`Caption`](#text-variants), which preset typography so that accessibility
+variants [`Heading`](#text-variants) / [`SubHeading`](#text-variants),
+which preset typography so that accessibility
 tooling can infer document outline without manually setting
 `AutomationProperties`. The trade-off the catalog makes here is bias
 toward composition: rich layouts come from many small text elements in a
@@ -34,22 +34,22 @@ prose, then jump to the control you need.
 
 # Text and Media
 
-This page covers every read-only-display and inline-rich-text control in
-Reactor. For input controls (`TextBox`, `PasswordBox`, `RichEditBox`),
+This page covers display text, inline rich text, rich-text editing, and media controls in
+Reactor. For single-line input controls (`TextBox`, `PasswordBox`),
 see [Forms](forms.md). For data-bound collections, see
 [Collections](collections.md).
 
 ## Text variants
 
 ```csharp
-Title(string)           // largest variant, ~40pt
-Heading(string)         // section title, ~28pt
+Title(string)           // WinUI title text style, ~28pt
+Heading(string)         // semantic heading, ~28pt
 SubHeading(string)      // sub-section header, ~20pt
 Subtitle(string)        // supporting line under a heading
 BodyLarge(string)       // lead paragraph
 TextBlock(string)       // body prose
 BodyStrong(string)      // body prose, semibold
-Caption(string)         // ~12pt, dimmed
+Caption(string)         // ~12pt metadata text
 ```
 
 ```csharp snippet="text-and-media/text-variants"
@@ -58,7 +58,8 @@ Caption(string)         // ~12pt, dimmed
 ![Heading / SubHeading / TextBlock / Caption stacked](screenshot://text-and-media/text-variants)
 
 `Heading`, `SubHeading`, and `Caption` return [`TextBlockElement`](components.md)
-with preset `FontSize`, weight, and `Foreground` from the active theme.
+with preset text sizing; `Heading` and `SubHeading` also set heading
+automation levels.
 They are the right tool for document outline — screen readers and the
 [accessibility scanner](accessibility.md) treat them as hierarchical
 landmarks, where a bare `TextBlock` styled with `.FontSize(24).Bold()` is
@@ -68,14 +69,14 @@ match the visual weight you want.
 
 | Factory | Default size | Use when |
 |---|---|---|
-| `Title` | ~40pt, semibold | The largest thing on a landing or hero surface. |
-| `Heading` | ~28pt, bold | One per page — the document title. |
+| `Title` | ~28pt, semibold | WinUI title-ramp text without heading semantics. |
+| `Heading` | ~28pt, bold | One per page — the semantic document title. |
 | `SubHeading` | ~20pt, semibold | Section header inside a long page. |
 | `Subtitle` | ~20pt, regular | Supporting line directly under a heading. |
 | `BodyLarge` | ~18pt | Lead paragraph or callout prose. |
 | `TextBlock` | Body | Paragraphs, labels, inline help. |
 | `BodyStrong` | Body, semibold | Emphasis inside body copy without a size jump. |
-| `Caption` | ~12pt, dimmed | Timestamps, metadata, helper text under a field. |
+| `Caption` | ~12pt | Timestamps, metadata, helper text under a field. |
 
 WinUI design page: [Typography in Windows 11](https://learn.microsoft.com/en-us/windows/apps/design/style/typography).
 

--- a/docs/_pipeline/templates/winforms-interop.md.dt
+++ b/docs/_pipeline/templates/winforms-interop.md.dt
@@ -300,7 +300,7 @@ handles lifecycle automatically. Reserve `ContentFactory` for components
 that need parameters or custom host setup.
 
 **Set an explicit background on root components.** XAML Islands have no
-default background. Use `.Background(SolidBackgroundFillColorBase)` for
+default background. Use `.Background(Theme.SolidBackground)` for
 theme-aware backgrounds.
 
 **Dock or anchor the island control.** `XamlIslandControl` supports

--- a/docs/contributing/doc-pipeline.md
+++ b/docs/contributing/doc-pipeline.md
@@ -542,3 +542,66 @@ mur docs check-tier --topic <name>
 # toward Comprehensive):
 mur docs check-tier --tier solid
 ```
+
+## 9. Doc-snippet analyzer gate
+
+Every `snippet=` block in `docs/guide/` is extracted verbatim from a doc app
+under `docs/_pipeline/apps/`. A doc app is therefore not a scratch project —
+it is the code the guides tell readers to write, and it is held to the same
+analyzer rules those readers get from the NuGet package.
+
+Two gaps used to hide that:
+
+1. Only `win2d-canvas` was listed in `Reactor.slnx`, so CI never built the
+   other 52 doc apps at all.
+2. A `ProjectReference` to `src/Reactor` does **not** flow `Reactor.Analyzers`
+   — it ships as a packed `<None Pack="true">` item — so even that one app
+   compiled without the rules its own readers are subject to.
+
+`docs/_pipeline/apps/Directory.Build.props` now wires the consumer analyzer
+bundle into every doc app, and the `docs-snippet-gate` job in
+`.github/workflows/ci.yml` builds them all through
+`docs/_pipeline/apps/DocApps.proj`. Any `REACTOR_*` diagnostic fails the job
+and is echoed as a GitHub annotation with its `file:line`.
+
+Rules that fire most often here, and what they mean for a snippet:
+
+| Rule | Why it matters in a doc app |
+|------|-----------------------------|
+| `REACTOR_THEME_001/004` | A hard-coded colour ignores the reader's theme. Use a `Theme` token. |
+| `REACTOR_MOD_003` | The receiver silently drops the modifier — the snippet does not do what the prose says. |
+| `REACTOR_A11Y_001/002/003/004` | The sample teaches an inaccessible control. |
+| `REACTOR_HOOKS_001/005` | The sample violates the rules of hooks. |
+| `REACTOR_DSL_001/002` | The sample teaches unstable list keys. |
+
+### Fix at the source
+
+Fix the code in `docs/_pipeline/apps/<topic>/App.cs`. Do **not** add
+`<NoWarn>`, `#pragma warning disable`, or an `.editorconfig` severity
+downgrade — `DocAppGateWiringTests` rejects those, because a suppression ships
+the anti-pattern to every reader who copies the snippet.
+
+The one exception is a page whose subject *is* the thing the rule flags: the
+provisional-API pages acknowledge `REACTOR_V1_PREVIEW`, and
+`rules-of-reactor` deliberately shows hook and key violations under "Wrong:"
+labels. Those pairs live in the `AllowedSuppressions` ledger in
+`tests/Reactor.DocPipeline.Tests/DocAppGateWiringTests.cs`, each with the
+justification that earned it. Adding a suppression without a ledger entry
+fails the test; leaving a ledger entry whose suppression is gone also fails it.
+
+### Running the same check locally
+
+```powershell
+# All doc apps, exactly as CI runs them.
+dotnet build docs/_pipeline/apps/DocApps.proj -t:Rebuild -c Debug -p:Platform=x64 `
+  -p:TreatWarningsAsErrors=true -p:WarningsNotAsErrors=NU1900
+
+# A single app while iterating.
+dotnet build docs/_pipeline/apps/<topic>/<topic>.csproj -c Debug -p:Platform=x64 `
+  --no-restore -p:BuildProjectReferences=false -t:Rebuild
+```
+
+`-t:Rebuild` is load-bearing: without it an up-to-date build never re-runs
+`csc`, so the analyzers do not run and a dirty app reports zero warnings.
+`-p:BuildProjectReferences=false` keeps several single-app builds from racing
+on `src/Reactor`'s `obj/bin`.

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -81,7 +81,7 @@ class StyledText : Component
             Heading("Heading element"),
             SubHeading("SubHeading element"),
             TextBlock("Regular text with modifiers")
-                .FontSize(14).Foreground("#0078D4"),
+                .FontSize(14).Foreground(Theme.Accent),
             Caption("Caption for fine print")
         ).Padding(24);
     }

--- a/docs/guide/accessibility.md
+++ b/docs/guide/accessibility.md
@@ -108,7 +108,7 @@ class Tier2Demo : Component
             ).FullDescription(
                 "Bar chart showing Q1 revenue: East $4.2M, " +
                 "West $3.8M, Central $2.1M")
-             .Padding(16).Background("#f5f5f5").CornerRadius(8),
+             .Padding(16).Background(Theme.CardBackground).CornerRadius(8),
             TextBlock("Decorative divider")
                 .Opacity(0.2)
                 .AccessibilityHidden()
@@ -298,21 +298,21 @@ class FocusTrapDemo : Component
         return VStack(12,
             SubHeading("Focus Trapping"),
             Button("Open Modal", () => setShowModal(true)),
-            When(showModal, () =>
-                Border(
-                    VStack(12,
-                        TextBlock("Modal Dialog").FontSize(18).Bold(),
-                        TextBlock("Tab/Shift+Tab stays inside this panel."),
-                        TextBox("", _ => { }, placeholderText: "Name")
-                            .TabIndex(0),
-                        Button("Close", () => setShowModal(false))
-                            .TabIndex(1)
-                    ).Padding(24)
-                ).WithBorder("#888", 1)
-                 .CornerRadius(8)
-                 .Background("#ffffff")
-                 .FocusTrap(trap)
-            )
+            Border(
+                VStack(12,
+                    TextBlock("Modal Dialog").FontSize(18).Bold(),
+                    TextBlock("Tab/Shift+Tab stays inside this panel."),
+                    TextBox("", _ => { }, placeholderText: "Name")
+                        .AutomationName("Name")
+                        .TabIndex(0),
+                    Button("Close", () => setShowModal(false))
+                        .TabIndex(1)
+                ).Padding(24)
+            ).WithBorder(Theme.CardStroke, 1)
+             .CornerRadius(8)
+             .Background(Theme.SolidBackground)
+             .FocusTrap(trap)
+             .IsVisible(showModal)
         ).Padding(24);
     }
 }
@@ -414,6 +414,8 @@ class SemanticPanelDemo : Component
                 Button(i <= rating ? "\u2605" : "\u2606",
                     () => setRating(i))
                     .AutomationName($"{i} star{(i == 1 ? "" : "s")}")
+                    .AccessibilityHidden()
+                    .WithKey($"star-{i}")
             ).ToArray())
             .Semantics(
                 role: "slider",

--- a/docs/guide/advanced.md
+++ b/docs/guide/advanced.md
@@ -474,8 +474,11 @@ component when items are added, removed, or the collection resets:
 ```csharp
 class ObservableCollectionDemo : Component
 {
-    private static readonly ObservableCollection<string> _tasks = new()
-        { "Review pull request", "Update documentation" };
+    private record TaskItem(int Id, string Title);
+
+    private static int _nextId = 3;
+    private static readonly ObservableCollection<TaskItem> _tasks = new()
+        { new TaskItem(1, "Review pull request"), new TaskItem(2, "Update documentation") };
 
     public override Element Render()
     {
@@ -490,15 +493,17 @@ class ObservableCollectionDemo : Component
                     .Width(200),
                 Button("Add", () => {
                     if (!string.IsNullOrWhiteSpace(input))
-                    { _tasks.Add(input.Trim()); setInput(""); }
+                    { _tasks.Add(new TaskItem(_nextId++, input.Trim())); setInput(""); }
                 })
             ),
             TextBlock($"{tasks.Count} tasks:").SemiBold(),
             VStack(4, tasks.Select((task, i) =>
                 HStack(8,
-                    TextBlock($"{i + 1}. {task}"),
-                    Button("Remove", () => _tasks.RemoveAt(i))
-                ).WithKey($"task-{i}-{task}")
+                    // The index is fine for display; it must not become the key.
+                    TextBlock($"{i + 1}. {task.Title}"),
+                    Button("Remove", () => _tasks.Remove(task))
+                        .AutomationName($"Remove {task.Title}")
+                ).WithKey(task.Id.ToString())   // stable identity survives removal
             ).ToArray())
         ).Padding(24);
     }

--- a/docs/guide/advanced.md
+++ b/docs/guide/advanced.md
@@ -48,10 +48,10 @@ class ErrorBoundaryDemo : Component
                 Component<BuggyComponent>(),
                 (Exception ex) => VStack(8,
                     TextBlock("Something went wrong").Bold()
-                        .Foreground("#d13438"),
+                        .Foreground(Theme.SystemCritical),
                     TextBlock(ex.Message).FontSize(12).Opacity(0.7)
                 ).Padding(12)
-                 .Background("#fde7e9")
+                 .Background(Theme.SystemCriticalBackground)
                  .CornerRadius(8)
             )
         ).Padding(24);
@@ -97,12 +97,12 @@ class ErrorBoundaryRetryDemo : Component
             ErrorBoundary(
                 Component<FlakyComponent>().WithKey($"flaky-{resetKey}"),
                 ex => VStack(8,
-                    TextBlock("Couldn't load.").Bold().Foreground("#d13438"),
+                    TextBlock("Couldn't load.").Bold().Foreground(Theme.SystemCritical),
                     TextBlock(ex.Message).FontSize(12).Opacity(0.7),
                     // Bumping resetKey reassigns identity to the child, so the
                     // ErrorBoundary mounts a fresh subtree on the next render.
                     Button("Retry", () => setResetKey(resetKey + 1))
-                ).Padding(12).Background("#fde7e9").CornerRadius(8)
+                ).Padding(12).Background(Theme.SystemCriticalBackground).CornerRadius(8)
             )
         ).Padding(24);
     }
@@ -114,7 +114,7 @@ class FlakyComponent : Component
     {
         var (attempt, _) = UseState(Random.Shared.Next(0, 3));
         if (attempt == 0) throw new InvalidOperationException("Service unavailable");
-        return TextBlock("Loaded.").Foreground("#107c10");
+        return TextBlock("Loaded.").Foreground(Theme.SystemSuccess);
     }
 }
 ```
@@ -154,7 +154,7 @@ class MemoSubtreeDemo : Component
                         TextBlock("Skips re-render when deps unchanged")
                             .FontSize(12).Opacity(0.6)
                     ).Padding(12)
-                ).Background("#f0f0f0").CornerRadius(8);
+                ).Background(Theme.CardBackground).CornerRadius(8);
             }, label)
         ).Padding(24);
     }
@@ -192,7 +192,9 @@ class ElementRefFocusDemo : Component
 
         return VStack(12,
             SubHeading("Imperative focus via ElementRef<T>"),
-            TextBox(name, setName, placeholderText: "Name").Ref(fieldRef),
+            TextBox(name, setName, placeholderText: "Name")
+                .AutomationName("Name")
+                .Ref(fieldRef),
             Button("Focus the field", () =>
                 fieldRef.Current?.Focus(FocusState.Programmatic))
         ).Padding(24);
@@ -373,9 +375,10 @@ class CustomHookDemo : Component
         var (isOn, toggle) = ctx.UseToggler();
         return VStack(8,
             SubHeading("Custom hook: UseToggler"),
-            Button(isOn ? "On" : "Off", toggle),
+            Button(isOn ? "On" : "Off", toggle)
+                .AutomationName("Toggle state"),
             TextBlock(isOn ? "State is on." : "State is off.")
-                .Foreground(isOn ? "#107c10" : "#666666")
+                .Foreground(isOn ? Theme.SystemSuccess : Theme.SecondaryText)
         ).Padding(24);
     });
 }
@@ -442,7 +445,8 @@ class ObservableTreeDemo : Component
                 header: "User Name"),
             ToggleSwitch(vm.DarkMode, v => vm.DarkMode = v,
                 header: "Dark Mode"),
-            Slider(vm.FontSize, 10, 32, v => vm.FontSize = (int)v),
+            Slider(vm.FontSize, 10, 32, v => vm.FontSize = (int)v)
+                .AutomationName("Font size"),
             TextBlock($"Preview: {vm.UserName}")
                 .FontSize(vm.FontSize).Bold()
         ).Padding(24);
@@ -482,6 +486,7 @@ class ObservableCollectionDemo : Component
             SubHeading("UseCollection"),
             HStack(8,
                 TextBox(input, setInput, placeholderText: "New task")
+                    .AutomationName("New task")
                     .Width(200),
                 Button("Add", () => {
                     if (!string.IsNullOrWhiteSpace(input))
@@ -763,20 +768,25 @@ handler that explicitly transitions the parent. See
 // current when the closure was created.
 class WrongThisCaptureDemo : Component
 {
-    public override Element Render() =>
-        Button("Load").Set(b => b.Loaded += (s, e) => this.OnChildLoaded());
+    public override Element Render()
+    {
+        // Don't do this:
+        // return Button("Load").Set(b => b.Loaded += (s, e) => this.OnChildLoaded());
+        return Button("Load");
+    }
 
     void OnChildLoaded() { }
 }
 ```
 
-`.Set(control => ...)` runs on every mount and update — every event
-subscription accumulates. The `this` inside the lambda is the parent
-component, captured at the lambda's closure site, which keeps a strong
-reference to a stale render's component instance after the parent has
-re-rendered. Two fixes: lift the handler to a stable `UseCallback`
-in the parent and pass it via [props](components.md), or use
-`.OnMount(...)` for a one-shot subscription with explicit cleanup.
+The commented `.Set(control => ...)` line is the bug: `.Set` runs on
+every mount and update, so every render would add another event
+subscription. The `this` inside the lambda is the parent component,
+captured at the lambda's closure site, which keeps a strong reference
+to a stale render's component instance after the parent has re-rendered.
+Two fixes: lift the handler to a stable `UseCallback` in the parent and
+pass it via [props](components.md), or use `.OnMount(...)` for a one-shot
+subscription with explicit cleanup.
 
 (`.Set` is generated per control-backed element — `ButtonElement.Set(Action<Button>)`,
 `TextBoxElement.Set(Action<TextBox>)`, and so on. Component elements returned by

--- a/docs/guide/analyzer-architecture.md
+++ b/docs/guide/analyzer-architecture.md
@@ -256,20 +256,63 @@ private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
     if (args.Count == 0)
         return;
 
-    // Check if the first argument is a string literal
-    var firstArg = args[0].Expression;
-    if (firstArg is not LiteralExpressionSyntax literal)
-        return;
-    if (!literal.IsKind(SyntaxKind.StringLiteralExpression))
-        return;
+    // Every string literal the first argument can evaluate to -- not just the argument itself.
+    // Gating on `firstArg is LiteralExpressionSyntax` let a selected/unselected pair like
+    // `.Background(isSelected ? "#E5F1FB" : "#FFFFFF")` through completely unreported, which is
+    // still two hard-coded colours and still ignores the reader's theme.
+    foreach (var literal in ColorLiterals(args[0].Expression))
+        ReportHardCodedColor(context, literal, methodName);
+}
 
-    var colorValue = literal.Token.ValueText;
+/// <summary>
+/// The string literals an argument can evaluate to.
+/// </summary>
+/// <remarks>
+/// Only value-<em>selecting</em> shapes are walked — a parenthesis, conditional, null-coalesce,
+/// or switch expression. Walking every descendant instead would reach into nested calls and
+/// report things that are not colours at all, e.g. the argument of
+/// <c>.Background(LookUpBrush("accent-ish"))</c>.
+/// </remarks>
+private static IEnumerable<LiteralExpressionSyntax> ColorLiterals(ExpressionSyntax? expression)
+{
+    switch (expression)
+    {
+        case LiteralExpressionSyntax literal when literal.IsKind(SyntaxKind.StringLiteralExpression):
+            yield return literal;
+            break;
+
+        case ParenthesizedExpressionSyntax parenthesized:
+            foreach (var nested in ColorLiterals(parenthesized.Expression)) yield return nested;
+            break;
+
+        case ConditionalExpressionSyntax conditional:
+            foreach (var nested in ColorLiterals(conditional.WhenTrue)) yield return nested;
+            foreach (var nested in ColorLiterals(conditional.WhenFalse)) yield return nested;
+            break;
+
+        case BinaryExpressionSyntax coalesce when coalesce.IsKind(SyntaxKind.CoalesceExpression):
+            foreach (var nested in ColorLiterals(coalesce.Left)) yield return nested;
+            foreach (var nested in ColorLiterals(coalesce.Right)) yield return nested;
+            break;
+
+        case SwitchExpressionSyntax switchExpression:
+            foreach (var arm in switchExpression.Arms)
+                foreach (var nested in ColorLiterals(arm.Expression)) yield return nested;
+            break;
+    }
+}
 ```
 
 [`REACTOR_THEME_001`](theming-tokens.md) is a counterpoint: the rule
-needs to read the string literal that follows
-`.Background("...")` / `.Foreground("...")` / `.WithBorder("...")` and
-map it to a suggested theme token. The descriptor message format has a
+needs to read the string literals an argument to
+`.Background("...")` / `.Foreground("...")` / `.WithBorder("...")` can
+evaluate to, and map each one to a suggested theme token. It walks the
+value-*selecting* shapes — a conditional, switch, null-coalesce, or
+parenthesis — rather than only accepting a bare literal, because
+`.Background(isSelected ? "#E5F1FB" : "#FFFFFF")` is still two
+hard-coded colours. It deliberately does not walk into nested calls,
+where a string is not necessarily a colour at all. The descriptor
+message format has a
 `{0}` slot for the suggested token, which the analyzer looks up in
 `ColorToThemeToken` after the syntactic match. The diagnostic flows
 through to a paired `CodeFixProvider` that rewrites the literal to the

--- a/docs/guide/animation.md
+++ b/docs/guide/animation.md
@@ -60,7 +60,8 @@ class OpacityDemo : Component
         return VStack(12,
             SubHeading("Opacity Transition"),
             Button(visible ? "Fade Out" : "Fade In",
-                () => setVisible(!visible)),
+                () => setVisible(!visible))
+                .AutomationName(visible ? "Fade out text" : "Fade in text"),
             TextBlock("This text fades in and out")
                 .FontSize(18).Bold()
                 .Opacity(visible ? 1.0 : 0.0)
@@ -90,12 +91,13 @@ class ScaleDemo : Component
         return VStack(12,
             SubHeading("Scale Transition"),
             Button(enlarged ? "Shrink" : "Enlarge",
-                () => setEnlarged(!enlarged)),
+                () => setEnlarged(!enlarged))
+                .AutomationName(enlarged ? "Shrink sample" : "Enlarge sample"),
             Border(
                 TextBlock("Scales up and down").FontSize(18).Bold()
             ).Padding(12)
              .CornerRadius(8)
-             .Background("#e8e8e8")
+             .Background(Theme.CardBackground)
              .Scale(enlarged ? 1.5f : 1.0f)
              .ScaleTransition()
         ).Padding(24);
@@ -125,7 +127,8 @@ class TranslationDemo : Component
         return VStack(12,
             SubHeading("Translation Transition"),
             Button(moved ? "Slide Back" : "Slide Right",
-                () => setMoved(!moved)),
+                () => setMoved(!moved))
+                .AutomationName(moved ? "Slide sample back" : "Slide sample right"),
             TextBlock("Slides horizontally")
                 .FontSize(18).Bold()
                 .Translation(moved ? 120f : 0f, 0f, 0f)
@@ -156,13 +159,14 @@ class BackgroundDemo : Component
         return VStack(12,
             SubHeading("Background Transition"),
             Button(warm ? "Cool Colors" : "Warm Colors",
-                () => setWarm(!warm)),
+                () => setWarm(!warm))
+                .AutomationName(warm ? "Switch to cool colors" : "Switch to warm colors"),
             VStack(8,
                 TextBlock("Background animates between colors")
-                    .Foreground("#ffffff").Bold()
+                    .Foreground(Theme.AccentText).Bold()
             ).Padding(16)
              .CornerRadius(8)
-             .Background(warm ? "#da3b01" : "#0078d4")
+             .Background(warm ? Theme.SystemCaution : Theme.Accent)
              .BackgroundTransition(TimeSpan.FromMilliseconds(600))
         ).Padding(24);
     }
@@ -190,13 +194,14 @@ class CombinedDemo : Component
         return VStack(12,
             SubHeading("Combined Transitions"),
             Button(active ? "Reset" : "Animate",
-                () => setActive(!active)),
+                () => setActive(!active))
+                .AutomationName(active ? "Reset combined transitions" : "Run combined transitions"),
             Border(
                 TextBlock("All at once").FontSize(16).Bold()
-                    .Foreground("#ffffff")
+                    .Foreground(Theme.AccentText)
             ).Padding(16)
              .CornerRadius(8)
-             .Background("#7b2ab5")
+             .Background(Theme.Accent)
              .Opacity(active ? 1.0 : 0.4)
              .Scale(active ? 1.2f : 1.0f)
              .Translation(active ? 40f : 0f, 0f, 0f)
@@ -236,14 +241,16 @@ class LayoutAnimationDemo : Component
                 {
                     nextId.Current++;
                     updateItems(l => [$"Item {nextId.Current}", .. l]);
-                }),
+                }).AutomationName("Add layout animation item"),
                 Button("Remove First", () =>
                     updateItems(l => l.Count > 0 ? l[1..] : l))
+                    .AutomationName("Remove first layout animation item")
             ),
             VStack(4, items.Select(item =>
-                TextBlock(item)
-                    .Padding(horizontal: 8, vertical: 12)
-                    .Background("#f0f0f0")
+                Border(
+                    TextBlock(item)
+                ).Padding(horizontal: 8, vertical: 12)
+                    .Background(Theme.CardBackground)
                     .CornerRadius(4)
                     .LayoutAnimation()
                     .WithKey($"item-{item}")
@@ -278,7 +285,8 @@ class ConnectedAnimationDemo : Component
 
         if (selected is not null)
             return VStack(12,
-                Button("Back to list", () => setSelected(null)),
+                Button("Back to list", () => setSelected(null))
+                    .AutomationName("Return to animation list"),
                 TextBlock(selected)
                     .FontSize(28).Bold()
                     .ConnectedAnimation($"title-{selected}")
@@ -290,7 +298,9 @@ class ConnectedAnimationDemo : Component
             VStack(4,
                 items.Select(item =>
                     Button(item, () => setSelected(item))
+                        .AutomationName($"Open {item}")
                         .ConnectedAnimation($"title-{item}")
+                        .WithKey($"source-{item}")
                 ).ToArray()
             )
         ).Padding(24);
@@ -342,8 +352,9 @@ class TransactionalAnimateDemo : Component
 {
     public override Element Render()
     {
-        var (items, setItems) = UseState<IReadOnlyList<Todo>>(
+        var initialItems = UseMemo<IReadOnlyList<Todo>>(() =>
             [new Todo("seed-1", "First"), new Todo("seed-2", "Second")]);
+        var (items, setItems) = UseState(initialItems);
 
         return VStack(12,
             SubHeading("Animations.Animate — structural changes"),
@@ -352,7 +363,8 @@ class TransactionalAnimateDemo : Component
             // with a spring. No per-element modifier needed.
             Button("Add", () =>
                 Animations.Animate(AnimationKind.Spring, () =>
-                    setItems([.. items, new Todo(Guid.NewGuid().ToString(), "New")]))),
+                    setItems([.. items, new Todo(Guid.NewGuid().ToString(), "New")])))
+                .AutomationName("Add animated todo"),
 
             ListView<Todo>(items, (t, _) => TextBlock(t.Title).Padding(8))
                 .Height(200)
@@ -449,7 +461,7 @@ class WithAnimationDemo : Component
                     {
                         setOpacity(opacity > 0.5 ? 0.2 : 1.0);
                     });
-            }),
+            }).AutomationName(opacity > 0.5 ? "Fade out with animation" : "Fade in with animation"),
             TextBlock("Compositor-animated via WithAnimation scope")
                 .FontSize(18).Bold()
                 .Opacity(opacity)
@@ -493,10 +505,11 @@ class AnimateDemo : Component
 
         return VStack(12,
             SubHeading(".Animate() Modifier"),
-            Button(active ? "Reset" : "Animate", () => setActive(!active)),
+            Button(active ? "Reset" : "Animate", () => setActive(!active))
+                .AutomationName(active ? "Reset animate modifier" : "Run animate modifier"),
             Border(
                 TextBlock("Spring-animated").FontSize(18).Bold()
-            ).Padding(12).CornerRadius(8).Background("#e8e8e8")
+            ).Padding(12).CornerRadius(8).Background(Theme.CardBackground)
              .Opacity(active ? 0.5 : 1.0)
              .Animate(Microsoft.UI.Reactor.Animation.Curve.Spring(0.65f))
         ).Padding(24);
@@ -533,14 +546,14 @@ class InteractionStatesDemo : Component
                 Border(
                     TextBlock("Hover me").FontSize(16).Bold()
                         .HAlign(HorizontalAlignment.Center).VAlign(VerticalAlignment.Center)
-                ).Padding(16).CornerRadius(8).Size(150, 60).Background("#50C878")
+                ).Padding(16).CornerRadius(8).Size(150, 60).Background(Theme.SystemSuccess)
                  .InteractionStates(s => s
                     .PointerOver(opacity: 0.85f, scale: 1.05f)
                     .Pressed(scale: 0.95f, opacity: 0.7f)),
                 Border(
                     TextBlock("Press me").FontSize(16).Bold()
                         .HAlign(HorizontalAlignment.Center).VAlign(VerticalAlignment.Center)
-                ).Padding(16).CornerRadius(8).Size(150, 60).Background("#9B59B6")
+                ).Padding(16).CornerRadius(8).Size(150, 60).Background(Theme.AccentSecondary)
                  .InteractionStates(s => s
                     .PointerOver(scale: 1.03f)
                     .Pressed(scale: 0.97f, opacity: 0.8f),
@@ -572,12 +585,13 @@ class TransitionDemo : Component
 
         return VStack(12,
             SubHeading("Enter/Exit Transition"),
-            Button(visible ? "Hide" : "Show", () => setVisible(!visible)),
+            Button(visible ? "Hide" : "Show", () => setVisible(!visible))
+                .AutomationName(visible ? "Hide transition sample" : "Show transition sample"),
             visible
                 ? Border(
                     TextBlock("Fade + Slide").FontSize(16).Bold()
                         .HAlign(HorizontalAlignment.Center).VAlign(VerticalAlignment.Center)
-                ).Padding(12).CornerRadius(8).Size(200, 60).Background("#E74C3C")
+                ).Padding(12).CornerRadius(8).Size(200, 60).Background(Theme.SystemCritical)
                  .Transition(Microsoft.UI.Reactor.Animation.Transition.Fade + Microsoft.UI.Reactor.Animation.Transition.Slide(Microsoft.UI.Reactor.Animation.Edge.Bottom))
                 : (Element)TextBlock("(removed from tree)")
         ).Padding(24);
@@ -610,13 +624,15 @@ class StaggerDemo : Component
 {
     public override Element Render()
     {
-        var (items, setItems) = UseState(new[] { "One", "Two", "Three", "Four", "Five" });
+        var initialItems = UseMemo(() => new[] { "One", "Two", "Three", "Four", "Five" });
+        var (items, setItems) = UseState(initialItems);
 
         return VStack(12,
             SubHeading("Staggered Animation"),
-            Button("Shuffle", () => setItems(items.OrderBy(_ => Random.Shared.Next()).ToArray())),
+            Button("Shuffle", () => setItems(items.OrderBy(_ => Random.Shared.Next()).ToArray()))
+                .AutomationName("Shuffle staggered items"),
             VStack(4, items.Select(item =>
-                TextBlock(item).Padding(horizontal: 8, vertical: 12).Background("#f0f0f0")
+                Border(TextBlock(item)).Padding(horizontal: 8, vertical: 12).Background(Theme.CardBackground)
                     .CornerRadius(4).LayoutAnimation()
                     .WithKey(item)
             ).ToArray()).Stagger(TimeSpan.FromMilliseconds(40))
@@ -646,11 +662,12 @@ class KeyframeDemo : Component
 
         return VStack(12,
             SubHeading("Keyframe Animation"),
-            Button("Pulse!", () => setCount(count + 1)),
+            Button("Pulse!", () => setCount(count + 1))
+                .AutomationName("Run pulse keyframe animation"),
             Border(
                 TextBlock("Pulse target").FontSize(16).Bold()
                     .HAlign(HorizontalAlignment.Center).VAlign(VerticalAlignment.Center)
-            ).Padding(12).CornerRadius(8).Size(200, 60).Background("#9B59B6")
+            ).Padding(12).CornerRadius(8).Size(200, 60).Background(Theme.AccentSecondary)
              .Keyframes("pulse", count, kf => kf
                 .Duration(600)
                 .At(0.0f, scale: global::System.Numerics.Vector3.One)
@@ -690,7 +707,7 @@ class ChoreographyDemo : Component
                     Microsoft.UI.Reactor.Animation.Curve.Ease(200), () => setPhase(1));
                 await Microsoft.UI.Reactor.Animation.AnimationScope.WithAnimationAsync(
                     Microsoft.UI.Reactor.Animation.Curve.Spring(0.7f), () => setPhase(2));
-            }),
+            }).AutomationName("Run choreography sequence"),
             TextBlock($"Phase: {phase}").FontSize(18).Bold()
                 .Opacity(phase == 0 ? 1.0 : phase == 1 ? 0.3 : 1.0)
         ).Padding(24);

--- a/docs/guide/architecture-overview.md
+++ b/docs/guide/architecture-overview.md
@@ -278,6 +278,13 @@ public UIElement? Reconcile(
         DebugElementsSkipped = 0;
         DebugUIElementsCreated = 0;
         DebugUIElementsModified = 0;
+        // Drop destination references a previous pass queued but never flushed. Every
+        // shipped host flushes at the end of each render, but a pass that threw
+        // mid-reconcile — or a Reconcile() caller that never flushes (tests,
+        // embedders) — must not accumulate strong UIElement refs. A list clear, so
+        // nothing here can throw and strand the depth counter incremented just above.
+        _pendingConnectedAnimationStarts.Clear();
+        _preparedConnectedAnimationKeys.Clear();
         if (ReactorFeatureFlags.HighlightReconcileChanges)
         {
             (_highlightMounted ??= new()).Clear();

--- a/docs/guide/async-resources.md
+++ b/docs/guide/async-resources.md
@@ -136,20 +136,21 @@ class InfiniteScrollExample : Component
             },
             deps: new object[] { "repo-main" });
 
-        // With a real virtualizer, drive fetches from ItemAt inside VirtualList's
-        // renderItem. The important bit: null return = placeholder row.
         return VStack(4,
             Heading($"Commits ({commits.TotalCount ?? 0})").FontSize(14),
-            VStack(2,
-                Enumerable.Range(0, Math.Min(commits.Items.Count, 6))
-                    .Select(i =>
-                    {
-                        var commit = commits.ItemAt(i);
-                        return commit is null
-                            ? TextBlock("…").Opacity(0.4).Padding(4)
-                            : TextBlock($"{commit.Sha} — {commit.Message}").Padding(4);
-                    })
-                    .ToArray())
+            VirtualList(
+                itemCount: commits.TotalCount ?? Math.Max(commits.Items.Count, 20),
+                renderItem: i =>
+                {
+                    var commit = commits.ItemAt(i);
+                    return commit is null
+                        ? TextBlock("…").Opacity(0.4).Padding(4)
+                        : TextBlock($"{commit.Sha} — {commit.Message}").Padding(4);
+                },
+                getItemKey: i => commits.ItemAt(i)?.Sha ?? $"placeholder-{i}",
+                itemHeight: 32,
+                onVisibleRangeChanged: (first, last) => commits.EnsureRange(first, last))
+                .Height(200)
         ).Padding(24);
     }
 }
@@ -227,7 +228,8 @@ class UseMutationExample : Component
             Heading($"Todos ({todos.Count})").FontSize(14),
             VStack(2, todos.Select(t =>
                 TextBlock(t.Title + (t.IsTemporary ? " (saving…)" : ""))
-                    .Opacity(t.IsTemporary ? 0.5 : 1.0)).ToArray()),
+                    .Opacity(t.IsTemporary ? 0.5 : 1.0)
+                    .WithKey(t.Title)).ToArray()),
             Button("Add Todo",
                 () => _ = mutation.RunAsync(new DemoApi.TodoInput($"Item {todos.Count + 1}")))
         ).Padding(24);

--- a/docs/guide/charting.md
+++ b/docs/guide/charting.md
@@ -45,19 +45,19 @@ collection and accessor functions for X and Y:
 ```csharp
 class LineChartDemo : Component
 {
+    private static readonly SalesPoint[] Data =
+    [
+        new(1, 120), new(2, 180), new(3, 150),
+        new(4, 220), new(5, 310), new(6, 280),
+        new(7, 350), new(8, 400), new(9, 380),
+        new(10, 420), new(11, 460), new(12, 510)
+    ];
+
     public override Element Render()
     {
-        var data = new SalesPoint[]
-        {
-            new(1, 120), new(2, 180), new(3, 150),
-            new(4, 220), new(5, 310), new(6, 280),
-            new(7, 350), new(8, 400), new(9, 380),
-            new(10, 420), new(11, 460), new(12, 510)
-        };
-
         return VStack(12,
             SubHeading("Line Chart"),
-            LineChart(data, d => d.Month, d => d.Revenue)
+            LineChart(Data, d => d.Month, d => d.Revenue)
                 .Title("Monthly Revenue — Line")
                 .SeriesName("Revenue")
                 .Units("months", "USD")
@@ -84,16 +84,16 @@ maps to the Y value:
 ```csharp
 class BarChartDemo : Component
 {
+    private static readonly SalesPoint[] Data =
+    [
+        new(1, 340), new(2, 420), new(3, 510), new(4, 380)
+    ];
+
     public override Element Render()
     {
-        var data = new SalesPoint[]
-        {
-            new(1, 340), new(2, 420), new(3, 510), new(4, 380)
-        };
-
         return VStack(12,
             SubHeading("Bar Chart"),
-            BarChart(data, d => d.Month, d => d.Revenue)
+            BarChart(Data, d => d.Month, d => d.Revenue)
                 .Title("Quarterly Revenue — Bar")
                 .SeriesName("Revenue")
                 .Units("quarters", "USD")
@@ -121,19 +121,19 @@ combines a filled area with a line overlay:
 ```csharp
 class AreaChartDemo : Component
 {
+    private static readonly SalesPoint[] Data =
+    [
+        new(1, 50), new(2, 120), new(3, 200),
+        new(4, 350), new(5, 480), new(6, 600),
+        new(7, 720), new(8, 850), new(9, 1020),
+        new(10, 1150), new(11, 1300), new(12, 1500)
+    ];
+
     public override Element Render()
     {
-        var data = new SalesPoint[]
-        {
-            new(1, 50), new(2, 120), new(3, 200),
-            new(4, 350), new(5, 480), new(6, 600),
-            new(7, 720), new(8, 850), new(9, 1020),
-            new(10, 1150), new(11, 1300), new(12, 1500)
-        };
-
         return VStack(12,
             SubHeading("Area Chart"),
-            AreaChart(data, d => d.Month, d => d.Revenue)
+            AreaChart(Data, d => d.Month, d => d.Revenue)
                 .Title("Monthly Revenue — Area")
                 .SeriesName("Revenue")
                 .Units("months", "USD")
@@ -161,19 +161,19 @@ for a donut chart:
 ```csharp
 class PieChartDemo : Component
 {
+    private static readonly CategoryData[] Data =
+    [
+        new("Engineering", 42),
+        new("Marketing", 18),
+        new("Sales", 25),
+        new("Support", 15)
+    ];
+
     public override Element Render()
     {
-        var data = new CategoryData[]
-        {
-            new("Engineering", 42),
-            new("Marketing", 18),
-            new("Sales", 25),
-            new("Support", 15)
-        };
-
         return VStack(12,
             SubHeading("Pie Chart"),
-            PieChart(data, d => d.Value, d => d.Name)
+            PieChart(Data, d => d.Value, d => d.Name)
                 .Title("Team Distribution")
                 .Description("Pie chart showing team size across Engineering, Marketing, Sales, and Support.")
                 .Width(300).Height(300)
@@ -218,27 +218,28 @@ with the new data:
 ```csharp
 class CombinedChartDemo : Component
 {
+    private static readonly SalesPoint[] Data2024 =
+    [
+        new(1, 100), new(2, 140), new(3, 180),
+        new(4, 200), new(5, 260), new(6, 300)
+    ];
+
+    private static readonly SalesPoint[] Data2025 =
+    [
+        new(1, 160), new(2, 220), new(3, 280),
+        new(4, 320), new(5, 390), new(6, 450)
+    ];
+
+    private static readonly string[] Years = ["2024", "2025"];
+
     public override Element Render()
     {
         var (year, setYear) = UseState(0);
-        var years = new[] { "2024", "2025" };
-
-        var data2024 = new SalesPoint[]
-        {
-            new(1, 100), new(2, 140), new(3, 180),
-            new(4, 200), new(5, 260), new(6, 300)
-        };
-        var data2025 = new SalesPoint[]
-        {
-            new(1, 160), new(2, 220), new(3, 280),
-            new(4, 320), new(5, 390), new(6, 450)
-        };
-
-        var data = year == 0 ? data2024 : data2025;
+        var data = year == 0 ? Data2024 : Data2025;
 
         return VStack(12,
             SubHeading("Interactive Chart"),
-            ComboBox(years, year, setYear),
+            ComboBox(Years, year, setYear),
             AreaChart(data, d => d.Month, d => d.Revenue)
                 .Title("Revenue by Year")
                 .SeriesName("Revenue")
@@ -268,12 +269,14 @@ diffs the old and new element trees and patches only what changed:
 ```csharp
 class DynamicDataDemo : Component
 {
+    private static readonly List<SalesPoint> InitialPoints =
+        Enumerable.Range(1, 8)
+            .Select(i => new SalesPoint(i, Random.Shared.Next(50, 500)))
+            .ToList();
+
     public override Element Render()
     {
-        var (points, updatePoints) = UseReducer(
-            Enumerable.Range(1, 8)
-                .Select(i => new SalesPoint(i, Random.Shared.Next(50, 500)))
-                .ToList());
+        var (points, updatePoints) = UseReducer(InitialPoints);
 
         return VStack(12,
             SubHeading("Dynamic Data"),
@@ -317,13 +320,13 @@ geometry, and returns any Element:
 ```csharp
 // Percent rendered inside the slice. The string label accessor
 // is still passed so screen readers describe the slice.
-PieChart(data, d => d.Value, d => d.Name)
+PieChart(Data, d => d.Value, d => d.Name)
     .Title("Team Distribution")
     .Width(300).Height(300)
     .InnerRadius(50).PadAngle(0.02)
     .LabelView((d, layout) =>
         TextBlock($"{layout.Fraction:P0}")
-            .FontSize(12).Bold().Foreground("White"))
+            .FontSize(12).Bold().Foreground(Theme.AccentText))
 ```
 
 ![Pie chart with the percent rendered inside each slice](images/charting/pie-label-view.png)
@@ -340,14 +343,14 @@ any Element. Each delegate receives the tick's domain value:
 
 ```csharp
 // X axis ticks: render month name plus a caption per tick.
-LineChart(data, d => d.Month, d => d.Revenue)
+LineChart(Data, d => d.Month, d => d.Revenue)
     .Title("Revenue by Month")
     .SeriesName("Revenue")
     .Width(600).Height(220)
     .Stroke("#0078D4").StrokeWidth(2.5)
     .ShowGrid(true).ShowAxes(true)
     .XTickLabelView(t => VStack(2,
-        TextBlock(months[Math.Clamp((int)t - 1, 0, months.Length - 1)])
+        TextBlock(Months[Math.Clamp((int)t - 1, 0, Months.Length - 1)])
             .FontSize(11).SemiBold(),
         TextBlock("month").FontSize(8).Opacity(0.6)))
 ```
@@ -400,19 +403,19 @@ annotations, and `.Interactive()` for keyboard navigation:
 /// </summary>
 class AccessibleChartDemo : Component
 {
+    private static readonly SalesPoint[] Data =
+    [
+        new(1, 120), new(2, 180), new(3, 150),
+        new(4, 220), new(5, 310), new(6, 280)
+    ];
+
     public override Element Render()
     {
-        var data = new SalesPoint[]
-        {
-            new(1, 120), new(2, 180), new(3, 150),
-            new(4, 220), new(5, 310), new(6, 280)
-        };
-
         return VStack(12,
             SubHeading("Accessible Chart"),
 
             // Static accessible chart: Title + SeriesName + Units
-            LineChart(data, d => d.Month, d => d.Revenue)
+            LineChart(Data, d => d.Month, d => d.Revenue)
                 .Title("Monthly Revenue 2024")
                 .SeriesName("Revenue")
                 .Units("months", "USD")
@@ -423,7 +426,7 @@ class AccessibleChartDemo : Component
                 .ShowGrid(true).ShowAxes(true),
 
             // Interactive accessible chart: adds keyboard nav and point invocation
-            BarChart(data, d => d.Month, d => d.Revenue)
+            BarChart(Data, d => d.Month, d => d.Revenue)
                 .Title("Monthly Revenue — Interactive")
                 .SeriesName("Revenue")
                 .Units("months", "USD")
@@ -691,12 +694,14 @@ public override Element Render()
 ```csharp
 class DynamicDataDemo : Component
 {
+    private static readonly List<SalesPoint> InitialPoints =
+        Enumerable.Range(1, 8)
+            .Select(i => new SalesPoint(i, Random.Shared.Next(50, 500)))
+            .ToList();
+
     public override Element Render()
     {
-        var (points, updatePoints) = UseReducer(
-            Enumerable.Range(1, 8)
-                .Select(i => new SalesPoint(i, Random.Shared.Next(50, 500)))
-                .ToList());
+        var (points, updatePoints) = UseReducer(InitialPoints);
 
         return VStack(12,
             SubHeading("Dynamic Data"),

--- a/docs/guide/cheat-sheet.md
+++ b/docs/guide/cheat-sheet.md
@@ -49,7 +49,8 @@ class StateVignette : Component
     public override Element Render()
     {
         var (count, setCount) = UseState(0);
-        return Button($"clicked {count}×", () => setCount(count + 1));
+        return Button($"clicked {count}×", () => setCount(count + 1))
+            .AutomationName($"Increment counter; clicked {count} times");
     }
 }
 ```
@@ -59,14 +60,14 @@ class EffectVignette : Component
 {
     public override Element Render()
     {
-        var (tick, setTick) = UseState(0);
+        var (tick, incrementTick) = UseReducer(0, threadSafe: true);
         UseEffect(() =>
         {
             var timer = new System.Timers.Timer(1000);
-            timer.Elapsed += (_, _) => setTick(tick + 1);
+            timer.Elapsed += (_, _) => incrementTick(t => t + 1);
             timer.Start();
             return () => timer.Dispose();
-        });
+        }, []);
         return TextBlock($"Tick: {tick}");
     }
 }
@@ -157,8 +158,8 @@ Full token catalog on [Theming Tokens](theming-tokens.md).
 **Controlled input.** `var (v, set) = UseState("")` →
 `TextBox(v, set)`.
 
-**Effect with cleanup.** Return a `Func<void>` from the effect lambda;
-Reactor calls it before the next run and on unmount.
+**Effect with cleanup.** Return a cleanup lambda from the effect lambda;
+Reactor calls it before the next run (when deps change) and on unmount.
 
 **Conditional render.** `cond ? Element1 : Empty()` keeps the element
 out of the tree when `cond` is false — see the

--- a/docs/guide/collections.md
+++ b/docs/guide/collections.md
@@ -272,7 +272,7 @@ class GridViewDemo : Component
                         TextBlock(contact.Name).Bold(),
                         TextBlock(contact.Email).FontSize(12).Opacity(0.6)
                     ).Padding(12)
-                     .Background("#f5f5f5")
+                     .Background(Theme.CardBackground)
                      .CornerRadius(8)
                      .Width(160).Height(80)
             ).Height(300)
@@ -336,7 +336,8 @@ class VirtualListRefDemo : Component
             SubHeading("VirtualListRef — Imperative Scroll"),
             HStack(8,
                 TextBox(targetIndex, setTargetIndex,
-                    placeholderText: "Index"),
+                    placeholderText: "Index")
+                    .AutomationName("Target index"),
                 Button("Scroll To", () =>
                 {
                     if (int.TryParse(targetIndex, out var idx))
@@ -502,17 +503,19 @@ class ForEachDemo : Component
     {
         var colors = new[]
         {
-            ("Red", "#ff4444"), ("Green", "#44ff44"),
-            ("Blue", "#4444ff"), ("Yellow", "#ffff44")
+            ("Primary", Theme.Accent), ("Secondary", Theme.AccentSecondary),
+            ("Tertiary", Theme.AccentTertiary), ("Subtle", Theme.SubtleFill)
         };
 
         return VStack(12,
             SubHeading("ForEach (non-virtualized)"),
             HStack(8,
-                ForEach(colors, ((string Name, string Hex) color) =>
-                    TextBlock(color.Name)
-                        .Padding(horizontal: 8, vertical: 16)
-                        .Background(color.Hex)
+                ForEach(colors, ((string Name, ThemeRef Brush) color) =>
+                    Border(
+                        TextBlock(color.Name)
+                            .Padding(horizontal: 8, vertical: 16)
+                    )
+                        .Background(color.Brush)
                         .CornerRadius(4)
                         .WithKey(color.Name)
                 )
@@ -542,7 +545,8 @@ class MultiSelectDemo : Component
     public override Element Render()
     {
         var contacts = SampleData.Contacts.Take(10).ToList();
-        var (selectedIds, setSelectedIds) = UseState(new List<string>());
+        var initialSelectedIds = UseMemo(() => new List<string>());
+        var (selectedIds, setSelectedIds) = UseState(initialSelectedIds);
 
         return VStack(12,
             SubHeading($"{selectedIds.Count} selected"),
@@ -589,29 +593,42 @@ removing an item causes every subsequent item to be rebuilt:
 ```csharp
 class WithKeyDemo : Component
 {
+    record FruitItem(string Id, string Name);
+
     public override Element Render()
     {
+        var initialItems = UseMemo(() => new List<FruitItem>
+        {
+            new("fruit-1", "Apple"),
+            new("fruit-2", "Banana"),
+            new("fruit-3", "Cherry")
+        });
         var (items, updateItems) = UseReducer(
-            new List<string> { "Apple", "Banana", "Cherry" });
+            initialItems);
         var (newItem, setNewItem) = UseState("");
+        var (nextId, setNextId) = UseState(4);
 
         return VStack(12,
             SubHeading("Stable Identity with WithKey"),
             HStack(8,
-                TextBox(newItem, setNewItem, placeholderText: "New item"),
+                TextBox(newItem, setNewItem, placeholderText: "New item")
+                    .AutomationName("New item"),
                 Button("Add", () => {
                     if (!string.IsNullOrWhiteSpace(newItem)) {
-                        updateItems(l => [.. l, newItem.Trim()]);
+                        var name = newItem.Trim();
+                        updateItems(l => [.. l, new FruitItem($"fruit-{nextId}", name)]);
+                        setNextId(nextId + 1);
                         setNewItem("");
                     }
                 })
             ),
-            VStack(4, items.Select((item, i) =>
+            VStack(4, items.Select((item, _) =>
                 HStack(8,
-                    TextBlock(item),
+                    TextBlock(item.Name),
                     Button("Remove", () => updateItems(
-                        l => l.Where((_, idx) => idx != i).ToList()))
-                ).WithKey($"item-{item}-{i}")
+                        l => l.Where(x => x.Id != item.Id).ToList()))
+                        .AutomationName($"Remove {item.Name}")
+                ).WithKey(item.Id)
             ).ToArray())
         ).Padding(24);
     }
@@ -694,25 +711,25 @@ travel with the items.
 WinUI `ListView` and `GridView` ship drag-reorder, and Reactor exposes
 the relevant properties through the `.Set` passthrough until a
 first-class fluent ships. Three properties switch the surface on —
-`CanReorderItems`, `AllowDrop`, and `CanDragItems` — and the list
-mutates its internal `ItemsSource` order on drop. Mirror the new order
-back into your state via the underlying `ItemsSource` collection or a
-`DragItemsCompleted` handler:
+`CanReorderItems`, `AllowDrop`, and `CanDragItems`. The compact snippet
+below shows those WinUI switches; for a state-backed list, mirror the
+new order back into your state via the underlying `ItemsSource`
+collection or a `DragItemsCompleted` handler:
 
 ```csharp
 class DragReorderDemo : Component
 {
     public override Element Render()
     {
-        var (items, setItems) = UseState(
-            new List<string> { "Alpha", "Bravo", "Charlie",
-                "Delta", "Echo", "Foxtrot" });
+        var initialItems = UseMemo(() => new List<string> { "Alpha", "Bravo", "Charlie",
+            "Delta", "Echo", "Foxtrot" });
+        var (items, setItems) = UseState(initialItems);
 
         // Reactor surfaces drag-reorder through the underlying WinUI
         // ListView's CanReorderItems / AllowDrop / CanDragItems. The
         // .Set passthrough is the supported escape hatch until a
-        // first-class fluent ships. The user's reorder is mirrored
-        // back into state via the ListView's reorder event.
+        // first-class fluent ships. The recipe linked below shows
+        // how to mirror a drop back into app state.
         return VStack(8,
             SubHeading("Drag to reorder"),
             ListView<string>(
@@ -858,7 +875,7 @@ class LetterJump : Component<IReadOnlyList<Person>>
                     {
                         if (groupStarts.TryGetValue(letter, out var start))
                             listRef.Current?.ScrollToIndex(start);
-                    })))
+                    }).AutomationName($"Jump to {letter}")))
         );
     }
 }
@@ -885,29 +902,42 @@ ForEach(items, (item, i) => Row(item).WithKey(i.ToString()))
 ```csharp
 class WithKeyDemo : Component
 {
+    record FruitItem(string Id, string Name);
+
     public override Element Render()
     {
+        var initialItems = UseMemo(() => new List<FruitItem>
+        {
+            new("fruit-1", "Apple"),
+            new("fruit-2", "Banana"),
+            new("fruit-3", "Cherry")
+        });
         var (items, updateItems) = UseReducer(
-            new List<string> { "Apple", "Banana", "Cherry" });
+            initialItems);
         var (newItem, setNewItem) = UseState("");
+        var (nextId, setNextId) = UseState(4);
 
         return VStack(12,
             SubHeading("Stable Identity with WithKey"),
             HStack(8,
-                TextBox(newItem, setNewItem, placeholderText: "New item"),
+                TextBox(newItem, setNewItem, placeholderText: "New item")
+                    .AutomationName("New item"),
                 Button("Add", () => {
                     if (!string.IsNullOrWhiteSpace(newItem)) {
-                        updateItems(l => [.. l, newItem.Trim()]);
+                        var name = newItem.Trim();
+                        updateItems(l => [.. l, new FruitItem($"fruit-{nextId}", name)]);
+                        setNextId(nextId + 1);
                         setNewItem("");
                     }
                 })
             ),
-            VStack(4, items.Select((item, i) =>
+            VStack(4, items.Select((item, _) =>
                 HStack(8,
-                    TextBlock(item),
+                    TextBlock(item.Name),
                     Button("Remove", () => updateItems(
-                        l => l.Where((_, idx) => idx != i).ToList()))
-                ).WithKey($"item-{item}-{i}")
+                        l => l.Where(x => x.Id != item.Id).ToList()))
+                        .AutomationName($"Remove {item.Name}")
+                ).WithKey(item.Id)
             ).ToArray())
         ).Padding(24);
     }

--- a/docs/guide/commanding.md
+++ b/docs/guide/commanding.md
@@ -44,7 +44,7 @@ class BasicCommandExample : Component
         };
 
         return VStack(12,
-            TextBox(text, v => { setText(v); setSaved(false); })
+            TextBox(text, v => { setText(v); setSaved(false); }, header: "Document")
                 .Width(400),
             HStack(8,
                 Button(saveCmd),
@@ -436,7 +436,7 @@ class ParameterizedCommandExample : Component
     public override Element Render()
     {
         var (items, setItems) = UseState<IReadOnlyList<TodoItem>>(
-            new[] { new TodoItem(1, "Buy milk"), new TodoItem(2, "Walk dog"), new TodoItem(3, "Ship doc") });
+            UseMemo(() => new[] { new TodoItem(1, "Buy milk"), new TodoItem(2, "Walk dog"), new TodoItem(3, "Ship doc") }, []));
 
         // One Command<TodoItem> drives every row.
         var delete = new Command<TodoItem>
@@ -453,6 +453,7 @@ class ParameterizedCommandExample : Component
                     // Inline button — Command<T> doesn't have a Button(cmd, arg) overload
                     // by design, so call .Execute(arg) directly from the click handler.
                     Button(delete.Label, () => delete.Execute?.Invoke(item))
+                        .AutomationName($"Delete {item.Title}")
                         .IsEnabled(delete.IsEnabled)))
         ).Padding(24);
     }
@@ -523,7 +524,7 @@ class CommandBarExample : Component
                 secondaryCommands: new[] {
                     AppBarButton(delete) }
             ),
-            TextBox(text, setText).Margin(16)
+            TextBox(text, setText, header: "Document").Margin(16)
         );
     }
 }
@@ -767,7 +768,7 @@ class CanExecuteDontExample : Component
             Execute = () => { if (text.Length > 0) Save(); },
         };
 
-        return VStack(12, TextBox(text, setText).Width(300), Button(save))
+        return VStack(12, TextBox(text, setText, header: "Document").Width(300), Button(save))
             .Padding(24);
 
         void Save() { }
@@ -796,7 +797,7 @@ class CanExecuteDoExample : Component
             CanExecute = text.Length > 0,
         };
 
-        return VStack(12, TextBox(text, setText).Width(300), Button(save))
+        return VStack(12, TextBox(text, setText, header: "Document").Width(300), Button(save))
             .Padding(24);
 
         void Save() { }

--- a/docs/guide/components.md
+++ b/docs/guide/components.md
@@ -52,6 +52,7 @@ class Greeting : Component
         return VStack(12,
             TextBlock($"Hello, {name}!").FontSize(20).Bold(),
             TextBox(name, setName, placeholderText: "Your name")
+                .AutomationName("Name")
                 .Width(200)
         ).Padding(16);
     }
@@ -80,9 +81,9 @@ class Alert : Component<AlertProps>
     {
         var bg = Props.Severity switch
         {
-            "error" => "#FDE7E9",
-            "warning" => "#FFF4CE",
-            _ => "#DFF6DD"
+            "error" => Theme.SystemCriticalBackground,
+            "warning" => Theme.SystemCautionBackground,
+            _ => Theme.SystemSuccessBackground
         };
 
         return Border(

--- a/docs/guide/context.md
+++ b/docs/guide/context.md
@@ -238,9 +238,11 @@ static class AppContexts
 
 class UserContextExample : Component
 {
+    private static readonly CurrentUser InitialUser = new("u1", "Alice", IsAdmin: true);
+
     public override Element Render()
     {
-        var (user, setUser) = UseState(new CurrentUser("u1", "Alice", IsAdmin: true));
+        var (user, setUser) = UseState(InitialUser);
 
         return VStack(12,
             HStack(8,

--- a/docs/guide/controls.md
+++ b/docs/guide/controls.md
@@ -84,7 +84,7 @@ class FormsGroup : Component
         var (volume, setVolume) = UseState(60.0);
 
         return VStack(8,
-            TextBox(name, setName, placeholderText: "Name").Width(200),
+            TextBox(name, setName, placeholderText: "Name", header: "Name").Width(200),
             CheckBox(agree, setAgree, label: "I agree"),
             Slider(volume, 0, 100, setVolume).Width(200),
             Button("Submit", () => { })

--- a/docs/guide/data-system.md
+++ b/docs/guide/data-system.md
@@ -194,8 +194,8 @@ class SelectionDemo : Component
 {
     public override Element Render()
     {
-        var (selected, setSelected) = UseState<IReadOnlySet<RowKey>>(
-            new HashSet<RowKey>());
+        var initialSelection = UseMemo<IReadOnlySet<RowKey>>(() => new HashSet<RowKey>());
+        var (selected, setSelected) = UseState(initialSelection);
 
         var source = UseMemo(() => new ListDataSource<Product>(
             SampleProducts.Items, p => (RowKey)p.Id));
@@ -399,7 +399,7 @@ class RowDetailsDemo : Component
                     TextBlock($"Full details for {product.Name}"),
                     TextBlock($"Category: {product.Category}"),
                     TextBlock($"Unit price: {product.Price:C2}, Stock: {product.Stock}")
-                ).Padding(16).Background("#f5f5f5")
+                ).Padding(16).Background(Theme.CardBackground)
         ).Height(400);
     }
 }

--- a/docs/guide/dev-tooling.md
+++ b/docs/guide/dev-tooling.md
@@ -76,7 +76,8 @@ class DevToolingApp : Component
                 Button("Click me", () => setCount(count + 1)),
                 TextBlock($"Clicked {count} times").SemiBold()
             ),
-            TextBox(message, setMessage, placeholderText: "Type something")
+            TextBox(message, setMessage, placeholderText: "Type something",
+                header: "Message")
                 .Width(300)
         ).Padding(24);
     }
@@ -426,7 +427,8 @@ class IterationDemo : Component
             Heading("Iteration Cycle Demo"),
             TextBlock("Add items, then edit this code and save to see hot reload."),
             HStack(8,
-                TextBox(input, setInput, placeholderText: "New item")
+                TextBox(input, setInput, placeholderText: "New item",
+                    header: "New item")
                     .Width(200),
                 Button("Add", () =>
                 {

--- a/docs/guide/dialogs-and-flyouts.md
+++ b/docs/guide/dialogs-and-flyouts.md
@@ -178,8 +178,7 @@ class DialogGatedPrimaryDemo : Component
             ContentDialog(
                 "Rename file",
                 VStack(8,
-                    TextBlock("New filename:"),
-                    TextBox(name, setName, placeholderText: "untitled.txt")
+                    TextBox(name, setName, placeholderText: "untitled.txt", header: "New filename")
                         .Width(280)),
                 primaryButtonText: "Rename") with
             {
@@ -403,12 +402,13 @@ class PopupDemo : Component
                 TextBlock("This is a Popup.").Bold(),
                 TextBlock("Click outside to dismiss.")
             ).Padding(12)
-        ).Background("#FFFFFF").WithBorder("#888888").CornerRadius(6);
+        ).Background(Theme.SolidBackground).WithBorder(Theme.ControlStroke).CornerRadius(6);
 
         return VStack(8,
             SubHeading("Popup"),
             Button(open ? "Hide popup" : "Show popup",
-                () => setOpen(!open)),
+                () => setOpen(!open))
+                .AutomationName(open ? "Hide popup" : "Show popup"),
             Popup(popupContent, isOpen: open,
                 onClosed: () => setOpen(false))
                 .IsLightDismissEnabled()
@@ -506,9 +506,10 @@ close.
 
 The exception is `Popup`. The popup has none of the above; it is a
 positioning primitive. For a popup that should behave like a modal,
-wrap its content with `UseFocusTrap` and apply the dialog role
-explicitly. `UseFocusTrap(bool isActive)` takes the active flag, and the
-handle attaches with the `.FocusTrap(handle)` element modifier — inside a
+wrap its content with `UseFocusTrap` and apply dialog semantics
+explicitly. `UseFocusTrap(bool isActive)` takes the active flag, the
+handle attaches with the `.FocusTrap(handle)` element modifier, and
+`.Semantics(role: "dialog")` supplies the screen-reader role — inside a
 `Component`, call the hook as `this.UseFocusTrap(...)` because it is an
 extension method:
 
@@ -532,7 +533,8 @@ class ModalPopupDemo : Component
                         TextBlock("Focus stays inside this popup."),
                         Button("Close", () => setOpen(false))
                     ).Padding(16)
-                ).FocusTrap(trap),
+                ).FocusTrap(trap)
+                 .Semantics(role: "dialog"),
                 isOpen: open,
                 onClosed: () => setOpen(false))
         ).Padding(24);

--- a/docs/guide/docking.md
+++ b/docs/guide/docking.md
@@ -100,7 +100,8 @@ matches panes by `Key` and preserves the element subtree (and its
 `UseState` slots) across tree rebuilds. There is no implicit
 `Title`-as-key fallback; always supply one.
 
-The `DockNode` algebra has three node kinds (all immutable records):
+The `DockNode` algebra has three core node families (all immutable
+records), plus the document/tool leaf specializations:
 
 | Type | Purpose |
 |------|---------|

--- a/docs/guide/effects.md
+++ b/docs/guide/effects.md
@@ -98,14 +98,14 @@ class DependencyEffectExample : Component
         }, query);
 
         return VStack(12,
-            TextBox(query, setQuery, placeholderText: "Search...").Width(300),
+            TextBox(query, setQuery, placeholderText: "Search...", header: "Search query").Width(300),
             TextBlock(results).Foreground(Theme.SecondaryText)
         ).Padding(24);
     }
 }
 ```
 
-![Search with debounced query](images/effects/dependency-effect.png)
+![Search reacting to query changes](images/effects/dependency-effect.png)
 
 Every time `query` changes, the effect runs again. Reactor compares the current
 dependencies to the previous ones using structural equality. If nothing
@@ -146,7 +146,8 @@ class TimerCleanupExample : Component
         return VStack(12,
             TextBlock($"Elapsed: {seconds}s").FontSize(24).Bold(),
             HStack(8,
-                Button(isRunning ? "Stop" : "Start", () => setIsRunning(!isRunning)),
+                Button(isRunning ? "Stop" : "Start", () => setIsRunning(!isRunning))
+                    .AutomationName(isRunning ? "Stop timer" : "Start timer"),
                 Button("Reset", () => updateSeconds(_ => 0))
             )
         ).Padding(24);
@@ -198,7 +199,7 @@ class AsyncLoadingExample : Component
 
         return VStack(8,
             Heading("Loaded Users"),
-            VStack(4, items.Select(name => TextBlock(name)).ToArray())
+            VStack(4, items.Select(name => TextBlock(name).WithKey(name)).ToArray())
         ).Padding(24);
     }
 }
@@ -291,7 +292,7 @@ class FetchCancellationExample : Component
         }, query);
 
         return VStack(8,
-            TextBox(query, setQuery).Width(250),
+            TextBox(query, setQuery, header: "Search query").Width(250),
             ForEach(items, i => TextBlock(i))
         ).Padding(24);
     }
@@ -374,7 +375,7 @@ class DepsLiteralDontExample : Component
         var options = new { Url = url, Limit = 10 };
         UseEffect(() => FetchAsync(options), options);
 
-        return TextBox(url, setUrl).Width(250).Padding(24);
+        return TextBox(url, setUrl, header: "Request URL").Width(250).Padding(24);
     }
 }
 ```
@@ -397,7 +398,7 @@ class DepsLiteralDoExample : Component
         // Do — pass the primitives, which compare by value.
         UseEffect(() => FetchAsync(url, 10), url);
 
-        return TextBox(url, setUrl).Width(250).Padding(24);
+        return TextBox(url, setUrl, header: "Request URL").Width(250).Padding(24);
     }
 }
 ```
@@ -415,25 +416,25 @@ class MissingCleanupDontExample : Component
         var (tick, updateTick) = UseReducer(0);
 
         // Don't — no cleanup, so the timer fires forever after unmount.
-        UseEffect(() =>
-        {
-            var timer = new PeriodicTimer(TimeSpan.FromSeconds(1));
-            _ = Task.Run(async () =>
-            {
-                while (await timer.WaitForNextTickAsync())
-                    updateTick(t => t + 1);
-            });
-        }, Array.Empty<object>());
+        // UseEffect(() =>
+        // {
+        //     var timer = new PeriodicTimer(TimeSpan.FromSeconds(1));
+        //     _ = Task.Run(async () =>
+        //     {
+        //         while (await timer.WaitForNextTickAsync())
+        //             updateTick(t => t + 1);
+        //     });
+        // }, Array.Empty<object>());
 
         return TextBlock($"Ticks: {tick}").Padding(24);
     }
 }
 ```
 
-The component unmounts, the timer keeps firing, the setter is called on a
-dead [`RenderContext`](hooks-internals.md), and the setter throws (or worse,
-silently leaks the closure tree the timer captured). Always return a
-cleanup that cancels the producer:
+If you leave the commented effect active, the component unmounts, the timer
+keeps firing, the setter is called on a dead [`RenderContext`](hooks-internals.md),
+and the setter throws (or worse, silently leaks the closure tree the timer
+captured). Always return a cleanup that cancels the producer:
 
 ```csharp
 class MissingCleanupDoExample : Component
@@ -485,8 +486,8 @@ class EffectVsMemoDontExample : Component
         UseEffect(() => setFull($"{first} {last}"), first, last);
 
         return VStack(8,
-            TextBox(first, setFirst).Width(150),
-            TextBox(last, setLast).Width(150),
+            TextBox(first, setFirst, header: "First name").Width(150),
+            TextBox(last, setLast, header: "Last name").Width(150),
             TextBlock(full)
         ).Padding(24);
     }
@@ -512,8 +513,8 @@ class EffectVsMemoDoExample : Component
         var stats = UseMemo(() => Compute(full), full);      // memoized when expensive
 
         return VStack(8,
-            TextBox(first, setFirst).Width(150),
-            TextBox(last, setLast).Width(150),
+            TextBox(first, setFirst, header: "First name").Width(150),
+            TextBox(last, setLast, header: "Last name").Width(150),
             TextBlock(full),
             TextBlock(stats)
         ).Padding(24);

--- a/docs/guide/extending-reactor-controls.md
+++ b/docs/guide/extending-reactor-controls.md
@@ -503,7 +503,7 @@ public static class StarMeter
         int maxRating = 5,
         string? caption = null,
         bool isClearEnabled = true) =>
-        Of(value, onValueChanged, maxRating, caption, isClearEnabled);
+        Of(Optional<double>.Of(value), onValueChanged, maxRating, caption, isClearEnabled);
 
     public static StarMeterElement Of(
         Optional<double> value,

--- a/docs/guide/flex-layout.md
+++ b/docs/guide/flex-layout.md
@@ -52,16 +52,16 @@ class FlexDirectionDemo : Component
         return VStack(16,
             SubHeading("Row (default)"),
             FlexRow(
-                TextBlock("A").Padding(12).Background("#e0e0ff"),
-                TextBlock("B").Padding(12).Background("#ffe0e0"),
-                TextBlock("C").Padding(12).Background("#e0ffe0")
+                Border("A").Padding(12).Background(Theme.AccentTertiary),
+                Border("B").Padding(12).Background(Theme.SystemCriticalBackground),
+                Border("C").Padding(12).Background(Theme.SystemSuccessBackground)
             ) with { ColumnGap = 8 },
 
             SubHeading("Column"),
             FlexColumn(
-                TextBlock("A").Padding(12).Background("#e0e0ff"),
-                TextBlock("B").Padding(12).Background("#ffe0e0"),
-                TextBlock("C").Padding(12).Background("#e0ffe0")
+                Border("A").Padding(12).Background(Theme.AccentTertiary),
+                Border("B").Padding(12).Background(Theme.SystemCriticalBackground),
+                Border("C").Padding(12).Background(Theme.SystemSuccessBackground)
             ) with { RowGap = 8 }
         ).Padding(24);
     }
@@ -88,16 +88,16 @@ class JustifyAlignDemo : Component
         return VStack(16,
             SubHeading("JustifyContent: SpaceBetween"),
             FlexRow(
-                TextBlock("Left").Padding(8).Background("#e0e0ff"),
-                TextBlock("Center").Padding(8).Background("#ffe0e0"),
-                TextBlock("Right").Padding(8).Background("#e0ffe0")
+                Border("Left").Padding(8).Background(Theme.AccentTertiary),
+                Border("Center").Padding(8).Background(Theme.SystemCriticalBackground),
+                Border("Right").Padding(8).Background(Theme.SystemSuccessBackground)
             ) with { JustifyContent = FlexJustify.SpaceBetween },
 
             SubHeading("AlignItems: Center"),
             FlexRow(
-                TextBlock("Short").Padding(8).Background("#e0e0ff"),
-                TextBlock("Tall\nItem").Padding(8).Background("#ffe0e0"),
-                TextBlock("Med").Padding(8).Background("#e0ffe0")
+                Border("Short").Padding(8).Background(Theme.AccentTertiary),
+                Border("Tall\nItem").Padding(8).Background(Theme.SystemCriticalBackground),
+                Border("Med").Padding(8).Background(Theme.SystemSuccessBackground)
             ) with {
                 AlignItems = FlexAlign.Center,
                 ColumnGap = 8
@@ -147,10 +147,11 @@ class WrapGapDemo : Component
             SubHeading("Wrapping Tags"),
             FlexRow(
                 tags.Select(tag =>
-                    TextBlock(tag)
+                    Border(tag)
                         .Padding(horizontal: 6, vertical: 12)
-                        .Background("#e8e8e8")
+                        .Background(Theme.ControlFillSecondary)
                         .CornerRadius(12)
+                        .WithKey(tag)
                 ).ToArray()
             ) with {
                 Wrap = FlexWrap.Wrap,
@@ -194,19 +195,19 @@ class GrowShrinkDemo : Component
         return VStack(16,
             SubHeading("Grow: sidebar + content"),
             FlexRow(
-                TextBlock("Sidebar")
-                    .Padding(16).Background("#e0e0ff")
+                Border("Sidebar")
+                    .Padding(16).Background(Theme.AccentTertiary)
                     .Flex(basis: 200, shrink: 0),
-                TextBlock("Main content area")
-                    .Padding(16).Background("#f0f0f0")
+                Border("Main content area")
+                    .Padding(16).Background(Theme.CardBackground)
                     .Flex(grow: 1)
             ) with { ColumnGap = 8 },
 
             SubHeading("Equal columns"),
             FlexRow(
-                TextBlock("Column 1").Padding(16).Background("#ffe0e0").Flex(grow: 1),
-                TextBlock("Column 2").Padding(16).Background("#e0ffe0").Flex(grow: 1),
-                TextBlock("Column 3").Padding(16).Background("#e0e0ff").Flex(grow: 1)
+                Border("Column 1").Padding(16).Background(Theme.SystemCriticalBackground).Flex(grow: 1),
+                Border("Column 2").Padding(16).Background(Theme.SystemSuccessBackground).Flex(grow: 1),
+                Border("Column 3").Padding(16).Background(Theme.AccentTertiary).Flex(grow: 1)
             ) with { ColumnGap = 8 }
         ).Padding(24);
     }
@@ -261,23 +262,23 @@ class MinSizingDemo : Component
         SubHeading("Default — items keep their min-content size"),
         FlexRow(
             Border("Long text that won't truncate").Flex(shrink: 1)
-                .Background("#e0e0ff").Padding(8),
+                .Background(Theme.AccentTertiary).Padding(8),
             Border("Short").Flex(shrink: 1)
-                .Background("#ffe0e0").Padding(8)
+                .Background(Theme.SystemCriticalBackground).Padding(8)
         ) with { ColumnGap = 8 },
 
         SubHeading("Opt out — minWidth: 0 lets items shrink below content"),
         FlexRow(
             Border("Long text that may be clipped").Flex(shrink: 1, minWidth: 0)
-                .Background("#e0e0ff").Padding(8),
+                .Background(Theme.AccentTertiary).Padding(8),
             Border("Short").Flex(shrink: 1, minWidth: 0)
-                .Background("#ffe0e0").Padding(8)
+                .Background(Theme.SystemCriticalBackground).Padding(8)
         ) with { ColumnGap = 8 },
 
         SubHeading("Explicit floor — never below 80px regardless of content"),
         FlexRow(
             Border("Hard floor").Flex(shrink: 1, minWidth: 80)
-                .Background("#e0ffe0").Padding(8)
+                .Background(Theme.SystemSuccessBackground).Padding(8)
         ) with { ColumnGap = 8 }
     ).Width(360);
 }
@@ -411,7 +412,7 @@ class AppShellDemo : Component
                 TextBlock("Inbox").Padding(8),
                 TextBlock("Drafts").Padding(8),
                 TextBlock("Sent").Padding(8)
-            ).Background("#f3f3f3")
+            ).Background(Theme.CardBackground)
              .Flex(basis: 220, shrink: 0),
 
             // Content — explicit basis: 0 + grow: 1 gives a single distribution
@@ -445,13 +446,13 @@ class ResponsiveNavDemo : Component
         // Wrap kicks in when the narrow viewport can no longer fit one row.
         // RowGap and ColumnGap apply between wrapped lines too — no manual margin.
         return FlexRow(
-            TextBlock("Home").Padding(8).Background("#e0e0ff"),
-            TextBlock("Catalog").Padding(8).Background("#e0e0ff"),
-            TextBlock("Pricing").Padding(8).Background("#e0e0ff"),
-            TextBlock("Docs").Padding(8).Background("#e0e0ff"),
-            TextBlock("About").Padding(8).Background("#e0e0ff"),
-            TextBlock("Contact").Padding(8).Background("#e0e0ff"),
-            TextBlock("Status").Padding(8).Background("#e0e0ff")
+            Border("Home").Padding(8).Background(Theme.AccentTertiary),
+            Border("Catalog").Padding(8).Background(Theme.AccentTertiary),
+            Border("Pricing").Padding(8).Background(Theme.AccentTertiary),
+            Border("Docs").Padding(8).Background(Theme.AccentTertiary),
+            Border("About").Padding(8).Background(Theme.AccentTertiary),
+            Border("Contact").Padding(8).Background(Theme.AccentTertiary),
+            Border("Status").Padding(8).Background(Theme.AccentTertiary)
         ) with {
             Wrap = FlexWrap.Wrap,
             ColumnGap = 8,
@@ -505,10 +506,10 @@ class WidthVsGrowWrong : Component
         // child sizing is governed by Flex(basis/grow/shrink). The 200 is
         // silently ignored when grow > 0 fills available space.
         return FlexRow(
-            TextBlock("Stays 200?")
+            Border("Stays 200?")
                 .Width(200)              // ignored — grow wins
                 .Flex(grow: 1)
-                .Background("#ffe0e0")
+                .Background(Theme.SystemCriticalBackground)
         ) with { ColumnGap = 8 };
     }
 }
@@ -528,9 +529,9 @@ class WidthVsGrowRight : Component
         // Do: encode the intended size as basis with shrink: 0 — Flex
         // owns the sizing math, so no surprise overrides.
         return FlexRow(
-            TextBlock("Exactly 200")
+            Border("Exactly 200")
                 .Flex(basis: 200, shrink: 0)
-                .Background("#e0ffe0")
+                .Background(Theme.SystemSuccessBackground)
                 .Padding(8)
         ) with { ColumnGap = 8 };
     }
@@ -555,7 +556,7 @@ container when total child width exceeds available space. Set
 vary. The cost is zero on rows that don't actually need to wrap — Yoga
 short-circuits when one line fits.
 
-### Reaching for `FlexPadding` when you wanted `.Padding`
+### Using `.Padding` when you wanted `FlexPadding`
 
 `FlexPadding` is a property on the FlexPanel itself, measured by Yoga
 inside the same algorithm that distributes children. The `.Padding(...)`

--- a/docs/guide/forms.md
+++ b/docs/guide/forms.md
@@ -40,7 +40,8 @@ class ControlledInputDemo : Component
 
         return VStack(12,
             SubHeading("Controlled Input"),
-            TextBox(name, setName, placeholderText: "Type your name"),
+            TextBox(name, setName, placeholderText: "Type your name",
+                header: "Name"),
             TextBlock($"You typed: {name}").Opacity(0.6)
         ).Padding(24);
     }
@@ -76,16 +77,18 @@ class InputTypesDemo : Component
             TextBox(text, setText, placeholderText: "Email",
                 header: "Email"),
             PasswordBox(password, setPassword,
-                placeholderText: "Enter password"),
-            Slider(volume, 0, 100, setVolume),
+                placeholderText: "Enter password")
+                .Header("Password")
+                .AutomationName("Password"),
+            Slider(volume, 0, 100, setVolume).Header("Volume"),
             NumberBox(count, setCount, header: "Quantity"),
             CheckBox(agree, setAgree, label: "I agree to the terms"),
             ToggleSwitch(notify, setNotify,
                 header: "Notifications"),
             ComboBox(["Admin", "Editor", "Viewer"],
                 role, setRole).Header("Role"),
-            RadioButtons(["Low", "Medium", "High"],
-                priority, setPriority)
+            (RadioButtons(["Low", "Medium", "High"],
+                priority, setPriority) with { Header = "Priority" })
         ).Padding(24);
     }
 }
@@ -134,7 +137,8 @@ class TextBoxConfigDemo : Component
                 .UrlInput(),
             TextBox(phone, setPhone, header: "Phone")
                 .PhoneInput(),
-            TextBox(search, setSearch, placeholderText: "Search…")
+            TextBox(search, setSearch, placeholderText: "Search…",
+                header: "Search")
                 .SearchInput(),
             TextBox(note, setNote, header: "Reference code")
                 .MaxLength(8)
@@ -314,6 +318,8 @@ class ValidationContextDemo : Component
                     .Foreground(Theme.SystemCritical).FontSize(12)),
             PasswordBox(password, v => { setPassword(v); ctx.NotifyValueChanged("password", v); },
                 placeholderText: "Min 8 characters")
+                .Header("Password")
+                .AutomationName("Password")
                 .Validate("password", password,
                     Validate.Required(),
                     Validate.MinLength(8)),
@@ -361,12 +367,14 @@ class FormFieldDemo : Component
             SubHeading("FormField Helper"),
             FormField(
                 TextBox(name, v => { setName(v); ctx.NotifyValueChanged("name", v); })
+                    .AutomationName("Full Name")
                     .Validate("name", name, Validate.Required()),
                 label: "Full Name",
                 required: true,
                 description: "As it appears on your ID"),
             FormField(
                 TextBox(email, v => { setEmail(v); ctx.NotifyValueChanged("email", v); })
+                    .AutomationName("Email Address")
                     .Validate("email", email,
                         Validate.Required(), Validate.Email()),
                 label: "Email Address",
@@ -510,6 +518,7 @@ class AutoSuggestDemo : Component
             AutoSuggestBox(text, setText,
                 onQuerySubmitted: q => setText(q))
                 .Header("Animal")
+                .AutomationName("Animal")
                 .QueryIcon(SymbolIcon("Find"))
                 .Width(280),
             // Suggestion list — bind to AutoSuggestBox.ItemsSource via .Set
@@ -519,7 +528,7 @@ class AutoSuggestDemo : Component
                 VStack(2,
                     ForEach(matches, m =>
                         TextBlock(m).Padding(8, 4))
-                ).Background("#F5F5F5").Width(280))
+                ).Background(Theme.CardBackground).Width(280))
         ).Padding(24);
     }
 }
@@ -660,12 +669,9 @@ class ColorPickerDemo : Component
                 .HexInputVisible(true)
                 .ColorSpectrumShape(
                     Microsoft.UI.Xaml.Controls.ColorSpectrumShape.Ring),
-            // Preview swatch driven by the picker.
-            Border(Empty())
-                .Background(
-                    new Microsoft.UI.Xaml.Media.SolidColorBrush(color))
-                .Width(80).Height(40)
-                .WithBorder("#888888")
+            TextBlock($"Selected: #{color.A:X2}{color.R:X2}{color.G:X2}{color.B:X2}")
+                .FontSize(12)
+                .Foreground(Theme.SecondaryText)
         ).Padding(24);
     }
 }
@@ -756,7 +762,8 @@ class ControlledInputDemo : Component
 
         return VStack(12,
             SubHeading("Controlled Input"),
-            TextBox(name, setName, placeholderText: "Type your name"),
+            TextBox(name, setName, placeholderText: "Type your name",
+                header: "Name"),
             TextBlock($"You typed: {name}").Opacity(0.6)
         ).Padding(24);
     }

--- a/docs/guide/forms.md
+++ b/docs/guide/forms.md
@@ -78,8 +78,7 @@ class InputTypesDemo : Component
                 header: "Email"),
             PasswordBox(password, setPassword,
                 placeholderText: "Enter password")
-                .Header("Password")
-                .AutomationName("Password"),
+                .Header("Password"),
             Slider(volume, 0, 100, setVolume).Header("Volume"),
             NumberBox(count, setCount, header: "Quantity"),
             CheckBox(agree, setAgree, label: "I agree to the terms"),
@@ -319,7 +318,6 @@ class ValidationContextDemo : Component
             PasswordBox(password, v => { setPassword(v); ctx.NotifyValueChanged("password", v); },
                 placeholderText: "Min 8 characters")
                 .Header("Password")
-                .AutomationName("Password")
                 .Validate("password", password,
                     Validate.Required(),
                     Validate.MinLength(8)),
@@ -518,7 +516,6 @@ class AutoSuggestDemo : Component
             AutoSuggestBox(text, setText,
                 onQuerySubmitted: q => setText(q))
                 .Header("Animal")
-                .AutomationName("Animal")
                 .QueryIcon(SymbolIcon("Find"))
                 .Width(280),
             // Suggestion list — bind to AutoSuggestBox.ItemsSource via .Set

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -304,7 +304,9 @@ class GettingStartedApp : Component
 
         return VStack(16,
             TextBlock($"Hello, {name}!").FontSize(24).Bold(),
-            TextBox(name, setName, placeholderText: "Enter your name").Width(250)
+            TextBox(name, setName, placeholderText: "Enter your name")
+                .AutomationName("Name")
+                .Width(250)
         ).Padding(24);
     }
 }
@@ -390,8 +392,12 @@ class MultipleStateExample : Component
 
         return VStack(12,
             TextBlock($"Hello, {fullName}!").FontSize(fontSize).Bold(),
-            TextBox(firstName, setFirstName, placeholderText: "First name").Width(200),
-            TextBox(lastName, setLastName, placeholderText: "Last name").Width(200),
+            TextBox(firstName, setFirstName, placeholderText: "First name")
+                .AutomationName("First name")
+                .Width(200),
+            TextBox(lastName, setLastName, placeholderText: "Last name")
+                .AutomationName("Last name")
+                .Width(200),
             HStack(8,
                 TextBlock("Font size:"),
                 Slider(fontSize, 10, 40, setFontSize).Width(200),
@@ -467,7 +473,7 @@ of items, a way to add new ones, and checkboxes to mark them done.
 First, define a simple record for items:
 
 ```csharp
-record TodoItem(string Text, bool Done);
+record TodoItem(string Id, string Text, bool Done);
 ```
 
 Now the full component:
@@ -484,13 +490,15 @@ class TodoApp : Component
 {
     public override Element Render()
     {
-        var (items, updateItems) = UseReducer(new List<TodoItem>
+        var initialItems = UseMemo(() => new List<TodoItem>
         {
-            new("Learn Reactor basics", true),
-            new("Build a todo app", false),
-            new("Explore hooks", false),
+            new("todo-1", "Learn Reactor basics", true),
+            new("todo-2", "Build a todo app", false),
+            new("todo-3", "Explore hooks", false),
         });
+        var (items, updateItems) = UseReducer(initialItems);
         var (newText, setNewText) = UseState("");
+        var (nextId, setNextId) = UseState(4);
 
         var doneCount = items.Count(i => i.Done);
 
@@ -501,12 +509,15 @@ class TodoApp : Component
             // Input row
             HStack(8,
                 TextBox(newText, setNewText, placeholderText: "What needs to be done?")
+                    .AutomationName("New todo")
                     .Width(300),
                 Button("Add", () =>
                 {
                     if (!string.IsNullOrWhiteSpace(newText))
                     {
-                        updateItems(list => [.. list, new TodoItem(newText.Trim(), false)]);
+                        var text = newText.Trim();
+                        updateItems(list => [.. list, new TodoItem($"todo-{nextId}", text, false)]);
+                        setNextId(nextId + 1);
                         setNewText("");
                     }
                 }).IsEnabled(!(string.IsNullOrWhiteSpace(newText)))
@@ -514,13 +525,15 @@ class TodoApp : Component
 
             // Item list
             VStack(4,
-                items.Select((item, index) =>
+                items.Select((item, _) =>
                     HStack(8,
                         CheckBox(item.Done, done =>
                             updateItems(list =>
                             {
                                 var copy = new List<TodoItem>(list);
-                                copy[index] = item with { Done = done };
+                                var itemIndex = copy.FindIndex(i => i.Id == item.Id);
+                                if (itemIndex >= 0)
+                                    copy[itemIndex] = item with { Done = done };
                                 return copy;
                             }),
                             label: item.Text
@@ -529,11 +542,11 @@ class TodoApp : Component
                             updateItems(list =>
                             {
                                 var copy = new List<TodoItem>(list);
-                                copy.RemoveAt(index);
+                                copy.RemoveAll(i => i.Id == item.Id);
                                 return copy;
                             })
-                        )
-                    ).WithKey($"todo-{index}")
+                        ).AutomationName($"Remove {item.Text}")
+                    ).WithKey(item.Id)
                 ).ToArray()
             ),
 
@@ -541,7 +554,7 @@ class TodoApp : Component
             When(doneCount > 0, () =>
                 Button($"Clear completed ({doneCount})", () =>
                     updateItems(list => list.Where(i => !i.Done).ToList())
-                )
+                ).AutomationName("Clear completed todos")
             )
         ).Padding(24);
     }
@@ -637,10 +650,19 @@ class CalculatorApp : Component
 
         Element NumButton(string digit) =>
             Button(digit, () => PressDigit(digit))
+                .AutomationName($"Digit {digit}")
                 .Width(60).Height(48);
 
         Element OpButton(string label, string opCode) =>
             Button(label, () => PressOp(opCode))
+                .AutomationName(opCode switch
+                {
+                    "+" => "Add",
+                    "-" => "Subtract",
+                    "*" => "Multiply",
+                    "/" => "Divide",
+                    _ => $"Operator {label}"
+                })
                 .Width(60).Height(48);
 
         return VStack(4,
@@ -659,7 +681,9 @@ class CalculatorApp : Component
                        NumButton("1"), NumButton("2"), NumButton("3")),
             HStack(4, OpButton("-", "-"),
                        NumButton("0"), OpButton("+", "+"),
-                       Button("=", PressEquals).Width(60).Height(48))
+                       Button("=", PressEquals)
+                          .AutomationName("Equals")
+                          .Width(60).Height(48))
         ).Padding(16);
     }
 

--- a/docs/guide/hooks.md
+++ b/docs/guide/hooks.md
@@ -57,10 +57,13 @@ class StateDemo : Component
             SubHeading("UseState"),
             TextBlock("Sample text").FontSize(size).Foreground(color),
             TextBox(color, setColor, placeholderText: "#hex color")
+                .AutomationName("Sample text color")
                 .Width(150),
             HStack(8,
                 TextBlock("Size:"),
-                Slider(size, 10, 48, setSize).Width(200)
+                Slider(size, 10, 48, setSize)
+                    .AutomationName("Sample text size")
+                    .Width(200)
             )
         );
     }
@@ -94,6 +97,7 @@ class ReducerDemo : Component
             SubHeading("UseReducer"),
             HStack(8,
                 TextBox(input, setInput, placeholderText: "Add item")
+                    .AutomationName("Item text")
                     .Width(180),
                 Button("Add", () =>
                 {
@@ -144,9 +148,11 @@ class ReduxReducerDemo : Component
             TextBlock($"Count: {state.Count}  (last: {state.LastAction})")
                 .FontSize(18).Bold(),
             HStack(8,
-                Button("-", () => dispatch(new Decrement())),
+                Button("-", () => dispatch(new Decrement()))
+                    .AutomationName("Decrement count"),
                 Button("Reset", () => dispatch(new Reset())),
                 Button("+", () => dispatch(new Increment()))
+                    .AutomationName("Increment count")
             )
         );
     }
@@ -194,7 +200,8 @@ class EffectDemo : Component
             SubHeading("UseEffect"),
             TextBlock($"Elapsed: {seconds}s").FontSize(18),
             HStack(8,
-                Button(running ? "Stop" : "Start", () => setRunning(!running)),
+                Button(running ? "Stop" : "Start", () => setRunning(!running))
+                    .AutomationName(running ? "Stop timer" : "Start timer"),
                 Button("Reset", () => updateSeconds(_ => 0))
             )
         );
@@ -239,7 +246,9 @@ class MemoDemo : Component
 
         return VStack(8,
             SubHeading("UseMemo"),
-            TextBox(input, setInput).Width(250),
+            TextBox(input, setInput)
+                .AutomationName("Text to analyze")
+                .Width(250),
             TextBlock($"Characters: {stats.Chars}, Words: {stats.Words}"),
             Caption($"Uppercased: {stats.Upper}")
         );
@@ -275,6 +284,7 @@ class RefDemo : Component
             SubHeading("UseRef"),
             TextBlock($"Render count: {renderCount.Current}").SemiBold(),
             TextBox(value, setValue, placeholderText: "Type to trigger renders")
+                .AutomationName("Render trigger text")
                 .Width(250),
             Caption("UseRef persists across renders without causing them")
         );
@@ -311,8 +321,10 @@ class CallbackDemo : Component
             SubHeading("UseCallback"),
             TextBlock($"Count: {count}").FontSize(18),
             TextBox(label, setLabel, placeholderText: "Button label")
+                .AutomationName("Button label")
                 .Width(200),
-            Button(label, stableIncrement),
+            Button(label, stableIncrement)
+                .AutomationName("Increment count"),
             Caption("The callback identity stays stable across renders")
         );
     }
@@ -567,7 +579,9 @@ class CustomHookDemo : Component
         var (debounced, setText) = ctx.UseDebouncedText("", 300);
         return VStack(8,
             SubHeading("Custom hook: UseDebouncedText"),
-            TextBox(debounced, setText, placeholderText: "Type…").Width(250),
+            TextBox(debounced, setText, placeholderText: "Type…")
+                .AutomationName("Text to debounce")
+                .Width(250),
             Caption($"Debounced: {debounced}")
         );
     });

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -81,7 +81,7 @@ class StyledText : Component
             Heading("Heading element"),
             SubHeading("SubHeading element"),
             TextBlock("Regular text with modifiers")
-                .FontSize(14).Foreground("#0078D4"),
+                .FontSize(14).Foreground(Theme.Accent),
             Caption("Caption for fine print")
         ).Padding(24);
     }

--- a/docs/guide/input-and-gestures.md
+++ b/docs/guide/input-and-gestures.md
@@ -64,11 +64,17 @@ class PointerModifiersExample : Component
             Border(TextBlock(hover ? "hovered" : "hover me")
                 .HAlign(HorizontalAlignment.Center).VAlign(VerticalAlignment.Center))
                 .Width(240).Height(120)
-                .Background(hover ? "#BFE3FF" : "#E5F1FB")
+                .Background(hover ? Theme.AccentTertiary : Theme.ControlFillSecondary)
                 .CornerRadius(8)
+                .IsTabStop(true)
                 .OnPointerEntered((_, _) => setHover(true))
                 .OnPointerExited((_, _) => setHover(false))
                 .OnTapped((_, _) => setTapCount(tapCount + 1))
+                .OnKeyDown((_, e) =>
+                {
+                    if (e.Key is VirtualKey.Enter or VirtualKey.Space)
+                        setTapCount(tapCount + 1);
+                })
                 .OnDoubleTap(() => setTapCount(0)),
 
             TextBlock($"Tapped {tapCount} time(s) — double-tap to reset")
@@ -98,6 +104,7 @@ class KeyboardEventsExample : Component
 
         return VStack(12,
             TextBox(value, setValue, placeholderText: "type here").Width(280)
+                .AutomationName("Text to submit")
                 // Tunnels first — the right spot to intercept before bubbling.
                 .OnPreviewKeyDown((_, _) => setLog("preview"))
                 // Bubbles — fires after the preview pair.
@@ -130,6 +137,7 @@ class FocusEventsExample : Component
 
         return VStack(12,
             TextBox(value, setValue, placeholderText: "email").Width(280)
+                .AutomationName("Email")
                 .OnGotFocus((_, _) => setHint("We never share your address."))
                 .OnLostFocus((_, _) => setHint("")),
 
@@ -213,10 +221,10 @@ class PanGestureExample : Component
         return VStack(8,
             Border(
                 Border(TextBlock("drag me")
-                    .HAlign(HorizontalAlignment.Center).VAlign(VerticalAlignment.Center))
+                    .HAlign(HorizontalAlignment.Center).VAlign(VerticalAlignment.Center)
+                    .Foreground(Theme.AccentText))
                     .Width(120).Height(120)
-                    .Background("#3A7BD5")
-                    .Foreground("#ffffff")
+                    .Background(Theme.Accent)
                     .CornerRadius(8)
                     .Translation(offset.X, offset.Y, 0)
                     .OnMount(fe => cardRef.Current = fe)
@@ -234,7 +242,7 @@ class PanGestureExample : Component
                             setOffset(committedRef.Current);
                         },
                         withInertia: true)
-            ).Height(260).Background("#f3f3f3").CornerRadius(8).Padding(16),
+            ).Height(260).Background(Theme.CardBackground).CornerRadius(8).Padding(16),
 
             Button("Reset position", Reset)
         );
@@ -266,6 +274,7 @@ lifts.
 
 ```csharp
 Image(imageUrl)
+    .AutomationName("Photo preview")
     .OnPinch(
         onChanged: g => Scale(g.Scale),
         withInertia: true)
@@ -290,7 +299,7 @@ class LongPressExample : Component
         return VStack(12,
             Border(TextBlock("Hold me")
                 .HAlign(HorizontalAlignment.Center).VAlign(VerticalAlignment.Center))
-                .Height(80).Background("#FFF4CE").CornerRadius(6).Padding(12)
+                .Height(80).Background(Theme.SystemCautionBackground).CornerRadius(6).Padding(12)
                 .OnLongPress(
                     g => setLog($"long-press after {g.Duration.TotalMilliseconds:F0}ms"),
                     enableMouseEmulation: true),
@@ -371,7 +380,9 @@ class UseElementFocusExample : Component
 
         return VStack(12,
             TextBlock("The field below auto-focuses on mount via UseElementFocus()."),
-            TextBox(name, setName, placeholderText: "name").Width(280).Ref(inputRef)
+            TextBox(name, setName, placeholderText: "name").Width(280)
+                .AutomationName("Name")
+                .Ref(inputRef)
         ).Padding(24);
     }
 }
@@ -407,7 +418,9 @@ class SearchBoxExample : Component
 
         return VStack(12,
             TextBlock("Text is pre-selected on mount via UseElementRef<TextBox>()."),
-            TextBox(query, setQuery).Width(280).Ref(inputRef)
+            TextBox(query, setQuery).Width(280)
+                .AutomationName("Search query")
+                .Ref(inputRef)
         ).Padding(24);
     }
 }
@@ -481,11 +494,12 @@ class KanbanDndExample : Component
 {
     public override Element Render()
     {
-        var (todo, setTodo) = UseState<IReadOnlyList<KanbanCard>>(new KanbanCard[]
+        var initialTodo = UseMemo(() => new KanbanCard[]
         {
             new("k1", "Write docs"),
             new("k2", "Ship feature"),
-        });
+        }, Array.Empty<object>());
+        var (todo, setTodo) = UseState<IReadOnlyList<KanbanCard>>(initialTodo);
         var (done, setDone) = UseState<IReadOnlyList<KanbanCard>>(Array.Empty<KanbanCard>());
 
         Element Column(string label,
@@ -497,8 +511,8 @@ class KanbanDndExample : Component
             {
                 var captured = card;
                 children.Add(
-                    Border(TextBlock(captured.Title).Foreground("#ffffff"))
-                        .Background("#4B7BEC").CornerRadius(6).Padding(10)
+                    Border(TextBlock(captured.Title).Foreground(Theme.AccentText))
+                        .Background(Theme.Accent).CornerRadius(6).Padding(10)
                         .OnDragStart<BorderElement, KanbanCard>(
                             getPayload: () => captured,
                             allowedOperations: DragOperations.Move,
@@ -520,9 +534,9 @@ class KanbanDndExample : Component
 
         return HStack(12,
             Border(Column("Todo", todo, setTodo))
-                .Width(240).Background("#F7F7F7").CornerRadius(6).Padding(10),
+                .Width(240).Background(Theme.CardBackground).CornerRadius(6).Padding(10),
             Border(Column("Done", done, setDone))
-                .Width(240).Background("#F1FFF4").CornerRadius(6).Padding(10)
+                .Width(240).Background(Theme.SystemSuccessBackground).CornerRadius(6).Padding(10)
         ).Padding(24);
     }
 }
@@ -575,7 +589,7 @@ visibility via `DragTargetArgs.UIOverride` — Reactor writes the changes back
 onto WinUI's `DragUIOverride` after your callback returns.
 
 ```csharp
-VStack(children)
+VStack(children.ToArray())
     .OnDragOver(args =>
     {
         args.UIOverride.Caption = "Move to Inbox";
@@ -666,9 +680,8 @@ see [recipes/drag-reorder](recipes/drag-reorder.md).
 
 ### Pinch-to-zoom on an image
 
-Combine `.OnPinch` with a `Translation` scale modifier driven from
-state. Scale is cumulative since `Began` — apply it directly to the
-element's `Scale` compositor property in `onChanged` for 60 Hz
+Combine `.OnPinch` with the element's `Scale` compositor property driven from
+state. Scale is cumulative since `Began` — apply it directly in `onChanged` for 60 Hz
 behavior (same pattern as pan above), then commit to `UseState` in
 `onEnded`. The reconciler unions `ManipulationModes` so adding
 `.OnRotate` on the same element is free.

--- a/docs/guide/layout.md
+++ b/docs/guide/layout.md
@@ -88,10 +88,11 @@ class GridDemo : Component
                 rows: [GridSize.Auto, GridSize.Auto],
                 TextBlock("Label").Bold().Grid(row: 0, column: 0),
                 TextBox("", _ => { }, placeholderText: "Input...")
+                    .AutomationName("Input")
                     .Grid(row: 0, column: 1),
                 Button("Go").Grid(row: 0, column: 2),
                 TextBlock("Status").Grid(row: 1, column: 0),
-                TextBlock("Ready").Foreground("#0078D4")
+                TextBlock("Ready").Foreground(Theme.Accent)
                     .Grid(row: 1, column: 1, columnSpan: 2)
             ).Height(80)
         );
@@ -210,7 +211,7 @@ class ScrollBorderDemo : Component
                             i => TextBlock($"Scrollable item {i}"))
                     ).Padding(8)
                 ).Height(120)
-            ).CornerRadius(4).Background("#F5F5F5")
+            ).CornerRadius(4).Background(Theme.CardBackground)
         );
     }
 }
@@ -256,7 +257,7 @@ class ExpanderCanvasDemo : Component
                         Microsoft.UI.Xaml.Controls.Canvas.SetTop((UIElement)c, 40);
                     })
                 ).Height(90).Width(300)
-            ).Background("#F5F5F5").CornerRadius(4)
+            ).Background(Theme.CardBackground).CornerRadius(4)
         );
     }
 }
@@ -287,11 +288,11 @@ class ResponsiveDemo : Component
         var content = new Element[]
         {
             Border(TextBlock("Panel A").Padding(16))
-                .Background("#E3F2FD").CornerRadius(4),
+                .Background(Theme.SystemNeutralBackground).CornerRadius(4),
             Border(TextBlock("Panel B").Padding(16))
-                .Background("#FFF3E0").CornerRadius(4),
+                .Background(Theme.SystemCautionBackground).CornerRadius(4),
             Border(TextBlock("Panel C").Padding(16))
-                .Background("#E8F5E9").CornerRadius(4),
+                .Background(Theme.SystemSuccessBackground).CornerRadius(4),
         };
 
         return VStack(8,
@@ -338,12 +339,14 @@ class AlignmentSizingDemo : Component
         SubHeading("Alignment and sizing"),
 
         TextBlock("Centered").HAlign(HorizontalAlignment.Center),
-        TextBlock("Fixed width").Width(200).Height(40).Background("#E5F1FB"),
+        Border(TextBlock("Fixed width"))
+            .Width(200).Height(40)
+            .Background(Theme.ControlFillSecondary),
 
         VStack(8,
             TextBlock("Item A"),
             TextBlock("Item B")
-        ).Margin(24).Padding(16).Background("#F3F3F3")
+        ).Margin(24).Padding(16).Background(Theme.ControlFillSecondary)
     );
 }
 ```
@@ -375,6 +378,7 @@ class ContentAlignmentDemo : Component
         // stretches too — without HorizontalContentAlignment the label
         // would stay centered in an otherwise full-width button.
         Button(TextBlock("Open"), () => { })
+            .AutomationName("Open")
             .HAlign(HorizontalAlignment.Stretch)
             .HorizontalContentAlignment(HorizontalAlignment.Stretch)
     ).Width(320);
@@ -459,15 +463,17 @@ class AutoGridExample : Component
 {
     public override Element Render()
     {
-        return WrapGrid(maxRowsOrColumns: 4,
-            children: Enumerable.Range(1, 11)
-                .Select(i =>
-                    Border(TextBlock($"Tile {i}").Padding(12))
-                        .Background(Theme.CardBackground)
-                        .CornerRadius(6)
-                        .Width(110).Height(60))
-                .Cast<Element?>()
-                .ToArray()
+        return Border(
+            WrapGrid(maxRowsOrColumns: 4,
+                children: Enumerable.Range(1, 11)
+                    .Select(i =>
+                        Border(TextBlock($"Tile {i}").Padding(12))
+                            .Background(Theme.CardBackground)
+                            .CornerRadius(6)
+                            .Width(110).Height(60))
+                    .Cast<Element?>()
+                    .ToArray()
+            )
         ).Padding(24);
     }
 }

--- a/docs/guide/localization.md
+++ b/docs/guide/localization.md
@@ -27,16 +27,16 @@ class DemoResourceProvider : IStringResourceProvider
     private readonly Dictionary<string, Dictionary<string, string>> _strings = new()
     {
         ["en-US"] = new() {
-            ["App.title"] = "My Application",
-            ["App.greeting"] = "Hello, {name}!",
+            ["App.Title"] = "My Application",
+            ["App.Greeting"] = "Hello, {name}!",
         },
         ["fr-FR"] = new() {
-            ["App.title"] = "Mon Application",
-            ["App.greeting"] = "Bonjour, {name} !",
+            ["App.Title"] = "Mon Application",
+            ["App.Greeting"] = "Bonjour, {name} !",
         },
         ["ar-SA"] = new() {
-            ["App.title"] = "\u062a\u0637\u0628\u064a\u0642\u064a",
-            ["App.greeting"] = "\u0645\u0631\u062d\u0628\u0627\u060c {name}!",
+            ["App.Title"] = "\u062a\u0637\u0628\u064a\u0642\u064a",
+            ["App.Greeting"] = "\u0645\u0631\u062d\u0628\u0627\u060c {name}!",
         }
     };
 
@@ -70,7 +70,8 @@ class LocaleSwitcher : Component
 
         return VStack(16,
             ComboBox(["English (US)", "Fran\u00e7ais", "\u0627\u0644\u0639\u0631\u0628\u064a\u0629"],
-                localeIndex, setLocaleIndex),
+                localeIndex, setLocaleIndex)
+                .Header("Locale"),
             LocaleProvider(locale,
                 Component<LocalizedContent>(),
                 resourceProvider: provider,
@@ -101,9 +102,9 @@ class LocalizedContent : Component
     public override Element Render()
     {
         var intl = UseIntl();
-        var title = intl.Message(new MessageKey("App", "title"));
+        var title = intl.Message(new MessageKey("App", "Title"));
         var greeting = intl.Message(
-            new MessageKey("App", "greeting"),
+            new MessageKey("App", "Greeting"),
             ("name", "Alice"));
 
         return VStack(12,
@@ -121,6 +122,11 @@ class LocalizedContent : Component
 `MessageKey` takes a namespace and key. The namespace maps to your `.resw`
 file name (e.g., `"App"` for `App.resw`). The accessor also exposes the
 current `Locale`, `Direction`, and `IsRtl` flag.
+
+In `.resw`-backed apps, `Reactor.Localization.Generator` reads the default
+locale's files at build time and emits the same keys as generated fields
+(for example, `Loc.App.Title`). These self-contained snippets spell out
+`new MessageKey(...)` so the in-memory provider remains visible.
 
 ## Formatting Numbers and Dates
 
@@ -188,13 +194,14 @@ class RtlDemo : Component
                         TextBlock(RtlHelper.IsRtlLocale(loc) ? "RTL" : "LTR")
                             .Bold()
                             .Foreground(RtlHelper.IsRtlLocale(loc)
-                                ? "#d13438" : "#107c10")
+                                ? Theme.SystemCritical : Theme.SystemSuccess)
                     )
+                    .WithKey(loc)
                 ).ToArray()
             ),
             When(intl.IsRtl, () =>
                 TextBlock("Current layout is right-to-left")
-                    .Foreground("#d13438").SemiBold())
+                    .Foreground(Theme.SystemCritical).SemiBold())
         ).Padding(24);
     }
 }
@@ -228,9 +235,9 @@ class PseudoLocDemo : Component
                 RenderEachTime(ctx =>
                 {
                     var intl = ctx.UseIntl();
-                    var title = intl.Message(new MessageKey("App", "title"));
+                    var title = intl.Message(new MessageKey("App", "Title"));
                     var greeting = intl.Message(
-                        new MessageKey("App", "greeting"),
+                        new MessageKey("App", "Greeting"),
                         ("name", "World"));
                     return VStack(4,
                         TextBlock(title).FontSize(18).Bold(),

--- a/docs/guide/navigation.md
+++ b/docs/guide/navigation.md
@@ -203,20 +203,20 @@ class LifecyclePage : Component
         UseNavigationLifecycle(
             onNavigatedTo: ctx =>
                 updateLog(l => [.. l,
-                    $"Arrived from {ctx.PreviousRoute}"]),
+                    $"{l.Count + 1}: Arrived from {ctx.PreviousRoute}"]),
             onNavigatingFrom: ctx =>
                 updateLog(l => [.. l,
-                    $"Leaving to {ctx.TargetRoute}"]),
+                    $"{l.Count + 1}: Leaving to {ctx.TargetRoute}"]),
             onNavigatedFrom: ctx =>
                 updateLog(l => [.. l,
-                    $"Left for {ctx.TargetRoute}"])
+                    $"{l.Count + 1}: Left for {ctx.TargetRoute}"])
         );
 
         return VStack(8,
             SubHeading("Lifecycle Events"),
             VStack(4,
                 log.TakeLast(5).Select(entry =>
-                    TextBlock(entry).FontSize(12).Opacity(0.7)
+                    TextBlock(entry).FontSize(12).Opacity(0.7).WithKey(entry)
                 ).ToArray()
             )
         ).Padding(16);
@@ -278,7 +278,7 @@ class PageTransitionsDemo : Component
             {
                 Route.Home => VStack(8,
                     TextBlock("Home").FontSize(24).Bold(),
-                    TextBlock("Slide transition on navigate")).Padding(16),
+                    TextBlock("DrillIn transition on navigate")).Padding(16),
                 Route.Settings => VStack(8,
                     TextBlock("Settings").FontSize(24).Bold(),
                     TextBlock("DrillIn transition to detail")).Padding(16),
@@ -388,9 +388,9 @@ class DeepLinkQueryDemo : Component
 }
 ```
 
-This example shows query parameters and optional path segments. The resolver
-parses `/users/42/posts?sort=date&page=2` into typed values you can use
-directly in route constructors.
+This example shows typed path parameters and query values. The resolver
+parses `/users/42/posts/7?sort=date` into typed values you can use directly
+in route constructors.
 
 ## Page Caching
 
@@ -430,6 +430,7 @@ class PageCachingDemo : Component
         VStack(8,
             TextBlock(name).FontSize(20).Bold(),
             TextBox("", _ => { }, placeholderText: "Type here — state persists")
+                .AutomationName($"{name} page note")
         ).Padding(16);
 }
 ```
@@ -594,14 +595,14 @@ class FrameEventsDemo : Component
             SubHeading("Frame events"),
             Frame(sourcePageType: typeof(DocsFrameDemoPage))
                 .Navigating(target =>
-                    updateLog(l => [.. l, $"Navigating to {target.Name}"]))
+                    updateLog(l => [.. l, $"{l.Count + 1}: Navigating to {target.Name}"]))
                 .Navigated(target =>
-                    updateLog(l => [.. l, $"Arrived at {target.Name}"]))
+                    updateLog(l => [.. l, $"{l.Count + 1}: Arrived at {target.Name}"]))
                 .NavigationFailed((target, ex) =>
-                    updateLog(l => [.. l, $"Failed {target.Name}: {ex.Message}"]))
+                    updateLog(l => [.. l, $"{l.Count + 1}: Failed {target.Name}: {ex.Message}"]))
                 .Height(300),
             VStack(4, log.TakeLast(6).Select(
-                entry => TextBlock(entry).FontSize(11).Opacity(0.6)
+                entry => TextBlock(entry).FontSize(11).Opacity(0.6).WithKey(entry)
             ).ToArray())
         ).Padding(24);
     }
@@ -711,6 +712,7 @@ class PaneOpenChangedDemo : Component
                 TextBlock(isPaneOpen ? "Pane is open" : "Pane is closed").Opacity(0.6),
                 Button(isPaneOpen ? "Close pane" : "Open pane",
                     () => setIsPaneOpen(!isPaneOpen))
+                    .AutomationName(isPaneOpen ? "Close pane" : "Open pane")
             ).Padding(24)
         ) with
         {
@@ -747,7 +749,9 @@ class ControlledPaneDemo : Component
                 NavItem("Settings", icon: "Setting", tag: "Settings")
             ],
             content: Button(isPaneOpen ? "Close pane" : "Open pane",
-                () => setIsPaneOpen(!isPaneOpen)).Padding(24)
+                () => setIsPaneOpen(!isPaneOpen))
+                .AutomationName(isPaneOpen ? "Close pane" : "Open pane")
+                .Padding(24)
         )
         // One call sets the pane state and wires the change handler, so the two
         // cannot drift apart.
@@ -886,9 +890,9 @@ class DiagnosticsDemo : Component
         UseEffect(() =>
         {
             EventHandler<NavigationDiagnosticEvent> onRequested =
-                (_, e) => updateLog(l => [.. l, $"Requested: {e.From} → {e.To}"]);
+                (_, e) => updateLog(l => [.. l, $"{l.Count + 1}: Requested {e.From} → {e.To}"]);
             EventHandler<NavigationDiagnosticEvent> onCompleted =
-                (_, e) => updateLog(l => [.. l, $"Completed: {e.To}"]);
+                (_, e) => updateLog(l => [.. l, $"{l.Count + 1}: Completed {e.To}"]);
 
             NavigationDiagnostics.NavigationRequested += onRequested;
             NavigationDiagnostics.NavigationCompleted += onCompleted;
@@ -906,7 +910,7 @@ class DiagnosticsDemo : Component
                 Button("Settings", () => nav.Navigate(Route.Settings))
             ),
             VStack(4, log.TakeLast(6).Select(
-                entry => TextBlock(entry).FontSize(11).Opacity(0.6)
+                entry => TextBlock(entry).FontSize(11).Opacity(0.6).WithKey(entry)
             ).ToArray()),
             NavigationHost(nav, route =>
                 TextBlock($"Page: {route}").Padding(16))

--- a/docs/guide/persistence.md
+++ b/docs/guide/persistence.md
@@ -25,7 +25,9 @@ class NotesEditor : Component
 
         return VStack(8,
             SubHeading("Notes"),
-            TextBox(text, setText, placeholderText: "Start typing…").Width(380),
+            TextBox(text, setText, placeholderText: "Start typing…")
+                .AutomationName("Notes body")
+                .Width(380),
             TextBlock($"{text.Length} characters").Opacity(0.6)
         ).Padding(16);
     }
@@ -108,16 +110,19 @@ class VersionedNotesEditor : Component
 {
     public override Element Render()
     {
+        var initialState = UseMemo(
+            () => new NotesStateV2("", DateTimeOffset.Now, ""),
+            Array.Empty<object>());
         var (state, setState) = UsePersisted(
             "notes/state-v2",
-            initialValue: new NotesStateV2("", DateTimeOffset.Now, ""),
+            initialValue: initialState,
             scope: PersistedScope.Application);
 
         return VStack(8,
             TextBox(state.Title, t => setState(state with { Title = t }),
-                placeholderText: "Title"),
+                placeholderText: "Title", header: "Title"),
             TextBox(state.Body, b => setState(state with { Body = b, LastEdit = DateTimeOffset.Now }),
-                placeholderText: "Body")
+                placeholderText: "Body", header: "Body")
         );
     }
 

--- a/docs/guide/reactor-vs-xaml.md
+++ b/docs/guide/reactor-vs-xaml.md
@@ -224,20 +224,21 @@ that matches a `TargetType` (or carries the style key). The bag is
 keyed by DP, and `BasedOn` chains styles through inheritance.
 
 Reactor has two analogues. The most common is a plain method that
-takes an element and applies modifiers:
+composes elements and modifiers:
 
 ```csharp
 // A XAML `Style` is a keyed bag of setters matched by TargetType. The
-// Reactor analogue is a plain method that applies modifiers — no static
-// registration, no runtime TargetType check, just composition.
+// Reactor analogue is a plain method that composes a wrapper element — no
+// static registration, no runtime TargetType check, just composition.
 static Element CardSurface(Element child) =>
-    child.Background(Theme.CardBackground)
-         .CornerRadius(8)
-         .Padding(16);
+    Border(child)
+        .Background(Theme.CardBackground)
+        .CornerRadius(8)
+        .Padding(16);
 ```
 
-Calling `CardSurface(TextBlock("hi"))` returns the modified element. This
-is just composition — no framework involvement, no static
+Calling `CardSurface(TextBlock("hi"))` returns a `Border` around the child
+with the card modifiers applied. This is just composition — no framework involvement, no static
 registration, no `Style.TargetType` check at runtime.
 
 For the handful of canonical WinUI named styles, the [styling](styling.md)

--- a/docs/guide/recipes/command-palette.md
+++ b/docs/guide/recipes/command-palette.md
@@ -16,6 +16,7 @@ overlay, layered over the page the same way the
 | Open / query / selection state | `UseState<bool>` / `UseState<string>` / `UseState<int>` |
 | Command catalog | [`Command`](../commanding.md) records — same shape used by `Button`, `MenuItem`, `AppBarButton` |
 | Filter | LINQ `Where(...Contains(query, OrdinalIgnoreCase))` |
+| Open focus | `UseElementFocus()` + `UseEffect` when `open` changes |
 | Open accelerator | [`.OnKeyDown`](../input-and-gestures.md) on the root surface |
 | List navigation | [`.OnPreviewKeyDown`](../input-and-gestures.md) on the palette container |
 | Overlay composition | `Group(page, palette)` — same shape as [Recipe: Modal dialog](modal-dialog.md) |
@@ -53,17 +54,21 @@ same record with a toolbar button or a context menu entry.
 
 ```csharp
 // Three pieces of state run the palette: whether it's open, the
-// typed query, and the highlighted row in the filtered list.
+// typed query, and the highlighted row in the filtered list. The
+// focus helper is separate; it moves focus into the query box on open.
 var (open, setOpen) = UseState(false);
 var (query, setQuery) = UseState("");
 var (index, setIndex) = UseState(0);
 var (last, setLast) = UseState<string?>(null);
+var (queryRef, requestQueryFocus) = this.UseElementFocus();
 ```
 
-Three hooks own the palette: `open` toggles the overlay, `query`
+Three state hooks own the palette: `open` toggles the overlay, `query`
 drives the filter, and `index` is the highlighted row. A fourth
 `last` hook just echoes the most recently executed command for the
-demo — it's not part of the palette pattern.
+demo — it's not part of the palette pattern. The focus helper is
+separate from palette state; it moves focus into the query box when
+the overlay opens.
 
 ### Filter
 
@@ -153,21 +158,32 @@ var page = VStack(12,
         : TextBlock($"Last command: {last}").Opacity(0.6)
 ).Padding(24);
 
+UseEffect(() =>
+{
+    if (open)
+        requestQueryFocus();
+    return () => { };
+}, open);
+
 Element palette = Border(
     VStack(0,
         TextBox(query, v => { setQuery(v); setIndex(0); },
-            placeholderText: "Type a command…").Width(420),
+            placeholderText: "Type a command…")
+            .AutomationName("Command search")
+            .Width(420)
+            .Ref(queryRef),
         matches.Length == 0
-            ? TextBlock("No commands match.").Padding(12).Opacity(0.6)
+            ? (Element)TextBlock("No commands match.").Padding(12).Opacity(0.6)
             : VStack(0,
                 matches.Select((c, i) =>
-                    TextBlock(c.Label)
-                        .Padding(10)
-                        .Background(i == safeIndex ? "#E5F1FB" : "#FFFFFF")
+                    Border(
+                        TextBlock(c.Label).Padding(10)
+                    ).Background(i == safeIndex ? Theme.AccentTertiary : Theme.CardBackground)
+                     .WithKey(c.Label)
                 ).ToArray<Element>()
             )
-    ).Background("#FFFFFF").CornerRadius(8).Width(440)
-).Background("#80000000").Padding(60)
+    ).Background(Theme.CardBackground).CornerRadius(8).Width(440)
+).Background(Theme.SmokeFill).Padding(60)
  .OnPreviewKeyDown(OnPaletteKey);
 
 var root = (open ? Group(page, palette) : page)
@@ -193,7 +209,7 @@ return root;
 
 The page renders normally; the palette is a `Border` wrapping a
 `VStack` returned alongside it in a `Group(page, palette)`. The
-scrim background `#80000000` dims the page underneath. The root
+theme smoke-fill scrim dims the page underneath. The root
 surface's `.OnKeyDown` watches for Ctrl+K and toggles `open`, which
 is the cheapest "global accelerator" that works from any focus state
 on the page.

--- a/docs/guide/recipes/drag-reorder.md
+++ b/docs/guide/recipes/drag-reorder.md
@@ -149,8 +149,8 @@ Element Row(TaskItem item)
             TextBlock(item.Title)
         )
         .Padding(10)
-        .Background(isFocused ? "#EEF4FB" : "#FFFFFF")
-        .WithBorder(isHover ? "#0078D4" : "#E1E1E1", isHover ? 2 : 1)
+        .Background(isFocused ? Theme.SubtleFill : Theme.CardBackground)
+        .WithBorder(isHover ? Theme.Accent : Theme.ControlStroke, isHover ? 2 : 1)
         .Opacity(isDragging ? 0.4 : 1.0)
         .IsTabStop(true)
         .OnGotFocus((_, _) => setFocusedId(item.Id))
@@ -163,6 +163,11 @@ Element Row(TaskItem item)
         {
             if (args.Data.TryGetTypedPayload<int>(out var srcId) && srcId != item.Id)
                 setHoverId(item.Id);
+        })
+        .OnDragLeave(_ =>
+        {
+            if (hoverId == item.Id)
+                setHoverId(null);
         })
         .OnDrop<StackElement, int>(srcId =>
         {
@@ -177,7 +182,7 @@ return VStack(8,
     TextBlock("Drag a row, or focus one and press Alt+Up / Alt+Down.")
         .Opacity(0.7),
     VStack(4,
-        items.Select(Row).ToArray()
+        items.Select(item => Row(item).WithKey(item.Id.ToString())).ToArray()
     )
 ).Padding(16).Width(320);
 ```

--- a/docs/guide/recipes/index.md
+++ b/docs/guide/recipes/index.md
@@ -8,6 +8,22 @@ palette, drag-to-reorder. The recipes here are not exhaustive apps;
 each is a single screen showing the pattern, and each ships a tiny
 doc app you can clone and adapt.
 
+## Gallery
+
+| Recipe | What it shows |
+|---|---|
+| [Login](login.md) | Per-keystroke validation, `UseMutation`-owned submit state, error display. |
+| [Master-detail](master-detail.md) | Two-pane selection-driven layout from a list and a record. |
+| [Settings page](settings-page.md) | Per-key `UsePersisted` for `Toggle` / `ComboBox` / `Slider`. |
+| [Paginated list](paginated-list.md) | `UseInfiniteResource` with empty / loading / error states and a load-more sentinel. |
+| [Modal dialog](modal-dialog.md) | Confirmation pattern with scrim and conditional render. |
+| [Multi-step form](multi-step-form.md) | Wizard navigation with per-step validation. |
+| [Search with suggestions](search-with-suggestions.md) | `UseMemo`-filtered suggestion list against a static catalog. |
+| [Command palette](command-palette.md) | Keyboard accelerator opening an overlay with a filtered command list. |
+| [Drag-reorder](drag-reorder.md) | Identity-preserving reorder of a keyed list, with a keyboard path. |
+
+## The gallery app
+
 ```csharp
 class RecipesIndexApp : Component
 {
@@ -15,19 +31,34 @@ class RecipesIndexApp : Component
         Heading("Recipes"),
         TextBlock("Real-world compositions made of Reactor primitives.")
             .Opacity(0.7),
-        HStack(8,
-            Tile("Login", "Validation + async submit"),
-            Tile("Master-detail", "Selection-driven layout"),
-            Tile("Settings", "Persisted preferences")
+        VStack(8,
+            HStack(8,
+                Tile("Login", "Validation + async submit"),
+                Tile("Master-detail", "Selection-driven layout"),
+                Tile("Settings", "Persisted preferences")),
+            HStack(8,
+                Tile("Paginated list", "Loading + empty + error states"),
+                Tile("Modal dialog", "Scrim + confirmation flow"),
+                Tile("Multi-step form", "Wizard validation")),
+            HStack(8,
+                Tile("Search", "Memoized suggestions"),
+                Tile("Command palette", "Keyboard-opened overlay"),
+                Tile("Drag-reorder", "Keyed list reordering"))
         )
     ).Padding(20);
+
+    private static Element Tile(string title, string sub) => VStack(4,
+        TextBlock(title).Bold(),
+        TextBlock(sub).Opacity(0.6)
+    ).Padding(12);
+}
 ```
 
 ![Recipes gallery preview](../images/recipes-index/gallery.png)
 
 The gallery uses the same primitives every recipe page does — a
-`VStack` for the column layout, `TextBlock` for descriptions, `HStack`
-for the tile row. The tile helper is a private static method, not a
+`VStack` for the column layout, `TextBlock` for descriptions, and
+`HStack` for each tile row. The tile helper is a private static method, not a
 component, so it has no hook scope:
 
 ```csharp
@@ -49,20 +80,6 @@ class GalleryShape : Component
     public override Element Render() => TextBlock("see docs/_pipeline/apps/recipe-*");
 }
 ```
-
-## Gallery
-
-| Recipe | What it shows |
-|---|---|
-| [Login](login.md) | Per-keystroke validation, `UseMutation`-owned submit state, error display. |
-| [Master-detail](master-detail.md) | Two-pane selection-driven layout from a list and a record. |
-| [Settings page](settings-page.md) | Per-key `UsePersisted` for `Toggle` / `ComboBox` / `Slider`. |
-| [Paginated list](paginated-list.md) | `UseInfiniteResource` with empty / loading / error states and a load-more sentinel. |
-| [Modal dialog](modal-dialog.md) | Confirmation pattern with scrim and conditional render. |
-| [Multi-step form](multi-step-form.md) | Wizard navigation with per-step validation. |
-| [Search with suggestions](search-with-suggestions.md) | `UseMemo`-filtered suggestion list against a static catalog. |
-| [Command palette](command-palette.md) | Keyboard accelerator opening an overlay with a filtered command list. |
-| [Drag-reorder](drag-reorder.md) | Identity-preserving reorder of a keyed list, with a keyboard path. |
 
 ## How to read a recipe
 

--- a/docs/guide/recipes/login.md
+++ b/docs/guide/recipes/login.md
@@ -101,14 +101,16 @@ return VStack(12,
     Heading("Sign in"),
     TextBox(email, setEmail, placeholderText: "you@example.com",
         header: "Email").Width(280),
-    PasswordBox(pwd, setPwd, placeholderText: "8+ characters"),
+    PasswordBox(pwd, setPwd, placeholderText: "8+ characters")
+        .AutomationName("Password"),
     signIn.Error is null
         ? Empty()
-        : TextBlock(signIn.Error.Message).Foreground("#C42B1C"),
+        : TextBlock(signIn.Error.Message).Foreground(Theme.SystemCritical),
     // SubmitAsync swallows the fault above, so this discard cannot
     // leave anything unobserved.
     Button(signIn.IsPending ? "Signing in…" : "Sign in",
             () => _ = SubmitAsync())
+        .AutomationName("Sign in")
         .IsEnabled(canSubmit)
 ).Padding(20).Width(320);
 ```
@@ -120,10 +122,9 @@ disabling the button is enough; an analyzer-flagged guard inside the
 mutator would double-fire on a re-render race. `signIn.IsPending` owns
 both the spinner label ("Signing in…") and the disabled state, so an
 in-flight submit can't be re-triggered by an Enter press.
-`() => _ = signIn.RunAsync((email, pwd))` is the standard fire-and-
-forget shape: the returned task carries the same fault that
-`signIn.Error` already holds, so the UI reads the handle rather than
-awaiting.
+`SubmitAsync` observes the task returned by `signIn.RunAsync((email, pwd))`
+while letting the mutation own the rendered error state, so the UI reads the
+handle instead of duplicating error flags.
 
 ## Tips
 

--- a/docs/guide/recipes/master-detail.md
+++ b/docs/guide/recipes/master-detail.md
@@ -55,7 +55,7 @@ var list = VStack(2,
             .WithKey(n.Id.ToString())
             .AutomationName(n.Title)
             .HAlign(Microsoft.UI.Xaml.HorizontalAlignment.Stretch)
-            .Background(n.Id == selectedId ? "#E5F1FB" : "#FFFFFF")
+            .Background(n.Id == selectedId ? Theme.SubtleFill : Theme.SolidBackground)
     ).ToArray()
 ).Width(200).Padding(8);
 

--- a/docs/guide/recipes/master-detail.md
+++ b/docs/guide/recipes/master-detail.md
@@ -10,7 +10,7 @@ is one `UseState` for the selected id and two slots in an `HStack`.
 | Slot | API |
 |---|---|
 | Selection state | `UseState<int?>` |
-| List render | `VStack` + `Select(...).ToArray()` |
+| List render | `VStack` + keyed `Select(...).ToArray()` |
 | Selected highlight | Per-row `.Background(...)` |
 | Detail branch | `Element` typed local for null case |
 | Layout split | `HStack(0, list, detail)` |
@@ -52,6 +52,8 @@ the selection actually changes.
 var list = VStack(2,
     Notes.Select(n =>
         Button(n.Title, () => setSelectedId(n.Id))
+            .WithKey(n.Id.ToString())
+            .AutomationName(n.Title)
             .HAlign(Microsoft.UI.Xaml.HorizontalAlignment.Stretch)
             .Background(n.Id == selectedId ? "#E5F1FB" : "#FFFFFF")
     ).ToArray()
@@ -69,7 +71,7 @@ return HStack(0, list, detail);
 
 ![Master-detail layout](../images/recipe-master-detail/layout.png)
 
-The list is a `VStack` of full-width buttons; the selected row gets a
+The list is a keyed `VStack` of full-width buttons; the selected row gets a
 distinct background. The detail pane is conditional — `selected is null`
 renders the empty state, otherwise the title + body. Both sides are
 plain elements; no intermediate component is needed.

--- a/docs/guide/recipes/modal-dialog.md
+++ b/docs/guide/recipes/modal-dialog.md
@@ -45,8 +45,7 @@ a re-render that includes the modal.
 
 ```csharp
 // Pair the dialog with a scrim (SmokeFill) so clicks outside the
-// dialog don't reach the page underneath. The focus trap lives on
-// the modal Border.
+// dialog don't reach the page underneath.
 Element modal = Border(
     VStack(16,
         Heading("Delete this item?"),
@@ -55,8 +54,8 @@ Element modal = Border(
             Button("Cancel", () => setOpen(false)),
             Button("Delete", () => { setDeleted(true); setOpen(false); })
         ).HAlign(Microsoft.UI.Xaml.HorizontalAlignment.Right)
-    ).Padding(20).Background("#FFFFFF").CornerRadius(8)
-).Background("#80000000").Padding(40);
+    ).Padding(20).Background(Theme.CardBackground).CornerRadius(8)
+).Background(Theme.SmokeFill).Padding(40);
 ```
 
 ![Delete confirmation modal](../images/recipe-modal-dialog/confirm.png)

--- a/docs/guide/recipes/multi-step-form.md
+++ b/docs/guide/recipes/multi-step-form.md
@@ -109,7 +109,9 @@ return VStack(16,
     HStack(8,
         Button("Back", () => setStep(step - 1)).IsEnabled(step != 0),
         Button(step == 2 ? "Submit" : "Next",
-            () => setStep(step + 1)).IsEnabled(canAdvance && step != 2)
+            () => setStep(step + 1))
+            .AutomationName(step == 2 ? "Submit form" : "Next step")
+            .IsEnabled(canAdvance && step != 2)
     )
 ).Padding(20).Width(380);
 ```

--- a/docs/guide/recipes/paginated-list.md
+++ b/docs/guide/recipes/paginated-list.md
@@ -103,7 +103,7 @@ else if (error is not null && loadedItems.Length == 0)
 {
     body = VStack(8,
         TextBlock($"Couldn't load commits: {error.Exception.Message}")
-            .Foreground("#C42B1C"),
+            .Foreground(Theme.SystemCritical),
         Button("Retry", () => commits.Retry())
     ).Padding(20);
 }
@@ -119,6 +119,7 @@ else
                 TextBlock(c.Sha).Opacity(0.5).Width(72),
                 TextBlock(c.Message)
             ).Padding(6)
+             .WithKey(c.Sha)
         ).ToArray()
     );
 }
@@ -128,11 +129,16 @@ else
 Element footer = atEnd
     ? TextBlock("— end of list —").Opacity(0.5).Padding(12)
     : error is not null && loadedItems.Length > 0
-        ? Button($"Retry — {error.Exception.Message}", () => commits.Retry()).Padding(8)
+        ? Button($"Retry — {error.Exception.Message}", () => commits.Retry())
+            .AutomationName("Retry loading the next page")
+            .Padding(8)
         : Button(
             loadingMore ? "Loading more…" : $"Load more ({commits.EstimatedRemaining} remaining)",
             () => commits.FetchNext()
-          ).IsEnabled(!loadingMore).Padding(8);
+          )
+            .AutomationName(loadingMore ? "Loading more commits" : "Load more commits")
+            .IsEnabled(!loadingMore)
+            .Padding(8);
 
 return VStack(0,
     Heading($"Commits ({commits.TotalCount ?? loadedItems.Length})").Padding(20),

--- a/docs/guide/recipes/search-with-suggestions.md
+++ b/docs/guide/recipes/search-with-suggestions.md
@@ -62,15 +62,17 @@ clears the input is essential.
 
 ```csharp
 return VStack(8,
-    TextBox(query, setQuery, placeholderText: "Search topics…").Width(300),
+    TextBox(query, setQuery, placeholderText: "Search topics…")
+        .AutomationName("Search topics")
+        .Width(300),
     suggestions.Length == 0
         ? Empty()
         : Border(
             VStack(2,
                 suggestions.Select(s =>
-                    TextBlock(s).Padding(8)).ToArray()
-            ).Background("#FFFFFF")
-        ).WithBorder("#E0E0E0").Width(300)
+                    TextBlock(s).Padding(8).WithKey(s)).ToArray()
+            ).Background(Theme.SolidBackground)
+        ).WithBorder(Theme.ControlStroke).Width(300)
 ).Padding(20);
 ```
 

--- a/docs/guide/recipes/settings-page.md
+++ b/docs/guide/recipes/settings-page.md
@@ -32,9 +32,9 @@ var (volume, setVolume) = UsePersisted("prefs/volume", 60.0,
     PersistedScope.Window);
 ```
 
-Three preferences, three keys. Each pref renders + persists
-independently, so adding a fourth is one line in `Render()` + one
-matching control. The `PersistedScope.Window` scope keeps the values
+Three preferences, three keys. Each pref persists independently, so
+adding a fourth is one line in `Render()` + one matching control. The
+`PersistedScope.Window` scope keeps the values
 inside the host window — flip to `PersistedScope.Application` for
 process-wide preferences (auth, locale, theme) per the
 [persistence](../persistence.md) page.
@@ -55,9 +55,10 @@ return VStack(16,
 
 ![Settings page](../images/recipe-settings-page/settings.png)
 
-A `VStack` of `SettingsRow`s; each row is a label + control. Reactor
-re-renders only the row whose state changed — the slider doesn't
-re-mount when you toggle notifications.
+A `VStack` of `SettingsRow`s; each row is a label + control. The page
+re-renders from the changed hook state, and the reconciler patches the
+existing controls in place — the slider doesn't re-mount when you toggle
+notifications.
 
 ### Row helper
 
@@ -67,13 +68,14 @@ re-mount when you toggle notifications.
 private static Element SettingsRow(string label, Element control) =>
     HStack(16,
         TextBlock(label).Width(120),
-        control
+        control.AutomationName(label)
     );
 ```
 
-A fixed-width label keeps the controls aligned across rows. The helper
-is a private static method, not a `Component` — it has no state, so a
-function returning an `Element` is the right shape.
+A fixed-width label keeps the controls aligned across rows, and the
+control receives the same text as its automation name. The helper is a
+private static method, not a `Component` — it has no state, so a function
+returning an `Element` is the right shape.
 
 ## Tips
 

--- a/docs/guide/reconciliation.md
+++ b/docs/guide/reconciliation.md
@@ -81,6 +81,13 @@ public UIElement? Reconcile(
         DebugElementsSkipped = 0;
         DebugUIElementsCreated = 0;
         DebugUIElementsModified = 0;
+        // Drop destination references a previous pass queued but never flushed. Every
+        // shipped host flushes at the end of each render, but a pass that threw
+        // mid-reconcile — or a Reconcile() caller that never flushes (tests,
+        // embedders) — must not accumulate strong UIElement refs. A list clear, so
+        // nothing here can throw and strand the depth counter incremented just above.
+        _pendingConnectedAnimationStarts.Clear();
+        _preparedConnectedAnimationKeys.Clear();
         if (ReactorFeatureFlags.HighlightReconcileChanges)
         {
             (_highlightMounted ??= new()).Clear();

--- a/docs/guide/rules-of-reactor.md
+++ b/docs/guide/rules-of-reactor.md
@@ -213,9 +213,16 @@ class TodoListBad : Component
     public override Element Render() => VStack(4,
         Items.Select(i =>
             // No .WithKey — reorder is destructive.
-            TextBox(i.Title, _ => { }, header: i.Id.ToString())
+            TextBox(i.Title, title => Rename(i, title), header: i.Id.ToString())
         ).ToArray()
     );
+
+    void Rename(TodoItem item, string title)
+    {
+        var index = System.Array.IndexOf(Items, item);
+        if (index >= 0)
+            Items[index] = item with { Title = title };
+    }
 }
 public record TodoItem(int Id, string Title);
 ```
@@ -229,10 +236,17 @@ class TodoListGood : Component
 
     public override Element Render() => VStack(4,
         Items.Select(i =>
-            TextBox(i.Title, _ => { }, header: i.Id.ToString())
+            TextBox(i.Title, title => Rename(i, title), header: i.Id.ToString())
                 .WithKey(i.Id.ToString())                  // stable identity
         ).ToArray()
     );
+
+    void Rename(TodoItem item, string title)
+    {
+        var index = System.Array.IndexOf(Items, item);
+        if (index >= 0)
+            Items[index] = item with { Title = title };
+    }
 }
 ```
 

--- a/docs/guide/status-and-info.md
+++ b/docs/guide/status-and-info.md
@@ -166,7 +166,7 @@ class ProgressRingDemo : Component
     public override Element Render() => VStack(12,
         SubHeading("ProgressRing"),
         // Determinate ring at 60%.
-        ProgressRing(0.6).Width(48).Height(48),
+        ProgressRing(60).Width(48).Height(48),
         // Indeterminate spinner.
         ProgressRing().IsActive().Width(48).Height(48)
     ).Padding(24);
@@ -174,8 +174,8 @@ class ProgressRingDemo : Component
 ```
 
 <!-- phantom:skip "ProgressBar" -->
-The `value` argument is 0–100 for `Progress(double)` and 0–1 for
-`ProgressRing(double)` — same convention as the underlying WinUI
+The `value` argument is 0–100 for both `Progress(double)` and
+`ProgressRing(double)` — the same convention as the underlying WinUI
 controls. There is no `ProgressBar(...)` factory: the linear bar is
 reached through `Progress` / `ProgressIndeterminate`, which is what the
 element record `ProgressElement` binds to (spec 039 §5).
@@ -194,12 +194,14 @@ class TeachingTipDemo : Component
     public override Element Render()
     {
         var (show, setShow) = UseState(false);
+        var target = this.UseElementRef<FrameworkElement>();
 
         return VStack(12,
             SubHeading("TeachingTip"),
-            Button("Show tip", () => setShow(true)),
+            Button("Show tip", () => setShow(true)).Ref(target),
             TeachingTip("Try the new sort menu",
-                "Sort across multiple columns by holding Shift.") with
+                "Sort across multiple columns by holding Shift.",
+                target: target) with
             {
                 IsOpen = show,
                 OnClosed = () => setShow(false),

--- a/docs/guide/styling.md
+++ b/docs/guide/styling.md
@@ -33,7 +33,7 @@ of mode.
 |---|---|---|
 | `Theme.Accent`, `Theme.PrimaryText`, etc. | Typed token | Always — these are the canonical brush references. |
 | `Theme.Ref("AnyResourceKey")` | String token | The brush isn't surfaced as a typed accessor (rare). |
-| `.Background(token)` / `.Foreground(token)` | Color modifier | Apply a token to any element. |
+| `.Background(token)` / `.Foreground(token)` | Color modifier | Apply a token to elements that expose that property (for example `Border` for backgrounds, `TextBlock` for foregrounds). |
 | `.Background("#RRGGBB")` | Color modifier | Brand colors that must stay constant across themes. |
 | `.AccentButton()`, `.SubtleButton()`, `.TextLink()` | Named-style fluent | The four canonical button shapes. No `.Resources` needed. |
 | `.Informational()` / `.Success()` / `.Warning()` / `.Error()` | Named-style fluent | InfoBar severity. |
@@ -55,11 +55,12 @@ class ThemeTokensExample : Component
             TextBlock("Primary Text").Foreground(Theme.PrimaryText),
             TextBlock("Secondary Text").Foreground(Theme.SecondaryText),
             TextBlock("Accent Text").Foreground(Theme.AccentText).SemiBold(),
-            TextBlock("On Accent Background")
-                .Foreground("#FFFFFF")
-                .Padding(horizontal: 8, vertical: 4)
-                .Background(Theme.Accent)
-                .CornerRadius(4)
+            Border(
+                TextBlock("On Accent Background")
+                    .Foreground(Theme.AccentText)
+                    .Padding(horizontal: 8, vertical: 4)
+            ).Background(Theme.Accent)
+             .CornerRadius(4)
         ).Padding(24);
     }
 }
@@ -115,7 +116,8 @@ that looks native in both light and dark mode.
 
 ## Color modifiers
 
-`.Background()` and `.Foreground()` accept three input shapes:
+`.Background()` and `.Foreground()` accept typed tokens and `Theme.Ref`
+tokens for theme-aware colors:
 
 ```csharp
 class ColorModifiersExample : Component
@@ -123,10 +125,14 @@ class ColorModifiersExample : Component
     public override Element Render()
     {
         return VStack(8,
-            TextBlock("Theme token").Background(Theme.SubtleFill).Padding(8),
-            TextBlock("Hex string").Background("#E8F5E9").Padding(8),
-            TextBlock("Mixed").Foreground(Theme.PrimaryText)
-                .Background("#1E1E2E").Padding(8)
+            Border(TextBlock("Typed token").Padding(8))
+                .Background(Theme.SubtleFill),
+            Border(TextBlock("Theme.Ref token").Padding(8))
+                .Background(Theme.Ref("AcrylicBackgroundFillColorDefaultBrush")),
+            Border(TextBlock("Token foreground + token background")
+                .Foreground(Theme.PrimaryText)
+                .Padding(8))
+                .Background(Theme.ControlFill)
         ).Padding(24);
     }
 }
@@ -136,10 +142,10 @@ class ColorModifiersExample : Component
 |---|---|---|
 | Typed token | `.Background(Theme.Accent)` | yes |
 | `Theme.Ref` | `.Background(Theme.Ref("MyCustomBrush"))` | yes |
-| Hex string | `.Background("#FF5733")` | no — frozen |
-| `Windows.UI.Color` | `.Background(Colors.Blue)` | no — frozen |
+| Hex string | `.Background("#FF5733")` | no — frozen; reserve for brand colors |
+| `Brush` | `.Background(new SolidColorBrush(...))` | no — frozen; avoid unless the color must not follow theme |
 
-Tokens are the right default. Reserve hex and `Color` for brand colors
+Tokens are the right default. Reserve hex and `Brush` for brand colors
 that should stay constant regardless of mode.
 
 ## Signal colors
@@ -160,12 +166,13 @@ class SignalColorsExample : Component
     }
 
     static Element Badge(string label, ThemeRef color) =>
-        TextBlock(label)
-            .FontSize(12).SemiBold()
-            .Foreground(color)
-            .Padding(horizontal: 8, vertical: 4)
-            .Background(Theme.SubtleFill)
-            .CornerRadius(4);
+        Border(
+            TextBlock(label)
+                .FontSize(12).SemiBold()
+                .Foreground(color)
+                .Padding(horizontal: 8, vertical: 4)
+        ).Background(Theme.SubtleFill)
+         .CornerRadius(4);
 }
 ```
 

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -36,13 +36,26 @@ class Counter : Component
 | Self-test | `tests/Reactor.SelfTests/` (fixtures in `Reactor.AppTests.Host`) | MSTest wrapping a TAP subprocess | Component renders into a real WinUI tree; assertions via `VisualTreeHelper`. |
 | App E2E | `tests/Reactor.AppTests/` | MSTest + winapp ui | Real user input, UIA properties as seen by assistive tech, cross-process behavior. |
 
-One command per suite — there are no filters to remember:
+Every suite runs on **Microsoft.Testing.Platform**. Full-suite commands are
+plain:
 
 <!-- ai:lock -->
 ```
 dotnet test tests/Reactor.Tests -p:Platform=x64
 dotnet test tests/Reactor.SelfTests
 dotnet test tests/Reactor.AppTests
+```
+<!-- /ai:lock -->
+
+For targeted runs, use the runner's current filter syntax: xUnit suites
+prefer MTP's `--filter-class` / `--filter-method` family, while the MSTest
+self-test and E2E suites keep VSTest-style `--filter` expressions:
+
+<!-- ai:lock -->
+```
+dotnet test tests/Reactor.Tests --filter-class "*ReconcilerMountUpdateTests*"
+dotnet test tests/Reactor.SelfTests --filter "ClassName~SkipReportingTests"
+dotnet test tests/Reactor.AppTests --filter "ClassName=Microsoft.UI.Reactor.AppTests.Tests.AccessibilityTests"
 ```
 <!-- /ai:lock -->
 
@@ -129,7 +142,8 @@ class EffectfulCounter : Component
             Log.Add($"effect:{count}");
             return () => Log.Add($"cleanup:{count}");
         }, count);
-        return Button($"count={count}", () => setCount(count + 1));
+        return Button($"count={count}", () => setCount(count + 1))
+            .AutomationName($"Counter is {count}");
     }
 }
 ```
@@ -194,7 +208,7 @@ control, so it runs in the headless unit suite:
 class IconOnlyButton : Component
 {
     public override Element Render() =>
-        Button(TextBlock("🔍"), null);      // icon content, no accessible name
+        Button(TextBlock("🔍"));            // icon content, no accessible name
 }
 
 class NamedButton : Component

--- a/docs/guide/text-and-media.md
+++ b/docs/guide/text-and-media.md
@@ -1,15 +1,15 @@
 > **WinUI reference:** For the full property surface and design guidance, see [Text Controls](https://learn.microsoft.com/en-us/windows/apps/design/controls/text-controls).
 
-Text and media controls are the read-only-display half of the Microsoft.UI.Reactor (Reactor)
+Text and media controls are the display, rich-text, and media half of the Microsoft.UI.Reactor (Reactor)
 catalog: surfaces that show content the user is reading, watching, or
-inspecting rather than editing. Most of them are thin wrappers over the
+inspecting, plus `RichEditBox` for rich-text editing. Most of them are thin wrappers over the
 WinUI text and media surface, so the modifier names and accessibility
 behavior match what a WinUI developer already knows. The two outliers are
 [`Markdown(string)`](#markdown-reactor-original) — a Reactor-original
 renderer that parses GFM-style Markdown into the same element tree the
 rest of your UI uses, no WebView round trip — and the semantic text
-variants [`Heading`](#text-variants) / [`SubHeading`](#text-variants) /
-[`Caption`](#text-variants), which preset typography so that accessibility
+variants [`Heading`](#text-variants) / [`SubHeading`](#text-variants),
+which preset typography so that accessibility
 tooling can infer document outline without manually setting
 `AutomationProperties`. The trade-off the catalog makes here is bias
 toward composition: rich layouts come from many small text elements in a
@@ -19,22 +19,22 @@ prose, then jump to the control you need.
 
 # Text and Media
 
-This page covers every read-only-display and inline-rich-text control in
-Reactor. For input controls (`TextBox`, `PasswordBox`, `RichEditBox`),
+This page covers display text, inline rich text, rich-text editing, and media controls in
+Reactor. For single-line input controls (`TextBox`, `PasswordBox`),
 see [Forms](forms.md). For data-bound collections, see
 [Collections](collections.md).
 
 ## Text variants
 
 ```csharp
-Title(string)           // largest variant, ~40pt
-Heading(string)         // section title, ~28pt
+Title(string)           // WinUI title text style, ~28pt
+Heading(string)         // semantic heading, ~28pt
 SubHeading(string)      // sub-section header, ~20pt
 Subtitle(string)        // supporting line under a heading
 BodyLarge(string)       // lead paragraph
 TextBlock(string)       // body prose
 BodyStrong(string)      // body prose, semibold
-Caption(string)         // ~12pt, dimmed
+Caption(string)         // ~12pt metadata text
 ```
 
 ```csharp
@@ -56,7 +56,8 @@ class TextVariantsDemo : Component
 ![Heading / SubHeading / TextBlock / Caption stacked](images/text-and-media/text-variants.png)
 
 `Heading`, `SubHeading`, and `Caption` return [`TextBlockElement`](components.md)
-with preset `FontSize`, weight, and `Foreground` from the active theme.
+with preset text sizing; `Heading` and `SubHeading` also set heading
+automation levels.
 They are the right tool for document outline — screen readers and the
 [accessibility scanner](accessibility.md) treat them as hierarchical
 landmarks, where a bare `TextBlock` styled with `.FontSize(24).Bold()` is
@@ -66,14 +67,14 @@ match the visual weight you want.
 
 | Factory | Default size | Use when |
 |---|---|---|
-| `Title` | ~40pt, semibold | The largest thing on a landing or hero surface. |
-| `Heading` | ~28pt, bold | One per page — the document title. |
+| `Title` | ~28pt, semibold | WinUI title-ramp text without heading semantics. |
+| `Heading` | ~28pt, bold | One per page — the semantic document title. |
 | `SubHeading` | ~20pt, semibold | Section header inside a long page. |
 | `Subtitle` | ~20pt, regular | Supporting line directly under a heading. |
 | `BodyLarge` | ~18pt | Lead paragraph or callout prose. |
 | `TextBlock` | Body | Paragraphs, labels, inline help. |
 | `BodyStrong` | Body, semibold | Emphasis inside body copy without a size jump. |
-| `Caption` | ~12pt, dimmed | Timestamps, metadata, helper text under a field. |
+| `Caption` | ~12pt | Timestamps, metadata, helper text under a field. |
 
 WinUI design page: [Typography in Windows 11](https://learn.microsoft.com/en-us/windows/apps/design/style/typography).
 
@@ -319,6 +320,8 @@ class ImageDemo : Component
         // Resource Uri — ms-appx:// for packaged assets, file:// for disk,
         // https:// for remote.
         Image("ms-appx:///Assets/StoreLogo.png")
+            .AutomationName("Reactor app logo")
+            .Set(img => img.Stretch = Microsoft.UI.Xaml.Media.Stretch.UniformToFill)
             .Width(96).Height(96),
         TextBlock("Stretch.UniformToFill for cover art; " +
                   "ImageFailed to detect missing assets.").Opacity(0.6)
@@ -365,8 +368,7 @@ class MediaPlayerDemo : Component
     public override Element Render() => VStack(8,
         SubHeading("MediaPlayerElement"),
         MediaPlayerElement(
-            "https://learn.microsoft.com/en-us/windows/apps/design/" +
-            "controls/images/ic_fluent_play_24_regular.svg")
+            "https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.mp4")
             .Width(420).Height(240)
             .Set(m =>
             {

--- a/docs/guide/theming-tokens.md
+++ b/docs/guide/theming-tokens.md
@@ -84,14 +84,14 @@ class SwatchGrid : Component
     private static Element SwatchSection(string title, (string Name, ThemeRef Ref)[] tokens) =>
         VStack(8,
             SubHeading(title),
-            VStack(4, tokens.Select(t => Row(t.Name, t.Ref)).ToArray())
+            VStack(4, tokens.Select(t => Row(t.Name, t.Ref).WithKey(t.Name)).ToArray())
         );
 
     private static Element Row(string name, ThemeRef token) => HStack(12,
         new BorderElement(Empty())
             .Background(token)
             .Size(40, 24)
-            .WithBorder("#DDDDDD"),
+            .WithBorder(Theme.ControlStroke),
         TextBlock(name).Width(220),
         TextBlock(token.ResourceKey).Opacity(0.6)
     );

--- a/docs/guide/win2d-canvas.md
+++ b/docs/guide/win2d-canvas.md
@@ -29,7 +29,8 @@ class ManualCanvasDemo : Component
 
         return VStack(12,
             SubHeading("Manual canvas"),
-            Button($"Redraw with count {count}", () => setCount(count + 1)),
+            Button($"Redraw with count {count}", () => setCount(count + 1))
+                .AutomationName("Redraw manual canvas"),
             Win2DCanvas((session, _) =>
             {
                 session.Clear(Colors.White);
@@ -366,7 +367,8 @@ class DrawCommandDemo : Component
                 deps: [count]);
 
             return VStack(12,
-                Button($"Redraw with count {count}", () => setCount(count + 1)),
+                Button($"Redraw with count {count}", () => setCount(count + 1))
+                    .AutomationName("Redraw draw command canvas"),
                 Win2DCanvas(draw, redrawKey: count)
                     .ClearColor(Colors.White)
                     .Width(240)

--- a/docs/guide/windows.md
+++ b/docs/guide/windows.md
@@ -262,7 +262,9 @@ visual clickable or `.IsDragRegion(true)` to force it draggable, and set
 (TitleBar("Gallery") with
 {
     Content = HStack(8,
-        AutoSuggestBox("", _ => {}).Width(200),
+        AutoSuggestBox("", _ => {})
+            .AutomationName("Search gallery")
+            .Width(200),
         Button(Icon(FontIcon("\uE713", fontSize: 16)), OnSettings)
             .AutomationName("Settings").IsDragRegion(false)),
 }).AutoRefreshDragRegions();
@@ -505,15 +507,18 @@ HWND interop.
 
 ```csharp
 // Both helpers return null when the user cancels the dialog.
-async Task OpenAsync()
+var pickFile = UseFilePickerAsync;
+var pickFolder = UseFolderPickerAsync;
+
+return Button("Open...", async () =>
 {
-    var file = await UseFilePickerAsync(new FilePickerOptions(
+    var file = await pickFile(new FilePickerOptions(
         FileTypeFilter: [".txt", ".md"]));
     if (file is null) return;
 
-    var folder = await UseFolderPickerAsync(new FolderPickerOptions());
+    var folder = await pickFolder(new FolderPickerOptions());
     if (folder is null) return;
-}
+});
 ```
 
 Caveats:

--- a/docs/guide/winforms-interop.md
+++ b/docs/guide/winforms-interop.md
@@ -144,7 +144,7 @@ class KeyboardDemo : Component
         // Tab/Shift+Tab cycles through Reactor controls normally.
         // Tab out of the last Reactor control returns focus to WinForms.
         return VStack(12,
-            TextBox(text, setText, placeholderText: "Type here...")
+            TextBox(text, setText, placeholderText: "Type here...", header: "Message")
                 .TabIndex(0),
             Button("Submit", () => { })
                 .TabIndex(1)
@@ -273,11 +273,13 @@ class BackgroundDemo : Component
         // Always set an explicit background on root content.
         // XAML Islands have no default background — without this,
         // content renders on a transparent surface.
-        return VStack(12,
-            TextBlock("Theme-aware background").Bold(),
-            TextBlock($"Count: {count}"),
-            Button("Increment", () => setCount(count + 1))
-        ).Padding(24).Background(SolidBackground);
+        return Grid([GridSize.Star()], [GridSize.Star()],
+            VStack(12,
+                TextBlock("Theme-aware background").Bold(),
+                TextBlock($"Count: {count}"),
+                Button("Increment", () => setCount(count + 1))
+            ).Padding(24)
+        ).Background(SolidBackground);
     }
 }
 ```
@@ -413,7 +415,7 @@ handles lifecycle automatically. Reserve `ContentFactory` for components
 that need parameters or custom host setup.
 
 **Set an explicit background on root components.** XAML Islands have no
-default background. Use `.Background(SolidBackgroundFillColorBase)` for
+default background. Use `.Background(Theme.SolidBackground)` for
 theme-aware backgrounds.
 
 **Dock or anchor the island control.** `XamlIslandControl` supports

--- a/docs/guide/xaml-developers.md
+++ b/docs/guide/xaml-developers.md
@@ -148,9 +148,9 @@ class GridTranslationPage : Component
             columns: [GridSize.Auto, GridSize.Star()],
             rows: [GridSize.Auto, GridSize.Auto],
             TextBlock("First name").Bold().Grid(row: 0, column: 0),
-            TextBox("", _ => { }).Grid(row: 0, column: 1),
+            TextBox("", _ => { }).AutomationName("First name").Grid(row: 0, column: 1),
             TextBlock("Last name").Bold().Grid(row: 1, column: 0),
-            TextBox("", _ => { }).Grid(row: 1, column: 1)
+            TextBox("", _ => { }).AutomationName("Last name").Grid(row: 1, column: 1)
         ) with
         {
             ColumnSpacing = 12,
@@ -320,7 +320,8 @@ class ObservableTreeDemo : Component
                 header: "User Name"),
             ToggleSwitch(vm.DarkMode, v => vm.DarkMode = v,
                 header: "Dark Mode"),
-            Slider(vm.FontSize, 10, 32, v => vm.FontSize = (int)v),
+            Slider(vm.FontSize, 10, 32, v => vm.FontSize = (int)v)
+                .AutomationName("Font size"),
             TextBlock($"Preview: {vm.UserName}")
                 .FontSize(vm.FontSize).Bold()
         ).Padding(24);

--- a/src/Reactor.Analyzers/AccessibilityAnalyzers.cs
+++ b/src/Reactor.Analyzers/AccessibilityAnalyzers.cs
@@ -231,8 +231,15 @@ public sealed class FormFieldLabelAnalyzer : DiagnosticAnalyzer
             }
         }
 
-        // Check the fluent chain for .AutomationName() or .LabeledBy()
-        if (HasModifierInChain(invocation, "AutomationName", "LabeledBy"))
+        // Check the fluent chain for a label-bearing modifier.
+        //
+        // `.Header(...)` counts: TextBox/ComboBox/Slider/ToggleSwitch/PasswordBox/AutoSuggestBox
+        // all expose it (ElementExtensions.cs), and it renders a *visible* label that WinUI already
+        // projects to the field's automation name. Omitting it here made the rule demand a
+        // redundant `.AutomationName("Password")` next to a `.Header("Password")` that was doing
+        // the job, which is worse guidance than the rule was written to give. The match is on the
+        // exact identifier, so `PaneHeader` / `TabStripHeader` / `RightHeader` do not satisfy it.
+        if (HasModifierInChain(invocation, "Header", "AutomationName", "LabeledBy"))
             return;
 
         context.ReportDiagnostic(Diagnostic.Create(

--- a/src/Reactor.Analyzers/HookRulesAnalyzer.cs
+++ b/src/Reactor.Analyzers/HookRulesAnalyzer.cs
@@ -233,8 +233,17 @@ public sealed class HookRulesAnalyzer : DiagnosticAnalyzer
         // </snippet:hook-rules-shape>
 
         // REACTOR_HOOKS_005: must be called from a Render() override or a Use* method.
+        //
+        // ...or from an inline function component. Memo(ctx => …) is a real component
+        // boundary, not an ordinary closure: MountMemoComponent allocates its own
+        // RenderContext, hangs a ComponentNode off it, and calls ctx.BeginRender(), so the
+        // lambda gets its own hook slots and re-runs as a unit. Treating that lambda like
+        // any other nested lambda reported correct code -- including the documented
+        // ctx.UseCanvasResources / ctx.UseDrawState Win2D pattern, whose whole point is
+        // device-lost recovery -- and pushed authors to hand-roll a weaker equivalent.
+        var inlineComponent = FindInlineComponentBoundary(context, invocation);
         var enclosing = FindEnclosingMethod(invocation);
-        if (!IsRenderOrCustomHook(enclosing))
+        if (inlineComponent is null && !IsRenderOrCustomHook(enclosing))
         {
             context.ReportDiagnostic(Diagnostic.Create(
                 HookOutsideRenderRule,
@@ -245,8 +254,11 @@ public sealed class HookRulesAnalyzer : DiagnosticAnalyzer
             return;
         }
 
-        // REACTOR_HOOKS_001: conditional hook.
-        if (FindConditionalAncestor(invocation, enclosing!) is { } kind)
+        // REACTOR_HOOKS_001: conditional hook. Inside an inline function component the
+        // lambda IS the boundary, so an `if` between it and the hook still counts, while
+        // the lambda itself no longer does.
+        SyntaxNode? boundary = inlineComponent ?? (SyntaxNode?)enclosing;
+        if (boundary is not null && FindConditionalAncestor(invocation, boundary) is { } kind)
         {
             context.ReportDiagnostic(Diagnostic.Create(
                 ConditionalHookRule,
@@ -378,6 +390,52 @@ public sealed class HookRulesAnalyzer : DiagnosticAnalyzer
     private static MethodDeclarationSyntax? FindEnclosingMethod(SyntaxNode node)
         => node.FirstAncestorOrSelf<MethodDeclarationSyntax>();
 
+    /// <summary>
+    /// Returns the lambda of the inline function component this hook belongs to, or
+    /// <see langword="null"/> if the hook is not called on such a lambda's own context.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The test is deliberately narrow: the invocation must be <c>receiver.UseXxx(…)</c> where
+    /// <c>receiver</c> binds to a lambda <b>parameter</b> whose type is
+    /// <c>Microsoft.UI.Reactor.Core.RenderContext</c>. That shape is exactly the inline function
+    /// component (<c>Memo(ctx =&gt; …)</c> and anything else taking
+    /// <c>Func&lt;RenderContext, Element&gt;</c>) — matching on the parameter type rather than on
+    /// the factory name keeps a future factory of the same shape working without another edit here.
+    /// </para>
+    /// <para>
+    /// What it deliberately does <em>not</em> exempt: a bare <c>UseState()</c> written inside a
+    /// <c>Memo</c> lambda. That call has no receiver, so it is the <em>enclosing</em> component's
+    /// hook running from a nested closure — still the real bug HOOKS_005 exists to catch. Only the
+    /// lambda's own context is blessed.
+    /// </para>
+    /// </remarks>
+    private static SyntaxNode? FindInlineComponentBoundary(
+        SyntaxNodeAnalysisContext context, InvocationExpressionSyntax invocation)
+    {
+        if (invocation.Expression is not MemberAccessExpressionSyntax member) return null;
+
+        var receiver = context.SemanticModel.GetSymbolInfo(member.Expression).Symbol;
+        if (receiver is not IParameterSymbol parameter) return null;
+        if (parameter.Type is not INamedTypeSymbol parameterType) return null;
+        if (!IsOrDerivesFrom(parameterType, "Microsoft.UI.Reactor.Core.RenderContext")) return null;
+
+        // The parameter must belong to a lambda that actually encloses this invocation, so a
+        // context captured from an unrelated sibling lambda cannot launder a bad hook site.
+        for (var node = (SyntaxNode?)invocation.Parent; node is not null; node = node.Parent)
+        {
+            if (node is not (SimpleLambdaExpressionSyntax or ParenthesizedLambdaExpressionSyntax)) continue;
+
+            if (context.SemanticModel.GetSymbolInfo(node).Symbol is IMethodSymbol lambda
+                && lambda.Parameters.Any(p => SymbolEqualityComparer.Default.Equals(p, parameter)))
+            {
+                return node;
+            }
+        }
+
+        return null;
+    }
+
     private static bool IsRenderOrCustomHook(MethodDeclarationSyntax? method)
     {
         if (method is null) return false;
@@ -389,10 +447,11 @@ public sealed class HookRulesAnalyzer : DiagnosticAnalyzer
     }
 
     /// <summary>
-    /// Walks ancestors from the invocation up to (but not past) the enclosing method's body.
-    /// If any ancestor is a conditional/loop/try construct, returns its human-readable name.
+    /// Walks ancestors from the invocation up to (but not past) the enclosing boundary — a method
+    /// body, or the lambda of an inline function component. If any ancestor is a conditional/loop/try
+    /// construct, returns its human-readable name.
     /// </summary>
-    private static string? FindConditionalAncestor(InvocationExpressionSyntax invocation, MethodDeclarationSyntax boundary)
+    private static string? FindConditionalAncestor(InvocationExpressionSyntax invocation, SyntaxNode boundary)
     {
         for (var node = (SyntaxNode?)invocation.Parent; node is not null && node != boundary; node = node.Parent)
         {

--- a/src/Reactor.Analyzers/HookRulesAnalyzer.cs
+++ b/src/Reactor.Analyzers/HookRulesAnalyzer.cs
@@ -396,12 +396,20 @@ public sealed class HookRulesAnalyzer : DiagnosticAnalyzer
     /// </summary>
     /// <remarks>
     /// <para>
-    /// The test is deliberately narrow: the invocation must be <c>receiver.UseXxx(…)</c> where
-    /// <c>receiver</c> binds to a lambda <b>parameter</b> whose type is
-    /// <c>Microsoft.UI.Reactor.Core.RenderContext</c>. That shape is exactly the inline function
-    /// component (<c>Memo(ctx =&gt; …)</c> and anything else taking
-    /// <c>Func&lt;RenderContext, Element&gt;</c>) — matching on the parameter type rather than on
-    /// the factory name keeps a future factory of the same shape working without another edit here.
+    /// Three conditions, all required: the invocation must be <c>receiver.UseXxx(…)</c> where
+    /// <c>receiver</c> binds to a lambda <b>parameter</b> of type
+    /// <c>Microsoft.UI.Reactor.Core.RenderContext</c>; that lambda must actually enclose the
+    /// invocation; and the lambda must be converted to a delegate <b>returning an
+    /// <c>Element</c></b> — the shape of an inline function component
+    /// (<c>Func&lt;RenderContext, Element&gt;</c>, as taken by <c>Memo</c>).
+    /// </para>
+    /// <para>
+    /// The return-type condition is what keeps this from becoming a false-negative machine.
+    /// <c>RenderContext</c> has a public constructor, so without it any helper taking a
+    /// <c>Action&lt;RenderContext&gt;</c> — including something deferred like
+    /// <c>Task.Run(() =&gt; …)</c> wrapped around a captured context — would silently exempt hooks
+    /// that HOOKS_005 exists to catch. A lambda that returns an <c>Element</c> is a render
+    /// function; one that returns anything else is not.
     /// </para>
     /// <para>
     /// What it deliberately does <em>not</em> exempt: a bare <c>UseState()</c> written inside a
@@ -426,11 +434,15 @@ public sealed class HookRulesAnalyzer : DiagnosticAnalyzer
         {
             if (node is not (SimpleLambdaExpressionSyntax or ParenthesizedLambdaExpressionSyntax)) continue;
 
-            if (context.SemanticModel.GetSymbolInfo(node).Symbol is IMethodSymbol lambda
-                && lambda.Parameters.Any(p => SymbolEqualityComparer.Default.Equals(p, parameter)))
-            {
-                return node;
-            }
+            if (context.SemanticModel.GetSymbolInfo(node).Symbol is not IMethodSymbol lambda) continue;
+            if (!lambda.Parameters.Any(p => SymbolEqualityComparer.Default.Equals(p, parameter))) continue;
+
+            // A render function returns an Element. Anything else taking a RenderContext is an
+            // ordinary callback and gets no exemption.
+            return lambda.ReturnType is INamedTypeSymbol returned
+                && IsOrDerivesFrom(returned, "Microsoft.UI.Reactor.Core.Element")
+                    ? node
+                    : null;
         }
 
         return null;

--- a/src/Reactor.Analyzers/UseThemeRefAnalyzer.cs
+++ b/src/Reactor.Analyzers/UseThemeRefAnalyzer.cs
@@ -102,15 +102,57 @@ public sealed class UseThemeRefAnalyzer : DiagnosticAnalyzer
         if (args.Count == 0)
             return;
 
-        // Check if the first argument is a string literal
-        var firstArg = args[0].Expression;
-        if (firstArg is not LiteralExpressionSyntax literal)
-            return;
-        if (!literal.IsKind(SyntaxKind.StringLiteralExpression))
-            return;
+        // Every string literal the first argument can evaluate to -- not just the argument itself.
+        // Gating on `firstArg is LiteralExpressionSyntax` let a selected/unselected pair like
+        // `.Background(isSelected ? "#E5F1FB" : "#FFFFFF")` through completely unreported, which is
+        // still two hard-coded colours and still ignores the reader's theme.
+        foreach (var literal in ColorLiterals(args[0].Expression))
+            ReportHardCodedColor(context, literal, methodName);
+    }
 
+    /// <summary>
+    /// The string literals an argument can evaluate to.
+    /// </summary>
+    /// <remarks>
+    /// Only value-<em>selecting</em> shapes are walked — a parenthesis, conditional, null-coalesce,
+    /// or switch expression. Walking every descendant instead would reach into nested calls and
+    /// report things that are not colours at all, e.g. the argument of
+    /// <c>.Background(LookUpBrush("accent-ish"))</c>.
+    /// </remarks>
+    private static IEnumerable<LiteralExpressionSyntax> ColorLiterals(ExpressionSyntax? expression)
+    {
+        switch (expression)
+        {
+            case LiteralExpressionSyntax literal when literal.IsKind(SyntaxKind.StringLiteralExpression):
+                yield return literal;
+                break;
+
+            case ParenthesizedExpressionSyntax parenthesized:
+                foreach (var nested in ColorLiterals(parenthesized.Expression)) yield return nested;
+                break;
+
+            case ConditionalExpressionSyntax conditional:
+                foreach (var nested in ColorLiterals(conditional.WhenTrue)) yield return nested;
+                foreach (var nested in ColorLiterals(conditional.WhenFalse)) yield return nested;
+                break;
+
+            case BinaryExpressionSyntax coalesce when coalesce.IsKind(SyntaxKind.CoalesceExpression):
+                foreach (var nested in ColorLiterals(coalesce.Left)) yield return nested;
+                foreach (var nested in ColorLiterals(coalesce.Right)) yield return nested;
+                break;
+
+            case SwitchExpressionSyntax switchExpression:
+                foreach (var arm in switchExpression.Arms)
+                    foreach (var nested in ColorLiterals(arm.Expression)) yield return nested;
+                break;
+        }
+    }
+    // </snippet:theme-ref-rule>
+
+    private static void ReportHardCodedColor(
+        SyntaxNodeAnalysisContext context, LiteralExpressionSyntax literal, string methodName)
+    {
         var colorValue = literal.Token.ValueText;
-        // </snippet:theme-ref-rule>
 
         // Suggest a specific theme token when the mapping also fits the target modifier — a surface
         // token is a poor foreground suggestion (and vice versa) — otherwise stay generic.
@@ -120,7 +162,7 @@ public sealed class UseThemeRefAnalyzer : DiagnosticAnalyzer
 
         context.ReportDiagnostic(Diagnostic.Create(
             Rule,
-            firstArg.GetLocation(),
+            literal.GetLocation(),
             suggestion,
             colorValue));
     }

--- a/tests/Reactor.DocPipeline.Tests/DocAppGateWiringTests.cs
+++ b/tests/Reactor.DocPipeline.Tests/DocAppGateWiringTests.cs
@@ -1,0 +1,372 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Cli.Docs.Tests;
+
+/// <summary>
+/// Guards the wiring that makes the <c>Doc snippet analyzer gate</c> CI job meaningful.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>The defect class.</b> Every <c>snippet=</c> block in <c>docs/guide/</c> is extracted
+/// verbatim from a doc app under <c>docs/_pipeline/apps/</c>, so a doc app <em>is</em> the code
+/// the guides tell readers to write. Two independent gaps let 276 analyzer diagnostics reach the
+/// published docset: only <c>win2d-canvas</c> was ever listed in <c>Reactor.slnx</c>, so the other
+/// 52 apps were never compiled by CI; and a <c>ProjectReference</c> to <c>src/Reactor</c> does not
+/// flow <c>Reactor.Analyzers</c> (it ships as a packed <c>&lt;None Pack="true"&gt;</c> item), so
+/// even that one app compiled without the rules its own readers are subject to. The result was
+/// snippets that compiled perfectly while warning in a reader's project — and, worse, snippets
+/// that silently did nothing the surrounding prose promised.
+/// </para>
+/// <para>
+/// <b>Why a wiring test and not a compile test.</b> The compile itself is the CI job: it builds
+/// <c>DocApps.proj</c> and fails on any <c>REACTOR_</c> diagnostic. That is the real gate, and
+/// duplicating it here would mean running MSBuild over 53 WinUI apps inside the headless unit
+/// suite. What a fast test <em>can</em> do is stop the gate from being quietly bypassed — which is
+/// the failure mode that produced this bug in the first place. Every fact below is about
+/// reachability and suppression, not about any individual snippet.
+/// </para>
+/// <para>
+/// <b>Non-vacuity.</b> Each fact is differential rather than a bare existence check: the glob is
+/// compared against the actual directory listing (not merely asserted non-empty), and the
+/// suppression scan is floored by <see cref="Suppression_Scan_Actually_Reads_The_Doc_Apps"/>, which
+/// fails if the scanner stops seeing files at all. Without that floor, a scanner that silently read
+/// zero files would report zero suppressions and pass forever.
+/// </para>
+/// </remarks>
+public class DocAppGateWiringTests
+{
+    private const string AppsRelative = "docs/_pipeline/apps";
+
+    /// <summary>
+    /// The gate is only as good as its reach: an app the traversal project does not match is an
+    /// app CI never compiles, which is exactly how 52 of 53 doc apps escaped for so long.
+    /// </summary>
+    [Fact]
+    public void Every_Doc_App_Is_Reachable_From_The_Traversal_Project()
+    {
+        var repoRoot = FindRepoRoot();
+        var appsDir = Path.Combine(repoRoot, AppsRelative.Replace('/', Path.DirectorySeparatorChar));
+
+        var onDisk = Directory
+            .EnumerateDirectories(appsDir)
+            .SelectMany(d => Directory.EnumerateFiles(d, "*.csproj", SearchOption.TopDirectoryOnly))
+            .Select(p => Path.GetFullPath(p))
+            .OrderBy(p => p, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        // A floor, so a directory walk that silently stops matching cannot pass as "all reachable".
+        Assert.True(
+            onDisk.Count >= 50,
+            $"Expected the doc-app corpus to still be ~53 projects; found {onDisk.Count}. "
+            + "If doc apps were intentionally removed, lower this floor deliberately.");
+
+        var proj = XDocument.Load(Path.Combine(appsDir, "DocApps.proj"));
+        var includes = proj.Descendants()
+            .Where(e => e.Name.LocalName == "DocApp")
+            .Select(e => (string?)e.Attribute("Include"))
+            .Where(v => !string.IsNullOrWhiteSpace(v))
+            .ToList();
+
+        Assert.NotEmpty(includes);
+
+        // Resolve the glob the same way MSBuild would, then compare sets. Comparing against the
+        // real listing (rather than asserting "the glob is non-empty") is what makes this fail if
+        // someone replaces the wildcard with a hand-maintained list that misses a new app.
+        var matched = new List<string>();
+        foreach (var include in includes)
+        {
+            var pattern = include!.Replace("$(MSBuildThisFileDirectory)", string.Empty)
+                                  .Replace('/', Path.DirectorySeparatorChar);
+            var dirPart = Path.GetDirectoryName(pattern) ?? "*";
+            var filePart = Path.GetFileName(pattern);
+
+            foreach (var dir in Directory.EnumerateDirectories(appsDir, dirPart))
+            {
+                matched.AddRange(Directory.EnumerateFiles(dir, filePart).Select(Path.GetFullPath));
+            }
+        }
+
+        var missing = onDisk
+            .Except(matched.Distinct(), StringComparer.OrdinalIgnoreCase)
+            .Select(p => Path.GetRelativePath(repoRoot, p))
+            .OrderBy(p => p, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        Assert.True(
+            missing.Count == 0,
+            "These doc apps are not matched by DocApps.proj, so CI never builds them and their "
+            + "snippets are ungated:\n  " + string.Join("\n  ", missing));
+    }
+
+    /// <summary>
+    /// The customer-facing analyzer bundle must be attached to the doc apps. Without it the gate
+    /// job builds all 53 apps and reports success while checking nothing.
+    /// </summary>
+    [Fact]
+    public void Doc_Apps_Import_The_Consumer_Analyzer_Bundle()
+    {
+        var repoRoot = FindRepoRoot();
+        var propsPath = Path.Combine(
+            repoRoot, AppsRelative.Replace('/', Path.DirectorySeparatorChar), "Directory.Build.props");
+
+        var props = XDocument.Load(propsPath);
+
+        var analyzerRefs = props.Descendants()
+            .Where(e => e.Name.LocalName == "ProjectReference")
+            .Where(e => ((string?)e.Attribute("Include") ?? string.Empty)
+                .Replace('\\', '/')
+                .Contains("src/Reactor.Analyzers/Reactor.Analyzers.csproj", StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        Assert.True(
+            analyzerRefs.Count == 1,
+            $"Expected exactly one Reactor.Analyzers ProjectReference in {AppsRelative}/Directory.Build.props, "
+            + $"found {analyzerRefs.Count}. Doc apps must compile under the same analyzer bundle their "
+            + "readers get from the nupkg.");
+
+        // OutputItemType="Analyzer" is the load-bearing attribute: without it the reference is a
+        // plain assembly reference, the rules never run, and the gate silently checks nothing.
+        Assert.Equal("Analyzer", (string?)analyzerRefs[0].Attribute("OutputItemType"));
+    }
+
+    /// <summary>
+    /// The one legitimate reason a doc app may silence a Reactor rule: the page exists to
+    /// document the very thing the rule flags. Each entry is an <c>(app, rule)</c> pair with the
+    /// justification that earned it.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A ledger rather than a free-for-all. Project-wide <c>&lt;NoWarn&gt;</c> is invisible at the
+    /// call site — the three entries below were already in the tree and were the reason those apps
+    /// reported a clean baseline during the sweep that produced this gate. Requiring each pair to
+    /// be listed here turns a silent suppression into a reviewable one: a new <c>NoWarn</c> fails
+    /// this test until someone writes down why.
+    /// </para>
+    /// <para>
+    /// <c>REACTOR_V1_PREVIEW</c> is not a code-quality rule — it is the provisional-API opt-in
+    /// (see <c>PoolPolicy</c>/<c>Reconciler</c>), so a page whose subject *is* the provisional API
+    /// must acknowledge it. The <c>rules-of-reactor</c> hook rules are different: that page teaches
+    /// the rules of hooks through labelled counterexamples, and "fixing" a deliberate
+    /// counterexample would delete the lesson.
+    /// </para>
+    /// </remarks>
+    private static readonly Dictionary<string, string[]> AllowedSuppressions = new(StringComparer.OrdinalIgnoreCase)
+    {
+        // Documents provisional control-authoring APIs, which is what the rule announces.
+        ["extending-reactor-controls"] = ["REACTOR_V1_PREVIEW"],
+
+        // Documents the provisional V1 reconciler protocol.
+        ["v1-protocol"] = ["REACTOR_V1_PREVIEW"],
+
+        // Teaches the rules of hooks by showing violations under "Wrong:" labels, and pairs a
+        // keyed list against an unkeyed one. The counterexamples are kept in their natural
+        // idiomatic shape on purpose: contorting the "bad" half to dodge the analyzer would make
+        // it differ from the "good" half in ways that have nothing to do with the lesson.
+        ["rules-of-reactor"] = ["REACTOR_HOOKS_001", "REACTOR_HOOKS_004", "REACTOR_HOOKS_005", "REACTOR_DSL_001"],
+    };
+
+    /// <summary>
+    /// A fix that silences a rule is not a fix. Doc apps are teaching material, so a suppression
+    /// there ships the anti-pattern to every reader who copies the snippet.
+    /// </summary>
+    [Fact]
+    public void No_Doc_App_Suppresses_A_Reactor_Rule()
+    {
+        var repoRoot = FindRepoRoot();
+        var appsDir = Path.Combine(repoRoot, AppsRelative.Replace('/', Path.DirectorySeparatorChar));
+
+        var offenders = new List<string>();
+        var pragma = new Regex(@"#pragma\s+warning\s+disable\s+(?<ids>[^\r\n/]+)", RegexOptions.Compiled);
+        var noWarn = new Regex(@"<NoWarn>(?<ids>[^<]*)</NoWarn>", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        var editorConfigNone = new Regex(
+            @"dotnet_diagnostic\.(?<id>REACTOR_[A-Z0-9_]+)\.severity\s*=\s*(none|silent|suggestion)",
+            RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        var reactorId = new Regex(@"REACTOR_[A-Z0-9_]+", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+        foreach (var file in Directory.EnumerateFiles(appsDir, "*", SearchOption.AllDirectories))
+        {
+            var name = Path.GetFileName(file);
+            var ext = Path.GetExtension(file);
+
+            // bin/obj carry generated copies; scanning them would double-report.
+            if (file.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal) ||
+                file.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var isSource = ext is ".cs" or ".csproj" or ".props" or ".proj";
+            var isEditorConfig = name.Equals(".editorconfig", StringComparison.OrdinalIgnoreCase);
+            if (!isSource && !isEditorConfig) continue;
+
+            var text = File.ReadAllText(file);
+            var rel = Path.GetRelativePath(repoRoot, file);
+            var app = OwningApp(appsDir, file);
+
+            foreach (var (kind, ids) in EnumerateSuppressed(text, pragma, noWarn, editorConfigNone, reactorId))
+            {
+                foreach (var id in ids)
+                {
+                    if (app is not null
+                        && AllowedSuppressions.TryGetValue(app, out var allowed)
+                        && allowed.Contains(id, StringComparer.OrdinalIgnoreCase))
+                    {
+                        continue;
+                    }
+
+                    offenders.Add($"{rel}: {kind} suppresses {id}");
+                }
+            }
+        }
+
+        Assert.True(
+            offenders.Count == 0,
+            "Doc-app snippets must not suppress Reactor analyzer rules -- readers copy these verbatim, "
+            + "and a suppression hides the anti-pattern rather than removing it. Fix the code, or, if "
+            + "the page genuinely documents what the rule flags, add the (app, rule) pair to "
+            + "AllowedSuppressions with a justification:\n  "
+            + string.Join("\n  ", offenders.OrderBy(o => o, StringComparer.Ordinal)));
+    }
+
+    /// <summary>
+    /// Every allow-listed suppression must still be load-bearing. An entry whose
+    /// <c>NoWarn</c> has since been removed is stale permission that would silently re-authorise a
+    /// future suppression nobody reviewed.
+    /// </summary>
+    [Fact]
+    public void Allowed_Suppressions_Are_All_Still_Used()
+    {
+        var repoRoot = FindRepoRoot();
+        var appsDir = Path.Combine(repoRoot, AppsRelative.Replace('/', Path.DirectorySeparatorChar));
+
+        var stale = new List<string>();
+        foreach (var (app, rules) in AllowedSuppressions)
+        {
+            var appDir = Path.Combine(appsDir, app);
+            Assert.True(Directory.Exists(appDir), $"AllowedSuppressions names '{app}', which no longer exists.");
+
+            var text = string.Concat(Directory
+                .EnumerateFiles(appDir, "*", SearchOption.AllDirectories)
+                .Where(f => Path.GetExtension(f) is ".cs" or ".csproj" or ".editorconfig")
+                .Where(f => !f.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal)
+                         && !f.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+                .Select(File.ReadAllText));
+
+            foreach (var rule in rules)
+            {
+                if (!text.Contains(rule, StringComparison.OrdinalIgnoreCase))
+                    stale.Add($"{app} -> {rule}");
+            }
+        }
+
+        Assert.True(
+            stale.Count == 0,
+            "These AllowedSuppressions entries are no longer present in the doc app. Remove them so "
+            + "the ledger keeps matching reality:\n  " + string.Join("\n  ", stale));
+    }
+
+    private static IEnumerable<(string Kind, List<string> Ids)> EnumerateSuppressed(
+        string text, Regex pragma, Regex noWarn, Regex editorConfigNone, Regex reactorId)
+    {
+        foreach (Match m in pragma.Matches(text))
+        {
+            var ids = reactorId.Matches(m.Groups["ids"].Value).Select(x => x.Value).ToList();
+            if (ids.Count > 0) yield return ("#pragma warning disable", ids);
+        }
+
+        foreach (Match m in noWarn.Matches(text))
+        {
+            var ids = reactorId.Matches(m.Groups["ids"].Value).Select(x => x.Value).ToList();
+            if (ids.Count > 0) yield return ("<NoWarn>", ids);
+        }
+
+        foreach (Match m in editorConfigNone.Matches(text))
+        {
+            yield return (".editorconfig severity", [m.Groups["id"].Value]);
+        }
+    }
+
+    /// <summary>Maps a file back to the doc app directory that owns it, or null if it sits above one.</summary>
+    private static string? OwningApp(string appsDir, string file)
+    {
+        var rel = Path.GetRelativePath(appsDir, file);
+        var first = rel.Split(Path.DirectorySeparatorChar, StringSplitOptions.RemoveEmptyEntries).FirstOrDefault();
+        return first is null || first.Contains('.') ? null : first;
+    }
+
+
+    /// <summary>
+    /// Floors <see cref="No_Doc_App_Suppresses_A_Reactor_Rule"/>. That test passes by reporting
+    /// nothing, which is indistinguishable from a scanner that reads no files at all — the exact
+    /// "a no-match is not a measurement" trap. This proves the corpus it walks is real and that the
+    /// patterns it uses can still match.
+    /// </summary>
+    [Fact]
+    public void Suppression_Scan_Actually_Reads_The_Doc_Apps()
+    {
+        var repoRoot = FindRepoRoot();
+        var appsDir = Path.Combine(repoRoot, AppsRelative.Replace('/', Path.DirectorySeparatorChar));
+
+        var sources = Directory
+            .EnumerateFiles(appsDir, "*.cs", SearchOption.AllDirectories)
+            .Where(f => !f.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal)
+                     && !f.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+            .ToList();
+
+        Assert.True(
+            sources.Count >= 50,
+            $"The suppression scan walked only {sources.Count} doc-app sources; it is no longer "
+            + "measuring the corpus it claims to cover.");
+
+        // Positive control: the same patterns, applied to a planted violation, must fire. Without
+        // this, a regex broken by a future edit would report zero offenders and pass forever.
+        var pragma = new Regex(@"#pragma\s+warning\s+disable\s+(?<ids>[^\r\n/]+)", RegexOptions.Compiled);
+        var reactorId = new Regex(@"REACTOR_[A-Z0-9_]+", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+        var planted = pragma.Match("#pragma warning disable REACTOR_THEME_001 // planted");
+        Assert.True(planted.Success);
+        Assert.Equal("REACTOR_THEME_001", reactorId.Match(planted.Groups["ids"].Value).Value);
+
+        // ...and must not fire on a non-Reactor suppression, or the gate would be noise.
+        var unrelated = pragma.Match("#pragma warning disable CS0168");
+        Assert.True(unrelated.Success);
+        Assert.DoesNotMatch(reactorId, unrelated.Groups["ids"].Value);
+    }
+
+    /// <summary>
+    /// The gate has to actually run. A traversal project and wired analyzers are inert if no
+    /// workflow builds them.
+    /// </summary>
+    [Fact]
+    public void Ci_Runs_The_Doc_Snippet_Gate()
+    {
+        var repoRoot = FindRepoRoot();
+        var ci = File.ReadAllText(Path.Combine(repoRoot, ".github", "workflows", "ci.yml"));
+
+        Assert.Contains("docs-snippet-gate:", ci, StringComparison.Ordinal);
+        Assert.Contains("DocApps.proj", ci, StringComparison.Ordinal);
+
+        // The scan must stay case-sensitive: an insensitive match also hits the restore's
+        // "warning NU1900: Error occurred ...", turning the gate into a flaky failure that
+        // someone would eventually "fix" by loosening it.
+        Assert.Contains("-CaseSensitive", ci, StringComparison.Ordinal);
+    }
+
+    private static string FindRepoRoot()
+    {
+        var dir = Directory.GetCurrentDirectory();
+        while (dir is not null)
+        {
+            if (File.Exists(Path.Combine(dir, "Reactor.slnx")) || Directory.Exists(Path.Combine(dir, ".git")))
+                return dir;
+            dir = Path.GetDirectoryName(dir);
+        }
+        throw new InvalidOperationException("Reactor repo root not found from test cwd.");
+    }
+}

--- a/tests/Reactor.DocPipeline.Tests/DocAppGateWiringTests.cs
+++ b/tests/Reactor.DocPipeline.Tests/DocAppGateWiringTests.cs
@@ -172,6 +172,25 @@ public class DocAppGateWiringTests
     };
 
     /// <summary>
+    /// The suppression patterns, declared once. Every test that reasons about suppressions runs
+    /// through <see cref="EnumerateSuppressed"/> so the ledger check, the corpus scan, and the
+    /// positive control cannot drift apart — a re-declared copy in one of them was how the
+    /// <c>&lt;NoWarn&gt;</c> and <c>.editorconfig</c> arms ended up with no positive control at all.
+    /// </summary>
+    private static readonly Regex Pragma =
+        new(@"#pragma\s+warning\s+disable\s+(?<ids>[^\r\n/]+)", RegexOptions.Compiled);
+
+    private static readonly Regex NoWarnTag =
+        new(@"<NoWarn>(?<ids>[^<]*)</NoWarn>", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+    private static readonly Regex EditorConfigDowngrade = new(
+        @"dotnet_diagnostic\.(?<id>REACTOR_[A-Z0-9_]+)\.severity\s*=\s*(none|silent|suggestion)",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+    private static readonly Regex ReactorId =
+        new(@"REACTOR_[A-Z0-9_]+", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+    /// <summary>
     /// A fix that silences a rule is not a fix. Doc apps are teaching material, so a suppression
     /// there ships the anti-pattern to every reader who copies the snippet.
     /// </summary>
@@ -182,34 +201,14 @@ public class DocAppGateWiringTests
         var appsDir = Path.Combine(repoRoot, AppsRelative.Replace('/', Path.DirectorySeparatorChar));
 
         var offenders = new List<string>();
-        var pragma = new Regex(@"#pragma\s+warning\s+disable\s+(?<ids>[^\r\n/]+)", RegexOptions.Compiled);
-        var noWarn = new Regex(@"<NoWarn>(?<ids>[^<]*)</NoWarn>", RegexOptions.Compiled | RegexOptions.IgnoreCase);
-        var editorConfigNone = new Regex(
-            @"dotnet_diagnostic\.(?<id>REACTOR_[A-Z0-9_]+)\.severity\s*=\s*(none|silent|suggestion)",
-            RegexOptions.Compiled | RegexOptions.IgnoreCase);
-        var reactorId = new Regex(@"REACTOR_[A-Z0-9_]+", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
-        foreach (var file in Directory.EnumerateFiles(appsDir, "*", SearchOption.AllDirectories))
+        foreach (var file in SuppressionScannableFiles(appsDir))
         {
-            var name = Path.GetFileName(file);
-            var ext = Path.GetExtension(file);
-
-            // bin/obj carry generated copies; scanning them would double-report.
-            if (file.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal) ||
-                file.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
-            {
-                continue;
-            }
-
-            var isSource = ext is ".cs" or ".csproj" or ".props" or ".proj";
-            var isEditorConfig = name.Equals(".editorconfig", StringComparison.OrdinalIgnoreCase);
-            if (!isSource && !isEditorConfig) continue;
-
             var text = File.ReadAllText(file);
             var rel = Path.GetRelativePath(repoRoot, file);
             var app = OwningApp(appsDir, file);
 
-            foreach (var (kind, ids) in EnumerateSuppressed(text, pragma, noWarn, editorConfigNone, reactorId))
+            foreach (var (kind, ids) in EnumerateSuppressed(text))
             {
                 foreach (var id in ids)
                 {
@@ -251,42 +250,67 @@ public class DocAppGateWiringTests
             var appDir = Path.Combine(appsDir, app);
             Assert.True(Directory.Exists(appDir), $"AllowedSuppressions names '{app}', which no longer exists.");
 
-            var text = string.Concat(Directory
-                .EnumerateFiles(appDir, "*", SearchOption.AllDirectories)
-                .Where(f => Path.GetExtension(f) is ".cs" or ".csproj" or ".editorconfig")
-                .Where(f => !f.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal)
-                         && !f.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
-                .Select(File.ReadAllText));
+            // Parsed, not text-matched. A raw Contains() over the app's sources kept an entry
+            // alive on nothing more than a code comment mentioning the rule ID, so a suppression
+            // could be deleted while its permission silently survived to bless the next one.
+            var suppressed = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var file in SuppressionScannableFiles(appDir))
+            {
+                foreach (var (_, ids) in EnumerateSuppressed(File.ReadAllText(file)))
+                {
+                    foreach (var id in ids) suppressed.Add(id);
+                }
+            }
 
             foreach (var rule in rules)
             {
-                if (!text.Contains(rule, StringComparison.OrdinalIgnoreCase))
+                if (!suppressed.Contains(rule))
                     stale.Add($"{app} -> {rule}");
             }
         }
 
         Assert.True(
             stale.Count == 0,
-            "These AllowedSuppressions entries are no longer present in the doc app. Remove them so "
-            + "the ledger keeps matching reality:\n  " + string.Join("\n  ", stale));
+            "These AllowedSuppressions entries no longer correspond to a real suppression in the doc "
+            + "app. Remove them so the ledger keeps matching reality:\n  " + string.Join("\n  ", stale));
     }
 
-    private static IEnumerable<(string Kind, List<string> Ids)> EnumerateSuppressed(
-        string text, Regex pragma, Regex noWarn, Regex editorConfigNone, Regex reactorId)
+    /// <summary>
+    /// The files a suppression can hide in. Shared so the corpus scan and the ledger check cannot
+    /// disagree about what was searched.
+    /// </summary>
+    private static IEnumerable<string> SuppressionScannableFiles(string root)
     {
-        foreach (Match m in pragma.Matches(text))
+        foreach (var file in Directory.EnumerateFiles(root, "*", SearchOption.AllDirectories))
         {
-            var ids = reactorId.Matches(m.Groups["ids"].Value).Select(x => x.Value).ToList();
+            // bin/obj carry generated copies; scanning them would double-report.
+            if (file.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal) ||
+                file.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var isSource = Path.GetExtension(file) is ".cs" or ".csproj" or ".props" or ".proj";
+            var isEditorConfig = Path.GetFileName(file).Equals(".editorconfig", StringComparison.OrdinalIgnoreCase);
+            if (isSource || isEditorConfig) yield return file;
+        }
+    }
+
+    private static IEnumerable<(string Kind, List<string> Ids)> EnumerateSuppressed(string text)
+    {
+        foreach (Match m in Pragma.Matches(text))
+        {
+            var ids = ReactorId.Matches(m.Groups["ids"].Value).Select(x => x.Value).ToList();
             if (ids.Count > 0) yield return ("#pragma warning disable", ids);
         }
 
-        foreach (Match m in noWarn.Matches(text))
+        foreach (Match m in NoWarnTag.Matches(text))
         {
-            var ids = reactorId.Matches(m.Groups["ids"].Value).Select(x => x.Value).ToList();
+            var ids = ReactorId.Matches(m.Groups["ids"].Value).Select(x => x.Value).ToList();
             if (ids.Count > 0) yield return ("<NoWarn>", ids);
         }
 
-        foreach (Match m in editorConfigNone.Matches(text))
+        foreach (Match m in EditorConfigDowngrade.Matches(text))
         {
             yield return (".editorconfig severity", [m.Groups["id"].Value]);
         }
@@ -324,38 +348,84 @@ public class DocAppGateWiringTests
             $"The suppression scan walked only {sources.Count} doc-app sources; it is no longer "
             + "measuring the corpus it claims to cover.");
 
-        // Positive control: the same patterns, applied to a planted violation, must fire. Without
-        // this, a regex broken by a future edit would report zero offenders and pass forever.
-        var pragma = new Regex(@"#pragma\s+warning\s+disable\s+(?<ids>[^\r\n/]+)", RegexOptions.Compiled);
-        var reactorId = new Regex(@"REACTOR_[A-Z0-9_]+", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        // Positive control: planted violations must come back out of the REAL scanner, one per
+        // arm. Replaying only the #pragma regex left <NoWarn> and .editorconfig with no control at
+        // all, so a break in either would have reported zero offenders and passed forever.
+        var planted = EnumerateSuppressed(
+                "#pragma warning disable REACTOR_THEME_001 // planted\n"
+                + "<NoWarn>$(NoWarn);REACTOR_HOOKS_001;CS0169</NoWarn>\n"
+                + "dotnet_diagnostic.REACTOR_DSL_001.severity = none\n")
+            .ToList();
 
-        var planted = pragma.Match("#pragma warning disable REACTOR_THEME_001 // planted");
-        Assert.True(planted.Success);
-        Assert.Equal("REACTOR_THEME_001", reactorId.Match(planted.Groups["ids"].Value).Value);
+        Assert.Equal(3, planted.Count);
+        Assert.Equal(
+            ["#pragma warning disable", "<NoWarn>", ".editorconfig severity"],
+            planted.Select(p => p.Kind));
+        Assert.Equal(
+            ["REACTOR_THEME_001", "REACTOR_HOOKS_001", "REACTOR_DSL_001"],
+            planted.SelectMany(p => p.Ids));
 
-        // ...and must not fire on a non-Reactor suppression, or the gate would be noise.
-        var unrelated = pragma.Match("#pragma warning disable CS0168");
-        Assert.True(unrelated.Success);
-        Assert.DoesNotMatch(reactorId, unrelated.Groups["ids"].Value);
+        // ...and must stay silent on non-Reactor suppressions, or the gate would be noise that
+        // someone eventually loosens.
+        Assert.Empty(EnumerateSuppressed(
+            "#pragma warning disable CS0168\n<NoWarn>$(NoWarn);CS0169;IDE0051</NoWarn>\n"));
     }
 
     /// <summary>
-    /// The gate has to actually run. A traversal project and wired analyzers are inert if no
-    /// workflow builds them.
+    /// The gate has to actually run, and has to fail closed. A traversal project and wired
+    /// analyzers are inert if no workflow builds them — or if the job that builds them is disabled,
+    /// or reports diagnostics without failing.
     /// </summary>
     [Fact]
     public void Ci_Runs_The_Doc_Snippet_Gate()
     {
         var repoRoot = FindRepoRoot();
-        var ci = File.ReadAllText(Path.Combine(repoRoot, ".github", "workflows", "ci.yml"));
+        var ci = File.ReadAllLines(Path.Combine(repoRoot, ".github", "workflows", "ci.yml"));
 
-        Assert.Contains("docs-snippet-gate:", ci, StringComparison.Ordinal);
-        Assert.Contains("DocApps.proj", ci, StringComparison.Ordinal);
+        var job = JobBlock(ci, "docs-snippet-gate");
+        Assert.True(job.Count > 0, "ci.yml no longer defines a `docs-snippet-gate` job.");
+
+        var body = string.Join("\n", job);
+
+        // Substring checks alone were theatre: a job left in place but switched off, or one that
+        // printed diagnostics and exited 0, still contained every string this used to assert.
+        Assert.DoesNotContain("if: false", body, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("continue-on-error: true", body, StringComparison.OrdinalIgnoreCase);
+
+        Assert.Contains("DocApps.proj", body, StringComparison.Ordinal);
+        Assert.Contains("REACTOR_", body, StringComparison.Ordinal);
+
+        // Fails closed: the diagnostic branch must terminate the job non-zero.
+        Assert.Contains("exit 1", body, StringComparison.Ordinal);
 
         // The scan must stay case-sensitive: an insensitive match also hits the restore's
         // "warning NU1900: Error occurred ...", turning the gate into a flaky failure that
         // someone would eventually "fix" by loosening it.
-        Assert.Contains("-CaseSensitive", ci, StringComparison.Ordinal);
+        Assert.Contains("-CaseSensitive", body, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Slices one job's lines out of a workflow file, from its <c>&lt;name&gt;:</c> key to the next
+    /// key at the same indent. Asserting against the whole file would let a match in an unrelated
+    /// job satisfy a check about this one.
+    /// </summary>
+    private static List<string> JobBlock(string[] lines, string jobName)
+    {
+        var start = Array.FindIndex(lines, l => l.TrimEnd() == $"  {jobName}:");
+        if (start < 0) return [];
+
+        var block = new List<string>();
+        for (var i = start + 1; i < lines.Length; i++)
+        {
+            var line = lines[i];
+            var isNextJob = line.Length > 2
+                && line[0] == ' ' && line[1] == ' ' && line[2] != ' '
+                && line.TrimEnd().EndsWith(':');
+            if (isNextJob) break;
+            block.Add(line);
+        }
+
+        return block;
     }
 
     private static string FindRepoRoot()

--- a/tests/Reactor.DocPipeline.Tests/DocAppGateWiringTests.cs
+++ b/tests/Reactor.DocPipeline.Tests/DocAppGateWiringTests.cs
@@ -51,7 +51,7 @@ public class DocAppGateWiringTests
     public void Every_Doc_App_Is_Reachable_From_The_Traversal_Project()
     {
         var repoRoot = FindRepoRoot();
-        var appsDir = Path.Combine(repoRoot, AppsRelative.Replace('/', Path.DirectorySeparatorChar));
+        var appsDir = AppsDir(repoRoot);
 
         var onDisk = Directory
             .EnumerateDirectories(appsDir)
@@ -66,7 +66,7 @@ public class DocAppGateWiringTests
             $"Expected the doc-app corpus to still be ~53 projects; found {onDisk.Count}. "
             + "If doc apps were intentionally removed, lower this floor deliberately.");
 
-        var proj = XDocument.Load(Path.Combine(appsDir, "DocApps.proj"));
+        var proj = XDocument.Load(RepoPath(appsDir, "DocApps.proj"));
         var includes = proj.Descendants()
             .Where(e => e.Name.LocalName == "DocApp")
             .Select(e => (string?)e.Attribute("Include"))
@@ -79,10 +79,12 @@ public class DocAppGateWiringTests
         // real listing (rather than asserting "the glob is non-empty") is what makes this fail if
         // someone replaces the wildcard with a hand-maintained list that misses a new app.
         var matched = new List<string>();
-        foreach (var include in includes)
+        var patterns = includes.Select(include =>
+            include!.Replace("$(MSBuildThisFileDirectory)", string.Empty)
+                    .Replace('/', Path.DirectorySeparatorChar));
+
+        foreach (var pattern in patterns)
         {
-            var pattern = include!.Replace("$(MSBuildThisFileDirectory)", string.Empty)
-                                  .Replace('/', Path.DirectorySeparatorChar);
             var dirPart = Path.GetDirectoryName(pattern) ?? "*";
             var filePart = Path.GetFileName(pattern);
 
@@ -112,8 +114,7 @@ public class DocAppGateWiringTests
     public void Doc_Apps_Import_The_Consumer_Analyzer_Bundle()
     {
         var repoRoot = FindRepoRoot();
-        var propsPath = Path.Combine(
-            repoRoot, AppsRelative.Replace('/', Path.DirectorySeparatorChar), "Directory.Build.props");
+        var propsPath = RepoPath(repoRoot, AppsRelative, "Directory.Build.props");
 
         var props = XDocument.Load(propsPath);
 
@@ -198,7 +199,7 @@ public class DocAppGateWiringTests
     public void No_Doc_App_Suppresses_A_Reactor_Rule()
     {
         var repoRoot = FindRepoRoot();
-        var appsDir = Path.Combine(repoRoot, AppsRelative.Replace('/', Path.DirectorySeparatorChar));
+        var appsDir = AppsDir(repoRoot);
 
         var offenders = new List<string>();
 
@@ -242,12 +243,12 @@ public class DocAppGateWiringTests
     public void Allowed_Suppressions_Are_All_Still_Used()
     {
         var repoRoot = FindRepoRoot();
-        var appsDir = Path.Combine(repoRoot, AppsRelative.Replace('/', Path.DirectorySeparatorChar));
+        var appsDir = AppsDir(repoRoot);
 
         var stale = new List<string>();
         foreach (var (app, rules) in AllowedSuppressions)
         {
-            var appDir = Path.Combine(appsDir, app);
+            var appDir = RepoPath(appsDir, app);
             Assert.True(Directory.Exists(appDir), $"AllowedSuppressions names '{app}', which no longer exists.");
 
             // Parsed, not text-matched. A raw Contains() over the app's sources kept an entry
@@ -262,11 +263,9 @@ public class DocAppGateWiringTests
                 }
             }
 
-            foreach (var rule in rules)
-            {
-                if (!suppressed.Contains(rule))
-                    stale.Add($"{app} -> {rule}");
-            }
+            stale.AddRange(rules
+                .Where(rule => !suppressed.Contains(rule))
+                .Select(rule => $"{app} -> {rule}"));
         }
 
         Assert.True(
@@ -335,7 +334,7 @@ public class DocAppGateWiringTests
     public void Suppression_Scan_Actually_Reads_The_Doc_Apps()
     {
         var repoRoot = FindRepoRoot();
-        var appsDir = Path.Combine(repoRoot, AppsRelative.Replace('/', Path.DirectorySeparatorChar));
+        var appsDir = AppsDir(repoRoot);
 
         var sources = Directory
             .EnumerateFiles(appsDir, "*.cs", SearchOption.AllDirectories)
@@ -380,7 +379,7 @@ public class DocAppGateWiringTests
     public void Ci_Runs_The_Doc_Snippet_Gate()
     {
         var repoRoot = FindRepoRoot();
-        var ci = File.ReadAllLines(Path.Combine(repoRoot, ".github", "workflows", "ci.yml"));
+        var ci = File.ReadAllLines(RepoPath(repoRoot, ".github/workflows/ci.yml"));
 
         var job = JobBlock(ci, "docs-snippet-gate");
         Assert.True(job.Count > 0, "ci.yml no longer defines a `docs-snippet-gate` job.");
@@ -427,6 +426,40 @@ public class DocAppGateWiringTests
 
         return block;
     }
+
+    /// <summary>
+    /// Combines repo-relative segments onto a trusted base, rejecting any segment that is rooted
+    /// or escapes the base.
+    /// </summary>
+    /// <remarks>
+    /// <c>Path.Combine</c> silently discards everything before a rooted segment, so
+    /// <c>Path.Combine(repoRoot, x)</c> quietly becomes <c>x</c> if <c>x</c> ever turns absolute.
+    /// Every path in this file is assembled from a repo-relative constant or an
+    /// <see cref="AllowedSuppressions"/> key, so the guard should never fire — it exists so that a
+    /// later edit which makes one of those absolute fails loudly here instead of silently walking
+    /// a different tree and reporting a clean result.
+    /// </remarks>
+    private static string RepoPath(string root, params string[] relativeSegments)
+    {
+        var combined = root;
+        foreach (var segment in relativeSegments)
+        {
+            var normalized = segment.Replace('/', Path.DirectorySeparatorChar);
+
+            Assert.False(
+                Path.IsPathRooted(normalized),
+                $"'{segment}' must be repo-relative; a rooted segment would silently discard '{combined}'.");
+
+            combined = Path.Combine(combined, normalized);
+        }
+
+        var resolved = Path.GetFullPath(combined);
+        Assert.StartsWith(Path.GetFullPath(root), resolved, StringComparison.OrdinalIgnoreCase);
+        return resolved;
+    }
+
+    /// <summary>The doc-app corpus root, assembled through <see cref="RepoPath"/>.</summary>
+    private static string AppsDir(string repoRoot) => RepoPath(repoRoot, AppsRelative);
 
     private static string FindRepoRoot()
     {

--- a/tests/Reactor.DocPipeline.Tests/DocAppGateWiringTests.cs
+++ b/tests/Reactor.DocPipeline.Tests/DocAppGateWiringTests.cs
@@ -450,7 +450,7 @@ public class DocAppGateWiringTests
                 Path.IsPathRooted(normalized),
                 $"'{segment}' must be repo-relative; a rooted segment would silently discard '{combined}'.");
 
-            combined = Path.Combine(combined, normalized);
+            combined = Path.Join(combined, normalized);
         }
 
         var resolved = Path.GetFullPath(combined);
@@ -466,7 +466,7 @@ public class DocAppGateWiringTests
         var dir = Directory.GetCurrentDirectory();
         while (dir is not null)
         {
-            if (File.Exists(Path.Combine(dir, "Reactor.slnx")) || Directory.Exists(Path.Combine(dir, ".git")))
+            if (File.Exists(Path.Join(dir, "Reactor.slnx")) || Directory.Exists(Path.Join(dir, ".git")))
                 return dir;
             dir = Path.GetDirectoryName(dir);
         }

--- a/tests/Reactor.Tests/AnalyzerTests/AccessibilityAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AccessibilityAnalyzerTests.cs
@@ -246,4 +246,54 @@ class C
         };
         await analyzerTest.RunAsync(TestContext.Current.CancellationToken);
     }
+
+    /// <summary>
+    /// A fluent <c>.Header(...)</c> renders a visible label and satisfies the rule. Before this,
+    /// the analyzer only recognised a named <c>header:</c> argument, so a field written in the
+    /// fluent style was told to add <c>.AutomationName(...)</c> on top of a label it already had —
+    /// and the guides were changed to teach that redundancy.
+    /// </summary>
+    [Fact]
+    public async Task PasswordBox_With_Fluent_Header_No_Diagnostic()
+    {
+        var test = @"
+class C
+{
+    static dynamic PasswordBox(dynamic value, string header = null) => null;
+
+    void M(dynamic value)
+    {
+        PasswordBox(value).Header(""Password"");
+    }
+}";
+        var analyzerTest = new CSharpAnalyzerTest<FormFieldLabelAnalyzer, DefaultVerifier>
+        {
+            TestCode = test,
+        };
+        await analyzerTest.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    /// <summary>
+    /// The match is on the exact identifier, so a container's header property does not launder an
+    /// unlabeled field sitting inside the same chain.
+    /// </summary>
+    [Fact]
+    public async Task TextBox_With_Only_A_PaneHeader_Still_Produces_Diagnostic()
+    {
+        var test = @"
+class C
+{
+    static dynamic TextBox(dynamic value, string header = null) => null;
+
+    void M(dynamic value)
+    {
+        {|REACTOR_A11Y_003:TextBox(value)|}.PaneHeader(""Not a field label"");
+    }
+}";
+        var analyzerTest = new CSharpAnalyzerTest<FormFieldLabelAnalyzer, DefaultVerifier>
+        {
+            TestCode = test,
+        };
+        await analyzerTest.RunAsync(TestContext.Current.CancellationToken);
+    }
 }

--- a/tests/Reactor.Tests/AnalyzerTests/HookRulesAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/HookRulesAnalyzerTests.cs
@@ -1142,4 +1142,150 @@ class C : Microsoft.UI.Reactor.Core.Component
         };
         await analyzerTest.RunAsync(TestContext.Current.CancellationToken);
     }
+
+    // ── Inline function components (Memo) ──────────────────────────────
+    //
+    // Memo(ctx => …) is a component boundary, not an ordinary closure: MountMemoComponent
+    // allocates a RenderContext, hangs a ComponentNode off it and calls ctx.BeginRender(),
+    // so the lambda owns its hook slots. The analyzer used to treat that lambda like any
+    // nested lambda and reported correct code — including the documented Win2D
+    // ctx.UseCanvasResources pattern, whose entire purpose is device-lost recovery.
+
+    private const string MemoStubs = @"
+namespace Microsoft.UI.Reactor.Core
+{
+    public class RenderContext { }
+    public class Element { }
+
+    public abstract class Component
+    {
+        protected internal RenderContext Context { get; } = new RenderContext();
+        public abstract Element Render();
+        protected (int, System.Action<int>) UseState(int initial) => (0, _ => { });
+    }
+}
+
+namespace Microsoft.UI.Reactor
+{
+    using Microsoft.UI.Reactor.Core;
+
+    public static class Factories
+    {
+        public static Element Memo(System.Func<RenderContext, Element> render, params object[] deps)
+            => new Element();
+    }
+
+    public static class CtxHooks
+    {
+        public static int UseCounter(this RenderContext ctx) => 0;
+    }
+}
+
+namespace App
+{
+    using Microsoft.UI.Reactor;
+    using Microsoft.UI.Reactor.Core;
+";
+
+    [Fact]
+    public async Task Hook_On_Memo_Own_Context_Is_Not_Reported()
+    {
+        var test = MemoStubs + @"
+    class C : Component
+    {
+        public override Element Render()
+            => Factories.Memo(ctx =>
+            {
+                var n = ctx.UseCounter();
+                return new Element();
+            });
+    }
+}";
+        var analyzerTest = new CSharpAnalyzerTest<HookRulesAnalyzer, DefaultVerifier>
+        {
+            TestCode = test,
+        };
+        await analyzerTest.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    /// <summary>
+    /// The exemption is scoped to the lambda's own context, not to "anything inside a Memo".
+    /// A conditional between the lambda and the hook still breaks slot ordering for that
+    /// inline component, exactly as it would inside Render().
+    /// </summary>
+    [Fact]
+    public async Task Conditional_Hook_Inside_Memo_Is_Still_Reported()
+    {
+        var test = MemoStubs + @"
+    class C : Component
+    {
+        public override Element Render()
+            => Factories.Memo(ctx =>
+            {
+                if (System.DateTime.Now.Ticks > 0)
+                {
+                    var n = {|REACTOR_HOOKS_001:ctx.UseCounter()|};
+                }
+                return new Element();
+            });
+    }
+}";
+        var analyzerTest = new CSharpAnalyzerTest<HookRulesAnalyzer, DefaultVerifier>
+        {
+            TestCode = test,
+        };
+        await analyzerTest.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    /// <summary>
+    /// The regression this exemption must not cause. A receiver-less <c>UseState()</c> written
+    /// inside a Memo lambda is the <em>enclosing</em> component's hook running from a nested
+    /// closure — it does not bind to the inline component's slots and is still the real bug.
+    /// </summary>
+    [Fact]
+    public async Task Enclosing_Components_Hook_Inside_Memo_Is_Still_Reported()
+    {
+        var test = MemoStubs + @"
+    class C : Component
+    {
+        public override Element Render()
+            => Factories.Memo(ctx =>
+            {
+                var (count, setCount) = {|REACTOR_HOOKS_001:UseState(0)|};
+                return new Element();
+            });
+    }
+}";
+        var analyzerTest = new CSharpAnalyzerTest<HookRulesAnalyzer, DefaultVerifier>
+        {
+            TestCode = test,
+        };
+        await analyzerTest.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    /// <summary>
+    /// A RenderContext parameter on an ordinary helper method is not an inline component, so a
+    /// hook there is still reported. Guards the exemption against widening to "any parameter
+    /// that happens to be a RenderContext".
+    /// </summary>
+    [Fact]
+    public async Task Hook_On_A_Plain_RenderContext_Parameter_Is_Still_Reported()
+    {
+        var test = MemoStubs + @"
+    class C : Component
+    {
+        public override Element Render() => new Element();
+
+        void NotARender(RenderContext ctx)
+        {
+            var n = {|REACTOR_HOOKS_005:ctx.UseCounter()|};
+        }
+    }
+}";
+        var analyzerTest = new CSharpAnalyzerTest<HookRulesAnalyzer, DefaultVerifier>
+        {
+            TestCode = test,
+        };
+        await analyzerTest.RunAsync(TestContext.Current.CancellationToken);
+    }
 }

--- a/tests/Reactor.Tests/AnalyzerTests/HookRulesAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/HookRulesAnalyzerTests.cs
@@ -1288,4 +1288,55 @@ namespace App
         };
         await analyzerTest.RunAsync(TestContext.Current.CancellationToken);
     }
+
+    /// <summary>
+    /// The exemption must not widen to "any lambda that takes a RenderContext". `RenderContext`
+    /// has a public constructor, so a helper accepting `Action&lt;RenderContext&gt;` is ordinary
+    /// user code, not a component boundary — hooks called there still break slot ordering and must
+    /// still be reported. Guards the false negative a review flagged on the first cut of this rule.
+    /// </summary>
+    [Fact]
+    public async Task Hook_On_A_Non_Render_Lambda_Taking_RenderContext_Is_Still_Reported()
+    {
+        var test = MemoStubs + @"
+    class C : Component
+    {
+        static void Helper(System.Action<RenderContext> body) { }
+
+        public override Element Render()
+        {
+            Helper(ctx => { var n = {|REACTOR_HOOKS_001:ctx.UseCounter()|}; });
+            return new Element();
+        }
+    }
+}";
+        var analyzerTest = new CSharpAnalyzerTest<HookRulesAnalyzer, DefaultVerifier>
+        {
+            TestCode = test,
+        };
+        await analyzerTest.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    /// <summary>
+    /// An expression-bodied Memo lambda is the same boundary as a block-bodied one; the exemption
+    /// must not depend on the body form.
+    /// </summary>
+    [Fact]
+    public async Task Hook_On_Memo_Context_With_Expression_Body_Is_Not_Reported()
+    {
+        var test = MemoStubs + @"
+    class C : Component
+    {
+        public override Element Render()
+            => Factories.Memo(ctx => Wrap(ctx.UseCounter()));
+
+        static Element Wrap(int n) => new Element();
+    }
+}";
+        var analyzerTest = new CSharpAnalyzerTest<HookRulesAnalyzer, DefaultVerifier>
+        {
+            TestCode = test,
+        };
+        await analyzerTest.RunAsync(TestContext.Current.CancellationToken);
+    }
 }

--- a/tests/Reactor.Tests/AnalyzerTests/UseThemeRefAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/UseThemeRefAnalyzerTests.cs
@@ -678,4 +678,97 @@ namespace TestApp
             FixedCode = code,
         }.RunAsync(TestContext.Current.CancellationToken);
     }
+
+    /// <summary>
+    /// A selected/unselected colour pair is still two hard-coded colours. The rule used to require
+    /// the argument itself to be a literal, so wrapping it in a conditional hid it completely —
+    /// which is how `docs/_pipeline/apps/recipe-master-detail` shipped a hex pair through a gate
+    /// built to stop exactly that.
+    /// </summary>
+    [Fact]
+    public async Task Detects_Both_Branches_Of_A_Conditional()
+    {
+        var test = @"
+class C
+{
+    void M(dynamic el, bool selected)
+    {
+        el.Background(selected ? {|REACTOR_THEME_001:""#E5F1FB""|} : {|REACTOR_THEME_001:""#FFFFFF""|});
+    }
+}";
+        var analyzerTest = new CSharpAnalyzerTest<UseThemeRefAnalyzer, DefaultVerifier>
+        {
+            TestCode = test,
+        };
+        await analyzerTest.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task Detects_Colors_In_A_Switch_Expression()
+    {
+        var test = @"
+class C
+{
+    void M(dynamic el, int state)
+    {
+        el.Foreground(state switch
+        {
+            0 => {|REACTOR_THEME_001:""#FF0000""|},
+            _ => {|REACTOR_THEME_001:""#00FF00""|},
+        });
+    }
+}";
+        var analyzerTest = new CSharpAnalyzerTest<UseThemeRefAnalyzer, DefaultVerifier>
+        {
+            TestCode = test,
+        };
+        await analyzerTest.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    /// <summary>
+    /// A conditional that already selects between theme tokens is correct code and must stay quiet.
+    /// </summary>
+    [Fact]
+    public async Task Conditional_Between_Theme_Tokens_Is_Not_Reported()
+    {
+        var test = @"
+class C
+{
+    static class Theme { public static object SubtleFill => null; public static object SolidBackground => null; }
+
+    void M(dynamic el, bool selected)
+    {
+        el.Background(selected ? Theme.SubtleFill : Theme.SolidBackground);
+    }
+}";
+        var analyzerTest = new CSharpAnalyzerTest<UseThemeRefAnalyzer, DefaultVerifier>
+        {
+            TestCode = test,
+        };
+        await analyzerTest.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    /// <summary>
+    /// Only value-selecting shapes are walked. A string handed to a nested call is not a colour
+    /// this rule can reason about, and reporting it would be a false positive.
+    /// </summary>
+    [Fact]
+    public async Task String_Inside_A_Nested_Call_Is_Not_Reported()
+    {
+        var test = @"
+class C
+{
+    static object LookUpBrush(string key) => null;
+
+    void M(dynamic el)
+    {
+        el.Background(LookUpBrush(""accent-ish""));
+    }
+}";
+        var analyzerTest = new CSharpAnalyzerTest<UseThemeRefAnalyzer, DefaultVerifier>
+        {
+            TestCode = test,
+        };
+        await analyzerTest.RunAsync(TestContext.Current.CancellationToken);
+    }
 }


### PR DESCRIPTION
## The problem

You hit a REACTOR_THEME_001 warning on a responsive-layout snippet you'd copied out of the guides. That turned out to be the visible edge of a systemic gap.

Every `snippet=` block in `docs/guide/` is extracted verbatim from a doc app under `docs/_pipeline/apps/`. A doc app **is** the code we tell people to write. Two independent gaps meant nothing ever checked it:

1. **Only `win2d-canvas` was listed in `Reactor.slnx`** — the other 52 doc apps were never compiled by CI at all.
2. **A `ProjectReference` to `src/Reactor` doesn't flow `Reactor.Analyzers`** — it ships as a packed `<None Pack="true">` item, so even that one app compiled without the rules its own readers are subject to.

Result: a snippet could compile perfectly for us and warn in every reader's project.

## What surfaced

Wiring the consumer analyzer bundle into the doc apps produced **276 diagnostics across 43 of 53 apps**:

| Rule | Count | What it means |
|---|---|---|
| `REACTOR_THEME_001` | 91 | Hard-coded colour instead of a `Theme` token |
| `REACTOR_A11Y_003` | 58 | Form field with no label |
| **`REACTOR_MOD_003`** | **45** | **Modifier the receiver silently drops** |
| `REACTOR_A11Y_001` | 33 | Icon-only button with no accessible name |
| **`REACTOR_HOOKS_001`** | **16** | **Hook called conditionally** |
| `REACTOR_DSL_001` | 15 | Dynamic list item missing `.WithKey` |
| others | 18 | |

The bolded rows are the ones that matter most: those snippets compiled, shipped, and **did not do what the surrounding prose promised**.

## Behavioural bugs fixed

- `TextBlock(...).Background(...)` / `.CornerRadius(...)` painted **nothing** — the modifier isn't applied to `TextBlockElement`. Present in `layout`, `styling`, `collections`, `animation`, `flex-layout`, `recipe-command-palette`.
- `ProgressRing(0.6)` was documented as "60%" — the API takes `60`, so the sample rendered ~0%.
- `recipes-index` advertised 9 recipes in its gallery and rendered 3.
- A `TeachingTip` with no target, so it never anchored.
- `effects` prose claimed debounce the snippet never implemented.
- `Padding` on `WrapGridElement` (dropped) in the responsive-layout section you were looking at.
- The `advanced` `UseCollection` sample keyed rows by **list index** while offering `RemoveAt(i)`, so deleting any earlier row rekeyed every later one — `REACTOR_DSL_002`'s exact anti-pattern, in the page teaching collections. It escaped the gate only because DSL_002 is Info, not Warning.

All fixed at the source — **no `NoWarn`, no `#pragma`, no `.editorconfig` downgrades**.

## Two analyzer bugs found along the way

**`HookRulesAnalyzer` false positive.** It treated *every* enclosing lambda as an illegal hook site, but `Memo(ctx => ...)` is a real component boundary — `MountMemoComponent` allocates its own `RenderContext` and calls `BeginRender()`, so the lambda owns its hook slots. The rule fired on correct code and pushed authors away from `ctx.UseCanvasResources`, whose entire purpose is **GPU device-lost recovery**. (My first pass actually "fixed" seven doc apps to satisfy the false positive, including dropping `UseCanvasResources` in Win2D; those were reverted once the real cause was found.)

The exemption requires the hook's receiver to be the lambda's **own** `RenderContext` parameter *and* the lambda to return an `Element`. Review caught that keying on the parameter type alone was too loose — `RenderContext` has a public constructor, so `Helper(ctx => ctx.UseState(...))` would have become a false negative. Mutation-tested: removing the return-type check reddens exactly the new regression test.

**`REACTOR_A11Y_003` under-recognised the DSL.** It accepted a named `header:` argument but not the fluent `.Header(...)`, so the guides were being changed to teach `.AutomationName("Password")` next to a `.Header("Password")` already doing the job. Fixed in the analyzer, where the gap was; the three redundant automation names are gone from the forms guide.

## The automated gate you asked for

- **`docs/_pipeline/apps/DocApps.proj`** — builds all 53 doc apps from a glob (not a hand-maintained list, which would reproduce this very defect one level up). Runs **serially**: measured at 45s serial vs 43s parallel, because the real cost is the shared framework projects built once either way. Parallelism bought two seconds and cost a class of flakiness — the first CI run failed with a NuGet restore race, and AGENTS.md documents the matching `CS2012` build-side hazard.
- **`Doc snippet analyzer gate` CI job** — promotes diagnostics with `TreatWarningsAsErrors` + `WarningsNotAsErrors=NU1900` so MSBuild owns severity, with a case-sensitive scan producing `file:line` annotations on top.
- **`DocAppGateWiringTests`** — keeps the gate honest rather than duplicating it: floors app coverage against the real directory listing, requires `OutputItemType="Analyzer"`, and turns suppressions into a reviewable ledger with written justifications.

That last test earned its keep immediately: it caught **three apps already silencing rules via `<NoWarn>`** (`rules-of-reactor`, `extending-reactor-controls`, `v1-protocol`) — which is exactly why they'd reported a clean baseline. They were blind, not clean.

## Verification

- **53/53** doc apps rebuild with **0** `REACTOR_` diagnostics under `TreatWarningsAsErrors`.
- **Positive control:** a planted `#123456` is still caught — an early "0 diagnostics" run turned out to be a failed test splice, not a working gate, so this was confirmed rather than assumed.
- 13,603 unit tests, 398 doc-pipeline tests, and all 22 CI checks pass.
- `docs check-tier` back to **0 errors**.

## Known gap (not addressed here)

**136 `csharp` fences in the templates are inline rather than `snippet=`-backed**, so nothing compiles them — concentrated in `input-and-gestures` (10), `text-and-media` (10), `hooks` (9), and `dialogs-and-flyouts` (8). Agents fixed the outright API errors they found, but converting these to snippet-backed code is a follow-up, since this gate can't see them.

## Review notes

- Guide changes under `docs/guide/**` are **generated** — review the templates and doc apps instead.
- `docs/guide/reconciliation.md` picks up a snippet that had gone stale against `src/Reactor/Core/Reconciler.cs` since 6786b216; a legitimate catch-up, not churn.
- `docs/contributing/doc-pipeline.md` documents the gate, the suppression ledger, and why `-t:Rebuild` is load-bearing locally.

🤖 Generated with [Copilot CLI](https://githubnext.com/projects/copilot-cli)