### PR TITLE
Fix REACTOR_DSL_001 for ForEach projections

### DIFF
--- a/docs/_pipeline/apps/collections/App.cs
+++ b/docs/_pipeline/apps/collections/App.cs
@@ -557,7 +557,8 @@ class LetterJump : Component<IReadOnlyList<Person>>
                     {
                         if (groupStarts.TryGetValue(letter, out var start))
                             listRef.Current?.ScrollToIndex(start);
-                    }).AutomationName($"Jump to {letter}")))
+                    }).AutomationName($"Jump to {letter}")
+                        .WithKey(letter.ToString())))
         );
     }
 }

--- a/docs/_pipeline/apps/commanding/App.cs
+++ b/docs/_pipeline/apps/commanding/App.cs
@@ -199,7 +199,8 @@ class ParameterizedCommandExample : Component
                     // by design, so call .Execute(arg) directly from the click handler.
                     Button(delete.Label, () => delete.Execute?.Invoke(item))
                         .AutomationName($"Delete {item.Title}")
-                        .IsEnabled(delete.IsEnabled)))
+                        .IsEnabled(delete.IsEnabled))
+                    .WithKey(item.Id.ToString()))
         ).Padding(24);
     }
 }

--- a/docs/_pipeline/apps/components/App.cs
+++ b/docs/_pipeline/apps/components/App.cs
@@ -221,7 +221,7 @@ class MutatingPropsDont : Component<ItemsProps>
         // Don't — this mutates the parent's collection, so the parent never
         // sees the change and doesn't re-render.
         Props.Items.Add("new item");
-        return VStack(4, ForEach(Props.Items, i => TextBlock(i)));
+        return VStack(4, ForEach(Props.Items, (item, i) => TextBlock(item).WithKey($"{i}-{item}")));
     }
 }
 // </snippet:mutating-props>

--- a/docs/_pipeline/apps/controls/App.cs
+++ b/docs/_pipeline/apps/controls/App.cs
@@ -55,7 +55,7 @@ class CollectionsGroup : Component
         var items = new[] { "Alpha", "Bravo", "Charlie", "Delta" };
         return VStack(4,
             TextBlock("Items").Bold(),
-            ForEach(items, item => TextBlock($"  • {item}"))
+            ForEach(items, item => TextBlock($"  • {item}").WithKey(item))
         ).Padding(16);
     }
 }
@@ -110,7 +110,7 @@ class DataSystemGroup : Component
             ForEach(rows, r => HStack(16,
                 TextBlock(r.Item1),
                 TextBlock(r.Item2.ToString())
-            ))
+            ).WithKey(r.Item1))
         ).Padding(16);
     }
 }

--- a/docs/_pipeline/apps/dev-tooling/App.cs
+++ b/docs/_pipeline/apps/dev-tooling/App.cs
@@ -81,7 +81,7 @@ class IterationDemo : Component
                     }
                 })
             ),
-            ForEach(items, item => TextBlock($"  - {item}"))
+            ForEach(items, (item, i) => TextBlock($"  - {item}").WithKey($"{i}-{item}"))
         ).Padding(24);
     }
 }

--- a/docs/_pipeline/apps/effects/App.cs
+++ b/docs/_pipeline/apps/effects/App.cs
@@ -164,7 +164,7 @@ class FetchCancellationExample : Component
 
         return VStack(8,
             TextBox(query, setQuery, header: "Search query").Width(250),
-            ForEach(items, i => TextBlock(i))
+            ForEach(items, item => TextBlock(item).WithKey(item))
         ).Padding(24);
     }
 }

--- a/docs/_pipeline/apps/forms/App.cs
+++ b/docs/_pipeline/apps/forms/App.cs
@@ -315,7 +315,7 @@ class AutoSuggestDemo : Component
             When(matches.Length > 0, () =>
                 VStack(2,
                     ForEach(matches, m =>
-                        TextBlock(m).Padding(8, 4))
+                        TextBlock(m).Padding(8, 4).WithKey(m))
                 ).Background(Theme.CardBackground).Width(280))
         ).Padding(24);
     }

