### PR TITLE
Declare selftest fixture tiers so packaged fixtures stop going amber

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,8 +159,11 @@ the alias stub inherits stdout while keeping package identity, which AUMID activ
 **Second gotcha:** a packaged fixture needs *two* declarations, not one. The
 `RequirePackagedTier` gate decides whether the body asserts; `SelfTestFixtureRegistry.TierRequirements`
 decides whether the unpackaged host runs it at all. Skip the second and the fixture self-skips
-into the amber skip inventory on every unpackaged run forever (issue #1154). Consequence worth
-knowing: **`--list-fixtures` is tier-dependent**, and both hosts print
+into the amber skip inventory on every unpackaged run forever (issue #1154). **The gate is not an
+independent identity check** — it and the tier filter share one entry-assembly predicate, so inside
+the packaged host it always returns true; `Packaged_IdentityGuard` failing its
+`PackageRuntime.IsPackaged` / `Package.Current` assertions is what detects a mis-launched packaged
+host. Consequence worth knowing: **`--list-fixtures` is tier-dependent**, and both hosts print
 `# Total not-applicable fixtures:` / `# Not applicable fixture list:` after `# Total failures:`
 so the exclusion is an assertable fact rather than a silent absence.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,7 +144,7 @@ Optionally: a factory method in `src/Reactor/Elements/Dsl.cs`, fluent modifiers 
 |---|---|---|
 | Algorithm, pure function, hook bookkeeping, D3 math | Unit test (xUnit) | `tests/Reactor.Tests/` |
 | Element mount/update against real WinUI controls | Selftest fixture | `tests/Reactor.AppTests.Host/SelfTest/Fixtures/` |
-| Behaviour that differs under MSIX identity (`ms-appx:`, `Package.Current`, MRT, `PackageRuntime.IsPackaged` branches) | Selftest fixture gated with `PackagedIdentityFixtures.RequirePackagedTier` | same folder; runs for real in `tests/Reactor.PackagedTests` |
+| Behaviour that differs under MSIX identity (`ms-appx:`, `Package.Current`, MRT, `PackageRuntime.IsPackaged` branches) | Selftest fixture gated with `PackagedIdentityFixtures.RequirePackagedTier` **and** declared `SelfTestTier.Packaged` | same folder; runs for real in `tests/Reactor.PackagedTests` |
 | Real user input, UIA properties, cross-process | E2E test (winapp ui) | `tests/Reactor.AppTests/Tests/` |
 
 Start with unit tests. Use selftests only when you need a live WinUI control. E2E is the slowest tier.
@@ -156,6 +156,13 @@ adds only MSIX properties plus a `Package.appxmanifest`. The whole corpus runs u
 **Gotcha worth not re-deriving:** the manifest's `uap5:AppExecutionAlias` is load-bearing — launching
 the alias stub inherits stdout while keeping package identity, which AUMID activation cannot do
 (it is brokered, so stdout can't be redirected at all).
+**Second gotcha:** a packaged fixture needs *two* declarations, not one. The
+`RequirePackagedTier` gate decides whether the body asserts; `SelfTestFixtureRegistry.TierRequirements`
+decides whether the unpackaged host runs it at all. Skip the second and the fixture self-skips
+into the amber skip inventory on every unpackaged run forever (issue #1154). Consequence worth
+knowing: **`--list-fixtures` is tier-dependent**, and both hosts print
+`# Total not-applicable fixtures:` / `# Not applicable fixture list:` after `# Total failures:`
+so the exclusion is an assertable fact rather than a silent absence.
 
 ### Console-mutating tests need collection isolation
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -549,11 +549,19 @@ The two steps do different jobs and neither replaces the other. The **declaratio
 *selection*: an undeclared fixture is offered to every tier, so the unpackaged host runs it, hits
 the gate, and emits a skip that lands in the run's amber skip inventory — a permanent entry
 describing a condition that is structural rather than incidental
-([#1154](https://github.com/microsoft/microsoft-ui-reactor/issues/1154)). The **gate** governs
-whether the body *asserts*: if this tier were ever launched without identity, it skips, and
-`IdentityDependentFixtures_Actually_Asserted` turns that into a red. Selection cannot do that job,
-because selection cannot observe identity — it keys off the entry assembly, and the unpackaged
-binary is a different binary.
+([#1154](https://github.com/microsoft/microsoft-ui-reactor/issues/1154)). The **gate** is what
+makes that mistake degrade gracefully: without it the fixture would reach `ApplicationData.Current`
+unpackaged and report an opaque `COMException` instead of a skip that states its reason.
+
+> **The gate is not a second, independent identity check — do not read it as one.** It and the
+> tier filter both call `PackagedIdentityFixtures.IsPackagedTier`, which compares the *entry
+> assembly name* and nothing else. Inside the packaged host it returns true whether or not the
+> process actually has MSIX identity, so the gate can never skip there. A mis-launched packaged
+> host — broken registration, stale alias, running the `.exe` straight out of the build output —
+> is caught by **`Packaged_IdentityGuard`**, which asserts `PackageRuntime.IsPackaged`,
+> `Package.Current` and the install location and **fails** when they don't hold. That failure, and
+> `IdentityDependentFixtures_Actually_Asserted` requiring the guard to have *passed*, is the whole
+> of the identity evidence.
 
 So `--list-fixtures` is **tier-dependent**: the unpackaged host does not list, and does not run,
 the fixtures declared `SelfTestTier.Packaged`. Both hosts print what they excluded, after
@@ -575,7 +583,9 @@ reason a *missing* trailer is never read as a count of zero — that would let a
 reporting satisfy the packaged assertion by silence.
 
 The gate keys off the entry assembly, not `PackageRuntime.IsPackaged`: a fixture that skipped
-whenever identity was missing would report green if this tier ever ran without it.
+whenever identity was missing would treat the fault as an excuse, reporting green where the tier
+should be red. The guard fixture fails instead — which is the behaviour that makes the requirement
+structural.
 
 If a fixture needs the *absence* of identity, `SelfTestTier.Unpackaged` is the mirror declaration;
 nothing uses it yet.

--- a/TESTING.md
+++ b/TESTING.md
@@ -132,7 +132,7 @@ The reliable tell is the module label. A run that started prints the handshake-d
 | An algorithm, pure function, record equality, hook bookkeeping, D3 math — anything that doesn't need a WinUI window | **Unit test** in `tests/Reactor.Tests/` |
 | How an element mounts/updates against a real WinUI control, layout math against real Yoga+XAML, reconciler behavior end-to-end, assertions via `VisualTreeHelper` | **Selftest fixture** in `tests/Reactor.AppTests.Host/SelfTest/Fixtures/` (registered in `SelfTestFixtureRegistry`, wrapped by a `[TestMethod]` in `SelfTestBatch`) |
 | Real user input (clicks, keystrokes, tab navigation), UIA properties as seen by assistive tech, cross-process behavior, XAML Island interop | **E2E test** in `tests/Reactor.AppTests/Tests/` |
-| Anything that changes under **MSIX package identity** — `ms-appx:` resolution, `Package.Current`, MRT lookups, `PackageRuntime.IsPackaged` branches | **Selftest fixture** as above, gated with `PackagedIdentityFixtures.RequirePackagedTier` so it self-skips in the unpackaged tier |
+| Anything that changes under **MSIX package identity** — `ms-appx:` resolution, `Package.Current`, MRT lookups, `PackageRuntime.IsPackaged` branches | **Selftest fixture** as above, gated with `PackagedIdentityFixtures.RequirePackagedTier` **and** declared `SelfTestTier.Packaged` so the unpackaged tier does not run it |
 
 Rule of thumb: start with a unit test. Drop to selftest only when you need a live control. Reach for E2E only when you need cross-process UIA — E2E is the slowest and flakiest tier.
 
@@ -302,12 +302,20 @@ why SKIPPED is not just a politer green. Always put an issue number in the reaso
 one; the reason string is all a reader of the skip report gets. And if you are reaching for a skip
 to silence a flake, fix the flake instead — a skip makes the flake invisible rather than absent.
 
+**"This tier structurally cannot run it" is not on that list, and must not be expressed as a skip.**
+A skip is a per-run observation; tier applicability is a fixed property of the fixture, so a skip
+would restate the same permanent fact on every run and accumulate in the amber inventory — which is
+what [#1154](https://github.com/microsoft/microsoft-ui-reactor/issues/1154) was. Declare the tier in
+`SelfTestFixtureRegistry.TierRequirements` instead and the fixture is simply not selected; see §3.
+
 For raw-TAP consumers (the AOT job pipes `--self-test` straight to a `.tap` artifact and greps
 `^not ok `), the Host emits a `# Total skipped fixtures: N` trailer — placed *after*
 `# Total failures:` so the abort discriminator below is unaffected — followed by
 `# Skipped fixture list: <names>` when non-zero. Each fully-skipped fixture also gets its own
-`# Fully skipped fixture: <name> - N check(s) skipped, 0 assertions ran` line as it happens. The
-three prefixes are deliberately distinct so a grep for one does not match the others.
+`# Fully skipped fixture: <name> - N check(s) skipped, 0 assertions ran` line as it happens.
+Alongside them, and reporting a different thing, come `# Total not-applicable fixtures: N` and
+`# Not applicable fixture list: <names>` (§3) — fixtures that deliberately did **not** run here.
+All five prefixes are deliberately distinct so a grep for one does not match the others.
 
 One fixture, `SelfTestVerdict_OnlySkips_PositiveControl`, is **expected** to be Skipped on every
 run. It asserts nothing on purpose: it is the positive control that proves the SKIPPED verdict
@@ -520,19 +528,57 @@ while still inheriting stdout — so the TAP contract and flags from tier 2 are 
 
 ### Writing a packaged fixture
 
-Fixtures live in the shared corpus (`tests/Reactor.AppTests.Host/SelfTest/Fixtures/`) and gate
-themselves:
+Fixtures live in the shared corpus (`tests/Reactor.AppTests.Host/SelfTest/Fixtures/`). Two steps,
+and both are load-bearing. **Gate** the fixture body:
 
 ```csharp
 if (!PackagedIdentityFixtures.RequirePackagedTier(H, this)) return;
 ```
 
-They run for real here and emit a single TAP skip in the unpackaged tier. Register them with the
-**`Packaged_`** prefix — that is what the shim's `IdentityDependentFixtures_Actually_Asserted`
-guard uses to decide which fixtures must never skip.
+and **declare** its tier in `SelfTestFixtureRegistry.TierRequirements`, beside its entry in
+`AllFixtures`:
+
+```csharp
+["Packaged_MyNewThing"] = SelfTestTier.Packaged,
+```
+
+Register it with the **`Packaged_`** prefix — that is what the shim's
+`IdentityDependentFixtures_Actually_Asserted` guard uses to decide which fixtures must never skip.
+
+The two steps do different jobs and neither replaces the other. The **declaration** governs
+*selection*: an undeclared fixture is offered to every tier, so the unpackaged host runs it, hits
+the gate, and emits a skip that lands in the run's amber skip inventory — a permanent entry
+describing a condition that is structural rather than incidental
+([#1154](https://github.com/microsoft/microsoft-ui-reactor/issues/1154)). The **gate** governs
+whether the body *asserts*: if this tier were ever launched without identity, it skips, and
+`IdentityDependentFixtures_Actually_Asserted` turns that into a red. Selection cannot do that job,
+because selection cannot observe identity — it keys off the entry assembly, and the unpackaged
+binary is a different binary.
+
+So `--list-fixtures` is **tier-dependent**: the unpackaged host does not list, and does not run,
+the fixtures declared `SelfTestTier.Packaged`. Both hosts print what they excluded, after
+`# Total failures:`:
+
+```
+# Total not-applicable fixtures: 3
+# Not applicable fixture list: Packaged_IdentityGuard, Packaged_SettingsStoreRoundTrip, …
+```
+
+That trailer exists because the fix for #1154 was a *removal*, and success and catastrophe produce
+the same observation when you fix something by removing it: "no amber" is what you get whether the
+filter works or whether somebody deleted the packaged corpus. Both shims assert on the trailer,
+and they demand opposite things — `SelfTestBatch.NotApplicableFixtures_AreExcludedFromThisTier`
+requires a non-empty list and that none of those names reached discovery or the run;
+`PackagedSelfTestBatch.EveryFixture_IsApplicableToThePackagedTier` requires **zero**. A tier probe
+stuck on one answer would otherwise look correct from whichever side agreed with it. For the same
+reason a *missing* trailer is never read as a count of zero — that would let a host which stopped
+reporting satisfy the packaged assertion by silence.
 
 The gate keys off the entry assembly, not `PackageRuntime.IsPackaged`: a fixture that skipped
 whenever identity was missing would report green if this tier ever ran without it.
+
+If a fixture needs the *absence* of identity, `SelfTestTier.Unpackaged` is the mirror declaration;
+nothing uses it yet.
 
 ### Scope and knobs
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -587,8 +587,11 @@ whenever identity was missing would treat the fault as an excuse, reporting gree
 should be red. The guard fixture fails instead — which is the behaviour that makes the requirement
 structural.
 
-If a fixture needs the *absence* of identity, `SelfTestTier.Unpackaged` is the mirror declaration;
-nothing uses it yet.
+If a fixture ever needs the *absence* of identity, adding a mirror `SelfTestTier.Unpackaged` is
+deliberately **two** changes, not one: the enum member, and relaxing
+`EveryFixture_IsApplicableToThePackagedTier` — which today requires the packaged host to exclude
+nothing, so the first unpackaged-only fixture would fail it while behaving correctly. Do both at
+once, with a real fixture to pin the contract against.
 
 ### Scope and knobs
 

--- a/tests/Reactor.AppTests.Host/Program.cs
+++ b/tests/Reactor.AppTests.Host/Program.cs
@@ -12,8 +12,14 @@ if (args.Contains("--list-fixtures"))
 {
     // Fast path: emit the selftest fixture registry, one name per line, and exit.
     // Used by Reactor.SelfTests to discover fixtures without launching WinUI.
-    foreach (var name in SelfTestFixtureRegistry.AllFixtures)
+    //
+    // Deliberately the CURRENT TIER's corpus, not the whole registry: a fixture this host
+    // cannot run must not get a test case that could only ever report "skipped" (issue #1154).
+    // The two wrappers' list parsers both drop `#` lines, so the trailer below is inert to
+    // discovery while still naming the exclusions for a human running this by hand.
+    foreach (var name in SelfTestFixtureRegistry.FixturesForCurrentTier)
         Console.WriteLine(name);
+    SelfTestRunner.WriteNotApplicableTrailer();
     return;
 }
 

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/PackagedIdentityFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/PackagedIdentityFixtures.cs
@@ -10,16 +10,26 @@ namespace Microsoft.UI.Reactor.AppTests.Host.SelfTest.Fixtures;
 /// </summary>
 /// <remarks>
 /// <para>These live in the shared fixture corpus rather than in a packaged-only source
-/// set, so the two hosts stay a single body of tests and <c>--list-fixtures</c> agrees
-/// across both tiers. What differs is the <see cref="IsPackagedTier"/> gate below.</para>
+/// set, so the two hosts stay a single body of tests. What differs is <i>selection</i>:
+/// they are declared <c>SelfTestTier.Packaged</c> in
+/// <c>SelfTestFixtureRegistry.TierRequirements</c>, so the unpackaged host neither lists
+/// nor runs them — <c>--list-fixtures</c> is deliberately tier-dependent (issue #1154).
+/// They previously ran everywhere and self-skipped, which restated a permanent structural
+/// fact as a per-run observation and left three entries in the amber skip inventory on
+/// every unpackaged run.</para>
+/// <para><b>The gate below is not redundant with that declaration.</b> Selection cannot
+/// observe identity — it keys off which binary is running, and the packaged host binary is
+/// a different binary. The gate is what catches the packaged host being launched
+/// <i>without</i> identity: a broken registration, a stale alias resolving to something
+/// else, someone running the .exe out of the build output. There the fixtures skip and
+/// <c>PackagedSelfTestBatch.IdentityDependentFixtures_Actually_Asserted</c> turns that into
+/// a red, rather than the suite reporting green while measuring nothing.</para>
 /// <para><b>Why the gate keys off the entry assembly.</b> A fixture that merely skipped
-/// whenever <c>PackageRuntime.IsPackaged</c> was false would be worse than useless: if
-/// the packaged tier ever launched the app without identity — a broken registration, a
-/// stale alias resolving to something else, someone running the .exe out of the build
-/// output — every identity check would quietly skip and the suite would report green
-/// while measuring nothing. That is precisely the failure mode this tier exists to
-/// remove. Keying off the entry assembly instead makes the requirement structural: the
-/// packaged host binary <i>must</i> have identity, and says so by failing.</para>
+/// whenever <c>PackageRuntime.IsPackaged</c> was false would be worse than useless: it
+/// would treat the missing-identity case as an excuse rather than a fault, which is
+/// precisely the failure mode this tier exists to remove. Keying off the entry assembly
+/// instead makes the requirement structural: the packaged host binary <i>must</i> have
+/// identity, and says so by failing.</para>
 /// </remarks>
 internal static class PackagedIdentityFixtures
 {
@@ -48,10 +58,17 @@ internal static class PackagedIdentityFixtures
     /// <c>false</c>.
     /// </summary>
     /// <remarks>
-    /// The skip's check name is derived from <paramref name="fixture"/> rather than passed
+    /// <para>The skip's check name is derived from <paramref name="fixture"/> rather than passed
     /// in, so callers cannot invent three different spellings for the same concept and the
     /// name always points at the fixture a reader has to go look at. Call it as
-    /// <c>RequirePackagedTier(H, this)</c>.
+    /// <c>RequirePackagedTier(H, this)</c>.</para>
+    /// <para><b>On the normal unpackaged path this is unreachable</b>, because the fixture is
+    /// declared <c>SelfTestTier.Packaged</c> and never selected there (issue #1154). It stays
+    /// because it guards a case selection cannot see: the <i>packaged</i> host running without
+    /// package identity. There the skip is what
+    /// <c>PackagedSelfTestBatch.IdentityDependentFixtures_Actually_Asserted</c> converts into a
+    /// failure — so this must keep skipping rather than assert, or that guard would never see
+    /// the condition it exists to report.</para>
     /// </remarks>
     internal static bool RequirePackagedTier(Harness h, SelfTestFixtureBase fixture)
     {

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/PackagedIdentityFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/PackagedIdentityFixtures.cs
@@ -17,13 +17,18 @@ namespace Microsoft.UI.Reactor.AppTests.Host.SelfTest.Fixtures;
 /// They previously ran everywhere and self-skipped, which restated a permanent structural
 /// fact as a per-run observation and left three entries in the amber skip inventory on
 /// every unpackaged run.</para>
-/// <para><b>The gate below is not redundant with that declaration.</b> Selection cannot
-/// observe identity — it keys off which binary is running, and the packaged host binary is
-/// a different binary. The gate is what catches the packaged host being launched
-/// <i>without</i> identity: a broken registration, a stale alias resolving to something
-/// else, someone running the .exe out of the build output. There the fixtures skip and
-/// <c>PackagedSelfTestBatch.IdentityDependentFixtures_Actually_Asserted</c> turns that into
-/// a red, rather than the suite reporting green while measuring nothing.</para>
+/// <para><b>Selection and the gate share one predicate, and that is deliberate.</b> Both
+/// <c>SelfTestFixtureRegistry.CurrentTier</c> and <see cref="RequirePackagedTier"/> read
+/// <see cref="IsPackagedTier"/>, which compares the <i>entry assembly name</i> and nothing
+/// else. So inside the packaged host the gate always returns <c>true</c> and never skips —
+/// including when that host was launched without MSIX identity. The gate is therefore
+/// <b>not</b> an independent identity check, and nothing here should be read as one.</para>
+/// <para><b>What actually catches a mis-launched packaged host is <see cref="IdentityGuard"/></b>
+/// — a broken registration, a stale alias, someone running the .exe straight out of the build
+/// output. It asserts <c>PackageRuntime.IsPackaged</c>, <c>Package.Current</c> and the install
+/// location, and <b>fails</b> when they do not hold;
+/// <c>PackagedSelfTestBatch.IdentityDependentFixtures_Actually_Asserted</c> additionally
+/// requires that fixture to have <i>passed</i>. That is the whole of the identity evidence.</para>
 /// <para><b>Why the gate keys off the entry assembly.</b> A fixture that merely skipped
 /// whenever <c>PackageRuntime.IsPackaged</c> was false would be worse than useless: it
 /// would treat the missing-identity case as an excuse rather than a fault, which is
@@ -62,13 +67,18 @@ internal static class PackagedIdentityFixtures
     /// in, so callers cannot invent three different spellings for the same concept and the
     /// name always points at the fixture a reader has to go look at. Call it as
     /// <c>RequirePackagedTier(H, this)</c>.</para>
-    /// <para><b>On the normal unpackaged path this is unreachable</b>, because the fixture is
-    /// declared <c>SelfTestTier.Packaged</c> and never selected there (issue #1154). It stays
-    /// because it guards a case selection cannot see: the <i>packaged</i> host running without
-    /// package identity. There the skip is what
-    /// <c>PackagedSelfTestBatch.IdentityDependentFixtures_Actually_Asserted</c> converts into a
-    /// failure — so this must keep skipping rather than assert, or that guard would never see
-    /// the condition it exists to report.</para>
+    /// <para><b>The skip arm is unreachable through either tier's runner</b>, and deliberately so.
+    /// In the packaged host <see cref="IsPackagedTier"/> is true, so this returns <c>true</c>
+    /// whether or not the process has MSIX identity — missing identity is reported by
+    /// <see cref="IdentityGuard"/> <i>failing</i>, not by anything here skipping. In the unpackaged
+    /// host the fixture is declared <c>SelfTestTier.Packaged</c> and never selected (issue #1154).
+    /// This is <b>not</b> a second, independent identity check.</para>
+    /// <para>It is kept because it is the safety net for a <i>missing or wrong tier
+    /// declaration</i>, which is the mistake a contributor will actually make. Drop the
+    /// <c>TierRequirements</c> entry and the fixture runs unpackaged again — with the gate it
+    /// degrades to a clean skip plus an amber inventory entry naming the reason, which is the
+    /// "you forgot to declare it" signal; without it, <c>ApplicationData.Current</c> throws and
+    /// the fixture reports an opaque <c>COMException</c> instead.</para>
     /// </remarks>
     internal static bool RequirePackagedTier(Harness h, SelfTestFixtureBase fixture)
     {

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/PackagedIdentityFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/PackagedIdentityFixtures.cs
@@ -18,7 +18,7 @@ namespace Microsoft.UI.Reactor.AppTests.Host.SelfTest.Fixtures;
 /// fact as a per-run observation and left three entries in the amber skip inventory on
 /// every unpackaged run.</para>
 /// <para><b>Selection and the gate share one predicate, and that is deliberate.</b> Both
-/// <c>SelfTestFixtureRegistry.CurrentTier</c> and <see cref="RequirePackagedTier"/> read
+/// <c>SelfTestFixtureRegistry</c>'s tier filter and <see cref="RequirePackagedTier"/> read
 /// <see cref="IsPackagedTier"/>, which compares the <i>entry assembly name</i> and nothing
 /// else. So inside the packaged host the gate always returns <c>true</c> and never skips —
 /// including when that host was launched without MSIX identity. The gate is therefore

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/TierDeclarationConsistencyFixture.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/TierDeclarationConsistencyFixture.cs
@@ -1,0 +1,55 @@
+using System.Threading.Tasks;
+
+namespace Microsoft.UI.Reactor.AppTests.Host.SelfTest.Fixtures;
+
+/// <summary>
+/// Asserts that <c>SelfTestFixtureRegistry.TierRequirements</c> only declares tiers for fixtures
+/// that still exist (issue #1154).
+///
+/// <para><b>Why a stale declaration is dangerous rather than untidy.</b> Both tier-filtered
+/// corpora are built by scanning <c>AllFixtures</c>, so a key naming a fixture that has been
+/// deleted from that array is <i>invisible</i> to every other guard in the mechanism. The
+/// unpackaged exclusion trailer simply drops from 3 to 2 — still satisfying
+/// <c>SelfTestBatch.NotApplicableFixtures_AreExcludedFromThisTier</c>'s "at least one" — and the
+/// packaged trailer stays 0, so both of those assertions pass while a fixture has silently
+/// vanished from the corpus. Silent partial deletion is exactly the failure this mechanism exists
+/// to make visible, and without this check it would walk straight through it.</para>
+///
+/// <para><b>Why it is a fixture rather than a wrapper test.</b> The registry is <c>internal</c> to
+/// this Host, and both <c>Reactor.SelfTests</c> and <c>Reactor.PackagedTests</c> reference the
+/// Host with <c>ReferenceOutputAssembly=false</c> — they drive it as a subprocess and never link
+/// against it. A fixture is the only code that can read the map, and it has the useful property of
+/// running in <i>both</i> tiers.</para>
+/// </summary>
+internal class TierDeclarationConsistencyFixture(Harness h) : SelfTestFixtureBase(h)
+{
+    /// <summary>Registered name; see <c>SelfTestFixtureRegistry.AllFixtures</c>.</summary>
+    public const string FixtureName = "SelfTestRegistry_TierDeclarationsMatchCorpus";
+
+    public override Task RunAsync()
+    {
+        var stale = SelfTestFixtureRegistry.StaleTierDeclarations();
+
+        if (stale.Length > 0)
+        {
+            // Named individually rather than counted: the whole point is to say which declaration
+            // outlived its fixture, because the reader's next question is "was that fixture
+            // deleted on purpose, or renamed and half-updated?".
+            Console.WriteLine(
+                "# Stale TierRequirements keys (declared, but absent from AllFixtures): " +
+                string.Join(", ", stale));
+        }
+
+        H.Check("TierDeclarations_AllNameALiveFixture", stale.Length == 0);
+
+        // A second, independent reading rather than a restatement: the first check can only fail,
+        // never confirm the map is doing anything. If TierRequirements were emptied, the check
+        // above would still pass — vacuously — while the tier mechanism silently stopped
+        // excluding anything. This asserts the map is non-empty, so "no stale keys" is a
+        // statement about a live map rather than about nothing at all.
+        H.Check("TierDeclarations_MapIsNotEmpty",
+            SelfTestFixtureRegistry.DeclaredTierFixtureCount > 0);
+
+        return Task.CompletedTask;
+    }
+}

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -1744,6 +1744,9 @@ internal static class SelfTestFixtureRegistry
         // Positive control for the three-state verdict (issue #1061). Asserts nothing on purpose;
         // its SKIPPED result is what SelfTestBatch.SkippedFixtures_AreReported checks for.
         SkipVerdictPositiveControl.FixtureName,
+
+        // Guards TierRequirements below against outliving its fixtures (issue #1154).
+        TierDeclarationConsistencyFixture.FixtureName,
     ];
 
     // ════════════════════════════════════════════════════════════════════
@@ -1752,15 +1755,21 @@ internal static class SelfTestFixtureRegistry
 
     /// <summary>
     /// Which host a fixture needs. <see cref="SelfTestTier.Any"/> — the overwhelming default —
-    /// means "runs everywhere"; the other two mean the fixture is <b>structurally</b> unable to
-    /// assert anywhere else.
+    /// means "runs everywhere"; <see cref="SelfTestTier.Packaged"/> means the fixture is
+    /// <b>structurally</b> unable to assert in the unpackaged host.
     /// </summary>
     /// <remarks>
-    /// <see cref="SelfTestTier.Unpackaged"/> is unused today and is defined because the concept is
-    /// symmetric, not speculatively: Reactor branches on <c>PackageRuntime.IsPackaged</c> in both
-    /// directions (<c>FileSettingsStore</c> is the mirror of <c>PackagedSettingsStore</c>), so the
-    /// opposite gate is one declaration away. It costs no extra code path — the test is
-    /// <c>required == Any || required == current</c>.
+    /// <para><b>There is deliberately no <c>Unpackaged</c> member</b>, although the concept is
+    /// symmetric and Reactor does branch on <c>PackageRuntime.IsPackaged</c> in both directions.
+    /// An earlier revision defined one "because it costs no extra code path"; that was wrong.
+    /// <c>PackagedSelfTestBatch.EveryFixture_IsApplicableToThePackagedTier</c> requires the
+    /// packaged host to exclude <b>nothing</b>, so the first legitimately unpackaged-only fixture
+    /// would fail that assertion while behaving perfectly — an enum member that cannot be used
+    /// without breaking a test in another project, and one nothing here could test today because
+    /// no such fixture exists.</para>
+    /// <para>Adding it later is a small change, but it is <i>two</i> changes: this enum, and
+    /// relaxing that packaged assertion to reject only excluded <see cref="SelfTestTier.Packaged"/>
+    /// fixtures. Do both at once, with a real fixture to pin the contract against.</para>
     /// </remarks>
     internal enum SelfTestTier
     {
@@ -1769,9 +1778,6 @@ internal static class SelfTestFixtureRegistry
 
         /// <summary>Needs MSIX package identity; only <c>Reactor.PackagedTests</c> can run it.</summary>
         Packaged,
-
-        /// <summary>Needs the absence of package identity; only the unpackaged host can run it.</summary>
-        Unpackaged,
     }
 
     /// <summary>
@@ -1788,12 +1794,17 @@ internal static class SelfTestFixtureRegistry
     /// <para><b>Keep the runtime gate too, but not because it re-checks identity.</b> A fixture
     /// declared here must still call <c>PackagedIdentityFixtures.RequirePackagedTier</c> — yet
     /// that gate reads the <i>same</i> <c>IsPackagedTier</c> entry-assembly predicate
-    /// <see cref="CurrentTier"/> does, so once selection admits a fixture the gate necessarily
-    /// returns true. It is not an independent identity check, and a mis-launched packaged host is
-    /// caught by <c>Packaged_IdentityGuard</c> failing its <c>PackageRuntime.IsPackaged</c> /
-    /// <c>Package.Current</c> assertions instead. The gate earns its place as the safety net for
-    /// a <i>missing</i> declaration: delete an entry from this map and the fixture degrades to a
-    /// clean skip with a stated reason rather than an opaque <c>COMException</c>.</para>
+    /// <see cref="AppliesToCurrentTier"/> does, so once selection admits a fixture the gate
+    /// necessarily returns true. It is not an independent identity check, and a mis-launched
+    /// packaged host is caught by <c>Packaged_IdentityGuard</c> failing its
+    /// <c>PackageRuntime.IsPackaged</c> / <c>Package.Current</c> assertions instead. The gate
+    /// earns its place as the safety net for a <i>missing</i> declaration: delete an entry from
+    /// this map and the fixture degrades to a clean skip with a stated reason rather than an
+    /// opaque <c>COMException</c>.</para>
+    ///
+    /// <para>Every key must also name a live entry in <see cref="AllFixtures"/> — see
+    /// <see cref="StaleTierDeclarations"/> for why a stale one is invisible to every other guard
+    /// here.</para>
     /// </summary>
     private static readonly Dictionary<string, SelfTestTier> TierRequirements =
         new(StringComparer.Ordinal)
@@ -1804,23 +1815,54 @@ internal static class SelfTestFixtureRegistry
         };
 
     /// <summary>
-    /// The tier this process is. Derived from <c>PackagedIdentityFixtures.IsPackagedTier</c>, the
-    /// same entry-assembly probe <c>RequirePackagedTier</c> uses — so selection and that gate are
-    /// one predicate, not two independent ones. Neither observes MSIX identity;
-    /// <c>Packaged_IdentityGuard</c> is what does.
+    /// The tier <paramref name="fixture"/> requires; <see cref="SelfTestTier.Any"/> when undeclared.
     /// </summary>
-    internal static SelfTestTier CurrentTier =>
-        PackagedIdentityFixtures.IsPackagedTier ? SelfTestTier.Packaged : SelfTestTier.Unpackaged;
-
-    /// <summary>The tier <paramref name="fixture"/> requires; <see cref="SelfTestTier.Any"/> when undeclared.</summary>
     internal static SelfTestTier RequiredTier(string fixture) =>
         TierRequirements.TryGetValue(fixture, out var tier) ? tier : SelfTestTier.Any;
 
-    private static bool AppliesToCurrentTier(string fixture)
-    {
-        var required = RequiredTier(fixture);
-        return required == SelfTestTier.Any || required == CurrentTier;
-    }
+    /// <summary>
+    /// Whether this host runs <paramref name="fixture"/>.
+    /// </summary>
+    /// <remarks>
+    /// Keys off <c>PackagedIdentityFixtures.IsPackagedTier</c> — the <i>same</i> entry-assembly
+    /// probe <c>RequirePackagedTier</c> uses, so selection and that gate are one predicate rather
+    /// than two independent ones. Neither observes MSIX identity; <c>Packaged_IdentityGuard</c>
+    /// is what does.
+    /// </remarks>
+    private static bool AppliesToCurrentTier(string fixture) =>
+        RequiredTier(fixture) switch
+        {
+            SelfTestTier.Packaged => PackagedIdentityFixtures.IsPackagedTier,
+            _ => true,
+        };
+
+    /// <summary>
+    /// Names in <see cref="TierRequirements"/> that are not in <see cref="AllFixtures"/>, i.e.
+    /// declarations for fixtures that no longer exist. Empty is the healthy answer.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>Why a stale key is worse than dead weight.</b> Both filtered corpora scan
+    /// <see cref="AllFixtures"/>, so a key naming a deleted fixture is <i>invisible</i> to every
+    /// other guard in this mechanism: the unpackaged trailer just drops from 3 to 2 — still
+    /// satisfying <c>NotApplicableFixtures_AreExcludedFromThisTier</c>'s <c>&gt; 0</c> — and the
+    /// packaged trailer stays 0, so both new assertions pass while a fixture has silently
+    /// vanished from the corpus. That is precisely the partial-deletion case this whole
+    /// mechanism exists to make visible, and it would have walked straight through it.</para>
+    /// <para>Asserted by the <c>SelfTestRegistry_TierDeclarationsMatchCorpus</c> fixture, which
+    /// runs in both tiers.</para>
+    /// </remarks>
+    internal static string[] StaleTierDeclarations() =>
+        TierRequirements.Keys
+            .Where(name => Array.IndexOf(AllFixtures, name) < 0)
+            .OrderBy(name => name, StringComparer.Ordinal)
+            .ToArray();
+
+    /// <summary>
+    /// How many fixtures carry a tier declaration. Exposed so
+    /// <c>SelfTestRegistry_TierDeclarationsMatchCorpus</c> can assert the map is non-empty —
+    /// without that, its "no stale keys" check would pass vacuously against an emptied map.
+    /// </summary>
+    internal static int DeclaredTierFixtureCount => TierRequirements.Count;
 
     /// <summary>
     /// The corpus this host actually runs. Both <c>--self-test</c> and <c>--list-fixtures</c> use
@@ -3511,6 +3553,7 @@ internal static class SelfTestFixtureRegistry
         "CmdBarFlyout_TargetKeepsItsOwnCallbacks" => new CommandBarFlyoutWiringFixtures.TargetKeepsItsOwnCallbacks(harness),
 
         SkipVerdictPositiveControl.FixtureName => new SkipVerdictPositiveControl(harness),
+        TierDeclarationConsistencyFixture.FixtureName => new TierDeclarationConsistencyFixture(harness),
 
         _ => null,
     };

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -1220,8 +1220,8 @@ internal static class SelfTestFixtureRegistry
         // Spec 036 — Window model live-shell coverage
         "WindowModel_LifecycleEvents",
         "WindowModel_WindowIconApplied",
-        // Packaged (MSIX) tier. These self-skip in the unpackaged host;
-        // Reactor.PackagedTests runs them with real package identity.
+        // Packaged (MSIX) tier. Declared SelfTestTier.Packaged in TierRequirements below, so the
+        // unpackaged host does not run them at all — see issue #1154.
         "Packaged_IdentityGuard",
         "Packaged_SettingsStoreRoundTrip",
         "Packaged_WindowIconFromResource",
@@ -1745,6 +1745,99 @@ internal static class SelfTestFixtureRegistry
         // its SKIPPED result is what SelfTestBatch.SkippedFixtures_AreReported checks for.
         SkipVerdictPositiveControl.FixtureName,
     ];
+
+    // ════════════════════════════════════════════════════════════════════
+    //  Tier applicability
+    // ════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// Which host a fixture needs. <see cref="SelfTestTier.Any"/> — the overwhelming default —
+    /// means "runs everywhere"; the other two mean the fixture is <b>structurally</b> unable to
+    /// assert anywhere else.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="SelfTestTier.Unpackaged"/> is unused today and is defined because the concept is
+    /// symmetric, not speculatively: Reactor branches on <c>PackageRuntime.IsPackaged</c> in both
+    /// directions (<c>FileSettingsStore</c> is the mirror of <c>PackagedSettingsStore</c>), so the
+    /// opposite gate is one declaration away. It costs no extra code path — the test is
+    /// <c>required == Any || required == current</c>.
+    /// </remarks>
+    internal enum SelfTestTier
+    {
+        /// <summary>Runs in every tier. The default for a fixture with no declaration.</summary>
+        Any,
+
+        /// <summary>Needs MSIX package identity; only <c>Reactor.PackagedTests</c> can run it.</summary>
+        Packaged,
+
+        /// <summary>Needs the absence of package identity; only the unpackaged host can run it.</summary>
+        Unpackaged,
+    }
+
+    /// <summary>
+    /// Fixtures that only apply to one tier. Everything absent from this map is
+    /// <see cref="SelfTestTier.Any"/>.
+    ///
+    /// <para><b>This is the declaration that removes a fixture from the other tier's corpus
+    /// entirely</b> — it is not run there, emits no TAP, and gets no test case. Before issue #1154
+    /// these fixtures ran everywhere and self-skipped, which put three permanent entries in
+    /// <c>SkippedFixtures_AreReported</c>'s amber inventory on every unpackaged run: a channel
+    /// whose value depends on being rare, describing a condition that is structural rather than
+    /// incidental. Declaring the requirement says the same thing once, as data.</para>
+    ///
+    /// <para><b>Keep the runtime gate too.</b> A fixture declared here must still call
+    /// <c>PackagedIdentityFixtures.RequirePackagedTier</c>: this map governs <i>selection</i>,
+    /// the gate governs whether the body <i>asserts</i>, and the two are deliberately
+    /// independent. If the packaged host is ever launched without identity the gate skips and
+    /// <c>PackagedSelfTestBatch.IdentityDependentFixtures_Actually_Asserted</c> turns that into a
+    /// red — which a selection-only mechanism could not do, because selection cannot observe
+    /// identity.</para>
+    /// </summary>
+    private static readonly Dictionary<string, SelfTestTier> TierRequirements =
+        new(StringComparer.Ordinal)
+        {
+            ["Packaged_IdentityGuard"] = SelfTestTier.Packaged,
+            ["Packaged_SettingsStoreRoundTrip"] = SelfTestTier.Packaged,
+            ["Packaged_WindowIconFromResource"] = SelfTestTier.Packaged,
+        };
+
+    /// <summary>The tier this process is, derived from the same entry-assembly probe the fixtures use.</summary>
+    internal static SelfTestTier CurrentTier =>
+        PackagedIdentityFixtures.IsPackagedTier ? SelfTestTier.Packaged : SelfTestTier.Unpackaged;
+
+    /// <summary>The tier <paramref name="fixture"/> requires; <see cref="SelfTestTier.Any"/> when undeclared.</summary>
+    internal static SelfTestTier RequiredTier(string fixture) =>
+        TierRequirements.TryGetValue(fixture, out var tier) ? tier : SelfTestTier.Any;
+
+    private static bool AppliesToCurrentTier(string fixture)
+    {
+        var required = RequiredTier(fixture);
+        return required == SelfTestTier.Any || required == CurrentTier;
+    }
+
+    /// <summary>
+    /// The corpus this host actually runs. Both <c>--self-test</c> and <c>--list-fixtures</c> use
+    /// it, so discovery and execution cannot disagree about the set.
+    /// </summary>
+    /// <remarks>
+    /// A property rather than a cached <c>static readonly</c> array on purpose: the cached form
+    /// would silently depend on being declared textually after <see cref="AllFixtures"/> and
+    /// <see cref="TierRequirements"/>, and moving either — an ordinary-looking edit in a 3000-line
+    /// registry — would evaluate it against a null array or an empty map and quietly return the
+    /// wrong corpus. Recomputing costs one scan of ~1500 strings, on the two or three calls a
+    /// process makes, against a suite measured in minutes.
+    /// </remarks>
+    public static string[] FixturesForCurrentTier => Array.FindAll(AllFixtures, AppliesToCurrentTier);
+
+    /// <summary>
+    /// The corpus this host deliberately does <b>not</b> run, named so the exclusion is a reported
+    /// fact rather than a silent absence. The Host prints these as a TAP trailer and both wrappers
+    /// assert on them: the unpackaged one that they really were excluded, the packaged one that
+    /// this list is <i>empty</i> — because a packaged run that filtered its identity fixtures out
+    /// would go green having measured nothing.
+    /// </summary>
+    public static string[] FixturesNotApplicableToCurrentTier =>
+        Array.FindAll(AllFixtures, name => !AppliesToCurrentTier(name));
 
     public static SelfTestFixtureBase? Create(string name, Harness harness) => name switch
     {

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -1785,13 +1785,15 @@ internal static class SelfTestFixtureRegistry
     /// whose value depends on being rare, describing a condition that is structural rather than
     /// incidental. Declaring the requirement says the same thing once, as data.</para>
     ///
-    /// <para><b>Keep the runtime gate too.</b> A fixture declared here must still call
-    /// <c>PackagedIdentityFixtures.RequirePackagedTier</c>: this map governs <i>selection</i>,
-    /// the gate governs whether the body <i>asserts</i>, and the two are deliberately
-    /// independent. If the packaged host is ever launched without identity the gate skips and
-    /// <c>PackagedSelfTestBatch.IdentityDependentFixtures_Actually_Asserted</c> turns that into a
-    /// red — which a selection-only mechanism could not do, because selection cannot observe
-    /// identity.</para>
+    /// <para><b>Keep the runtime gate too, but not because it re-checks identity.</b> A fixture
+    /// declared here must still call <c>PackagedIdentityFixtures.RequirePackagedTier</c> — yet
+    /// that gate reads the <i>same</i> <c>IsPackagedTier</c> entry-assembly predicate
+    /// <see cref="CurrentTier"/> does, so once selection admits a fixture the gate necessarily
+    /// returns true. It is not an independent identity check, and a mis-launched packaged host is
+    /// caught by <c>Packaged_IdentityGuard</c> failing its <c>PackageRuntime.IsPackaged</c> /
+    /// <c>Package.Current</c> assertions instead. The gate earns its place as the safety net for
+    /// a <i>missing</i> declaration: delete an entry from this map and the fixture degrades to a
+    /// clean skip with a stated reason rather than an opaque <c>COMException</c>.</para>
     /// </summary>
     private static readonly Dictionary<string, SelfTestTier> TierRequirements =
         new(StringComparer.Ordinal)
@@ -1801,7 +1803,12 @@ internal static class SelfTestFixtureRegistry
             ["Packaged_WindowIconFromResource"] = SelfTestTier.Packaged,
         };
 
-    /// <summary>The tier this process is, derived from the same entry-assembly probe the fixtures use.</summary>
+    /// <summary>
+    /// The tier this process is. Derived from <c>PackagedIdentityFixtures.IsPackagedTier</c>, the
+    /// same entry-assembly probe <c>RequirePackagedTier</c> uses — so selection and that gate are
+    /// one predicate, not two independent ones. Neither observes MSIX identity;
+    /// <c>Packaged_IdentityGuard</c> is what does.
+    /// </summary>
     internal static SelfTestTier CurrentTier =>
         PackagedIdentityFixtures.IsPackagedTier ? SelfTestTier.Packaged : SelfTestTier.Unpackaged;
 
@@ -1833,8 +1840,12 @@ internal static class SelfTestFixtureRegistry
     /// The corpus this host deliberately does <b>not</b> run, named so the exclusion is a reported
     /// fact rather than a silent absence. The Host prints these as a TAP trailer and both wrappers
     /// assert on them: the unpackaged one that they really were excluded, the packaged one that
-    /// this list is <i>empty</i> — because a packaged run that filtered its identity fixtures out
-    /// would go green having measured nothing.
+    /// this list is <i>empty</i>. The packaged direction is a narrower guard than it first looks —
+    /// dropping the <i>whole</i> identity set is already caught by
+    /// <c>IdentityDependentFixtures_Actually_Asserted</c>, which fails when
+    /// <c>Packaged_IdentityGuard</c> is missing. What it adds is the selectively-misdeclared case
+    /// (a non-guard fixture dropped while the guard survives) and proof that the trailer itself
+    /// still works.
     /// </summary>
     public static string[] FixturesNotApplicableToCurrentTier =>
         Array.FindAll(AllFixtures, name => !AppliesToCurrentTier(name));

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestRunner.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestRunner.cs
@@ -90,6 +90,51 @@ internal static class SelfTestRunner
     /// </remarks>
     internal const string SuiteElapsedMarker = "# Suite elapsed: ";
 
+    /// <summary>
+    /// TAP comment for the count of fixtures this tier deliberately did not run:
+    /// <c># Total not-applicable fixtures: &lt;n&gt;</c>, followed by
+    /// <see cref="NotApplicableListMarker"/> when non-zero.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>Why an absence gets a trailer.</b> Issue #1154 removed three <c>Packaged_*</c>
+    /// fixtures from the unpackaged corpus rather than letting them self-skip into the amber
+    /// inventory. But "the fixtures are not here" and "the fixtures were deleted" look identical
+    /// from outside, and so do "the tier filter works" and "the tier filter silently matched
+    /// nothing". Naming the excluded set turns the exclusion into an observation both wrappers
+    /// can assert on — the unpackaged one that it happened, the packaged one that it did
+    /// <i>not</i>.</para>
+    /// <para>Emitted after <c># Total failures:</c>, for the same reason the skip trailer is:
+    /// that line is the documented "the Host reached the end of its run" discriminator. The
+    /// prefixes are deliberately distinct from <c># Total skipped fixtures:</c> /
+    /// <c># Skipped fixture list:</c> so a grep for one cannot match the other. Both literals are
+    /// duplicated in the two wrappers, which cannot reference this assembly
+    /// (<c>ReferenceOutputAssembly=false</c>) — change one, change all three.</para>
+    /// </remarks>
+    internal const string NotApplicableCountMarker = "# Total not-applicable fixtures: ";
+
+    /// <summary>
+    /// TAP comment listing the excluded fixture names, comma-separated. See
+    /// <see cref="NotApplicableCountMarker"/>.
+    /// </summary>
+    internal const string NotApplicableListMarker = "# Not applicable fixture list: ";
+
+    /// <summary>
+    /// Reports the fixtures this tier does not run. Shared by <c>--self-test</c> and
+    /// <c>--list-fixtures</c> so the two can never disagree about the exclusion.
+    /// </summary>
+    /// <remarks>
+    /// Reports the whole tier-excluded set regardless of <see cref="Filter"/>: applicability is a
+    /// property of the tier, and a <c>--filter</c> run narrowing this list would make the
+    /// wrappers' assertions depend on which subset happened to be selected.
+    /// </remarks>
+    internal static void WriteNotApplicableTrailer()
+    {
+        var excluded = SelfTestFixtureRegistry.FixturesNotApplicableToCurrentTier;
+        Console.WriteLine(NotApplicableCountMarker + excluded.Length);
+        if (excluded.Length > 0)
+            Console.WriteLine(NotApplicableListMarker + string.Join(", ", excluded));
+    }
+
     private static TimeSpan ResolveHangTimeout()
     {
         var env = Environment.GetEnvironmentVariable("REACTOR_SELFTEST_HANG_TIMEOUT_SECONDS");
@@ -339,12 +384,21 @@ internal static class SelfTestRunner
                     // committed skip is a configuration error, so it aborts the run
                     // via the catch below rather than being reported as a result.
                     // Validated against the full registry, not `fixtures`, so a
-                    // --filter run doesn't flag every unrelated pattern.
+                    // --filter run doesn't flag every unrelated pattern. It stays the
+                    // FULL registry rather than the tier's slice for the same reason:
+                    // a pattern naming a fixture this tier doesn't run is still a valid
+                    // pattern, not a stale one.
                     ValidateDefaultSkipPatterns(allFixtures);
 
+                    // The tier's corpus, not the registry's. A fixture declared for the other
+                    // tier is structurally unable to assert here, so it is not run at all —
+                    // rather than run and self-skip, which put a permanent amber entry in the
+                    // run's skip inventory on every run (issue #1154).
+                    var tierFixtures = SelfTestFixtureRegistry.FixturesForCurrentTier;
+
                     var fixtures = Filter is not null
-                        ? allFixtures.Where(f => f.Contains(Filter, StringComparison.OrdinalIgnoreCase)).ToArray()
-                        : allFixtures;
+                        ? tierFixtures.Where(f => f.Contains(Filter, StringComparison.OrdinalIgnoreCase)).ToArray()
+                        : tierFixtures;
                     harness.SetupTitleBar(fixtures.Length);
                     window.Activate();
                     await Harness.Render(); // wait for initial layout
@@ -550,6 +604,7 @@ internal static class SelfTestRunner
                     Console.WriteLine($"# Total skipped fixtures: {skippedFixtures.Count}");
                     if (skippedFixtures.Count > 0)
                         Console.WriteLine($"# Skipped fixture list: {string.Join(", ", skippedFixtures)}");
+                    WriteNotApplicableTrailer();
                     Console.WriteLine(SuiteElapsedMarker +
                         Stopwatch.GetElapsedTime(suiteStart).TotalSeconds
                             .ToString("F1", global::System.Globalization.CultureInfo.InvariantCulture));

--- a/tests/Reactor.AppTests.Host/probe-aot-skips.ps1
+++ b/tests/Reactor.AppTests.Host/probe-aot-skips.ps1
@@ -40,8 +40,10 @@ $patterns = [regex]::Matches($skipBlockMatch.Groups[1].Value, '"([^"]+)"') | For
 $exactPatterns = $patterns | Where-Object { -not $_.EndsWith('*') }
 $wildcardPatterns = $patterns | Where-Object { $_.EndsWith('*') }
 
-# Get full fixture list once.
-$allFixtures = & $exe --list-fixtures | Where-Object { $_ -match '\S' }
+# Get this tier's fixture list once. TAP comments are dropped: --list-fixtures ends with the
+# tier-exclusion trailer (issue #1154), and a '#' line reaching the wildcard expansion below
+# would be probed as though it were a fixture name.
+$allFixtures = & $exe --list-fixtures | Where-Object { $_ -match '\S' -and $_ -notmatch '^\s*#' }
 
 # Expand wildcards against the fixture registry.
 $fixturesToTest = New-Object System.Collections.Generic.HashSet[string]

--- a/tests/Reactor.PackagedTests/PackagedHarnessTests.cs
+++ b/tests/Reactor.PackagedTests/PackagedHarnessTests.cs
@@ -310,6 +310,26 @@ public class PackagedHarnessTests
         Assert.IsNull(report.Count);
     }
 
+    /// <summary>
+    /// Two trailers in one buffer is this shim's <i>normal</i> case — <c>_fullOutput</c> holds the
+    /// main run and, under a narrow filter, the identity-guard second pass. A zero trailer omits
+    /// its list line, so a parser that only overwrites the names when it sees a list would let the
+    /// earlier trailer's entries survive and report "zero exclusions" alongside a stale list.
+    /// </summary>
+    [TestMethod]
+    public void Not_Applicable_Zero_Trailer_Clears_Earlier_Names()
+    {
+        var report = PackagedSelfTestBatch.ExtractNotApplicableFixtures(
+            PackagedSelfTestBatch.NotApplicableCountMarker + "2\n" +
+            PackagedSelfTestBatch.NotApplicableListMarker + "Packaged_IdentityGuard, Packaged_Other\n" +
+            "--- identity guard pass ---\n" +
+            PackagedSelfTestBatch.NotApplicableCountMarker + "0\n");
+
+        Assert.AreEqual(0, report.Count);
+        Assert.AreEqual(0, report.Names.Count,
+            $"Stale names survived a later zero trailer: {string.Join(", ", report.Names)}");
+    }
+
     // ── Host-directory override ────────────────────────────────────────
 
     /// <summary>

--- a/tests/Reactor.PackagedTests/PackagedHarnessTests.cs
+++ b/tests/Reactor.PackagedTests/PackagedHarnessTests.cs
@@ -242,6 +242,74 @@ public class PackagedHarnessTests
         CollectionAssert.AreEqual(new[] { "Packaged_One", "packaged_three" }, names);
     }
 
+    // ── Tier applicability (issue #1154) ───────────────────────────────
+
+    /// <summary>
+    /// The distinction <c>EveryFixture_IsApplicableToThePackagedTier</c> rests on. That assertion
+    /// demands a count of <b>zero</b>, so if a missing trailer parsed as zero, a host that stopped
+    /// reporting altogether would satisfy it by silence — this tier would go green having
+    /// established nothing about whether it ran its identity fixtures at all, which is the exact
+    /// failure mode the tier exists to remove.
+    /// </summary>
+    [TestMethod]
+    public void Not_Applicable_Trailer_Absent_Is_Not_Zero()
+    {
+        const string run = "# Running: F\nok F_Check\n# Total failures: 0\n";
+
+        var missing = PackagedSelfTestBatch.ExtractNotApplicableFixtures(run);
+        var zero = PackagedSelfTestBatch.ExtractNotApplicableFixtures(
+            run + PackagedSelfTestBatch.NotApplicableCountMarker + "0\n");
+
+        Assert.IsNull(missing.Count, "Absent trailer must not be reported as a count.");
+        Assert.AreEqual(0, zero.Count, "An explicit zero is a measurement, not an absence.");
+    }
+
+    /// <summary>
+    /// Names have to survive, because the failure message is the only thing that tells a reader
+    /// <i>which</i> fixtures the packaged host decided it could not run — and the answer is
+    /// almost certainly the identity set.
+    /// </summary>
+    [TestMethod]
+    public void Not_Applicable_Trailer_Names_Are_Parsed()
+    {
+        var report = PackagedSelfTestBatch.ExtractNotApplicableFixtures(
+            PackagedSelfTestBatch.NotApplicableCountMarker + "2\n" +
+            PackagedSelfTestBatch.NotApplicableListMarker +
+            "Packaged_IdentityGuard, Packaged_SettingsStoreRoundTrip\n");
+
+        Assert.AreEqual(2, report.Count);
+        CollectionAssert.AreEqual(
+            new[] { "Packaged_IdentityGuard", "Packaged_SettingsStoreRoundTrip" },
+            report.Names.ToArray());
+    }
+
+    /// <summary>
+    /// The skip trailers sit two lines above the exclusion trailer in the same stream and share
+    /// its shape. Reading one as the other would let a run with a single skipped fixture report a
+    /// non-zero exclusion count and redden this tier for the wrong reason.
+    /// </summary>
+    [TestMethod]
+    public void Skip_Trailers_Are_Not_The_Not_Applicable_Trailer()
+    {
+        var report = PackagedSelfTestBatch.ExtractNotApplicableFixtures(
+            "# Total skipped fixtures: 1\n# Skipped fixture list: Some_Fixture\n");
+
+        Assert.IsNull(report.Count);
+    }
+
+    /// <summary>
+    /// A garbled count must not default to zero: zero is the answer this tier wants to hear, so a
+    /// malformed line must not be able to supply it.
+    /// </summary>
+    [TestMethod]
+    public void Not_Applicable_Malformed_Count_Is_Not_Zero()
+    {
+        var report = PackagedSelfTestBatch.ExtractNotApplicableFixtures(
+            PackagedSelfTestBatch.NotApplicableCountMarker + "several\n");
+
+        Assert.IsNull(report.Count);
+    }
+
     // ── Host-directory override ────────────────────────────────────────
 
     /// <summary>

--- a/tests/Reactor.PackagedTests/PackagedSelfTestBatch.cs
+++ b/tests/Reactor.PackagedTests/PackagedSelfTestBatch.cs
@@ -192,18 +192,18 @@ public class PackagedSelfTestBatch
     /// The tier's own anti-vacuity gate.
     /// </summary>
     /// <remarks>
-    /// Every identity-dependent fixture self-skips when it is not running in the packaged
-    /// host, which is what lets the corpus stay shared between the two tiers. That skip is
-    /// correct in the unpackaged tier and catastrophic here: if this tier ever launched the
-    /// host without identity, the fixtures would skip, <c>Fixture</c> would report
-    /// Inconclusive rather than failed, and the suite would look fine while measuring
-    /// nothing. This asserts they actually ran assertions, so "the packaged tier did not run
-    /// packaged" can only ever surface as a failure.
-    /// <para>Checked across <b>every</b> <c>Packaged_</c> fixture rather than just the guard:
-    /// those fixtures are structurally identity-dependent (they all gate on
-    /// <c>RequirePackagedTier</c>), so a skip in the packaged host is always a bug, and
-    /// pinning the assertion to one hardcoded name left every fixture added later
-    /// unprotected.</para>
+    /// <para>The load-bearing half is the guard's <b>verdict</b>. <c>Packaged_IdentityGuard</c>
+    /// asserts <c>PackageRuntime.IsPackaged</c>, <c>Package.Current</c> and the install location,
+    /// so a tier launched without MSIX identity — from the build output rather than through the
+    /// execution alias — makes it <i>fail</i>. Requiring it to be present and Passed is what
+    /// stops "the packaged tier did not run packaged" from reporting green.</para>
+    /// <para><b>The skip sweep below is a backstop, not the identity check.</b>
+    /// <c>RequirePackagedTier</c> keys off the entry-assembly name, so inside this host it returns
+    /// true whether or not the process has identity and cannot produce a skip here. The sweep
+    /// therefore catches a different class: a <c>Packaged_</c> fixture that asserted nothing for
+    /// some other reason — an environmental skip added later, or the gate's semantics changing
+    /// under it. Checked across every <c>Packaged_</c> fixture rather than one hardcoded name, so
+    /// fixtures added later are covered too.</para>
     /// </remarks>
     [TestMethod]
     public void IdentityDependentFixtures_Actually_Asserted()
@@ -234,8 +234,10 @@ public class PackagedSelfTestBatch
             0, skipped.Length,
             $"These identity-dependent fixtures skipped inside the packaged tier, so they " +
             $"asserted nothing:\n  {string.Join("\n  ", skipped)}\n" +
-            "A fixture gated on RequirePackagedTier must always run here — a skip means the " +
-            "host lacked package identity or the gate itself is broken.");
+            "A fixture declared SelfTestTier.Packaged must always assert here. Note this cannot " +
+            "be the RequirePackagedTier gate firing — it keys off the entry-assembly name, which " +
+            "matches in this host regardless of identity — so look for an environmental skip " +
+            "inside the fixture, or a change to the gate's semantics.");
     }
 
     /// <summary>
@@ -245,17 +247,20 @@ public class PackagedSelfTestBatch
     /// <remarks>
     /// <para>Identity-dependent fixtures are declared <c>SelfTestTier.Packaged</c> in
     /// <c>SelfTestFixtureRegistry.TierRequirements</c>, so the unpackaged host filters them out of
-    /// its corpus entirely (issue #1154). That filter keys off the same entry-assembly probe the
-    /// fixtures' own gate uses — and if it ever answered "unpackaged" <i>here</i>, this tier would
-    /// silently drop the only fixtures it exists to run, discover a corpus without them, and go
-    /// green having measured nothing. No other assertion catches that: they would not be missing
-    /// results, they would not be skips, they simply would not be part of the run, so
-    /// <see cref="Fixture"/> is never asked about them and
-    /// <see cref="IdentityDependentFixtures_Actually_Asserted"/> finds nothing to complain
-    /// about.</para>
-    /// <para>Hence the assertion is on the count the host itself reports, not on the discovered
-    /// set: the trailer is emitted before any filtering this shim does, so it describes the host's
-    /// own view of its corpus.</para>
+    /// its corpus entirely (issue #1154). That filter keys off an entry-assembly probe, and if it
+    /// ever answered "unpackaged" <i>here</i>, this tier would run a corpus with no identity
+    /// fixtures in it.</para>
+    /// <para><b>The gap this closes is narrower than "the tier would go green having measured
+    /// nothing".</b> Dropping the <i>whole</i> <c>Packaged_</c> set is already caught by
+    /// <see cref="IdentityDependentFixtures_Actually_Asserted"/>, which fails outright when
+    /// <c>Packaged_IdentityGuard</c> is absent from the parsed results. What is <i>not</i> covered
+    /// there is a selectively misdeclared fixture — a non-guard one dropped while the guard
+    /// survives, so the guard still passes and the missing fixture is simply never asked about,
+    /// being neither a failure nor a skip nor a missing result. This also validates the trailer
+    /// itself, which nothing else in this tier reads.</para>
+    /// <para>The assertion is on the count the host reports rather than on the discovered set: the
+    /// trailer is emitted before any filtering this shim does, so it describes the host's own view
+    /// of its corpus.</para>
     /// </remarks>
     [TestMethod]
     public void EveryFixture_IsApplicableToThePackagedTier()
@@ -287,8 +292,7 @@ public class PackagedSelfTestBatch
             "Every fixture must be applicable here — this is the tier that runs the " +
             $"'{IdentityFixturePrefix}' set for real. The most likely cause is " +
             "SelfTestFixtureRegistry.CurrentTier resolving to Unpackaged inside the packaged host, " +
-            "which would remove exactly those fixtures and leave the run green having measured " +
-            "nothing.");
+            "which would remove exactly those fixtures from the run.");
     }
 
     /// <summary>
@@ -296,9 +300,14 @@ public class PackagedSelfTestBatch
     /// list:</c> trailers. Marker literals duplicated from <c>SelfTestRunner</c>.
     /// </summary>
     /// <remarks>
-    /// The count is parsed independently of the list rather than derived from it, so a stream
-    /// truncated between the two lines is visible as a disagreement instead of silently reading
-    /// as an empty exclusion set — which is the answer this tier wants to hear.
+    /// A parseable count starts a new trailer and clears names carried from an earlier one: a zero
+    /// trailer legitimately omits its list line, so without the reset a later <c>0</c> would
+    /// inherit the previous trailer's names. That matters here because <c>_fullOutput</c> can hold
+    /// two host invocations — the main run and the identity-guard second pass — so two trailers in
+    /// one buffer is the normal case, not a pathological one.
+    /// <para>The count is parsed independently of the list rather than derived from it, so a
+    /// stream truncated between the two lines is visible as a disagreement instead of silently
+    /// reading as an empty exclusion set — which is the answer this tier wants to hear.</para>
     /// </remarks>
     internal static NotApplicableReport ExtractNotApplicableFixtures(string stdout)
     {
@@ -316,6 +325,7 @@ public class PackagedSelfTestBatch
                         System.Globalization.CultureInfo.InvariantCulture, out var parsed))
                 {
                     count = parsed;
+                    names = [];
                 }
             }
             else if (line.StartsWith(NotApplicableListMarker, StringComparison.Ordinal))

--- a/tests/Reactor.PackagedTests/PackagedSelfTestBatch.cs
+++ b/tests/Reactor.PackagedTests/PackagedSelfTestBatch.cs
@@ -291,7 +291,7 @@ public class PackagedSelfTestBatch
             $"tier':\n  {string.Join("\n  ", report.Names)}\n" +
             "Every fixture must be applicable here — this is the tier that runs the " +
             $"'{IdentityFixturePrefix}' set for real. The most likely cause is " +
-            "SelfTestFixtureRegistry.CurrentTier resolving to Unpackaged inside the packaged host, " +
+            "PackagedIdentityFixtures.IsPackagedTier evaluating false inside the packaged host, " +
             "which would remove exactly those fixtures from the run.");
     }
 

