### PR TITLE
Stop stating template-specific facts as Reactor invariants

### DIFF
--- a/plugins/reactor/skills/reactor-getting-started/SKILL.md
+++ b/plugins/reactor/skills/reactor-getting-started/SKILL.md
@@ -50,7 +50,7 @@ description: "Reactor essentials in one place — React-to-Reactor mental model,
 
 ## Starting a new app
 
-`dotnet new reactorapp -n <Name>` scaffolds the canonical shape: `App.cs` (entry point + initial component, with the seven-line using block at the top) plus `<Name>.csproj`. See the anti-probe + `mur check` notes under "Use a `.csproj` …" below for what comes out of the scaffold.
+`dotnet new reactorapp -n <Name>` scaffolds the canonical shape: `App.cs` (entry point + initial component, with the `using` block at the top) plus `<Name>.csproj`. See the anti-probe + `mur check` notes under "Use a `.csproj` …" below for what comes out of the scaffold.
 
 For a single-file `dotnet run App.cs` demo (no `.csproj`), prepend the file-level `#:package` / `#:property` headers — see `reactor-build-and-check`'s single-file-scripts section.
 
@@ -78,7 +78,7 @@ still succeeds, so nothing surfaces the mistake.** Switch modes only when the us
 the whole property *set*, not a single flag — the `packaging` guide has both shapes in full,
 including the explicit-`MSIX` form.
 
-**After `dotnet new reactorapp -n <Name>`, the workspace contains `App.cs` (entry point + initial component) and `<Name>.csproj`, plus a `Properties/launchSettings.json` for F5 — and nothing else you need to touch.** Other Reactor templates scaffold more files (a packaged one adds MSIX packaging inputs); those are not source — leave them alone. There is no `Program.cs` and no `GlobalUsings.cs` — modify `App.cs` in place. The `.csproj` does **not** enable implicit usings; `App.cs` has its own `using` directives at the top — the same set listed in the *Required imports* section below — which is the only place you add new namespaces (e.g. `using System.Linq;` when you reach for `.Select(...)`). Don't probe the `.csproj` after scaffolding unless you're adding a `PackageReference` or changing a property — `Restore succeeded.` in the scaffold stdout is the only confirmation you need.
+**After `dotnet new reactorapp -n <Name>`, the workspace contains `App.cs` (entry point + initial component) and `<Name>.csproj`, plus a `Properties/launchSettings.json` for F5 — and nothing else you need to touch.** Other Reactor templates scaffold more files (a packaged one adds MSIX packaging inputs); those are not source — leave them alone. There is no `Program.cs` and no `GlobalUsings.cs` — modify `App.cs` in place. `App.cs` has its own `using` directives at the top — see the *Required imports* section below — and that is where you add new namespaces (e.g. `using System.Linq;` when you reach for `.Select(...)`). Some templates enable implicit usings, so a namespace may already be in scope. Don't probe the `.csproj` after scaffolding unless you're adding a `PackageReference` or changing a property — `Restore succeeded.` in the scaffold stdout is the only confirmation you need.
 
 **The scaffolded csproj ships with `WindowsAppSDKSelfContained=true` and a Debug-only ItemGroup that adds `Microsoft.UI.Reactor.Devtools` + `Reactor.DevtoolsSupport=true`.** Together they make `dotnet watch run` (and the very rough, experimental Visual Studio embedded-preview extension) hot-reload safe and F5 (which passes `--devtools` from `Properties/launchSettings.json`) bring up the devtools menu. The VS extension is currently the roughest Reactor surface; do not present it as stable. Release builds drop the devtools package and host-config switch so trim / AOT analyzers stay quiet — see the `packaging` guide for the full rationale before flipping either knob.
 

--- a/plugins/reactor/skills/reactor-getting-started/SKILL.md
+++ b/plugins/reactor/skills/reactor-getting-started/SKILL.md
@@ -60,22 +60,25 @@ For a single-file `dotnet run App.cs` demo (no `.csproj`), prepend the file-leve
 
 `UseWinUI` MUST be `true`. **No XAML files of any kind.**
 
