### PR TITLE
docs: stop prescribing MSBuild-only switches on `dotnet test` (#1140)

### DIFF
--- a/.github/skills/coverage-uplift/SKILL.md
+++ b/.github/skills/coverage-uplift/SKILL.md
@@ -117,8 +117,19 @@ dotnet test tests/Reactor.AppTests -p:Platform=x64
 Always pass `-p:Platform=x64` (AnyCPU app/test builds fail with *"WindowsAppSDKSelfContained
 requires a supported Windows architecture"*) and `-p:SkipSignaturesGen=true` on
 `Reactor.Tests` to dodge the `CS2012 …\intermediatexaml\Reactor.dll` race. If the race
-persists under parallel builds, escalate: prebuild `src/Reactor` first, then add `-m:1`
-`-nodereuse:false` and `$env:MSBUILDDISABLENODEREUSE='1'`.
+persists under parallel builds, escalate **on the `dotnet build` line only** — prebuild
+`src/Reactor` first, then add `-m:1 -nodereuse:false` (or set
+`$env:MSBUILDDISABLENODEREUSE='1'`) to the build — and keep running the suite through the
+separate `dotnet test … --no-build` line above.
+
+**Never move `-m:1` or `-nodereuse:false` onto a `dotnet test` command** (issue #1140):
+those are MSBuild-only switches, and `dotnet test` forwards every token it does not
+recognise to the **test executable**, which rejects it and exits 5 before running anything.
+Nothing prints why — you just get `Zero tests ran / total: 0 / failed: 0 / skipped: 0`,
+which reads green, so a coverage run reports no failures while measuring nothing. The tell
+is the module label: `net10.0-windows10.0.22621.0` instead of `net10.0|x64`. `-p:…` is a
+real `dotnet test` option and is safe, as is the `MSBUILDDISABLENODEREUSE` environment
+variable. See `TESTING.md` → *MSBuild switches are not `dotnet test` switches*.
 
 E2E input needs an interactive desktop: if `SendInput`/`GetCursorPos` return
 `ACCESS_DENIED (err 5)` your local session can't inject input — validate the fixture over

--- a/.github/skills/coverage-uplift/SKILL.md
+++ b/.github/skills/coverage-uplift/SKILL.md
@@ -123,13 +123,15 @@ persists under parallel builds, escalate **on the `dotnet build` line only** —
 separate `dotnet test … --no-build` line above.
 
 **Never move `-m:1` or `-nodereuse:false` onto a `dotnet test` command** (issue #1140):
-those are MSBuild-only switches, and `dotnet test` forwards every token it does not
-recognise to the **test executable**, which rejects it and exits 5 before running anything.
-Nothing prints why — you just get `Zero tests ran / total: 0 / failed: 0 / skipped: 0`,
-which reads green, so a coverage run reports no failures while measuring nothing. The tell
-is the module label: `net10.0-windows10.0.22621.0` instead of `net10.0|x64`. `-p:…` is a
-real `dotnet test` option and is safe, as is the `MSBUILDDISABLENODEREUSE` environment
-variable. See `TESTING.md` → *MSBuild switches are not `dotnet test` switches*.
+`dotnet test` does not accept those switches, and the test host does not recognise them
+either, so it exits 5 before running anything. Nothing prints why — you just get
+`Zero tests ran / total: 0 / failed: 0 / skipped: 0`, which reads green, so a coverage run
+reports no failures while measuring nothing. The tell is the module label:
+`net10.0-windows10.0.22621.0` instead of `net10.0|x64`. Runner options such as
+`--filter-class`, `--parallel` and `--max-threads` are fine — they are forwarded to the test
+app on purpose. `-p:…` is a real `dotnet test` option and is safe, as is the
+`MSBUILDDISABLENODEREUSE` environment variable. See `TESTING.md` → *MSBuild switches are not
+`dotnet test` switches*.
 
 E2E input needs an interactive desktop: if `SendInput`/`GetCursorPos` return
 `ACCESS_DENIED (err 5)` your local session can't inject input — validate the fixture over

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -215,12 +215,13 @@ Hard-won specifics that repeatedly cost sessions time. Prefer these exact comman
   dotnet test  tests/Reactor.Tests --no-build -p:Platform=x64
   ```
 - **Never append an MSBuild-only switch to `dotnet test`** (issue #1140). `-m:1`,
-  `-nodereuse:false`, `--nologo`, `-t:`, `-warnaserror` and friends are *not* `dotnet test`
-  options, and MTP mode forwards every unrecognised token to the **test executable** rather
-  than to MSBuild. The test host rejects it as an unknown option and exits
-  **5 (`InvalidCommandLine`)** before running anything — and **the rejected-option message is
-  never surfaced**, so the only signals are the exit code and a summary that reads green in
-  prose:
+  `-nodereuse:false`, `--nologo`, `-warnaserror` and friends are *not* `dotnet test`
+  options, and anything `dotnet test` does not recognise is forwarded to the **test
+  executable**. That forwarding is normal — it is how `--filter-class`, `--parallel` and
+  `--report-trx` reach the runner — but an MSBuild-only switch is recognised by *neither*
+  layer, so MTP rejects it and exits **5 (`InvalidCommandLine`)** before running anything.
+  **The rejected-option message is never surfaced**, so the only signals are the exit code
+  and a summary that reads green in prose:
   ```text
   ...\Reactor.Tests.dll (net10.0-windows10.0.22621.0) Zero tests ran
   Test run summary: Zero tests ran
@@ -230,10 +231,11 @@ Hard-won specifics that repeatedly cost sessions time. Prefer these exact comman
   The reliable tell is the module label: a run that actually started prints the
   handshake-derived `net10.0|x64`, so the full `net10.0-windows10.0.22621.0` means the test
   host died before its handshake. Exit 5 is *invalid command line*, **not** MTP's zero-tests
-  policy (that is exit 8). `-p:…` **is** a real `dotnet test` option and does reach MSBuild,
-  which is why `-p:SkipSignaturesGen=true` and `-p:Platform=x64` are safe there; measured on
-  this tree, `$env:MSBUILDDISABLENODEREUSE='1'` is also safe, because an environment variable
-  is not an argv token. See
+  policy (that is exit 8). `-p:…` **is** a real `dotnet test` option, which is why
+  `-p:SkipSignaturesGen=true` and `-p:Platform=x64` are safe there; measured on this tree,
+  `$env:MSBUILDDISABLENODEREUSE='1'` is also safe, because an environment variable is not an
+  argv token. Note `dotnet test --help` is not a reliable safe-list — `-t:`/`-target:` and
+  `--property` are accepted but unlisted. See
   [`TESTING.md`](TESTING.md#msbuild-switches-are-not-dotnet-test-switches).
 - **Fast selftest loop** (TAP `ok`/`not ok`): `dotnet run --project tests/Reactor.AppTests.Host --no-build -c Debug -p:Platform=x64 -- --self-test --filter "<Prefix>"`.
 - **Headless unit tests cannot construct any `Microsoft.UI.Xaml` object** — control, brush,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -206,8 +206,35 @@ Hard-won specifics that repeatedly cost sessions time. Prefer these exact comman
   they disappear before investigating them independently.
 - **Add `-p:SkipSignaturesGen=true` to local `tests/Reactor.Tests` builds** to avoid the
   XAML-markup/SignaturesGen race: `CSC error CS2012: Cannot open '...\obj\...\intermediatexaml\Reactor.dll' ... used by another process`. If it still races under
-  parallel WinUI builds, prebuild `src/Reactor` alone first, then add `-m:1`
-  `-nodereuse:false` and `$env:MSBUILDDISABLENODEREUSE='1'`. (`-p:CI=true` also skips it.)
+  parallel WinUI builds, prebuild `src/Reactor` alone first, then escalate **on the build
+  command only** — `-m:1 -nodereuse:false` (or `$env:MSBUILDDISABLENODEREUSE='1'`) — and run
+  the suite separately with `--no-build`. (`-p:CI=true` also skips SignaturesGen.)
+  ```powershell
+  dotnet build src/Reactor/Reactor.csproj -p:Platform=x64 -m:1 -nodereuse:false
+  dotnet build tests/Reactor.Tests -p:Platform=x64 -p:SkipSignaturesGen=true -m:1 -nodereuse:false
+  dotnet test  tests/Reactor.Tests --no-build -p:Platform=x64
+  ```
+- **Never append an MSBuild-only switch to `dotnet test`** (issue #1140). `-m:1`,
+  `-nodereuse:false`, `--nologo`, `-t:`, `-warnaserror` and friends are *not* `dotnet test`
+  options, and MTP mode forwards every unrecognised token to the **test executable** rather
+  than to MSBuild. The test host rejects it as an unknown option and exits
+  **5 (`InvalidCommandLine`)** before running anything — and **the rejected-option message is
+  never surfaced**, so the only signals are the exit code and a summary that reads green in
+  prose:
+  ```text
+  ...\Reactor.Tests.dll (net10.0-windows10.0.22621.0) Zero tests ran
+  Test run summary: Zero tests ran
+    error: 1
+    total: 0   failed: 0   succeeded: 0   skipped: 0
+  ```
+  The reliable tell is the module label: a run that actually started prints the
+  handshake-derived `net10.0|x64`, so the full `net10.0-windows10.0.22621.0` means the test
+  host died before its handshake. Exit 5 is *invalid command line*, **not** MTP's zero-tests
+  policy (that is exit 8). `-p:…` **is** a real `dotnet test` option and does reach MSBuild,
+  which is why `-p:SkipSignaturesGen=true` and `-p:Platform=x64` are safe there; measured on
+  this tree, `$env:MSBUILDDISABLENODEREUSE='1'` is also safe, because an environment variable
+  is not an argv token. See
+  [`TESTING.md`](TESTING.md#msbuild-switches-are-not-dotnet-test-switches).
 - **Fast selftest loop** (TAP `ok`/`not ok`): `dotnet run --project tests/Reactor.AppTests.Host --no-build -c Debug -p:Platform=x64 -- --self-test --filter "<Prefix>"`.
 - **Headless unit tests cannot construct any `Microsoft.UI.Xaml` object** — control, brush,
   geometry, `BitmapImage`, or **`AutomationPeer`-derived** type — you get a `COMException`.

--- a/TESTING.md
+++ b/TESTING.md
@@ -83,7 +83,7 @@ but `dotnet test` does not accept them and the test host has never heard of them
 
 | Handled by `dotnet test` | Forwarded, and valid | Recognised by neither — breaks the run |
 |---|---|---|
-| `-p:` / `--property`, `-c`, `-f`, `-r`, `-a` / `--arch`, `--os`, `-v`, `-e`, `-t:` / `-target:`, `--no-build`, `--no-restore`, `-bl` | `--filter`, `--filter-class`, `--filter-trait`, `--parallel`, `--max-threads`, `--report-trx`, `--hangdump`, `--minimum-expected-tests` | `-m` / `-maxcpucount`, `-nodereuse` / `-nr`, `--nologo`, `-warnaserror`, `-graphBuild` |
+| `-p:` / `--property`, `-c`, `-f`, `-r`, `-a` / `--arch`, `--os`, `-v`, `-e`, `-t:` / `-target:`, `--no-build`, `--no-restore`, `-bl`, `--results-directory`, `--minimum-expected-tests` | `--filter`, `--filter-class`, `--filter-trait`, `--parallel`, `--max-threads`, `--report-trx`, `--hangdump` | `-m` / `-maxcpucount`, `-nodereuse` / `-nr`, `--nologo`, `-warnaserror`, `-graphBuild` |
 
 Two of these are counter-intuitive enough to call out. `--nologo` is a real `dotnet build`
 switch and reads like a harmless one, but `dotnet test` does not accept it, so it kills the

--- a/TESTING.md
+++ b/TESTING.md
@@ -65,22 +65,32 @@ packages are already referenced by the projects that need them.
 
 ### MSBuild switches are not `dotnet test` switches
 
-`dotnet test` does **not** hand leftover arguments to MSBuild. The SDK composes its MSBuild
-command line only from the options it recognises; every token it does *not* recognise is
-appended to the **test executable's own** command line, where MTP rejects it as an unknown
-option and exits **5 (`InvalidCommandLine`)** before a single test runs.
+Every flag on a `dotnet test` command line is handled by one of two layers, and it
+matters which:
 
-The rule is simply *"if `dotnet test --help` doesn't list it, it goes to the test app"* —
-so check there when in doubt rather than assuming an MSBuild switch carries over.
+1. **`dotnet test` itself** recognises a set of options and uses them to drive the build
+   and the run — `-p:` / `--property`, `-c`, `-f`, `-r`, `-a` / `--arch`, `--os`, `-v`,
+   `-e`, `-t:` / `-target:`, `--no-build`, `--no-restore`, `-bl`.
+2. **Everything else is forwarded verbatim to the test executable**, where MTP and the
+   xUnit runner parse it. That is not a failure mode — it is how the whole table above
+   works. `--filter-class`, `--parallel`, `--max-threads`, `--report-trx` and `--hangdump`
+   are all forwarded, and all valid.
 
-| Reaches MSBuild — safe | Goes to the test app — breaks the run |
-|---|---|
-| `-p:` / `--property`, `-c`, `-f`, `-r`, `-a` / `--arch`, `--os`, `-v`, `-e`, `--no-build`, `--no-restore`, and `-bl` | `-m` / `-maxcpucount`, `-nodereuse` / `-nr`, `--nologo`, `-t:` / `-target:`, `-warnaserror`, and every other MSBuild-only switch |
+The run breaks only when a token is recognised by **neither** layer. MTP then rejects it as
+an unknown option and exits **5 (`InvalidCommandLine`)** before a single test runs.
+MSBuild-only switches are the common way to land in that gap: they look like build flags,
+but `dotnet test` does not accept them and the test host has never heard of them.
 
-`--nologo` is in the right-hand column on purpose: it is a real `dotnet build` switch and
-reads like a harmless one, but `dotnet test` does not recognise it, so it kills the run
-exactly like `-m:1` does. `-bl` is the one exception — the SDK lifts binlog arguments out
-before forwarding the rest.
+| Handled by `dotnet test` | Forwarded, and valid | Recognised by neither — breaks the run |
+|---|---|---|
+| `-p:` / `--property`, `-c`, `-f`, `-r`, `-a` / `--arch`, `--os`, `-v`, `-e`, `-t:` / `-target:`, `--no-build`, `--no-restore`, `-bl` | `--filter`, `--filter-class`, `--filter-trait`, `--parallel`, `--max-threads`, `--report-trx`, `--hangdump`, `--minimum-expected-tests` | `-m` / `-maxcpucount`, `-nodereuse` / `-nr`, `--nologo`, `-warnaserror`, `-graphBuild` |
+
+Two of these are counter-intuitive enough to call out. `--nologo` is a real `dotnet build`
+switch and reads like a harmless one, but `dotnet test` does not accept it, so it kills the
+run exactly like `-m:1`. Conversely `-t:`/`-target:` **is** accepted, even though
+`dotnet test --help` does not list it — so "not in `--help`" is not a reliable test for
+whether a flag is safe. When in doubt, run the command against a known-passing filter and
+check that the test count is non-zero.
 
 Environment variables are not argv tokens, so `MSBUILDDISABLENODEREUSE=1` is safe — it
 reaches MSBuild and never reaches the test host.

--- a/TESTING.md
+++ b/TESTING.md
@@ -63,6 +63,53 @@ packages are already referenced by the projects that need them.
 > `--filter-class "*SwallowedErrorAudit*"` both select the same 11 tests, and
 > `--filter-class` against `tests/Reactor.SelfTests` exits 5.
 
+### MSBuild switches are not `dotnet test` switches
+
+`dotnet test` does **not** hand leftover arguments to MSBuild. The SDK composes its MSBuild
+command line only from the options it recognises; every token it does *not* recognise is
+appended to the **test executable's own** command line, where MTP rejects it as an unknown
+option and exits **5 (`InvalidCommandLine`)** before a single test runs.
+
+The rule is simply *"if `dotnet test --help` doesn't list it, it goes to the test app"* —
+so check there when in doubt rather than assuming an MSBuild switch carries over.
+
+| Reaches MSBuild — safe | Goes to the test app — breaks the run |
+|---|---|
+| `-p:` / `--property`, `-c`, `-f`, `-r`, `-a` / `--arch`, `--os`, `-v`, `-e`, `--no-build`, `--no-restore`, and `-bl` | `-m` / `-maxcpucount`, `-nodereuse` / `-nr`, `--nologo`, `-t:` / `-target:`, `-warnaserror`, and every other MSBuild-only switch |
+
+`--nologo` is in the right-hand column on purpose: it is a real `dotnet build` switch and
+reads like a harmless one, but `dotnet test` does not recognise it, so it kills the run
+exactly like `-m:1` does. `-bl` is the one exception — the SDK lifts binlog arguments out
+before forwarding the rest.
+
+Environment variables are not argv tokens, so `MSBUILDDISABLENODEREUSE=1` is safe — it
+reaches MSBuild and never reaches the test host.
+
+So when a build needs `-m:1 -nodereuse:false` (the `CS2012 …\intermediatexaml\Reactor.dll`
+race — see [`AGENTS.md`](AGENTS.md) field notes), split the command in two:
+
+```bash
+dotnet build tests/Reactor.Tests -p:Platform=x64 -p:SkipSignaturesGen=true -m:1 -nodereuse:false
+dotnet test  tests/Reactor.Tests --no-build -p:Platform=x64
+```
+
+**Recognising the failure.** Nothing prints *why* the command line was rejected — the test
+host's message is not surfaced — so the run looks like this, and the summary prose scans as
+green even though nothing ran:
+
+```text
+...\Reactor.Tests.dll (net10.0-windows10.0.22621.0) Zero tests ran
+Test run summary: Zero tests ran
+  error: 1
+  total: 0   failed: 0   succeeded: 0   skipped: 0
+```
+
+The reliable tell is the module label. A run that started prints the handshake-derived
+`net10.0|x64`; a rejected one falls back to the project's full
+`net10.0-windows10.0.22621.0`, because the test host died before its handshake. Exit 5 is
+*invalid command line* — the same code MSTest returns for `--filter-class` above — and is
+**not** MTP's zero-tests policy, which is exit 8. (Issue #1140.)
+
 ## When to write which test
 
 | If you're testing… | Write a… |

--- a/TESTING.md
+++ b/TESTING.md
@@ -92,8 +92,9 @@ run exactly like `-m:1`. Conversely `-t:`/`-target:` **is** accepted, even thoug
 whether a flag is safe. When in doubt, run the command against a known-passing filter and
 check that the test count is non-zero.
 
-Environment variables are not argv tokens, so `MSBUILDDISABLENODEREUSE=1` is safe — it
-reaches MSBuild and never reaches the test host.
+Environment variables are not argv tokens, so `MSBUILDDISABLENODEREUSE=1` is safe. The test
+host does inherit it — child processes inherit the environment — but it is never parsed as
+an MTP option, which is what the rejection above turns on.
 
 So when a build needs `-m:1 -nodereuse:false` (the `CS2012 …\intermediatexaml\Reactor.dll`
 race — see [`AGENTS.md`](AGENTS.md) field notes), split the command in two:

--- a/docs/specs/tasks/async-resources-implementation.md
+++ b/docs/specs/tasks/async-resources-implementation.md
@@ -418,7 +418,7 @@ Note: the first three rules below are pre-existing gaps for **all** hooks; file 
 Run before merging any phase:
 
 - [ ] **All unit tests** (`dotnet test tests/Reactor.Tests`) — 2,200+ existing + phase-specific additions
-- [ ] **All threading tests** run both serially and under load — `dotnet test tests/Reactor.Tests --parallel none` and `dotnet test tests/Reactor.Tests --max-threads 4` — to expose contention that only appears when collections run concurrently. (Do **not** use `-m:1`/`-m:4` here: those are MSBuild switches, and `dotnet test` forwards unrecognised tokens to the test host, which rejects them and runs zero tests — issue #1140.)
+- [ ] **All threading tests** run both serially and under load — `dotnet test tests/Reactor.Tests -p:Platform=x64 --parallel none` and `dotnet test tests/Reactor.Tests -p:Platform=x64 --max-threads 4` — to expose contention that only appears when collections run concurrently. (Do **not** use `-m:1`/`-m:4` here: those are MSBuild switches that `dotnet test` does not accept, and the test host rejects them and runs zero tests — issue #1140.)
 - [ ] **All selfhost fixtures** (`dotnet run --project tests/Reactor.AppTests.Host -- --self-test`) including the `AsyncResource.*` prefix
 - [ ] **Framerate fixtures** (`--filter "AsyncResource.Framerate"`) — these are the regression canary for "works once, breaks at 60Hz"
 - [ ] **E2E regression** (`dotnet test tests/Reactor.AppTests`) — no new E2E tests required; verify no existing AT/a11y regression

--- a/docs/specs/tasks/async-resources-implementation.md
+++ b/docs/specs/tasks/async-resources-implementation.md
@@ -418,7 +418,7 @@ Note: the first three rules below are pre-existing gaps for **all** hooks; file 
 Run before merging any phase:
 
 - [ ] **All unit tests** (`dotnet test tests/Reactor.Tests`) — 2,200+ existing + phase-specific additions
-- [ ] **All threading tests** with `-m:1` (single process) and `-m:4` (parallel) to expose contention that only appears under load
+- [ ] **All threading tests** run both serially and under load — `dotnet test tests/Reactor.Tests --parallel none` and `dotnet test tests/Reactor.Tests --max-threads 4` — to expose contention that only appears when collections run concurrently. (Do **not** use `-m:1`/`-m:4` here: those are MSBuild switches, and `dotnet test` forwards unrecognised tokens to the test host, which rejects them and runs zero tests — issue #1140.)
 - [ ] **All selfhost fixtures** (`dotnet run --project tests/Reactor.AppTests.Host -- --self-test`) including the `AsyncResource.*` prefix
 - [ ] **Framerate fixtures** (`--filter "AsyncResource.Framerate"`) — these are the regression canary for "works once, breaks at 60Hz"
 - [ ] **E2E regression** (`dotnet test tests/Reactor.AppTests`) — no new E2E tests required; verify no existing AT/a11y regression


### PR DESCRIPTION
Fixes #1140.

## What was wrong

`dotnet test tests/Reactor.Tests … -m:1` (or `-nodereuse:false`) reports `Zero tests ran`, exit 5, while the identical command without the flag passes. The `AGENTS.md` field notes prescribed exactly those flags as the CS2012 workaround, so following the documented remedy silently turned "the suite passed" into "the suite never ran".

## Root cause

Not a Reactor bug and not a node-reuse bug — it is argument routing in the .NET 10 SDK's MTP `dotnet test` path.

Every flag on a `dotnet test` command line is handled by one of two layers. `dotnet test` recognises a set of options itself; **everything else is forwarded verbatim to the test executable**, where MTP and the xUnit runner parse it. Forwarding is normal — it is how `--filter-class`, `--parallel` and `--report-trx` work. The run breaks only when a token is recognised by **neither** layer, which is where MSBuild-only switches land: MTP rejects them and exits **5 (`InvalidCommandLine`)** before running anything.

Because the process dies before the IPC handshake, `TestApplicationHandler.OnTestProcessExited` takes the `HandshakeFailure` branch and labels the module with the MSBuild `TargetFramework`. **That is the `net10.0-windows…` vs `net10.0|x64` split the issue flagged — a symptom of the missing handshake, not a cause.**

The SDK trace (`DOTNET_CLI_TEST_TRACEFILE`) shows it directly:

```
Starting test process with command '...\Reactor.Tests.exe' and arguments
' --filter FullyQualifiedName~AgentKitDocGate -m:1 --server dotnettestcli --dotnet-test-pipe ...'
Test Process exited with non-zero exit code: 5
```

`-m:1` is on the test app's argv; every `-p:…` is absent from it, having stayed on the MSBuild side.

## Measured, not assumed

Each arm run in isolation with the exit code captured immediately:

| Flags | Result | Exit |
|---|---|---|
| baseline | 136 passed | 0 |
| `-m:1` / `-nodereuse:false` / `-nr:false` | Zero tests ran | 5 |
| `--nologo` / `-warnaserror` / `-graphBuild` / `-maxcpucount:1` | Zero tests ran | 5 |
| `-t:Build` / `-target:Build` / `--property:…` / `-v:q` / `-bl` | passed | 0 |
| `MSBUILDDISABLENODEREUSE=1` in env, no flag | 136 passed | 0 |
| build with the flags, then `dotnet test --no-build` | 136 passed | 0 |

## Two corrections to the issue report

- **Exit 5 is `InvalidCommandLine`, not a zero-tests verdict.** MTP's `ZeroTests` is 8. The run was rejected at argument parsing, so the zero-tests policy never ran.
- **`MSBUILDDISABLENODEREUSE=1` does not reproduce it.** The report claimed the env var "silently reproduces the bug"; measured, it runs 136 tests and exits 0. An environment variable is not an argv token, so it is never parsed as an MTP option.

## Changes (documentation only)

- **`AGENTS.md`** — the CS2012 escalation now applies to the **build command only**, with the two-step `dotnet build … -m:1 -nodereuse:false` → `dotnet test … --no-build` recipe, plus a new field note carrying the failure signature.
- **`TESTING.md`** — new *"MSBuild switches are not `dotnet test` switches"* section: the two-layer routing model, a three-column table (handled by `dotnet test` / forwarded and valid / recognised by neither), and how to recognise a rejected run.
- **`.github/skills/coverage-uplift/SKILL.md`** — same correction; a silent zero-test run is especially costly when the task is measuring coverage.
- **`docs/specs/tasks/async-resources-implementation.md`** — the threading checklist asked for `-m:1`/`-m:4`; replaced with `--parallel none` / `--max-threads 4` (plus the required `-p:Platform=x64`), the knobs that actually control xunit concurrency.

Deliberately unchanged: `.github/skills/analyzer-dym/SKILL.md` (prescribes only the safe `-p:` flag), `build/pipelines/templates/reactor-build-steps.yml` (`-maxcpucount:1` there is on a `dotnet build` line), and `ci.yml` (verified unaffected).

## Review corrections

The first commit had four factual errors, all found in review and all now measured rather than reasoned about:

1. **Over-claim on forwarding** (Copilot) — the text implied every forwarded token is rejected, which contradicted both the Flag-translation table it was appended to and this PR's own `--parallel none` recommendation. Reframed around the three-way distinction.
2. **`-t:` / `-target:` wrongly listed as breaking** — measured exit 0; they are accepted.
3. **A false heuristic** — "if `dotnet test --help` doesn't list it, it goes to the test app" is wrong: neither `-t:` nor `--property` is listed, yet both work.
4. **Missing `-p:Platform=x64`** in the async-resources commands — as written they failed with `WIN2D0001 … built as 'AnyCPU'`, exit 1.

Two further precision fixes came from later review rounds: the `MSBUILDDISABLENODEREUSE` claim ("never reaches the test host" — the child does inherit the environment; it is simply never parsed as an option), and `--minimum-expected-tests`, which is consumed by `dotnet test` and not forwarded. For the latter I re-traced the whole column rather than fix one cell, confirming the remaining entries do appear in the child argv.

## Worth recording

The rejected-option message is **never surfaced** — the SDK trace shows empty stdout/stderr for the child. All you get is exit 5, `error: 1`, and a summary whose prose scans green. That, rather than the exit code, is the real hazard, and it is why the module label is the thing to check.

## Verification

Full `tests/Reactor.Tests` suite green: **13,630 total, 0 failed, 64 skipped** (pre-existing).