--- a/tests/Reactor.PackagedTests/PackagedSelfTestBatch.cs
+++ b/tests/Reactor.PackagedTests/PackagedSelfTestBatch.cs
@@ -264,16 +264,24 @@ public class PackagedSelfTestBatch
 
         var report = ExtractNotApplicableFixtures(_fullOutput);
 
-        Assert.IsNotNull(
-            report.Count,
-            $"The packaged host emitted no '{NotApplicableCountMarker.Trim()}' trailer, so nothing " +
-            "establishes that it considered its identity-dependent fixtures applicable. Either " +
-            "SelfTestRunner.WriteNotApplicableTrailer stopped being called, or the marker literal " +
-            "drifted between the host and this file — they are duplicated, not shared, because " +
-            $"the host is referenced with ReferenceOutputAssembly=false.\n{Tail(_fullOutput, 2000)}");
+        // Pattern-matched into a non-nullable local rather than asserting and then dereferencing
+        // `report.Count`. `Assert.IsNotNull` is invisible to nullable flow analysis, so the reads
+        // below would each need a `!` — an unchecked claim, and one that would quietly become
+        // wrong if the guard were ever relaxed. This states the same test where the compiler and
+        // CodeQL can both see it.
+        if (report.Count is not { } reportedCount)
+        {
+            Assert.Fail(
+                $"The packaged host emitted no '{NotApplicableCountMarker.Trim()}' trailer, so nothing " +
+                "establishes that it considered its identity-dependent fixtures applicable. Either " +
+                "SelfTestRunner.WriteNotApplicableTrailer stopped being called, or the marker literal " +
+                "drifted between the host and this file — they are duplicated, not shared, because " +
+                $"the host is referenced with ReferenceOutputAssembly=false.\n{Tail(_fullOutput, 2000)}");
+            return;
+        }
 
         Assert.AreEqual(
-            0, report.Count!.Value,
+            0, reportedCount,
             "The packaged host excluded fixtures from its own corpus as 'not applicable to this " +
             $"tier':\n  {string.Join("\n  ", report.Names)}\n" +
             "Every fixture must be applicable here — this is the tier that runs the " +

--- a/tests/Reactor.PackagedTests/PackagedSelfTestBatch.cs
+++ b/tests/Reactor.PackagedTests/PackagedSelfTestBatch.cs
@@ -53,6 +53,25 @@ public class PackagedSelfTestBatch
 
     internal sealed record FixtureOutcome(FixtureStatus Status, string Detail);
 
+    /// <summary>
+    /// The host's <c># Total not-applicable fixtures:</c> trailer. Duplicated from
+    /// <c>SelfTestRunner.NotApplicableCountMarker</c>, which this project cannot reference.
+    /// </summary>
+    internal const string NotApplicableCountMarker = "# Total not-applicable fixtures: ";
+
+    /// <summary>
+    /// The host's <c># Not applicable fixture list:</c> trailer. Duplicated from
+    /// <c>SelfTestRunner.NotApplicableListMarker</c>.
+    /// </summary>
+    internal const string NotApplicableListMarker = "# Not applicable fixture list: ";
+
+    /// <summary>
+    /// What the host said it deliberately did not run. A <see langword="null"/>
+    /// <paramref name="Count"/> means the trailer was absent, which is not the same fact as a
+    /// count of zero: absent means nothing reported, zero means everything applied.
+    /// </summary>
+    internal sealed record NotApplicableReport(int? Count, IReadOnlyList<string> Names);
+
     // ────────────────────────────────────────────────────────────────────
     //  Run
     // ────────────────────────────────────────────────────────────────────
@@ -217,6 +236,88 @@ public class PackagedSelfTestBatch
             $"asserted nothing:\n  {string.Join("\n  ", skipped)}\n" +
             "A fixture gated on RequirePackagedTier must always run here — a skip means the " +
             "host lacked package identity or the gate itself is broken.");