-**Don't set `WindowsPackageType` yourself — keep whatever the scaffold produced.** Reactor supports
-both shapes and the template decides which you get:
+**Don't change the packaging mode of a project you didn't scaffold — keep whatever the scaffold
+produced.** Reactor works in both shapes:
 
-- **Unpackaged** (`<WindowsPackageType>None</WindowsPackageType>`, no `Package.appxmanifest`) — runs
-  from any folder, no MSIX registration.
-- **Packaged** (`<EnableMsixTooling>true</EnableMsixTooling>` plus `Package.appxmanifest`,
-  `app.manifest` and `Assets\`) — single-project MSIX; launches with package identity, which is what
-  APIs gated on identity require.
+- **Unpackaged** — `<WindowsPackageType>None</WindowsPackageType>`, no `Package.appxmanifest`.
+  `None` wins over `EnableMsixTooling`, so a project carrying both still builds unpackaged. Runs
+  from any folder, no MSIX registration. This is what `dotnet new reactorapp` produces today.
+- **Packaged** — has a `Package.appxmanifest`. Either omit `WindowsPackageType` entirely (the
+  default produces a packaged app) or set it to `MSIX`; pair it with `EnableMsixTooling=true` for
+  the single-project MSIX tooling. Launches with package identity, which is what identity-gated
+  APIs require.
 
-Neither is "the" Reactor shape. If a scaffold gave you a `Package.appxmanifest`, it is a packaged
-project on purpose — **adding `<WindowsPackageType>None</WindowsPackageType>` to it silently
-downgrades it to unpackaged and strips its identity.** Change packaging only when the user asks for a
-specific mode, and then change it deliberately: the two shapes need different property *sets*, not a
-single flag flipped.
+Neither is "the" Reactor shape, and neither is signalled by one property alone. **If a project has a
+`Package.appxmanifest`, it is packaged on purpose — adding
+`<WindowsPackageType>None</WindowsPackageType>` to it silently strips its identity, and the build
+still succeeds, so nothing surfaces the mistake.** Switch modes only when the user asks, and switch
+the whole property *set*, not a single flag — the `packaging` guide has both shapes in full,
+including the explicit-`MSIX` form.
 
-**After `dotnet new reactorapp -n <Name>`, the workspace contains `App.cs` (entry point + initial component) and `<Name>.csproj`, plus a `Properties/launchSettings.json` for F5 — and nothing else you need to touch.** (A packaged template additionally emits `Package.appxmanifest`, `app.manifest` and an `Assets\` folder; those are MSIX packaging inputs, not source — leave them alone.) There is no `Program.cs` and no `GlobalUsings.cs` — modify `App.cs` in place. The `.csproj` does **not** enable implicit usings; `App.cs` has its own `using` directives at the top — the same set listed in the *Required imports* section below — which is the only place you add new namespaces (e.g. `using System.Linq;` when you reach for `.Select(...)`). Don't probe the `.csproj` after scaffolding unless you're adding a `PackageReference` or changing a property — `Restore succeeded.` in the scaffold stdout is the only confirmation you need.
+**After `dotnet new reactorapp -n <Name>`, the workspace contains `App.cs` (entry point + initial component) and `<Name>.csproj`, plus a `Properties/launchSettings.json` for F5 — and nothing else you need to touch.** Other Reactor templates scaffold more files (a packaged one adds MSIX packaging inputs); those are not source — leave them alone. There is no `Program.cs` and no `GlobalUsings.cs` — modify `App.cs` in place. The `.csproj` does **not** enable implicit usings; `App.cs` has its own `using` directives at the top — the same set listed in the *Required imports* section below — which is the only place you add new namespaces (e.g. `using System.Linq;` when you reach for `.Select(...)`). Don't probe the `.csproj` after scaffolding unless you're adding a `PackageReference` or changing a property — `Restore succeeded.` in the scaffold stdout is the only confirmation you need.
 
 **The scaffolded csproj ships with `WindowsAppSDKSelfContained=true` and a Debug-only ItemGroup that adds `Microsoft.UI.Reactor.Devtools` + `Reactor.DevtoolsSupport=true`.** Together they make `dotnet watch run` (and the very rough, experimental Visual Studio embedded-preview extension) hot-reload safe and F5 (which passes `--devtools` from `Properties/launchSettings.json`) bring up the devtools menu. The VS extension is currently the roughest Reactor surface; do not present it as stable. Release builds drop the devtools package and host-config switch so trim / AOT analyzers stay quiet — see the `packaging` guide for the full rationale before flipping either knob.
 

--- a/plugins/reactor/skills/reactor-getting-started/SKILL.md
+++ b/plugins/reactor/skills/reactor-getting-started/SKILL.md
@@ -58,9 +58,24 @@ For a single-file `dotnet run App.cs` demo (no `.csproj`), prepend the file-leve
 
 … multiple files, **analyzers** (single-file `.cs` builds don't load them), or shared project references. `dotnet new reactorapp` scaffolds the canonical csproj — you don't need to author one from scratch.
 
-`WindowsPackageType` MUST be `None` (unpackaged, no App.xaml). `UseWinUI` MUST be `true`. **No XAML files of any kind.**
+`UseWinUI` MUST be `true`. **No XAML files of any kind.**
 
-**After `dotnet new reactorapp -n <Name>`, the workspace contains exactly two source files: `App.cs` (entry point + initial component) and `<Name>.csproj`, plus a `Properties/launchSettings.json` for F5.** There is no `Program.cs` and no `GlobalUsings.cs` — modify `App.cs` in place. The `.csproj` does **not** enable implicit usings; `App.cs` has its own `using` directives at the top — the same set listed in the *Required imports* section below — which is the only place you add new namespaces (e.g. `using System.Linq;` when you reach for `.Select(...)`). Don't probe the `.csproj` after scaffolding unless you're adding a `PackageReference` or changing a property — `Restore succeeded.` in the scaffold stdout is the only confirmation you need.
+**Don't set `WindowsPackageType` yourself — keep whatever the scaffold produced.** Reactor supports
+both shapes and the template decides which you get:
+
+- **Unpackaged** (`<WindowsPackageType>None</WindowsPackageType>`, no `Package.appxmanifest`) — runs
+  from any folder, no MSIX registration.
+- **Packaged** (`<EnableMsixTooling>true</EnableMsixTooling>` plus `Package.appxmanifest`,
+  `app.manifest` and `Assets\`) — single-project MSIX; launches with package identity, which is what
+  APIs gated on identity require.
+
+Neither is "the" Reactor shape. If a scaffold gave you a `Package.appxmanifest`, it is a packaged
+project on purpose — **adding `<WindowsPackageType>None</WindowsPackageType>` to it silently
+downgrades it to unpackaged and strips its identity.** Change packaging only when the user asks for a
+specific mode, and then change it deliberately: the two shapes need different property *sets*, not a
+single flag flipped.
+
+**After `dotnet new reactorapp -n <Name>`, the workspace contains `App.cs` (entry point + initial component) and `<Name>.csproj`, plus a `Properties/launchSettings.json` for F5 — and nothing else you need to touch.** (A packaged template additionally emits `Package.appxmanifest`, `app.manifest` and an `Assets\` folder; those are MSIX packaging inputs, not source — leave them alone.) There is no `Program.cs` and no `GlobalUsings.cs` — modify `App.cs` in place. The `.csproj` does **not** enable implicit usings; `App.cs` has its own `using` directives at the top — the same set listed in the *Required imports* section below — which is the only place you add new namespaces (e.g. `using System.Linq;` when you reach for `.Select(...)`). Don't probe the `.csproj` after scaffolding unless you're adding a `PackageReference` or changing a property — `Restore succeeded.` in the scaffold stdout is the only confirmation you need.
 
 **The scaffolded csproj ships with `WindowsAppSDKSelfContained=true` and a Debug-only ItemGroup that adds `Microsoft.UI.Reactor.Devtools` + `Reactor.DevtoolsSupport=true`.** Together they make `dotnet watch run` (and the very rough, experimental Visual Studio embedded-preview extension) hot-reload safe and F5 (which passes `--devtools` from `Properties/launchSettings.json`) bring up the devtools menu. The VS extension is currently the roughest Reactor surface; do not present it as stable. Release builds drop the devtools package and host-config switch so trim / AOT analyzers stay quiet — see the `packaging` guide for the full rationale before flipping either knob.
 


### PR DESCRIPTION
## Problem

`reactor-getting-started/SKILL.md` states template-specific facts as if they were invariants of Reactor. The headline case:

> `WindowsPackageType` MUST be `None` (unpackaged, no App.xaml).

That is a property of the current `dotnet new reactorapp` template, not of Reactor. The practical effect is that an agent handed a **packaged** Reactor project edits it back to unpackaged, because the skill tells it to. Adding `<WindowsPackageType>None</WindowsPackageType>` to a project that has a `Package.appxmanifest` silently drops its package identity — and the build still succeeds, so nothing surfaces the mistake.

This matters now that packaged Reactor templates are being added in microsoft/WindowsAppSDK#6620: with this line in place, that template change cannot land on its own.

## Approach

This PR does **not** flip the mandate to "packaged". The shipped template is still unpackaged, and a skill that contradicts its own template causes the same class of failure in the other direction. Instead the skill stops mandating a mode at all: it describes both shapes, and tells the agent to keep whatever the scaffold produced.

That is correct against today's template *and* against a packaged one, so there is **no ordering dependency** with #6620.

## Packaging semantics, verified experimentally

Both shapes built from a clean tree on the same SDK:

| csproj | MSIX artifacts produced | Result |
|---|---|---|
| `WindowsPackageType` **absent** + `EnableMsixTooling=true` | `AppxManifest.xml`, `resources.pri`, `*.build.appxrecipe` | **packaged** |
| `WindowsPackageType=None` + `EnableMsixTooling=true` | none | **unpackaged** |

Two conclusions, both reflected in the wording:

- `None` **overrides** `EnableMsixTooling` — a project with both builds unpackaged.
- `WindowsPackageType=MSIX` is **not required**. Omitting the property entirely yields a packaged app off the default, and that is the shape #6620's own template uses (`EnableMsixTooling=true`, no `WindowsPackageType`). Wording that made `MSIX` mandatory would have described that scaffold as broken.

Neither mode is signalled by one property alone. `Package.appxmanifest` is the discriminator — `app.manifest` is not, since it also appears in unpackaged projects (e.g. `tests/startup_perf/BlankWinUI3`).

## Also: the same defect, one sentence away

The same paragraph asserts:

> The `.csproj` does **not** enable implicit usings

True for `dotnet new reactorapp`; **false** for #6620, which sets `<ImplicitUsings>enable</ImplicitUsings>` — its `App.cs` opens with six usings rather than seven, dropping `using System;`. The sentence's own example misfires too: an agent told to add `using System.Linq;` finds it already in scope.

Reworded to be template-neutral, so it needs no follow-up when #6620 lands. The adjacent "exactly two source files" claim is dropped for the same reason — a packaged scaffold additionally emits `Package.appxmanifest`, `app.manifest` and `Assets\`.

## Why this is worth doing

Measured on the win-dev-skills benchmark harness, comparing unpackaged and packaged Reactor arms on identical scenarios:

| Arm | n | `project` subscore | mean |
|---|---|---|---|
| Reactor unpackaged | 6 | 4, 5, 5, 5, 6, 7 | 5.33 |
| Reactor packaged | 2 | 8, 8 | 8.00 |
| WinUI/XAML (reference) | 2 | 9, 10 | 9.50 |

Every packaged observation sits above the entire unpackaged range. On the one clean same-run pair the total score moved 72 → 75, with the whole delta coming from `project` 5 → 8.

The reverse failure is also observed: in a trial where the agent ignored the scaffold and hand-authored a packaged-looking `.csproj`, the result would not launch — `winapp run` reported *"The manifest contains a placeholder for the executable but no .exe files were found in the input folder"*. Guidance that disagrees with the template is what produces that outcome.

## Scope

One file, docs only. No code, no template, no behaviour change.