--- a/docs/_pipeline/apps/hooks/App.cs
+++ b/docs/_pipeline/apps/hooks/App.cs
@@ -55,7 +55,7 @@ class ReducerDemo : Component
                 Button("Clear", () =>
                     updateItems(_ => new List<string>()))
             ),
-            ForEach(items, item => TextBlock($"  - {item}"))
+            ForEach(items, (item, i) => TextBlock($"  - {item}").WithKey($"{i}-{item}"))
         );
     }
 }

--- a/docs/_pipeline/apps/layout/App.cs
+++ b/docs/_pipeline/apps/layout/App.cs
@@ -97,7 +97,7 @@ class ScrollBorderDemo : Component
                     VStack(4,
                         ForEach(
                             Enumerable.Range(1, 20),
-                            i => TextBlock($"Scrollable item {i}"))
+                            i => TextBlock($"Scrollable item {i}").WithKey(i.ToString()))
                     ).Padding(8)
                 ).Height(120)
             ).CornerRadius(4).Background(Theme.CardBackground)

--- a/src/Reactor.Analyzers/MissingWithKeyAnalyzer.cs
+++ b/src/Reactor.Analyzers/MissingWithKeyAnalyzer.cs
@@ -10,14 +10,16 @@ using Microsoft.CodeAnalysis.Diagnostics;
 namespace Microsoft.UI.Reactor.Analyzers;
 
 /// <summary>
-/// <c>REACTOR_DSL_001</c> — when a LINQ <c>Select</c> projects to Reactor
-/// elements and the result is materialized into a layout container's children
+/// <c>REACTOR_DSL_001</c> — when a LINQ <c>Select</c> or Reactor
+/// <c>ForEach</c> projects to Reactor elements and the result is materialized
+/// into a layout container's children
 /// (<c>VStack</c>, <c>HStack</c>, <c>FlexRow</c>, <c>FlexColumn</c>, <c>Grid</c>, ...),
 /// every projected element should call <c>.WithKey(...)</c>. Without keys, the
 /// reconciler matches positionally and re-mounts every row on insert / reorder
 /// — losing focus, animation state, and ElementRef identity.
 ///
-/// Heuristic: a <c>Select(x =&gt; expr)</c> invocation whose lambda body
+/// Heuristic: a <c>Select(x =&gt; expr)</c> or Reactor <c>ForEach(items, x =&gt; expr)</c>
+/// invocation whose lambda body
 /// (a) returns a Reactor element-shaped expression, and
 /// (b) contains no <c>.WithKey(</c> token anywhere in the lambda body.
 ///