+    }
+
+    /// <summary>
+    /// The mirror of <c>SelfTestBatch.NotApplicableFixtures_AreExcludedFromThisTier</c>, and the
+    /// half that guards the dangerous direction.
+    /// </summary>
+    /// <remarks>
+    /// <para>Identity-dependent fixtures are declared <c>SelfTestTier.Packaged</c> in
+    /// <c>SelfTestFixtureRegistry.TierRequirements</c>, so the unpackaged host filters them out of
+    /// its corpus entirely (issue #1154). That filter keys off the same entry-assembly probe the
+    /// fixtures' own gate uses — and if it ever answered "unpackaged" <i>here</i>, this tier would
+    /// silently drop the only fixtures it exists to run, discover a corpus without them, and go
+    /// green having measured nothing. No other assertion catches that: they would not be missing
+    /// results, they would not be skips, they simply would not be part of the run, so
+    /// <see cref="Fixture"/> is never asked about them and
+    /// <see cref="IdentityDependentFixtures_Actually_Asserted"/> finds nothing to complain
+    /// about.</para>
+    /// <para>Hence the assertion is on the count the host itself reports, not on the discovered
+    /// set: the trailer is emitted before any filtering this shim does, so it describes the host's
+    /// own view of its corpus.</para>
+    /// </remarks>
+    [TestMethod]
+    public void EveryFixture_IsApplicableToThePackagedTier()
+    {
+        FailIfNotInitialized();
+
+        var report = ExtractNotApplicableFixtures(_fullOutput);
+
+        Assert.IsNotNull(
+            report.Count,
+            $"The packaged host emitted no '{NotApplicableCountMarker.Trim()}' trailer, so nothing " +
+            "establishes that it considered its identity-dependent fixtures applicable. Either " +
+            "SelfTestRunner.WriteNotApplicableTrailer stopped being called, or the marker literal " +
+            "drifted between the host and this file — they are duplicated, not shared, because " +
+            $"the host is referenced with ReferenceOutputAssembly=false.\n{Tail(_fullOutput, 2000)}");
+
+        Assert.AreEqual(
+            0, report.Count!.Value,
+            "The packaged host excluded fixtures from its own corpus as 'not applicable to this " +
+            $"tier':\n  {string.Join("\n  ", report.Names)}\n" +
+            "Every fixture must be applicable here — this is the tier that runs the " +
+            $"'{IdentityFixturePrefix}' set for real. The most likely cause is " +
+            "SelfTestFixtureRegistry.CurrentTier resolving to Unpackaged inside the packaged host, " +
+            "which would remove exactly those fixtures and leave the run green having measured " +
+            "nothing.");
+    }
+
+    /// <summary>
+    /// Reads the host's <c># Total not-applicable fixtures:</c> / <c># Not applicable fixture
+    /// list:</c> trailers. Marker literals duplicated from <c>SelfTestRunner</c>.
+    /// </summary>
+    /// <remarks>
+    /// The count is parsed independently of the list rather than derived from it, so a stream
+    /// truncated between the two lines is visible as a disagreement instead of silently reading
+    /// as an empty exclusion set — which is the answer this tier wants to hear.
+    /// </remarks>
+    internal static NotApplicableReport ExtractNotApplicableFixtures(string stdout)
+    {
+        if (string.IsNullOrEmpty(stdout)) return new NotApplicableReport(null, []);
+
+        int? count = null;
+        string[] names = [];
+
+        foreach (var line in stdout.Split('\n').Select(static raw => raw.Trim()))
+        {
+            if (line.StartsWith(NotApplicableCountMarker, StringComparison.Ordinal))
+            {
+                if (int.TryParse(line[NotApplicableCountMarker.Length..].Trim(),
+                        System.Globalization.NumberStyles.Integer,
+                        System.Globalization.CultureInfo.InvariantCulture, out var parsed))
+                {
+                    count = parsed;
+                }
+            }
+            else if (line.StartsWith(NotApplicableListMarker, StringComparison.Ordinal))
+            {
+                names = line[NotApplicableListMarker.Length..]
+                    .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            }
+        }
+
+        return new NotApplicableReport(count, names);
     }
 
     /// <summary>

--- a/tests/Reactor.SelfTests/SelfTestBatch.cs
+++ b/tests/Reactor.SelfTests/SelfTestBatch.cs
@@ -1401,7 +1401,7 @@ public class SelfTestBatch
             $"  (a) SelfTestFixtureRegistry.TierRequirements was emptied, so nothing is declared " +
             $"tier-specific any more and those fixtures are back to self-skipping into the amber " +
             $"inventory (issue #1154 restored).\n" +
-            $"  (b) SelfTestFixtureRegistry.CurrentTier mis-evaluates — if it answered 'Packaged' " +
+            $"  (b) PackagedIdentityFixtures.IsPackagedTier mis-evaluates — if it answered true " +
             $"here, the filter would be a no-op in both tiers while still looking like it worked.\n" +
             $"  (c) The packaged fixtures were deleted. Their coverage is the only thing that runs " +
             $"under real MSIX identity; restore them rather than this assertion.");

--- a/tests/Reactor.SelfTests/SelfTestBatch.cs
+++ b/tests/Reactor.SelfTests/SelfTestBatch.cs
@@ -1266,6 +1266,178 @@ public class SelfTestBatch
     /// </summary>
     internal const string SkipVerdictControlFixture = "SelfTestVerdict_OnlySkips_PositiveControl";
 