@@ -44,7 +46,7 @@ public sealed class MissingWithKeyAnalyzer : DiagnosticAnalyzer
     private static readonly DiagnosticDescriptor Rule = new(
         Id,
         "Dynamic list item missing .WithKey",
-        "Element produced by Select(...) doesn't call .WithKey(...). Without a key, the reconciler matches by position and re-mounts every row on insert/reorder, losing focus, animation, and ElementRef state.",
+        "Element produced by Select(...) or ForEach(...) doesn't call .WithKey(...). Without a key, the reconciler matches by position and re-mounts every row on insert/reorder, losing focus, animation, and ElementRef state.",
         "Reactor.Dsl",
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
@@ -73,8 +75,13 @@ public sealed class MissingWithKeyAnalyzer : DiagnosticAnalyzer
     {
         var inv = (InvocationExpressionSyntax)ctx.Node;
 
-        if (inv.Expression is not MemberAccessExpressionSyntax member) return;
-        var methodName = member.Name.Identifier.ValueText;
+        var methodName = inv.Expression switch
+        {
+            MemberAccessExpressionSyntax member => member.Name.Identifier.ValueText,
+            IdentifierNameSyntax id => id.Identifier.ValueText,
+            _ => null,
+        };
+        if (methodName is null) return;
 
         // REACTOR_DSL_002 — a present-but-non-stable key. The analysis is
         // triggered by each `.WithKey(...)` invocation (not the enclosing
@@ -89,16 +96,21 @@ public sealed class MissingWithKeyAnalyzer : DiagnosticAnalyzer
         // REACTOR_DSL_001 — a missing key on a Select projection.
         if (methodName == "Select")
         {
-            AnalyzeMissingKey(ctx, inv);
+            AnalyzeMissingKey(ctx, inv, lambdaIndex: 0);
+            return;
+        }
+
+        if (methodName == "ForEach" && IsReactorForEachReceiver(inv.Expression))
+        {
+            AnalyzeMissingKey(ctx, inv, lambdaIndex: 1);
         }
     }
 
     // <snippet:with-key-rule>
-    static void AnalyzeMissingKey(SyntaxNodeAnalysisContext ctx, InvocationExpressionSyntax inv)
+    static void AnalyzeMissingKey(SyntaxNodeAnalysisContext ctx, InvocationExpressionSyntax inv, int lambdaIndex)
     {
-        // Single lambda argument with an invocation body.
-        if (inv.ArgumentList.Arguments.Count != 1) return;
-        if (inv.ArgumentList.Arguments[0].Expression is not LambdaExpressionSyntax lambda) return;
+        if (inv.ArgumentList.Arguments.Count <= lambdaIndex) return;
+        if (inv.ArgumentList.Arguments[lambdaIndex].Expression is not LambdaExpressionSyntax lambda) return;
 
         var body = lambda.Body;
         if (body is BlockSyntax block) body = ExtractReturnExpression(block) ?? body;

--- a/src/Reactor.Analyzers/MissingWithKeyCodeFix.cs
+++ b/src/Reactor.Analyzers/MissingWithKeyCodeFix.cs
@@ -12,7 +12,8 @@ namespace Microsoft.UI.Reactor.Analyzers;
 /// <summary>
 /// Code fix for <see cref="MissingWithKeyAnalyzer"/> (<c>REACTOR_DSL_001</c>) —
 /// appends <c>.WithKey(...)</c> to the lambda body of a <c>.Select(item => …)</c>
-/// projection whose result is consumed by a layout factory.
+/// or Reactor <c>ForEach(items, item => …)</c> projection whose result is
+/// consumed by a layout factory.
 ///
 /// Three offers, in order of preference:
 /// <list type="number">
@@ -53,11 +54,7 @@ public sealed class MissingWithKeyCodeFix : CodeFixProvider
             var selectInv = root.FindNode(diagnostic.Location.SourceSpan) as InvocationExpressionSyntax;
             if (selectInv is null) continue;
 
-            // The analyzer only fires when:
-            //   .Select(lambda) — single argument, lambda body is an Invocation
-            // so we can re-derive the same shape without re-running the heuristic.
-            if (selectInv.ArgumentList.Arguments.Count != 1) continue;
-            if (selectInv.ArgumentList.Arguments[0].Expression is not LambdaExpressionSyntax lambda) continue;
+            if (!TryGetProjectionLambda(selectInv, out var lambda)) continue;
 
             var body = lambda.Body;
             ExpressionSyntax? targetExpr = null;
@@ -122,7 +119,7 @@ public sealed class MissingWithKeyCodeFix : CodeFixProvider
     static string? ExtractParameterName(LambdaExpressionSyntax lambda) => lambda switch
     {
         SimpleLambdaExpressionSyntax simple => simple.Parameter.Identifier.ValueText,
-        ParenthesizedLambdaExpressionSyntax paren when paren.ParameterList.Parameters.Count == 1
+        ParenthesizedLambdaExpressionSyntax paren when paren.ParameterList.Parameters.Count >= 1
             => paren.ParameterList.Parameters[0].Identifier.ValueText,
         _ => null,
     };
@@ -153,6 +150,47 @@ public sealed class MissingWithKeyCodeFix : CodeFixProvider
 
         return null;
     }
+
+    static bool TryGetProjectionLambda(InvocationExpressionSyntax inv, out LambdaExpressionSyntax lambda)
+    {
+        lambda = null!;
+
+        var methodName = inv.Expression switch
+        {
+            MemberAccessExpressionSyntax member => member.Name.Identifier.ValueText,
+            IdentifierNameSyntax id => id.Identifier.ValueText,
+            _ => null,
+        };
+        if (methodName is null) return false;
+
+        var lambdaIndex = methodName switch
+        {
+            "Select" => 0,
+            "ForEach" when IsReactorForEachReceiver(inv.Expression) => 1,
+            _ => -1,
+        };
+        if (lambdaIndex < 0) return false;
+        if (inv.ArgumentList.Arguments.Count <= lambdaIndex) return false;
+        if (inv.ArgumentList.Arguments[lambdaIndex].Expression is not LambdaExpressionSyntax found) return false;
+
+        lambda = found;
+        return true;
+    }
+
+    static bool IsReactorForEachReceiver(ExpressionSyntax invoked) => invoked switch
+    {
+        IdentifierNameSyntax => true,
+        MemberAccessExpressionSyntax m => SimpleName(m.Expression) == "Factories",
+        _ => false,
+    };
+
+    static string? SimpleName(ExpressionSyntax expr) => expr switch
+    {
+        IdentifierNameSyntax id => id.Identifier.ValueText,
+        MemberAccessExpressionSyntax m => m.Name.Identifier.ValueText,
+        QualifiedNameSyntax q => q.Right.Identifier.ValueText,
+        _ => null,
+    };
 
     static bool ImplementsIReactorKeyed(ITypeSymbol type)
     {

--- a/src/Reactor.Analyzers/MissingWithKeyCodeFix.cs
+++ b/src/Reactor.Analyzers/MissingWithKeyCodeFix.cs
@@ -51,8 +51,10 @@ public sealed class MissingWithKeyCodeFix : CodeFixProvider
 
         foreach (var diagnostic in context.Diagnostics)
         {
-            var selectInv = root.FindNode(diagnostic.Location.SourceSpan) as InvocationExpressionSyntax;
-            if (selectInv is null) continue;
+            var reported = root.FindNode(
+                diagnostic.Location.SourceSpan,
+                getInnermostNodeForTie: true);
+            if (reported is not InvocationExpressionSyntax selectInv) continue;
 
             if (!TryGetProjectionLambda(selectInv, out var lambda)) continue;
 

--- a/tests/Reactor.Tests/AnalyzerTests/MissingWithKeyAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/MissingWithKeyAnalyzerTests.cs
@@ -107,6 +107,80 @@ namespace TestApp
     }
 
     [Fact]
+    public async Task Fires_On_ForEach_Into_FlexColumn_Without_WithKey()
+    {
+        var source = Stubs + @"
+namespace TestApp
+{
+    using System.Collections.Generic;
+    using Microsoft.UI.Reactor.Core;
+    using static Microsoft.UI.Reactor.Core.Factories;
+
+    public record Row(string Id, string Text);
+
+    public static class C
+    {
+        public static Element Build(IReadOnlyList<Row> rows)
+            => FlexColumn({|REACTOR_DSL_001:ForEach(rows, (r, i) => TextBlock(r.Text))|});
+    }
+}";
+
+        await new CSharpAnalyzerTest<MissingWithKeyAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task Fires_On_Qualified_Factories_ForEach_Without_WithKey()
+    {
+        var source = Stubs + @"
+namespace TestApp
+{
+    using System.Collections.Generic;
+    using Microsoft.UI.Reactor.Core;
+
+    public record Row(string Id, string Text);
+
+    public static class C
+    {
+        public static Element Build(IReadOnlyList<Row> rows)
+            => Factories.FlexColumn({|REACTOR_DSL_001:Factories.ForEach(rows, (r, i) => Factories.TextBlock(r.Text))|});
+    }
+}";
+
+        await new CSharpAnalyzerTest<MissingWithKeyAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task No_Diagnostic_When_WithKey_Already_Present_On_ForEach()
+    {
+        var source = Stubs + @"
+namespace TestApp
+{
+    using System.Collections.Generic;
+    using Microsoft.UI.Reactor.Core;
+    using static Microsoft.UI.Reactor.Core.Factories;
+
+    public record Row(string Id, string Text);
+
+    public static class C
+    {
+        public static Element Build(IReadOnlyList<Row> rows)
+            => FlexColumn(ForEach(rows, (r, i) => TextBlock(r.Text).WithKey(r.Id)));
+    }
+}";
+
+        await new CSharpAnalyzerTest<MissingWithKeyAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
     public async Task No_Diagnostic_When_Select_Goes_To_Plain_List()
     {
         // The result of Select is materialized to List<Element>, not consumed
@@ -229,6 +303,55 @@ namespace TestApp
             TestCode = before,
             FixedCode = after,
             CodeActionEquivalenceKey = $"{MissingWithKeyAnalyzer.Id}_WithKey_Item_Id",
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task CodeFix_Offers_WithKey_Item_On_ForEach()
+    {
+        var before = Stubs + @"
+namespace TestApp
+{
+    using System.Collections.Generic;
+    using Microsoft.UI.Reactor.Core;
+    using static Microsoft.UI.Reactor.Core.Factories;
+
+    public record Row(string Id, string Text) : IReactorKeyed
+    {
+        string IReactorKeyed.Key => Id;
+    }
+
+    public static class C
+    {
+        public static Element Build(IReadOnlyList<Row> rows)
+            => FlexColumn({|REACTOR_DSL_001:ForEach(rows, (r, i) => TextBlock(r.Text))|});
+    }
+}";
+
+        var after = Stubs + @"
+namespace TestApp
+{
+    using System.Collections.Generic;
+    using Microsoft.UI.Reactor.Core;
+    using static Microsoft.UI.Reactor.Core.Factories;
+
+    public record Row(string Id, string Text) : IReactorKeyed
+    {
+        string IReactorKeyed.Key => Id;
+    }
+
+    public static class C
+    {
+        public static Element Build(IReadOnlyList<Row> rows)
+            => FlexColumn(ForEach(rows, (r, i) => TextBlock(r.Text).WithKey(r)));
+    }
+}";
+
+        await new CSharpCodeFixTest<MissingWithKeyAnalyzer, MissingWithKeyCodeFix, DefaultVerifier>
+        {
+            TestCode = before,
+            FixedCode = after,
+            CodeActionEquivalenceKey = $"{MissingWithKeyAnalyzer.Id}_WithKey_Item",
         }.RunAsync(TestContext.Current.CancellationToken);
     }
 


### PR DESCRIPTION

## Summary

Teach `REACTOR_DSL_001` to recognize Reactor `ForEach` projections in addition to `Select`, so missing `.WithKey(...)` warnings now cover the documented list-building idiom. Also update the code fix and add analyzer coverage for bare and qualified `ForEach` calls.

## Linked issue / spec

Fixes #1156

## Test plan

- [x] Added analyzer tests for bare `ForEach(...)`, `Factories.ForEach(...)`, and keyed `ForEach(...)`
- [x] Added code-fix coverage for `ForEach(...)`
- [x] Built `src/Reactor.Analyzers/Reactor.Analyzers.csproj --no-restore -p:Platform=x64`
- [ ] Full `dotnet test tests/Reactor.Tests` could not be completed in this environment because unrelated repo build issues blocked the test project