+    // ════════════════════════════════════════════════════════════════════
+    //  Tier applicability (issue #1154)
+    // ════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// The Host's <c># Total not-applicable fixtures:</c> trailer. Duplicated from
+    /// <c>SelfTestRunner.NotApplicableCountMarker</c>, which cannot be referenced from here.
+    /// </summary>
+    internal const string NotApplicableCountMarker = "# Total not-applicable fixtures: ";
+
+    /// <summary>
+    /// The Host's <c># Not applicable fixture list:</c> trailer. Duplicated from
+    /// <c>SelfTestRunner.NotApplicableListMarker</c>.
+    /// </summary>
+    internal const string NotApplicableListMarker = "# Not applicable fixture list: ";
+
+    /// <summary>
+    /// What the Host said it deliberately did not run. <paramref name="Count"/> is
+    /// <see langword="null"/> when the trailer was absent entirely, which is a different fact from
+    /// a count of zero: absent means the mechanism is silent, zero means it ran everything.
+    /// </summary>
+    internal sealed record NotApplicableReport(int? Count, IReadOnlyList<string> Names);
+
+    /// <summary>
+    /// Reads the Host's tier-exclusion trailer.
+    /// </summary>
+    /// <remarks>
+    /// Last-wins on both markers, for the same reason <see cref="ExtractSuiteElapsedSeconds"/> is:
+    /// a re-entered Host can emit the trailer twice and the final one describes the run being
+    /// reported on. The count is parsed independently of the list so the two can be <i>compared</i>
+    /// — a truncated stream that drops the list line while keeping the count is exactly the case
+    /// worth catching, and a parser that derived the count from the list could not see it.
+    /// </remarks>
+    internal static NotApplicableReport ExtractNotApplicableFixtures(string stdout)
+    {
+        if (string.IsNullOrEmpty(stdout)) return new NotApplicableReport(null, []);
+
+        int? count = null;
+        string[] names = [];
+
+        foreach (var line in stdout.Split('\n', StringSplitOptions.TrimEntries))
+        {
+            if (line.StartsWith(NotApplicableCountMarker, StringComparison.Ordinal))
+            {
+                if (int.TryParse(line[NotApplicableCountMarker.Length..].Trim(),
+                        System.Globalization.NumberStyles.Integer,
+                        System.Globalization.CultureInfo.InvariantCulture, out var parsed))
+                {
+                    count = parsed;
+                }
+            }
+            else if (line.StartsWith(NotApplicableListMarker, StringComparison.Ordinal))
+            {
+                names = line[NotApplicableListMarker.Length..]
+                    .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            }
+        }
+
+        return new NotApplicableReport(count, names);
+    }
+
+    /// <summary>
+    /// Proves the tier filter actually removed the fixtures this host cannot run, rather than the
+    /// fixtures having quietly ceased to exist.
+    ///
+    /// <para><b>Why an absence needs an assertion.</b> Issue #1154's fix is a removal: three
+    /// <c>Packaged_*</c> fixtures used to run here, self-skip, and put a permanent amber entry in
+    /// <see cref="SkippedFixtures_AreReported"/>. They now aren't selected at all. The trouble with
+    /// fixing something by removal is that success and catastrophe produce the identical
+    /// observation — "no amber" is what you get whether the filter works or whether somebody
+    /// deleted the packaged corpus. Nothing else in this suite can tell those apart: the packaged
+    /// tier is a separate project in a separate CI job, and every other test here reasons about
+    /// fixtures that <i>did</i> report.</para>
+    ///
+    /// <para>So this asserts the mechanism positively, in the tier where it fires. This wrapper
+    /// always drives the <b>unpackaged</b> Host, so a non-empty exclusion set is deterministic
+    /// rather than machine-dependent — there is no configuration in which zero is the healthy
+    /// answer here.</para>
+    ///
+    /// <para>The mirror assertion lives in <c>PackagedSelfTestBatch</c> and demands the opposite:
+    /// zero exclusions there. Together they pin the filter in both directions, which matters
+    /// because a tier probe stuck on one answer would otherwise look correct from whichever side
+    /// happened to agree with it.</para>
+    /// </summary>
+    [TestMethod]
+    public void NotApplicableFixtures_AreExcludedFromThisTier()
+    {
+        Assert.IsTrue(_initialized, "Self-test batch did not run.");
+        if (_initError is not null)
+            Assert.Fail(_initError);
+
+        if (_timedOut || _abortedReason is not null)
+        {
+            Assert.Inconclusive(
+                $"{_abortedReason ?? "The suite was killed by its process budget"}; the Host never " +
+                $"reached its trailers, so the absence of the exclusion report says nothing about " +
+                $"the tier filter.");
+        }
+
+        var report = ExtractNotApplicableFixtures(_fullOutput);
+
+        Assert.IsNotNull(report.Count,
+            $"The Host completed its run but emitted no '{NotApplicableCountMarker.Trim()}' " +
+            $"trailer, so nothing reports which fixtures this tier declined to run. Either " +
+            $"SelfTestRunner.WriteNotApplicableTrailer stopped being called, or the marker literal " +
+            $"drifted between SelfTestRunner and this file — they are duplicated, not shared, " +
+            $"because the Host is referenced with ReferenceOutputAssembly=false.");
+
+        Assert.AreEqual(report.Count!.Value, report.Names.Count,
+            $"The Host reported {report.Count} not-applicable fixture(s) but named " +
+            $"{report.Names.Count}. The TAP stream is inconsistent with itself — most likely " +
+            $"truncated between the two trailer lines, which would make every check below reason " +
+            $"about a partial list.\nNamed: {string.Join(", ", report.Names)}");
+
+        Assert.IsTrue(report.Count.Value > 0,
+            $"This wrapper always runs the UNPACKAGED Host, where the '{PackagedFixturePrefix}' " +
+            $"fixtures are declared SelfTestTier.Packaged and must therefore be excluded — so zero " +
+            $"is never the healthy answer here. Something removed the mechanism or its subject:\n" +
+            $"  (a) SelfTestFixtureRegistry.TierRequirements was emptied, so nothing is declared " +
+            $"tier-specific any more and those fixtures are back to self-skipping into the amber " +
+            $"inventory (issue #1154 restored).\n" +
+            $"  (b) SelfTestFixtureRegistry.CurrentTier mis-evaluates — if it answered 'Packaged' " +
+            $"here, the filter would be a no-op in both tiers while still looking like it worked.\n" +
+            $"  (c) The packaged fixtures were deleted. Their coverage is the only thing that runs " +
+            $"under real MSIX identity; restore them rather than this assertion.");
+
+        // Discovery and the run must agree. `--list-fixtures` and the run list are fed from the
+        // same registry property precisely so they cannot diverge, and this is what would catch
+        // it if one of them were repointed at the unfiltered corpus: an excluded fixture that
+        // still had a `[TestMethod]` would report "was not reported by the Host" — a red that
+        // names the wrong cause entirely.
+        var discovered = new HashSet<string>(FixtureNames.Value, StringComparer.Ordinal);
+        var leakedIntoDiscovery = report.Names.Where(discovered.Contains).ToArray();
+
+        Assert.AreEqual(0, leakedIntoDiscovery.Length,
+            $"`--list-fixtures` offered fixture(s) the run then declared not applicable:\n  " +
+            $"{string.Join("\n  ", leakedIntoDiscovery)}\n" +
+            $"Discovery and execution must be fed from the same tier-filtered set " +
+            $"(SelfTestFixtureRegistry.FixturesForCurrentTier), or each of these gets a test case " +
+            $"that can only ever fail for want of a result.");
+
+        var leakedIntoRun = report.Names.Where(_byFixture.ContainsKey).ToArray();
+
+        Assert.AreEqual(0, leakedIntoRun.Length,
+            $"Fixture(s) declared not applicable to this tier nonetheless produced TAP output:\n  " +
+            $"{string.Join("\n  ", leakedIntoRun)}\n" +
+            $"The trailer and the run disagree, so one of them is lying about what executed.");
+
+        // Informational, not a warning: this is the channel that replaces what the amber used to
+        // carry, and the whole point of the change is that a structural exclusion is not a
+        // finding. Best-effort because the assertions above are the load-bearing half — unlike the
+        // duration and skip reports, nothing here is silent without it.
+        var markdown =
+            $"### ℹ️ Selftest fixtures not applicable to this tier\n\n" +
+            $"{report.Count} fixture(s) were excluded from this run because they require a " +
+            $"different host, and were not executed:\n\n" +
+            string.Join("", report.Names.Select(n => $"- `{n}`\n")) +
+            $"\n<sub>Declared in `SelfTestFixtureRegistry.TierRequirements`. These are asserted " +
+            $"for real by `Reactor.PackagedTests`. Background: issue #1154.</sub>";
+
+        Console.WriteLine($"Not applicable to this tier ({report.Count}): {string.Join(", ", report.Names)}");
+        PublishBestEffort(
+            () => TryAppendSummary(Environment.GetEnvironmentVariable(StepSummaryEnvVar), markdown),
+            "the tier-exclusion report");
+    }
+
+    /// <summary>
+    /// Naming convention for identity-dependent fixtures, quoted in the diagnostic above so it
+    /// points at a real set of names. Mirrors <c>PackagedSelfTestBatch.IdentityFixturePrefix</c>.
+    /// </summary>
+    internal const string PackagedFixturePrefix = "Packaged_";
+
     /// <summary>
     /// The one assertion that observes the <b>real</b> Host's real skip output, and the only thing
     /// that can catch the two projects drifting apart.
@@ -1628,10 +1800,7 @@ public class SelfTestBatch
             throw new InvalidOperationException(
                 $"`--list-fixtures` failed with exit code {exitCode}.\nstdout:\n{stdout}\nstderr:\n{stderr}");
 
-        var names = stdout.Split('\n', StringSplitOptions.RemoveEmptyEntries)
-            .Select(l => l.Trim())
-            .Where(l => l.Length > 0)
-            .ToArray();
+        var names = ParseFixtureNames(stdout);
 
         if (names.Length == 0)
             throw new InvalidOperationException(
@@ -1639,6 +1808,25 @@ public class SelfTestBatch
 
         return names;
     }
+
+    /// <summary>
+    /// Reduces a <c>--list-fixtures</c> dump to fixture names.
+    /// </summary>
+    /// <remarks>
+    /// TAP comments are not fixture names. The Host appends its tier-exclusion trailer to this
+    /// stream (issue #1154), and <c>--list-fixtures</c> is free to grow further comments; treating
+    /// one as a name would manufacture a <c>[TestMethod]</c> for a fixture that cannot exist, which
+    /// would then fail as "was not reported by the Host" — a red naming the wrong cause entirely.
+    /// Mirrors <c>PackagedSelfTestBatch.ParseFixtureList</c>, which has always filtered them.
+    /// <para>Split out from <see cref="LoadFixtureNames"/> so the filter is testable without
+    /// launching a Host: the whole point of a guard against a malformed line is that it holds for
+    /// lines the current Host does not happen to emit.</para>
+    /// </remarks>
+    internal static string[] ParseFixtureNames(string stdout) =>
+        stdout.Split('\n', StringSplitOptions.RemoveEmptyEntries)
+            .Select(l => l.Trim())
+            .Where(l => l.Length > 0 && !l.StartsWith('#'))
+            .ToArray();
 
     // -- Process runner: async reads + timeout race with kill ------------------
 

--- a/tests/Reactor.SelfTests/SelfTestBatch.cs
+++ b/tests/Reactor.SelfTests/SelfTestBatch.cs
@@ -1367,20 +1367,29 @@ public class SelfTestBatch
 
         var report = ExtractNotApplicableFixtures(_fullOutput);
 
-        Assert.IsNotNull(report.Count,
-            $"The Host completed its run but emitted no '{NotApplicableCountMarker.Trim()}' " +
-            $"trailer, so nothing reports which fixtures this tier declined to run. Either " +
-            $"SelfTestRunner.WriteNotApplicableTrailer stopped being called, or the marker literal " +
-            $"drifted between SelfTestRunner and this file — they are duplicated, not shared, " +
-            $"because the Host is referenced with ReferenceOutputAssembly=false.");
+        // Pattern-matched into a non-nullable local rather than asserting and then dereferencing
+        // `report.Count`. `Assert.IsNotNull` is invisible to nullable flow analysis, so the three
+        // reads below would each need a `!` — an unchecked claim, and one that would quietly
+        // become wrong if the guard were ever relaxed. This states the same test where the
+        // compiler and CodeQL can both see it.
+        if (report.Count is not { } reportedCount)
+        {
+            Assert.Fail(
+                $"The Host completed its run but emitted no '{NotApplicableCountMarker.Trim()}' " +
+                $"trailer, so nothing reports which fixtures this tier declined to run. Either " +
+                $"SelfTestRunner.WriteNotApplicableTrailer stopped being called, or the marker literal " +
+                $"drifted between SelfTestRunner and this file — they are duplicated, not shared, " +
+                $"because the Host is referenced with ReferenceOutputAssembly=false.");
+            return;
+        }
 
-        Assert.AreEqual(report.Count!.Value, report.Names.Count,
-            $"The Host reported {report.Count} not-applicable fixture(s) but named " +
+        Assert.AreEqual(reportedCount, report.Names.Count,
+            $"The Host reported {reportedCount} not-applicable fixture(s) but named " +
             $"{report.Names.Count}. The TAP stream is inconsistent with itself — most likely " +
             $"truncated between the two trailer lines, which would make every check below reason " +
             $"about a partial list.\nNamed: {string.Join(", ", report.Names)}");
 
-        Assert.IsTrue(report.Count.Value > 0,
+        Assert.IsTrue(reportedCount > 0,
             $"This wrapper always runs the UNPACKAGED Host, where the '{PackagedFixturePrefix}' " +
             $"fixtures are declared SelfTestTier.Packaged and must therefore be excluded — so zero " +
             $"is never the healthy answer here. Something removed the mechanism or its subject:\n" +

--- a/tests/Reactor.SelfTests/SelfTestBatch.cs
+++ b/tests/Reactor.SelfTests/SelfTestBatch.cs
@@ -1295,9 +1295,13 @@ public class SelfTestBatch
     /// <remarks>
     /// Last-wins on both markers, for the same reason <see cref="ExtractSuiteElapsedSeconds"/> is:
     /// a re-entered Host can emit the trailer twice and the final one describes the run being
-    /// reported on. The count is parsed independently of the list so the two can be <i>compared</i>
-    /// — a truncated stream that drops the list line while keeping the count is exactly the case
-    /// worth catching, and a parser that derived the count from the list could not see it.
+    /// reported on. A parseable count <b>starts</b> a new trailer and clears any names carried
+    /// from an earlier one — a zero trailer legitimately omits its list line, so without the reset
+    /// a later `0` would inherit the previous trailer's names and report an internally
+    /// contradictory "zero exclusions, here are three of them".
+    /// <para>The count is parsed independently of the list so the two can be <i>compared</i> — a
+    /// truncated stream that drops the list line while keeping the count is exactly the case worth
+    /// catching, and a parser that derived the count from the list could not see it.</para>
     /// </remarks>
     internal static NotApplicableReport ExtractNotApplicableFixtures(string stdout)
     {
@@ -1315,6 +1319,7 @@ public class SelfTestBatch
                         System.Globalization.CultureInfo.InvariantCulture, out var parsed))
                 {
                     count = parsed;
+                    names = [];
                 }
             }
             else if (line.StartsWith(NotApplicableListMarker, StringComparison.Ordinal))

--- a/tests/Reactor.SelfTests/TierApplicabilityTests.cs
+++ b/tests/Reactor.SelfTests/TierApplicabilityTests.cs
@@ -126,6 +126,27 @@ public class TierApplicabilityTests
     }
 
     /// <summary>
+    /// The asymmetric half of last-wins, and the one that is easy to get wrong: a <b>zero</b>
+    /// trailer carries no list line, so a parser that only overwrites <c>Names</c> when it sees a
+    /// list would leave the earlier trailer's entries in place and report "zero exclusions — here
+    /// are three of them". Two host invocations in one buffer is the packaged shim's normal case
+    /// (main run plus the identity-guard second pass), so this is a reachable shape rather than a
+    /// contrived one.
+    /// </summary>
+    [TestMethod]
+    public void ZeroTrailerAfterNonZero_DoesNotInheritTheOlderNames()
+    {
+        var report = SelfTestBatch.ExtractNotApplicableFixtures(
+            $"{Count}2\n{List}Packaged_IdentityGuard, Packaged_SettingsStoreRoundTrip\n"
+            + RunBody + $"{Count}0\n");
+
+        Assert.AreEqual(0, report.Count);
+        Assert.AreEqual(0, report.Names.Count,
+            "The later trailer reported zero exclusions, so the earlier trailer's names must not " +
+            $"survive it. Carried over: {string.Join(", ", report.Names)}");
+    }
+
+    /// <summary>
     /// A malformed later marker must not discard a value already parsed, or a stray line could
     /// silence the whole report. Mirrors the rule <c>SuiteElapsed_LastParseableMarkerWins</c>
     /// pins for the duration trailer.

--- a/tests/Reactor.SelfTests/TierApplicabilityTests.cs
+++ b/tests/Reactor.SelfTests/TierApplicabilityTests.cs
@@ -1,0 +1,198 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.UI.Reactor.SelfTests;
+
+/// <summary>
+/// Headless guards for the tier-applicability reporting added for issue #1154. Everything here is
+/// pure, so this class does not launch the Host and does not trigger <see cref="SelfTestBatch"/>'s
+/// <c>[ClassInitialize]</c>.
+///
+/// <para><b>What is being defended.</b> Three <c>Packaged_*</c> fixtures used to run in the
+/// unpackaged host, self-skip, and leave a permanent amber entry in
+/// <c>SkippedFixtures_AreReported</c> — a channel whose value depends on being rare. They are now
+/// declared <c>SelfTestTier.Packaged</c> and are not selected here at all. That is a fix by
+/// <i>removal</i>, and the trouble with those is that success and catastrophe look identical from
+/// outside: "no amber" is what you get whether the filter works or whether somebody deleted the
+/// packaged corpus. The Host therefore names what it excluded, and
+/// <c>NotApplicableFixtures_AreExcludedFromThisTier</c> asserts on it. These tests pin the parser
+/// that assertion depends on.</para>
+///
+/// <para><b>The distinction that carries the weight</b> is <i>absent trailer</i> versus <i>zero
+/// exclusions</i>. Absent means the reporting mechanism is silent; zero means the host ran
+/// everything. Collapsing them would make a Host that stopped emitting the trailer entirely
+/// indistinguishable from a healthy packaged run — and the packaged shim's mirror assertion
+/// demands exactly zero, so it would then pass on silence. Several tests below exist only to keep
+/// those two apart.</para>
+/// </summary>
+[TestClass]
+public class TierApplicabilityTests
+{
+    private const string Count = SelfTestBatch.NotApplicableCountMarker;
+    private const string List = SelfTestBatch.NotApplicableListMarker;
+
+    private const string RunBody =
+        "TAP version 14\n1..2\n# Running: A\nok A_Check\n# Running: B\nok B_Check\n# Total failures: 0\n";
+
+    // ------------------------------------------------------------------ the happy path
+
+    /// <summary>
+    /// Stated as a differential over the same stream, so a parser that hard-coded the packaged
+    /// fixture names — or returned a canned list for anything — fails here. Only the trailer
+    /// differs between the two arms.
+    /// </summary>
+    [TestMethod]
+    public void TrailerNamesTheExcludedFixtures()
+    {
+        var without = SelfTestBatch.ExtractNotApplicableFixtures(RunBody);
+        var with = SelfTestBatch.ExtractNotApplicableFixtures(
+            RunBody + $"{Count}2\n{List}Packaged_IdentityGuard, Packaged_SettingsStoreRoundTrip\n");
+
+        Assert.IsNull(without.Count, "No trailer in the stream, so there is nothing to report.");
+        Assert.AreEqual(2, with.Count);
+        CollectionAssert.AreEqual(
+            new[] { "Packaged_IdentityGuard", "Packaged_SettingsStoreRoundTrip" },
+            with.Names.ToArray(),
+            "The names are what the assertion cross-checks against discovery and against the " +
+            "parsed results, so they have to survive the comma split with their whitespace " +
+            "trimmed.");
+    }
+
+    // ------------------------------------------------------------------ absent vs zero
+
+    /// <summary>
+    /// The load-bearing distinction. <c>PackagedSelfTestBatch</c> asserts the count is <b>zero</b>
+    /// in the packaged tier; if a missing trailer parsed as zero, a Host that stopped reporting
+    /// altogether would satisfy that assertion by silence — the tier would go green having
+    /// established nothing about its own corpus, which is the failure mode the packaged tier
+    /// exists to remove.
+    /// </summary>
+    [TestMethod]
+    public void MissingTrailer_IsNotTheSameAsZeroExclusions()
+    {
+        var missing = SelfTestBatch.ExtractNotApplicableFixtures(RunBody);
+        var zero = SelfTestBatch.ExtractNotApplicableFixtures(RunBody + $"{Count}0\n");
+
+        Assert.IsNull(missing.Count, "Absent trailer must not be reported as a count.");
+        Assert.AreEqual(0, zero.Count, "An explicit zero is a measurement, not an absence.");
+        Assert.AreEqual(0, zero.Names.Count, "A zero count legitimately carries no list line.");
+    }
+
+    /// <summary>
+    /// A count that cannot be parsed must stay <see langword="null"/> rather than default to zero,
+    /// for the same reason: zero is the answer the packaged tier wants to hear, so a malformed
+    /// line must not be able to supply it.
+    /// </summary>
+    [TestMethod]
+    public void MalformedCount_DoesNotMasqueradeAsZero()
+    {
+        var report = SelfTestBatch.ExtractNotApplicableFixtures(RunBody + $"{Count}three\n");
+
+        Assert.IsNull(report.Count,
+            "'three' is not a count. Reading it as 0 would let a garbled trailer assert that " +
+            "every fixture applied to this tier.");
+    }
+
+    // ------------------------------------------------------------------ truncation
+
+    /// <summary>
+    /// The count is parsed independently of the list precisely so the two can be compared. A
+    /// stream cut between the two trailer lines is a realistic failure here — the Host ends its
+    /// run with a teardown-free <c>TerminateProcess</c> (issue #680) — and a parser that derived
+    /// the count from the list would report a consistent, wrong, smaller answer instead.
+    /// </summary>
+    [TestMethod]
+    public void CountWithoutItsList_IsVisibleAsADisagreement()
+    {
+        var report = SelfTestBatch.ExtractNotApplicableFixtures(RunBody + $"{Count}3\n");
+
+        Assert.AreEqual(3, report.Count);
+        Assert.AreEqual(0, report.Names.Count,
+            "The list line never arrived, and the count must not be back-filled from it — the " +
+            "gap is the finding.");
+    }
+
+    /// <summary>
+    /// A re-entered Host can emit the trailer twice; the final one describes the run being
+    /// reported on. Same last-wins rule as <c>ExtractSuiteElapsedSeconds</c>.
+    /// </summary>
+    [TestMethod]
+    public void LastTrailerWins()
+    {
+        var report = SelfTestBatch.ExtractNotApplicableFixtures(
+            $"{Count}1\n{List}Stale_Fixture\n" + RunBody + $"{Count}2\n{List}Real_One, Real_Two\n");
+
+        Assert.AreEqual(2, report.Count);
+        CollectionAssert.AreEqual(new[] { "Real_One", "Real_Two" }, report.Names.ToArray());
+    }
+
+    /// <summary>
+    /// A malformed later marker must not discard a value already parsed, or a stray line could
+    /// silence the whole report. Mirrors the rule <c>SuiteElapsed_LastParseableMarkerWins</c>
+    /// pins for the duration trailer.
+    /// </summary>
+    [TestMethod]
+    public void MalformedLaterMarker_DoesNotDiscardAParsedCount()
+    {
+        var report = SelfTestBatch.ExtractNotApplicableFixtures(
+            $"{Count}2\n{List}Real_One, Real_Two\n" + RunBody + $"{Count}\n");
+
+        Assert.AreEqual(2, report.Count,
+            "An unparseable marker is skipped, not treated as a new answer.");
+    }
+
+    // ------------------------------------------------------------------ marker isolation
+
+    /// <summary>
+    /// The new prefixes share a shape with the skip trailers that sit two lines above them in the
+    /// same stream. TESTING.md states the rule that a grep for one must not match the others, and
+    /// this is where it is enforced: <c># Total skipped fixtures:</c> and
+    /// <c># Skipped fixture list:</c> must be inert here.
+    /// </summary>
+    [TestMethod]
+    public void SkipTrailers_AreNotMistakenForTheExclusionTrailer()
+    {
+        var report = SelfTestBatch.ExtractNotApplicableFixtures(
+            RunBody +
+            "# Total skipped fixtures: 1\n" +
+            "# Skipped fixture list: SelfTestVerdict_OnlySkips_PositiveControl\n");
+
+        Assert.IsNull(report.Count,
+            "The skip trailers were read as the exclusion trailer. Those two reports mean " +
+            "opposite things — one names fixtures that ran and established nothing, the other " +
+            "names fixtures that deliberately did not run.");
+    }
+
+    // ------------------------------------------------------------------ discovery
+
+    /// <summary>
+    /// Discovery reads the same stream the trailer is appended to, so a comment must not become a
+    /// fixture name. It would get a <c>[TestMethod]</c> of its own that could only ever fail as
+    /// "was not reported by the Host" — a red pointing at a fixture that does not exist.
+    /// </summary>
+    [TestMethod]
+    public void FixtureNameParsing_DropsTapComments()
+    {
+        var names = SelfTestBatch.ParseFixtureNames(
+            $"Alpha_One\nBeta_Two\n{Count}1\n{List}Packaged_IdentityGuard\n");
+
+        CollectionAssert.AreEqual(new[] { "Alpha_One", "Beta_Two" }, names,
+            "Only the two real names are fixtures; both trailer lines are TAP comments.");
+    }
+
+    /// <summary>
+    /// The other direction: the comment filter must key on the comment marker, not on anything
+    /// resembling the excluded names, or a legitimately-named fixture could be dropped from
+    /// discovery and silently never run.
+    /// </summary>
+    [TestMethod]
+    public void FixtureNameParsing_KeepsNamesThatResembleTheTrailer()
+    {
+        var names = SelfTestBatch.ParseFixtureNames(
+            "Packaged_IdentityGuard\nNotApplicable_Fixture\nTotal_Fixture\n");
+
+        CollectionAssert.AreEqual(
+            new[] { "Packaged_IdentityGuard", "NotApplicable_Fixture", "Total_Fixture" }, names,
+            "These are fixture names, not comments — the packaged host lists the first one for " +
+            "real, so dropping it would empty the tier this whole mechanism exists to feed.");
+    }
+}


### PR DESCRIPTION
Fixes #1154.

## The problem

`Packaged_*` fixtures share one corpus with the unpackaged tier and self-skip there, so every unpackaged run left three permanent entries in `SkippedFixtures_AreReported`'s amber inventory — a channel whose value depends on being rare — growing by one line per packaged fixture added.

Those fixtures can never assert unpackaged: selection keys off the entry assembly, so the condition is **structural**. A skip is a per-run observation; this is a fixed property of the fixture, and restating it every run was the wrong shape.

## The approach

Rather than the issue's recommended option B (a machine-readable category on each `# SKIP` directive), applicability is declared on the **fixture**, once:

```csharp
["Packaged_IdentityGuard"] = SelfTestTier.Packaged,
```

Both `--self-test` and `--list-fixtures` are fed from `SelfTestFixtureRegistry.FixturesForCurrentTier`, so a fixture this host cannot run is not selected, emits no TAP, and gets no test case.

This is **not** the issue's rejected option D. The source corpus stays shared and identical; only the runtime *selection* differs, declared as data in one place. The visible cost is that `--list-fixtures` becomes tier-dependent — which is exactly the fact being modelled.

**What it doesn't touch:** `SkippedFixtures_AreReported` needed no edit — with the fixtures unselected its amber clears on its own. The `# SKIP` taxonomy, `Harness.Skip`, `TryParseSkipDirective`, `FixtureStatus` and every existing skip test are unchanged.

### The gate is *not* a second identity check

Worth stating explicitly, because an earlier revision of this PR got it wrong and review caught it. `RequirePackagedTier` and the tier filter both read `PackagedIdentityFixtures.IsPackagedTier`, which compares the entry assembly **name** and nothing else. Inside the packaged host it returns true whether or not the process has MSIX identity, so the gate can never skip there.

What establishes identity is **`Packaged_IdentityGuard`** asserting `PackageRuntime.IsPackaged`, `Package.Current` and the install location, and **failing** when they don't hold — plus `IdentityDependentFixtures_Actually_Asserted` requiring that fixture to have *passed*.

The gate is kept for what it actually does: make a *missing* tier declaration degrade into a clean skip with a stated reason, instead of an opaque `COMException` from `ApplicationData.Current`. It is deliberately **not** changed to observe identity — a fixture that skips when `IsPackaged` is false treats a fault as an excuse, which is the failure mode this tier exists to remove.

### There is no `Unpackaged` tier, on purpose

An earlier revision added one for symmetry, arguing it "costs no extra code path". Review showed it does: `EveryFixture_IsApplicableToThePackagedTier` requires the packaged host to exclude *nothing*, so the first legitimately unpackaged-only fixture would have failed that assertion while behaving correctly — and nothing could test the alternative today, because no such fixture exists. Adding it later is deliberately **two** changes: the enum member, and relaxing that assertion to reject only excluded `SelfTestTier.Packaged` fixtures. Both at once, with a real fixture to pin the contract.

## Keeping an absence honest

Fixing something by removal is the risk here: *"no amber"* is what you get whether the filter works or whether somebody deleted the packaged corpus. So the host names what it excluded, after `# Total failures:` and with prefixes distinct from the skip trailers:

```
# Total not-applicable fixtures: 3
# Not applicable fixture list: Packaged_IdentityGuard, Packaged_SettingsStoreRoundTrip, …
```

The two shims then assert **opposite** things:

| shim | assertion | what it catches |
|---|---|---|
| `SelfTestBatch.NotApplicableFixtures_AreExcludedFromThisTier` | list non-empty, and none of those names reached discovery or the run | filter removed, declaration emptied, or the packaged fixtures deleted |
| `PackagedSelfTestBatch.EveryFixture_IsApplicableToThePackagedTier` | count is **zero** | a *selectively* misdeclared fixture — one dropped while the guard survives — plus proof the trailer itself works |

The packaged direction is narrower than it first looks: dropping the *whole* identity set is already caught by `IdentityDependentFixtures_Actually_Asserted` failing on the absent guard.

**A stale declaration would have defeated both.** Both filtered corpora scan `AllFixtures`, so a `TierRequirements` key naming a deleted fixture is invisible: the unpackaged trailer just drops 3 → 2 (still satisfying "at least one") and the packaged trailer stays 0, so both assertions pass while a fixture silently vanishes — exactly the partial-deletion case this mechanism exists to catch. `SelfTestRegistry_TierDeclarationsMatchCorpus` now asserts every key names a live fixture, *and* that the map is non-empty so the first check can't pass vacuously. It's a fixture rather than a wrapper test because the registry is `internal` to the Host, which both shims reference with `ReferenceOutputAssembly=false`.

A *missing* trailer is deliberately never read as a count of zero — that would let a host which stopped reporting satisfy the packaged assertion by silence. For the same reason a parseable count *starts* a new trailer and clears carried-over names: a zero trailer omits its list line, so without the reset a later `0` would inherit the previous trailer's entries. Two trailers in one buffer is the packaged shim's normal case (main run plus identity-guard second pass).

## Verification

### CI before/after, same infrastructure

`main` at `60774b9c` (run 33434238067) vs this PR at `c00e04ec` (run 33354178090), both `windows-latest`, same week:

| | `main` | this PR |
|---|---|---|
| `skipped` | **5** | **1** |
| `Packaged_*` reported Skipped | all three | none |
| `SkippedFixtures_AreReported` | **amber** — *"4 fixture(s) ran NO assertions"*, listing all three | **passes** |
| total / succeeded | 1563 / 1558 | 1570 / 1569 |

`main`'s log still carries the issue's reported output verbatim; on this branch the only remaining skip is `SelfTestVerdict_OnlySkips_PositiveControl`, which exists on purpose to be skipped. The counts reconciled exactly at that commit: **1563 − 3 + 10 = 1570**. MTP only prints failures and skips, so that arithmetic is what establishes the new tests are genuinely *in* the run rather than silently absent.

Packaged job: **1526 total, 0 failed, 1 skipped** (the same positive control), with **no `Packaged_*` skips** — they ran and asserted under real identity. Both directions of the guard fired on real CI: non-empty exclusion list unpackaged, zero packaged.

### Mutation checks

Every new guard was verified by breaking its target, not just by going green:

| mutation | expected result | observed |
|---|---|---|
| empty `TierRequirements` | issue's amber returns **and** the exclusion test reddens | both, amber reproduced verbatim |
| remove the parser's `names = []` reset | only `ZeroTrailerAfterNonZero_DoesNotInheritTheOlderNames` reddens | 9 passed, 1 failed |
| add a `Packaged_DeletedFixture` key | `TierDeclarations_AllNameALiveFixture` reddens and names the key | confirmed; non-empty check stayed green |

### Local

- Release builds clean for both touched projects (where `TreatWarningsAsErrors` applies).
- 36/36 headless; full unpackaged suite **1572 total, 0 failed, 1 skipped**; 55/55 packaged under real MSIX identity, and the new registry fixture green under identity too.

## Docs

`TESTING.md` §2 and §3, `AGENTS.md`, and the `PackagedIdentityFixtures` / `RequirePackagedTier` doc comments say a packaged fixture needs *two* declarations, explain why neither replaces the other, and state plainly that the gate is not an identity check. `probe-aot-skips.ps1` drops `#` lines for the same reason the two shim parsers do.

## Known trade-off

A fixture *wrongly* declared packaged-only silently leaves the unpackaged run. It still runs in the packaged CI job, so coverage moves rather than disappears, and the trailer names it on every run. The reverse mistake — a new packaged fixture nobody declared — still self-skips and still goes amber, which is the "you forgot to declare it" signal.
