### PR TITLE
Attribute thin helpers to their callers and stamp converted arguments (spec 010)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,31 @@ Conventions for contributors:
   `ReactorSourceMap.Enabled` switch, which the devtools verb sets automatically. When
   the runtime switch is off, no locations are populated; in Release, the generator is
   not loaded unless the MSBuild property is explicitly enabled.
+- **`[ReactorSourceTransparent]` — attribute a thin helper to its caller, and per-argument
+  source mapping for implicitly converted children (spec 010).** Two follow-ups that close
+  the attribution gaps the initial source-mapping drop documented.
+
+  Marking a static, `Element`-returning helper
+  `[Microsoft.UI.Reactor.Diagnostics.ReactorSourceTransparent]` stops the generator
+  stamping DSL calls inside it and instead stamps calls *to* it, so a forwarder like
+  `Field(label, value)` reports each caller's own line rather than collapsing every call
+  site onto one line in its body. Annotated helpers compose: the deferral walks outward
+  until it reaches a caller that is not annotated. It is deliberately opt-in — for a
+  `Component.Render()` body the body line is the correct answer. An annotation the
+  generator cannot honour (a `private` helper, an instance method, a local function)
+  reports **`REACTOR_SOURCEMAP_001`** and leaves attribution exactly as it would be
+  without the attribute, so a bad annotation is never worse than none. The attribute is
+  read from metadata, so libraries can annotate their own forwarders;
+  `PendingFactory.Pending` now does, and its callers get a location where they
+  previously got `null`.
+
+  Separately, arguments that reach an `Element` parameter through an implicit
+  user-defined conversion — `VStack("a", "b")`, via `implicit operator Element(string)` —
+  are now stamped at **the argument's own line**. Those elements are built by an operator
+  body inside Reactor, which interceptors structurally cannot reach (they intercept
+  ordinary method calls, never operators), so they previously reported no location at
+  all. Applies to any user-defined conversion to `Element`, respects first-stamp-wins,
+  and never writes into a `params` array the caller owns.
 - **`NavigationTransition.Entrance()` — the WinUI page-refresh motion as a first-class
   transition (spec 011 §6).** The incoming page slides up a short distance and fades in,
   mirroring WinUI's `EntranceNavigationTransitionInfo`. `EntranceTransition` is public and

--- a/docs/_pipeline/templates/source-mapping.md.dt
+++ b/docs/_pipeline/templates/source-mapping.md.dt
@@ -173,20 +173,11 @@ is exactly where the author wrote the UI, and deferring it to the caller would b
 a regression.
 
 For a *thin forwarder*, whose own line carries no information anyone wants, mark
-it `[ReactorSourceTransparent]`:
+it `[ReactorSourceTransparent]`. This is the helper the source-map explorer
+sample uses for its two order rows — click them in the running app and they
+report their own distinct call sites, not this helper's body:
 
-```csharp
-using Microsoft.UI.Reactor.Diagnostics;
-
-[ReactorSourceTransparent]
-internal static Element Field(string label, string value)
-    => HStack(TextBlock(label), TextBlock(value));
-
-// Each row now reports ITS OWN line, instead of both reporting
-// the HStack( line inside Field.
-var form = VStack(
-    Field("Name", name),
-    Field("Email", email));
+```csharp snippet="source:samples/apps/source-map-explorer/App.cs#transparent-helper"
 ```
 
 Two rules do the work, and they compose. The generator emits no interceptor for
@@ -196,6 +187,11 @@ therefore keeps deferring outward until it reaches a caller that is not
 annotated. First-stamp-wins still applies, so a helper that merely passes an
 element through does not relabel it.
 
+Because rule 1 suppresses stamping for *everything* inside an annotated method,
+that includes argument-position stamps (below): a bare-string child written
+inside a transparent helper is not stamped either, since the element belongs to
+whoever called the helper.
+
 The annotated method has to be one the generator can emit a forwarding call to:
 
 | Requirement | Why |
@@ -203,7 +199,8 @@ The annotated method has to be one the generator can emit a forwarding call to:
 | `static` | Intercepting an instance method needs an extension-method interceptor, a different shape that is not supported |
 | Returns an `Element` (including `Element?`) | There is nothing else to stamp |
 | `public` or `internal`, never `private` or `protected` | The interceptor lives in a generated file and must be able to name the method |
-| Not a local function | C# interceptors cannot intercept local functions |
+| An ordinary method — not an operator, accessor, constructor or local function | C# interceptors can only intercept calls to ordinary methods |
+| No `ref` / `out` / `in` parameters | The interceptor has to restate the signature and call the original with exactly the arguments it received |
 | Not declared in a `file`-local or generic type | Generated code cannot name the first; interceptors cannot be declared for the second |
 
 An annotation that fails any of these is reported as **`REACTOR_SOURCEMAP_001`**

--- a/docs/_pipeline/templates/source-mapping.md.dt
+++ b/docs/_pipeline/templates/source-mapping.md.dt
@@ -158,18 +158,98 @@ already stores -> `Element.CallSite`. It returns `null` when the control
 was not produced by Reactor, when the assembly was built without source
 mapping, or when nothing stamped that element.
 
+### Helper methods and `[ReactorSourceTransparent]`
+
+By default a helper is attributed to *itself*. In
+
+```csharp
+static Element MyHeader() => TextBlock("header");
+```
+
+the call site of `TextBlock` is inside `MyHeader`, so every caller of `MyHeader`
+collapses onto that one line. That default is deliberate: for most
+element-returning methods — a `Component.Render()` body above all — the body line
+is exactly where the author wrote the UI, and deferring it to the caller would be
+a regression.
+
+For a *thin forwarder*, whose own line carries no information anyone wants, mark
+it `[ReactorSourceTransparent]`:
+
+```csharp
+using Microsoft.UI.Reactor.Diagnostics;
+
+[ReactorSourceTransparent]
+internal static Element Field(string label, string value)
+    => HStack(TextBlock(label), TextBlock(value));
+
+// Each row now reports ITS OWN line, instead of both reporting
+// the HStack( line inside Field.
+var form = VStack(
+    Field("Name", name),
+    Field("Email", email));
+```
+
+Two rules do the work, and they compose. The generator emits no interceptor for
+DSL calls *inside* an annotated method, and instead intercepts calls *to* it,
+stamping the caller's line. An annotated helper calling another annotated helper
+therefore keeps deferring outward until it reaches a caller that is not
+annotated. First-stamp-wins still applies, so a helper that merely passes an
+element through does not relabel it.
+
+The annotated method has to be one the generator can emit a forwarding call to:
+
+| Requirement | Why |
+|---|---|
+| `static` | Intercepting an instance method needs an extension-method interceptor, a different shape that is not supported |
+| Returns an `Element` (including `Element?`) | There is nothing else to stamp |
+| `public` or `internal`, never `private` or `protected` | The interceptor lives in a generated file and must be able to name the method |
+| Not a local function | C# interceptors cannot intercept local functions |
+| Not declared in a `file`-local or generic type | Generated code cannot name the first; interceptors cannot be declared for the second |
+
+An annotation that fails any of these is reported as **`REACTOR_SOURCEMAP_001`**
+(a warning) rather than silently doing nothing, and attribution falls back to the
+helper's own line — so a bad annotation is never worse than no annotation. The
+usual `#pragma warning disable REACTOR_SOURCEMAP_001` suppresses it if you
+annotated a method deliberately knowing it cannot be honoured.
+
+The attribute also works across assemblies: it is read from metadata, so a
+library can annotate its own forwarders and consumers get the benefit.
+`Pending(fallback, child)` is annotated this way inside Reactor itself.
+
+### Bare strings and other implicit conversions
+
+`Element` declares `implicit operator Element(string)`, so `VStack("hi")` builds
+its child by calling `TextBlock` *inside Reactor's own assembly*. That call site
+cannot be intercepted — interceptors work on ordinary method calls, never on
+operators, and the operator body is already compiled into `Reactor.dll`.
+
+Instead, the enclosing factory call stamps the converted argument as it passes
+it through, using **the argument expression's own line**:
+
+```csharp
+VStack(
+    "a",   // reports this line
+    "b");  // and this one
+```
+
+This applies to any implicit user-defined conversion to `Element`, including ones
+your own types declare — not just `string`. Two limits are worth knowing:
+
+- It only fills in locations nothing else supplies. An argument that already
+  carries a `CallSite` (an explicitly written `TextBlock("x")`, or a conversion
+  whose operator body lives in *your* compilation and was therefore intercepted)
+  keeps the location it already had.
+- It applies only to arguments written at the call site. `VStack(myArray)` passes
+  an array you own, whose elements were converted where the array was built, so
+  nothing is stamped and your array is never written to.
+
 ### Known limitations
 
-- **Helper methods attribute to themselves.** A helper `MyHeader()` that
-  calls `TextBlock(...)` reports the line inside `MyHeader`, not the line
-  that called it — interceptors replace the call site, and that *is* the
-  call site. Wrap reusable UI in a named component when you want the
-  caller's identity.
-- **Bare-string children are not stamped.** `VStack("hi")` goes through
-  the implicit `string` → `Element` conversion, whose `TextBlock` call
-  lives in the framework, not your code. Those elements report `null`
-  rather than a misleading framework location. Write `TextBlock("hi")`
-  explicitly if you need the location.
+- **Unannotated helper methods attribute to themselves.** A helper `MyHeader()`
+  that calls `TextBlock(...)` reports the line inside `MyHeader`, not the line
+  that called it — interceptors replace the call site, and that *is* the call
+  site. Mark a thin forwarder `[ReactorSourceTransparent]` (above) to defer to
+  the caller, or wrap reusable UI in a named component.
 - **Wrapped third-party controls are not stamped.** A factory generated by
   `[GenerateReactorWrapper]` lives on the element type
   (`MyControlElement.MyControl(...)`), not on `Factories`, and is invisible
@@ -178,14 +258,15 @@ mapping, or when nothing stamped that element.
   Those elements report `null` rather than a wrong line. If you need a
   location for a wrapped control, call it from a named component and use
   the component's identity.
-- **Entry points outside `Factories` are not stamped.** A few
-  element-producing APIs live elsewhere — `Pending(fallback, child)`
-  (`PendingFactory`) and `intl.RichMessage(...)` (`IntlAccessor`) are the
-  built-in examples. They build their element by calling `Factories` from
-  inside Reactor's own assembly, where there is no call site in your
-  compilation to intercept, so the element they return reports `null`. The
-  elements you pass *into* them are ordinary call sites and are stamped
-  normally.
+- **Unannotated entry points outside `Factories` are not stamped.** A few
+  element-producing APIs live elsewhere — `PropertyGridDefaults`'s templates and
+  `intl.RichMessage(...)` (`IntlAccessor`) are built-in examples. They build their
+  element by calling `Factories` from inside Reactor's own assembly, where there is
+  no call site in your compilation to intercept, so the element they return reports
+  `null`. The elements you pass *into* them are ordinary call sites and are stamped
+  normally. A static forwarder in this position can opt in with
+  `[ReactorSourceTransparent]`, which is what `Pending(fallback, child)` does;
+  `intl.RichMessage` cannot, because it is an instance method.
 
 ## Tips
 

--- a/docs/guide/reference/hooks/Pending.md
+++ b/docs/guide/reference/hooks/Pending.md
@@ -20,3 +20,13 @@ element simply chooses which rendered tree to show — there is no unwinding
 of rendering, and no reconciler involvement.
 
 
+Marked `ReactorSourceTransparentAttribute` (spec 010) because it is a
+pure forwarder: the element is really built by the `Component<,>` call
+on the next line, inside Reactor's own assembly, where no consumer call site
+exists to intercept. Without the annotation a `Pending(...)` element reports
+no location at all. With it, the interceptor in the consumer's compilation stamps
+the line they wrote `Pending(` on, which is the answer they were looking for.
+
+
+
+

--- a/docs/guide/reference/hooks/Pending.md
+++ b/docs/guide/reference/hooks/Pending.md
@@ -20,7 +20,8 @@ element simply chooses which rendered tree to show — there is no unwinding
 of rendering, and no reconciler involvement.
 
 
-Marked `ReactorSourceTransparentAttribute` (spec 010) because it is a
+Marked `[ReactorSourceTransparent]` (see
+`ReactorSourceTransparentAttribute`, spec 010) because it is a
 pure forwarder: the element is really built by the `Component<,>` call
 on the next line, inside Reactor's own assembly, where no consumer call site
 exists to intercept. Without the annotation a `Pending(...)` element reports

--- a/docs/guide/source-mapping.md
+++ b/docs/guide/source-mapping.md
@@ -212,20 +212,32 @@ is exactly where the author wrote the UI, and deferring it to the caller would b
 a regression.
 
 For a *thin forwarder*, whose own line carries no information anyone wants, mark
-it `[ReactorSourceTransparent]`:
+it `[ReactorSourceTransparent]`. This is the helper the source-map explorer
+sample uses for its two order rows — click them in the running app and they
+report their own distinct call sites, not this helper's body:
 
 ```csharp
-using Microsoft.UI.Reactor.Diagnostics;
-
+/// <summary>
+/// A thin forwarder: its own line carries nothing a reader wants, so it is marked
+/// source-transparent and each element it returns is attributed to the CALLER's
+/// line instead of to the <c>VStack(</c> below.
+/// </summary>
+/// <remarks>
+/// Click the two order rows in the running sample: without the attribute both report
+/// this method's body line, because that is genuinely where <c>VStack</c> was called.
+/// With it they report the two distinct <c>OrderLine(</c> call sites above.
+/// <para>
+/// It must be <c>internal</c> rather than <c>private</c> — the generated interceptor
+/// lives in another file and has to be able to name it. A <c>private</c> helper here
+/// would report <c>REACTOR_SOURCEMAP_001</c> instead of taking effect.
+/// </para>
+/// </remarks>
 [ReactorSourceTransparent]
-internal static Element Field(string label, string value)
-    => HStack(TextBlock(label), TextBlock(value));
-
-// Each row now reports ITS OWN line, instead of both reporting
-// the HStack( line inside Field.
-var form = VStack(
-    Field("Name", name),
-    Field("Email", email));
+internal static Element OrderLine(string label, string amount) =>
+    VStack(
+        TextBlock(label),
+        TextBlock(amount).Bold()
+    ).Spacing(2);
 ```
 
 Two rules do the work, and they compose. The generator emits no interceptor for
@@ -235,6 +247,11 @@ therefore keeps deferring outward until it reaches a caller that is not
 annotated. First-stamp-wins still applies, so a helper that merely passes an
 element through does not relabel it.
 
+Because rule 1 suppresses stamping for *everything* inside an annotated method,
+that includes argument-position stamps (below): a bare-string child written
+inside a transparent helper is not stamped either, since the element belongs to
+whoever called the helper.
+
 The annotated method has to be one the generator can emit a forwarding call to:
 
 | Requirement | Why |
@@ -242,7 +259,8 @@ The annotated method has to be one the generator can emit a forwarding call to:
 | `static` | Intercepting an instance method needs an extension-method interceptor, a different shape that is not supported |
 | Returns an `Element` (including `Element?`) | There is nothing else to stamp |
 | `public` or `internal`, never `private` or `protected` | The interceptor lives in a generated file and must be able to name the method |
-| Not a local function | C# interceptors cannot intercept local functions |
+| An ordinary method — not an operator, accessor, constructor or local function | C# interceptors can only intercept calls to ordinary methods |
+| No `ref` / `out` / `in` parameters | The interceptor has to restate the signature and call the original with exactly the arguments it received |
 | Not declared in a `file`-local or generic type | Generated code cannot name the first; interceptors cannot be declared for the second |
 
 An annotation that fails any of these is reported as **`REACTOR_SOURCEMAP_001`**

--- a/docs/guide/source-mapping.md
+++ b/docs/guide/source-mapping.md
@@ -197,18 +197,98 @@ already stores -> `Element.CallSite`. It returns `null` when the control
 was not produced by Reactor, when the assembly was built without source
 mapping, or when nothing stamped that element.
 
+### Helper methods and `[ReactorSourceTransparent]`
+
+By default a helper is attributed to *itself*. In
+
+```csharp
+static Element MyHeader() => TextBlock("header");
+```
+
+the call site of `TextBlock` is inside `MyHeader`, so every caller of `MyHeader`
+collapses onto that one line. That default is deliberate: for most
+element-returning methods — a `Component.Render()` body above all — the body line
+is exactly where the author wrote the UI, and deferring it to the caller would be
+a regression.
+
+For a *thin forwarder*, whose own line carries no information anyone wants, mark
+it `[ReactorSourceTransparent]`:
+
+```csharp
+using Microsoft.UI.Reactor.Diagnostics;
+
+[ReactorSourceTransparent]
+internal static Element Field(string label, string value)
+    => HStack(TextBlock(label), TextBlock(value));
+
+// Each row now reports ITS OWN line, instead of both reporting
+// the HStack( line inside Field.
+var form = VStack(
+    Field("Name", name),
+    Field("Email", email));
+```
+
+Two rules do the work, and they compose. The generator emits no interceptor for
+DSL calls *inside* an annotated method, and instead intercepts calls *to* it,
+stamping the caller's line. An annotated helper calling another annotated helper
+therefore keeps deferring outward until it reaches a caller that is not
+annotated. First-stamp-wins still applies, so a helper that merely passes an
+element through does not relabel it.
+
+The annotated method has to be one the generator can emit a forwarding call to:
+
+| Requirement | Why |
+|---|---|
+| `static` | Intercepting an instance method needs an extension-method interceptor, a different shape that is not supported |
+| Returns an `Element` (including `Element?`) | There is nothing else to stamp |
+| `public` or `internal`, never `private` or `protected` | The interceptor lives in a generated file and must be able to name the method |
+| Not a local function | C# interceptors cannot intercept local functions |
+| Not declared in a `file`-local or generic type | Generated code cannot name the first; interceptors cannot be declared for the second |
+
+An annotation that fails any of these is reported as **`REACTOR_SOURCEMAP_001`**
+(a warning) rather than silently doing nothing, and attribution falls back to the
+helper's own line — so a bad annotation is never worse than no annotation. The
+usual `#pragma warning disable REACTOR_SOURCEMAP_001` suppresses it if you
+annotated a method deliberately knowing it cannot be honoured.
+
+The attribute also works across assemblies: it is read from metadata, so a
+library can annotate its own forwarders and consumers get the benefit.
+`Pending(fallback, child)` is annotated this way inside Reactor itself.
+
+### Bare strings and other implicit conversions
+
+`Element` declares `implicit operator Element(string)`, so `VStack("hi")` builds
+its child by calling `TextBlock` *inside Reactor's own assembly*. That call site
+cannot be intercepted — interceptors work on ordinary method calls, never on
+operators, and the operator body is already compiled into `Reactor.dll`.
+
+Instead, the enclosing factory call stamps the converted argument as it passes
+it through, using **the argument expression's own line**:
+
+```csharp
+VStack(
+    "a",   // reports this line
+    "b");  // and this one
+```
+
+This applies to any implicit user-defined conversion to `Element`, including ones
+your own types declare — not just `string`. Two limits are worth knowing:
+
+- It only fills in locations nothing else supplies. An argument that already
+  carries a `CallSite` (an explicitly written `TextBlock("x")`, or a conversion
+  whose operator body lives in *your* compilation and was therefore intercepted)
+  keeps the location it already had.
+- It applies only to arguments written at the call site. `VStack(myArray)` passes
+  an array you own, whose elements were converted where the array was built, so
+  nothing is stamped and your array is never written to.
+
 ### Known limitations
 
-- **Helper methods attribute to themselves.** A helper `MyHeader()` that
-  calls `TextBlock(...)` reports the line inside `MyHeader`, not the line
-  that called it — interceptors replace the call site, and that *is* the
-  call site. Wrap reusable UI in a named component when you want the
-  caller's identity.
-- **Bare-string children are not stamped.** `VStack("hi")` goes through
-  the implicit `string` → `Element` conversion, whose `TextBlock` call
-  lives in the framework, not your code. Those elements report `null`
-  rather than a misleading framework location. Write `TextBlock("hi")`
-  explicitly if you need the location.
+- **Unannotated helper methods attribute to themselves.** A helper `MyHeader()`
+  that calls `TextBlock(...)` reports the line inside `MyHeader`, not the line
+  that called it — interceptors replace the call site, and that *is* the call
+  site. Mark a thin forwarder `[ReactorSourceTransparent]` (above) to defer to
+  the caller, or wrap reusable UI in a named component.
 - **Wrapped third-party controls are not stamped.** A factory generated by
   `[GenerateReactorWrapper]` lives on the element type
   (`MyControlElement.MyControl(...)`), not on `Factories`, and is invisible
@@ -217,14 +297,15 @@ mapping, or when nothing stamped that element.
   Those elements report `null` rather than a wrong line. If you need a
   location for a wrapped control, call it from a named component and use
   the component's identity.
-- **Entry points outside `Factories` are not stamped.** A few
-  element-producing APIs live elsewhere — `Pending(fallback, child)`
-  (`PendingFactory`) and `intl.RichMessage(...)` (`IntlAccessor`) are the
-  built-in examples. They build their element by calling `Factories` from
-  inside Reactor's own assembly, where there is no call site in your
-  compilation to intercept, so the element they return reports `null`. The
-  elements you pass *into* them are ordinary call sites and are stamped
-  normally.
+- **Unannotated entry points outside `Factories` are not stamped.** A few
+  element-producing APIs live elsewhere — `PropertyGridDefaults`'s templates and
+  `intl.RichMessage(...)` (`IntlAccessor`) are built-in examples. They build their
+  element by calling `Factories` from inside Reactor's own assembly, where there is
+  no call site in your compilation to intercept, so the element they return reports
+  `null`. The elements you pass *into* them are ordinary call sites and are stamped
+  normally. A static forwarder in this position can opt in with
+  `[ReactorSourceTransparent]`, which is what `Pending(fallback, child)` does;
+  `intl.RichMessage` cannot, because it is an instance method.
 
 ## Tips
 

--- a/plugins/reactor/skills/reactor-dsl/references/reactor.api.txt
+++ b/plugins/reactor/skills/reactor-dsl/references/reactor.api.txt
@@ -4600,6 +4600,9 @@ Mount(Func<RenderContext, Element> renderFunc) → void
 bool Enabled { get; set; }
 GetSource(UIElement control) → SourceLocation?
 
+### class ReactorSourceTransparentAttribute
+new()
+
 ### static class ReactorTrace
 Subscribe(Action<ReactorEvent> onEvent, EventLevel level = EventLevel.Verbose, EventKeywords keywords = EventKeywords.All) → IDisposable
 

--- a/samples/apps/source-map-explorer/App.cs
+++ b/samples/apps/source-map-explorer/App.cs
@@ -164,7 +164,6 @@ internal sealed class App : Component
             Heading("Reactor source map explorer"),
             TextBlock("Click anything on the left. Every element below is a plain display leaf — no callbacks, no keys.")
                 .Foreground(Theme.SecondaryText),
-
             HStack(
                 Button(mapping ? "Source mapping: ON" : "Source mapping: OFF", () =>
                 {
@@ -184,16 +183,10 @@ internal sealed class App : Component
                         Heading("Order summary"),
                         TextBlock("Two items, ready to ship."),
                         Border(
-                            VStack(
-                                TextBlock("Wireless keyboard"),
-                                TextBlock("$79.00").Bold()
-                            ).Spacing(2)
+                            OrderLine("Wireless keyboard", "$79.00")
                         ).Padding(10).Background(Theme.SubtleFill),
                         Border(
-                            VStack(
-                                TextBlock("USB-C cable"),
-                                TextBlock("$12.00").Bold()
-                            ).Spacing(2)
+                            OrderLine("USB-C cable", "$12.00")
                         ).Padding(10).Background(Theme.SubtleFill),
                         HStack(
                             TextBlock("Total").Bold(),
@@ -227,4 +220,28 @@ internal sealed class App : Component
             ).Spacing(16)
         ).Spacing(14).Padding(20);
     }
+
+    // <snippet:transparent-helper>
+    /// <summary>
+    /// A thin forwarder: its own line carries nothing a reader wants, so it is marked
+    /// source-transparent and each element it returns is attributed to the CALLER's
+    /// line instead of to the <c>VStack(</c> below.
+    /// </summary>
+    /// <remarks>
+    /// Click the two order rows in the running sample: without the attribute both report
+    /// this method's body line, because that is genuinely where <c>VStack</c> was called.
+    /// With it they report the two distinct <c>OrderLine(</c> call sites above.
+    /// <para>
+    /// It must be <c>internal</c> rather than <c>private</c> — the generated interceptor
+    /// lives in another file and has to be able to name it. A <c>private</c> helper here
+    /// would report <c>REACTOR_SOURCEMAP_001</c> instead of taking effect.
+    /// </para>
+    /// </remarks>
+    [ReactorSourceTransparent]
+    internal static Element OrderLine(string label, string amount) =>
+        VStack(
+            TextBlock(label),
+            TextBlock(amount).Bold()
+        ).Spacing(2);
+    // </snippet:transparent-helper>
 }

--- a/skills/reactor.api.txt
+++ b/skills/reactor.api.txt
@@ -4600,6 +4600,9 @@ Mount(Func<RenderContext, Element> renderFunc) → void
 bool Enabled { get; set; }
 GetSource(UIElement control) → SourceLocation?
 
+### class ReactorSourceTransparentAttribute
+new()
+
 ### static class ReactorTrace
 Subscribe(Action<ReactorEvent> onEvent, EventLevel level = EventLevel.Verbose, EventKeywords keywords = EventKeywords.All) → IDisposable
 

--- a/src/Reactor.SourceMap.Generator/Reactor.SourceMap.Generator.csproj
+++ b/src/Reactor.SourceMap.Generator/Reactor.SourceMap.Generator.csproj
@@ -32,8 +32,11 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <!-- RS2008: this component ships no diagnostics of its own, so the analyzer
-         release-tracking files do not apply. -->
+    <!-- RS2008: the one diagnostic this component reports (REACTOR_SOURCEMAP_001)
+         belongs to the source-map generator, not to the Reactor.Analyzers bundle, so
+         it is documented in docs/guide/source-mapping.md rather than tracked in that
+         package's AnalyzerReleases files. Adding a row there would claim an id the
+         analyzer assembly does not declare. -->
     <NoWarn>$(NoWarn);RS2008</NoWarn>
   </PropertyGroup>
 

--- a/src/Reactor.SourceMap.Generator/SourceMapInterceptorGenerator.cs
+++ b/src/Reactor.SourceMap.Generator/SourceMapInterceptorGenerator.cs
@@ -7,6 +7,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
 
 namespace Microsoft.UI.Reactor.SourceMap.Generator;
 
@@ -38,6 +39,41 @@ public sealed class SourceMapInterceptorGenerator : IIncrementalGenerator
     internal const string InterceptorNamespace = "Microsoft.UI.Reactor.Generated";
     private const string FactoriesMetadataName = "Microsoft.UI.Reactor.Factories";
     private const string ElementMetadataName = "Microsoft.UI.Reactor.Core.Element";
+    private const string EmptyElementMetadataName = "Microsoft.UI.Reactor.Core.EmptyElement";
+
+    /// <summary>
+    /// The opt-in marker for helper-method attribution (mechanism 1). Matched by
+    /// display string rather than <c>GetTypeByMetadataName</c> so a consumer that
+    /// somehow sees two copies of the type still gets consistent treatment.
+    /// </summary>
+    internal const string TransparentAttributeMetadataName =
+        "Microsoft.UI.Reactor.Diagnostics.ReactorSourceTransparentAttribute";
+
+    /// <summary>
+    /// Reported when <c>[ReactorSourceTransparent]</c> is applied to a method the
+    /// generator cannot emit a forwarding interceptor for.
+    ///
+    /// <para>The alternative — doing nothing — would make the attribute a silent
+    /// no-op on exactly the shape people reach for first (a <c>private static</c>
+    /// helper inside a component), with no signal that the intended attribution
+    /// never happened.</para>
+    /// </summary>
+    internal static readonly DiagnosticDescriptor UnusableTransparentAnnotation = new(
+        "REACTOR_SOURCEMAP_001",
+        "[ReactorSourceTransparent] cannot be honoured on this method",
+        "'{0}' is marked [ReactorSourceTransparent], but source attribution cannot be deferred to its "
+        + "callers because {1}. Elements it returns keep reporting its own line.",
+        "Reactor.SourceMap",
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description:
+        "The source-map generator honours [ReactorSourceTransparent] by emitting an interceptor that "
+        + "forwards to the annotated method and stamps the caller's line. That is only possible for a "
+        + "static, Element-returning, ordinary method that generated code in the same compilation can "
+        + "name - so public or internal, not private, not a local function, and not nested in a "
+        + "file-local or generic type. When the annotation cannot be honoured the generator leaves the "
+        + "method's own call sites stamped as usual, so attribution is never worse than it would be "
+        + "without the attribute.");
 
     /// <summary>
     /// DSL factories that return an element the CALLER supplied rather than one they
@@ -81,6 +117,19 @@ public sealed class SourceMapInterceptorGenerator : IIncrementalGenerator
             .Where(static x => x is not null)
             .Collect();
 
+        // Spec 010 — mechanism 1's failure mode. `[ReactorSourceTransparent]` is opt-in,
+        // so the only feedback a consumer gets is whether attribution moved; on an
+        // annotation the generator cannot honour, nothing moves and nothing says why.
+        // This pass reports that case instead. It reads the ANNOTATED DECLARATIONS
+        // rather than the call sites, so a method that is annotated but never called
+        // still warns.
+        var annotationProblems = context.SyntaxProvider.ForAttributeWithMetadataName(
+                TransparentAttributeMetadataName,
+                predicate: static (_, _) => true,
+                transform: static (ctx, ct) => DescribeAnnotationProblem(ctx, ct))
+            .Where(static x => x is not null)
+            .Collect();
+
         var input = callSites.Combine(enabled).Combine(needsPolyfill).Combine(pathMap);
 
         context.RegisterSourceOutput(input, static (spc, tuple) =>
@@ -88,6 +137,19 @@ public sealed class SourceMapInterceptorGenerator : IIncrementalGenerator
             var (((sites, isEnabled), polyfill), map) = tuple;
             if (!isEnabled || sites.IsDefaultOrEmpty) return;
             spc.AddSource("ReactorSourceMap.Interceptors.g.cs", Emit(sites!, polyfill, map));
+        });
+
+        // Gated on the same opt-in as the interceptors: in a compilation where the
+        // generator emits nothing, the attribute is inert by design and a warning about
+        // it would be noise.
+        context.RegisterSourceOutput(annotationProblems.Combine(enabled), static (spc, tuple) =>
+        {
+            var (problems, isEnabled) = tuple;
+            if (!isEnabled) return;
+            foreach (var problem in problems)
+            {
+                spc.ReportDiagnostic(problem!.ToDiagnostic());
+            }
         });
     }
 
@@ -112,7 +174,9 @@ public sealed class SourceMapInterceptorGenerator : IIncrementalGenerator
         // constructed symbol.
         method = method.OriginalDefinition;
 
-        // Only the Reactor DSL surface.
+        // Only the Reactor DSL surface, plus (spec 010 mechanism 1) any static
+        // Element-returning method the author explicitly marked
+        // `[ReactorSourceTransparent]`.
         //
         // Deliberately NOT widened to "any static that returns an Element", which
         // would be the obvious way to also cover the factories
@@ -127,13 +191,28 @@ public sealed class SourceMapInterceptorGenerator : IIncrementalGenerator
         // WrapperFactoryInterceptionTests, which pins the limitation. Coverage that
         // varies with project shape is worse than a documented, uniform gap.
         // Corollary of the same filter: element-producing entry points that live
-        // OUTSIDE Factories are likewise unstamped — `PendingFactory.Pending(...)`
-        // builds its element by calling `Factories.Component<,>` from inside Reactor's
-        // own assembly, where there is no call site in the consumer's compilation to
-        // intercept, and instance members such as `IntlAccessor.RichMessage(...)` are
-        // already excluded by the IsStatic check above. Both report no location rather
-        // than a framework line, and are pinned by NonFactoriesEntryPointTests.
-        if (method.ContainingType?.ToDisplayString() != FactoriesMetadataName) return null;
+        // OUTSIDE Factories are likewise unstamped unless annotated —
+        // `PendingFactory.Pending(...)` builds its element by calling
+        // `Factories.Component<,>` from inside Reactor's own assembly, where there is no
+        // call site in the consumer's compilation to intercept, and instance members such
+        // as `IntlAccessor.RichMessage(...)` are already excluded by the IsStatic check
+        // above. Both report no location rather than a framework line, and are pinned by
+        // NonFactoriesEntryPointTests.
+        //
+        // The annotation is what makes the widening safe: it is a per-method assertion by
+        // the author that the method's own line carries no information, so intercepting
+        // the CALL to it is the attribution they want. Without it there is no way to tell
+        // a thin forwarder from a `Render()` body, where the body line is correct.
+        var compilation = ctx.SemanticModel.Compilation;
+        var isFactory = method.ContainingType?.ToDisplayString() == FactoriesMetadataName;
+        var isTransparentTarget = IsTransparent(method);
+
+        if (!isFactory && !isTransparentTarget) return null;
+
+        // Resolved once per candidate, and only AFTER the cheap filters above, so an
+        // ordinary invocation never pays for it. Every "is this an Element" question below
+        // goes through these symbols rather than a rendered type name — see ReturnsElement.
+        if (compilation.GetTypeByMetadataName(ElementMetadataName) is not { } elementSymbol) return null;
 
         // Pass-throughs are never stamped, because they did not create the element.
         // When/If/Expr return `then()` / `render()` verbatim, so the returned element
@@ -151,7 +230,12 @@ public sealed class SourceMapInterceptorGenerator : IIncrementalGenerator
         // base-Element-returning factories that take a Func<...Element...> ever stops
         // matching it, so a fourth pass-through is a loud failure rather than a silent
         // misattribution.
-        if (PassThroughFactories.Contains(method.Name)) return null;
+        if (isFactory && PassThroughFactories.Contains(method.Name)) return null;
+
+        // Mechanism 1 rule 2. An annotated method is only worth intercepting if the
+        // emitted interceptor can actually forward to it by name; the diagnostic pass
+        // reports the ones that cannot, so silence here is never the whole story.
+        if (!isFactory && !IsForwardable(method, compilation, elementSymbol)) return null;
 
         // Generic factories (Component<T>, Component<T,TProps>, ForEach<T>, Memo<TKey>,
         // ListView<T>, …). An interceptor for a generic method has to restate the
@@ -167,7 +251,20 @@ public sealed class SourceMapInterceptorGenerator : IIncrementalGenerator
         if (method.Parameters.Any(p => p.RefKind != RefKind.None)) return null;
 
         // Must return something we can stamp.
-        if (!ReturnsElement(method.ReturnType)) return null;
+        if (!ReturnsElement(method.ReturnType, elementSymbol)) return null;
+
+        // Mechanism 1 rule 1, and the whole of rule 3. A call written INSIDE a
+        // transparent method is not stamped at all, because the element it produces
+        // belongs to whoever called that method. Rule 2 then stamps it at that outer
+        // call site. Applying this to transparent-target calls as well as factory calls
+        // is what makes the behaviour recursive: transparent calling transparent keeps
+        // deferring outward until it reaches a caller that is not annotated.
+        //
+        // Conditioned on the enclosing method being FORWARDABLE, not merely annotated:
+        // if no rule-2 interceptor will exist to re-stamp at the caller, suppressing here
+        // would trade today's "the helper's line" for "no line at all". An annotation the
+        // generator cannot honour must never make attribution worse than no annotation.
+        if (IsInsideTransparentMethod(ctx.SemanticModel, invocation, compilation, elementSymbol, ct)) return null;
 
         var location = ctx.SemanticModel.GetInterceptableLocation(invocation, ct);
         if (location is null) return null;
@@ -206,7 +303,292 @@ public sealed class SourceMapInterceptorGenerator : IIncrementalGenerator
             attribute: location.GetInterceptsLocationAttributeSyntax(),
             filePath: ResolveMappedPath(lineSpan, invocation.SyntaxTree.FilePath),
             line: lineSpan.StartLinePosition.Line + 1,
-            signature: Signature.From(method));
+            signature: Signature.From(method, elementSymbol, compilation.GetTypeByMetadataName(EmptyElementMetadataName)),
+            argumentStamps: DescribeArgumentStamps(ctx, invocation, method, elementSymbol, ct));
+    }
+
+    // ── Mechanism 2: argument-position stamping ───────────────────────────
+
+    /// <summary>
+    /// Finds the arguments of this call that reached their <c>Element</c> parameter
+    /// through an implicit <em>user-defined</em> conversion, and records the line each
+    /// one was written on.
+    ///
+    /// <para><b>Why this exists.</b> <c>Element.cs</c> declares
+    /// <c>implicit operator Element(string text) =&gt; Factories.TextBlock(text)</c>, so
+    /// in <c>VStack("hi")</c> the child element is built by a <c>TextBlock</c> call
+    /// inside Reactor's own assembly. That call site is not in the consumer's
+    /// compilation, and it cannot be reached any other way: per the interceptors spec,
+    /// "interception can only occur for calls to ordinary member methods — not
+    /// constructors, delegates, properties, local functions, <em>operators</em>", and
+    /// the operator's body is already compiled into Reactor.dll. The one place the
+    /// consumer's line number is still available is the ENCLOSING call, which the
+    /// generator is already intercepting — so the interceptor stamps the converted
+    /// argument on its way past.</para>
+    ///
+    /// <para><b>Per argument, not per call.</b> The line recorded is the argument
+    /// expression's own start line, so
+    /// <code>
+    /// VStack(
+    ///     "a",   // reports this line
+    ///     "b");  // and this one
+    /// </code>
+    /// does not collapse both children onto the <c>VStack(</c> line.</para>
+    ///
+    /// <para><b>Only compiler-built arrays are touched.</b> A <c>params</c> argument in
+    /// expanded form is an array the compiler materialized at this call site, so the
+    /// interceptor owns it and may write back into its slots. In normal form
+    /// (<c>VStack(myArray)</c>) the array belongs to the caller — and, being an array of
+    /// already-converted elements, carries no per-element conversions anyway — so
+    /// nothing is emitted for it and no caller-visible array is ever mutated.</para>
+    /// </summary>
+    private static ImmutableArray<ArgumentStamp> DescribeArgumentStamps(
+        GeneratorSyntaxContext ctx,
+        InvocationExpressionSyntax invocation,
+        IMethodSymbol method,
+        INamedTypeSymbol elementSymbol,
+        System.Threading.CancellationToken ct)
+    {
+        // Symbol-only pre-check before touching the operation tree. GetOperation binds a
+        // full IOperation graph for the invocation, which is markedly more work than the
+        // GetSymbolInfo this generator already does — and the overwhelming majority of DSL
+        // calls (every `TextBlock(string)`, every modifier-shaped factory) have no
+        // Element-typed parameter for a conversion to land on. Skipping those keeps the
+        // per-call-site generation cost where layer 1 measured it.
+        if (!CouldHaveConvertedArguments(method, elementSymbol))
+            return ImmutableArray<ArgumentStamp>.Empty;
+
+        if (ctx.SemanticModel.GetOperation(invocation, ct) is not IInvocationOperation operation)
+            return ImmutableArray<ArgumentStamp>.Empty;
+
+        ImmutableArray<ArgumentStamp>.Builder? builder = null;
+
+        foreach (var argument in operation.Arguments)
+        {
+            if (argument.Parameter is null) continue;
+            var ordinal = argument.Parameter.Ordinal;
+
+            if (argument.ArgumentKind == ArgumentKind.ParamArray)
+            {
+                // Expanded form. `IsImplicit` on the array creation is the load-bearing
+                // check: it is what distinguishes the array the compiler built for THIS
+                // call site (safe to write into) from one the caller handed over.
+                if (argument.Value is not IArrayCreationOperation { Initializer: { } initializer } creation
+                    || !creation.IsImplicit
+                    || creation.Type is not IArrayTypeSymbol arrayType
+                    || !IsElementItself(arrayType.ElementType, elementSymbol))
+                {
+                    continue;
+                }
+
+                for (int i = 0; i < initializer.ElementValues.Length; i++)
+                {
+                    if (TryDescribeConvertedArgument(initializer.ElementValues[i], ordinal, i, elementSymbol, ct) is { } stamp)
+                    {
+                        (builder ??= ImmutableArray.CreateBuilder<ArgumentStamp>()).Add(stamp);
+                    }
+                }
+            }
+            else if (argument.ArgumentKind == ArgumentKind.Explicit
+                     && IsElementItself(argument.Parameter.Type, elementSymbol)
+                     && TryDescribeConvertedArgument(argument.Value, ordinal, arrayIndex: -1, elementSymbol, ct) is { } single)
+            {
+                (builder ??= ImmutableArray.CreateBuilder<ArgumentStamp>()).Add(single);
+            }
+        }
+
+        return builder is null ? ImmutableArray<ArgumentStamp>.Empty : builder.ToImmutable();
+    }
+
+    /// <summary>
+    /// True when at least one parameter could receive an implicitly converted
+    /// <c>Element</c>. Purely a cost filter for
+    /// <see cref="DescribeArgumentStamps"/> — the per-argument analysis re-checks
+    /// everything it depends on.
+    /// </summary>
+    private static bool CouldHaveConvertedArguments(IMethodSymbol method, INamedTypeSymbol elementSymbol)
+    {
+        foreach (var parameter in method.Parameters)
+        {
+            if (IsElementItself(parameter.Type, elementSymbol)) return true;
+            if (parameter.Type is IArrayTypeSymbol array && IsElementItself(array.ElementType, elementSymbol))
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Describes one argument if — and only if — it reached <c>Element</c> through an
+    /// implicit user-defined conversion. An argument that was already an
+    /// element (<c>VStack(TextBlock("a"))</c>) is left alone: its own call site is
+    /// intercepted directly and is the more precise answer.
+    /// </summary>
+    private static ArgumentStamp? TryDescribeConvertedArgument(
+        IOperation value,
+        int parameterOrdinal,
+        int arrayIndex,
+        INamedTypeSymbol elementSymbol,
+        System.Threading.CancellationToken ct)
+    {
+        if (value is not IConversionOperation conversion) return null;
+        if (!conversion.Conversion.IsUserDefined) return null;
+        if (conversion.OperatorMethod is null) return null;
+
+        // The operator's RESULT has to be exactly Element, because the emitted helper is
+        // typed `Element?` in and `Element?` out and its return value is written back
+        // into the argument slot. A hypothetical operator producing a derived record
+        // would not round-trip through it.
+        if (!IsElementItself(conversion.Type, elementSymbol)) return null;
+
+        var operand = conversion.Operand;
+        var tree = operand.Syntax.SyntaxTree;
+        var lineSpan = tree.GetMappedLineSpan(operand.Syntax.Span, ct);
+
+        return new ArgumentStamp(
+            parameterOrdinal,
+            arrayIndex,
+            ResolveMappedPath(lineSpan, tree.FilePath),
+            lineSpan.StartLinePosition.Line + 1);
+    }
+
+    /// <summary>
+    /// True for <c>Element</c> exactly, false for a derived element record.
+    ///
+    /// <para>Compares SYMBOLS, not rendered names, for the reason spelled out on
+    /// <see cref="ReturnsElement"/>: a <c>params Element?[]</c> parameter reports its
+    /// element type as <c>Microsoft.UI.Reactor.Core.Element?</c>, and a string comparison
+    /// against the bare metadata name silently misses every one of them.</para>
+    /// </summary>
+    private static bool IsElementItself(ITypeSymbol? type, INamedTypeSymbol elementSymbol)
+        => type is not null && SymbolEqualityComparer.Default.Equals(type, elementSymbol);
+
+    // ── Mechanism 1: transparent helpers ──────────────────────────────────
+
+    private static bool IsTransparent(IMethodSymbol method)
+    {
+        foreach (var attribute in method.GetAttributes())
+        {
+            if (attribute.AttributeClass?.ToDisplayString() == TransparentAttributeMetadataName)
+                return true;
+        }
+        return false;
+    }
+
+    private static bool IsForwardable(IMethodSymbol method, Compilation compilation, INamedTypeSymbol elementSymbol)
+        => ForwardabilityProblem(method, compilation, elementSymbol) is null;
+
+    /// <summary>
+    /// Why an interceptor cannot be emitted for calls to <paramref name="method"/>, or
+    /// null when one can. The string is the tail of the
+    /// <c>REACTOR_SOURCEMAP_001</c> message, so it reads as "…because {0}".
+    ///
+    /// <para>Shared by the discovery pass (which needs the boolean) and the diagnostic
+    /// pass (which needs the reason), so the rule that silences the attribute and the
+    /// rule that explains the silence cannot drift apart.</para>
+    /// </summary>
+    private static string? ForwardabilityProblem(
+        IMethodSymbol method, Compilation compilation, INamedTypeSymbol elementSymbol)
+    {
+        if (method.MethodKind == MethodKind.LocalFunction)
+            return "C# interceptors cannot intercept calls to local functions";
+        if (method.MethodKind != MethodKind.Ordinary)
+            return "C# interceptors can only intercept calls to ordinary methods";
+        if (!method.IsStatic)
+        {
+            // Intercepting an instance method requires the interceptor to be an
+            // extension method whose `this` parameter matches the receiver. Supportable,
+            // but it is a separate shape from the static forwarding used here, so it is
+            // an explicit gap rather than something that silently half-works.
+            return "it is an instance method, and only static helpers are supported";
+        }
+        if (!ReturnsElement(method.ReturnType, elementSymbol))
+            return "it does not return a Microsoft.UI.Reactor.Core.Element";
+        if (method.Parameters.Any(p => p.RefKind != RefKind.None))
+            return "it has a by-ref parameter";
+        if (method.IsGenericMethod && method.TypeParameters.Any(HasUnrenderableConstraint))
+            return "its type parameters cannot be restated on an interceptor";
+
+        for (var type = method.ContainingType; type is not null; type = type.ContainingType)
+        {
+            if (type.IsFileLocal)
+                return "it is declared in a file-local type, which generated code cannot name";
+            // "Interceptors cannot be declared in generic types at any level of nesting",
+            // and an interceptor for a method in a generic type would additionally have to
+            // restate the containing type's arity. Out of scope.
+            if (type.IsGenericType)
+                return "it is declared in a generic type";
+        }
+
+        // The interceptor lives in a generated file, so a private or protected member is
+        // out of reach however the call site is written. Asking the compilation settles
+        // internal-across-assemblies (InternalsVisibleTo) correctly too.
+        if (!compilation.IsSymbolAccessibleWithin(method, compilation.Assembly))
+            return "generated code cannot reach it; make it internal or public";
+
+        return null;
+    }
+
+    /// <summary>
+    /// True when <paramref name="node"/> sits inside a transparent method whose calls
+    /// the generator will actually intercept.
+    ///
+    /// <para>Walks the SYMBOL chain rather than the syntax tree so lambdas and local
+    /// functions defer outward for free: the enclosing symbol of a call inside
+    /// <c>() =&gt; TextBlock("x")</c> is the lambda, whose containing symbol is the
+    /// method that declared it. The walk stops at the type boundary, which is where
+    /// "inside a method" stops meaning anything.</para>
+    /// </summary>
+    private static bool IsInsideTransparentMethod(
+        SemanticModel model,
+        SyntaxNode node,
+        Compilation compilation,
+        INamedTypeSymbol elementSymbol,
+        System.Threading.CancellationToken ct)
+    {
+        for (var symbol = model.GetEnclosingSymbol(node.SpanStart, ct);
+             symbol is not null;
+             symbol = symbol.ContainingSymbol)
+        {
+            if (symbol is ITypeSymbol or INamespaceSymbol) return false;
+            if (symbol is IMethodSymbol enclosing
+                && IsTransparent(enclosing)
+                && IsForwardable(enclosing, compilation, elementSymbol))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static AnnotationProblem? DescribeAnnotationProblem(
+        GeneratorAttributeSyntaxContext ctx,
+        System.Threading.CancellationToken ct)
+    {
+        if (ctx.TargetSymbol is not IMethodSymbol method) return null;
+
+        var compilation = ctx.SemanticModel.Compilation;
+        if (compilation.GetTypeByMetadataName(ElementMetadataName) is not { } elementSymbol) return null;
+        if (ForwardabilityProblem(method, compilation, elementSymbol) is not { } problem) return null;
+
+        // Point at the attribute rather than the whole method: it is the attribute that
+        // has no effect, and squiggling an entire method body would be disproportionate.
+        //
+        // A real syntax-tree Location, not Location.Create(path, span, lineSpan): only a
+        // location that maps back into a tree in this compilation can be turned off with
+        // `#pragma warning disable REACTOR_SOURCEMAP_001`. An external-file location would
+        // produce a warning the consumer cannot suppress — and, because Release treats
+        // warnings as errors, an unsuppressible build break on code that is deliberately
+        // shaped that way. Holding a Location keeps its tree alive in the incremental
+        // cache, which is the accepted cost; this pass yields nothing at all in the normal
+        // case.
+        var reference = ctx.Attributes.Length > 0 ? ctx.Attributes[0].ApplicationSyntaxReference : null;
+        var location = reference is not null
+            ? reference.GetSyntax(ct).GetLocation()
+            : ctx.TargetNode.GetLocation();
+
+        return new AnnotationProblem(location, method.Name, problem);
     }
 
     /// <summary>
@@ -236,10 +618,32 @@ public sealed class SourceMapInterceptorGenerator : IIncrementalGenerator
     /// </summary>
     private static bool HasUnrenderableConstraint(ITypeParameterSymbol tp) => false;
 
-    private static bool ReturnsElement(ITypeSymbol type)    {
+    /// <summary>
+    /// True when <paramref name="type"/> is <c>Element</c> or derives from it.
+    ///
+    /// <para><b>Compares symbols, deliberately.</b> The obvious implementation walks
+    /// <c>BaseType</c> comparing <c>ToDisplayString()</c> against the metadata name, and
+    /// it is subtly wrong: the default display format <em>renders nullability</em>, so a
+    /// method declared to return exactly <c>Element?</c> reports
+    /// <c>Microsoft.UI.Reactor.Core.Element?</c>, never matches, and — because
+    /// <c>Element</c>'s base is <c>object</c> — the walk goes straight past the answer.
+    /// Such a method would be silently skipped. Measured directly against Roslyn 5.9:
+    /// <c>Element?.BaseType</c> is <c>object</c>, while
+    /// <c>SymbolEqualityComparer.Default.Equals(Element?, Element)</c> is <c>true</c>
+    /// (<c>IncludeNullability</c> is <c>false</c>, which is the pair that proves Default
+    /// ignores annotations rather than the two simply being the same symbol).</para>
+    ///
+    /// <para>A nullable DERIVED type is unaffected either way — <c>TextBlockElement?</c>
+    /// has an unannotated <c>BaseType</c> — which is exactly why the bug stayed latent:
+    /// no factory in the DSL returns bare <c>Element?</c> today. It stops being latent
+    /// with <c>[ReactorSourceTransparent]</c>, where a consumer's conditional helper
+    /// returning <c>Element?</c> is an entirely natural shape.</para>
+    /// </summary>
+    private static bool ReturnsElement(ITypeSymbol type, INamedTypeSymbol elementSymbol)
+    {
         for (var t = type; t is not null; t = t.BaseType)
         {
-            if (t.ToDisplayString() == ElementMetadataName) return true;
+            if (SymbolEqualityComparer.Default.Equals(t, elementSymbol)) return true;
         }
         return false;
     }
@@ -279,19 +683,51 @@ public sealed class SourceMapInterceptorGenerator : IIncrementalGenerator
         sb.AppendLine("    {");
 
         int index = 0;
+        var needsArgumentHelper = sites.Any(static s => s is { ArgumentStamps.IsEmpty: false });
+
         foreach (var site in sites.Where(static s => s is not null))
         {
             var sig = site!.Signature;
             var mapped = ApplyPathMap(site.FilePath, pathMap);
             var name = $"__Reactor_{sig.MethodName}_{index}";
+            var stamps = site.ArgumentStamps;
 
             sb.AppendLine($"        {site.Attribute}");
             sb.AppendLine($"        public static {sig.ReturnType} {name}{sig.TypeParameterList}({sig.ParameterList})");
             foreach (var clause in sig.ConstraintClauses)
                 sb.AppendLine($"            {clause}");
             sb.AppendLine("        {");
-            sb.AppendLine($"            var __e = {sig.OwnerType}.{sig.MethodName}{sig.TypeArgumentList}({sig.ArgumentList});");
-            sb.AppendLine("            if (!global::Microsoft.UI.Reactor.Diagnostics.ReactorSourceMap.Enabled) return __e;");
+
+            if (stamps.IsEmpty)
+            {
+                sb.AppendLine($"            var __e = {sig.OwnerType}.{sig.MethodName}{sig.TypeArgumentList}({sig.ArgumentList});");
+                sb.AppendLine("            if (!global::Microsoft.UI.Reactor.Diagnostics.ReactorSourceMap.Enabled) return __e;");
+            }
+            else
+            {
+                // Arguments have to be stamped BEFORE the factory runs, because the
+                // factory copies them into the element it builds — afterwards the array
+                // slot is no longer what anyone reads. That forces the flag to be read
+                // up front, and caching it in a local is not just tidier: the flag is a
+                // mutable process-global, so two separate reads could straddle a write
+                // and stamp the arguments of a call whose result is then left unstamped.
+                sb.AppendLine("            var __on = global::Microsoft.UI.Reactor.Diagnostics.ReactorSourceMap.Enabled;");
+                sb.AppendLine("            if (__on)");
+                sb.AppendLine("            {");
+                foreach (var stamp in stamps)
+                {
+                    var target = stamp.ArrayIndex < 0
+                        ? $"__a{stamp.ParameterOrdinal}"
+                        : $"__a{stamp.ParameterOrdinal}[{stamp.ArrayIndex}]";
+                    var stampPath = ApplyPathMap(stamp.FilePath, pathMap);
+                    sb.AppendLine(
+                        $"                {target} = __ReactorStampArgument({target}, {Literal(stampPath)}, {stamp.Line})!;");
+                }
+                sb.AppendLine("            }");
+                sb.AppendLine($"            var __e = {sig.OwnerType}.{sig.MethodName}{sig.TypeArgumentList}({sig.ArgumentList});");
+                sb.AppendLine("            if (!__on) return __e;");
+            }
+
             // The null guard is emitted only for a nullable-annotated return; on a
             // non-nullable one it would be dead code the nullable analysis flags.
             if (sig.ReturnsNullable)
@@ -304,7 +740,9 @@ public sealed class SourceMapInterceptorGenerator : IIncrementalGenerator
             // "first stamp wins" would let the wrapper claim it. This guard still
             // earns its place for a factory that returns a CACHED element it did not
             // build on this call (a memo hit), where the existing stamp is the right
-            // answer and this call site is not.
+            // answer and this call site is not. It is also what keeps a transparent
+            // helper from overwriting a location its own caller-supplied argument
+            // already carries.
             sb.AppendLine("            if (__e.CallSite is not null) return __e;");
             // EmptyElement is a shared singleton (EmptyElement.Instance) that Mount
             // filters out before it ever becomes a control, so a location stamped here
@@ -328,6 +766,31 @@ public sealed class SourceMapInterceptorGenerator : IIncrementalGenerator
             sb.AppendLine("        }");
             sb.AppendLine();
             index++;
+        }
+
+        if (needsArgumentHelper)
+        {
+            // Emitted only when something calls it, so a project with no implicit
+            // conversions in argument position gets a byte-identical file to before.
+            sb.AppendLine("        /// <summary>Stamps an argument that reached its Element parameter through an implicit user-defined conversion.</summary>");
+            sb.AppendLine("        private static global::Microsoft.UI.Reactor.Core.Element? __ReactorStampArgument(");
+            sb.AppendLine("            global::Microsoft.UI.Reactor.Core.Element? __value, string __file, int __line)");
+            sb.AppendLine("        {");
+            sb.AppendLine("            if (__value is null) return __value;");
+            // First stamp wins, exactly as on the return path: an argument that already
+            // knows where it came from is never relabelled by the call it is passed to.
+            sb.AppendLine("            if (__value.CallSite is not null) return __value;");
+            // Same singleton reasoning as the return path — and here it is not merely a
+            // cost question: EmptyElement.Instance is shared process-wide, so cloning it
+            // into an argument slot would hand a different instance to code that compares
+            // by reference.
+            sb.AppendLine("            if (__value is global::Microsoft.UI.Reactor.Core.EmptyElement) return __value;");
+            sb.AppendLine("            return __value with");
+            sb.AppendLine("            {");
+            sb.AppendLine("                CallSite = new global::Microsoft.UI.Reactor.Core.SourceLocation(__file, __line)");
+            sb.AppendLine("            };");
+            sb.AppendLine("        }");
+            sb.AppendLine();
         }
 
         sb.AppendLine("    }");
@@ -378,12 +841,14 @@ public sealed class SourceMapInterceptorGenerator : IIncrementalGenerator
 
     private sealed class CallSite : IEquatable<CallSite>
     {
-        public CallSite(string attribute, string filePath, int line, Signature signature)
+        public CallSite(string attribute, string filePath, int line, Signature signature,
+                        ImmutableArray<ArgumentStamp> argumentStamps)
         {
             Attribute = attribute;
             FilePath = filePath;
             Line = line;
             Signature = signature;
+            ArgumentStamps = argumentStamps;
         }
 
         public string Attribute { get; }
@@ -391,12 +856,19 @@ public sealed class SourceMapInterceptorGenerator : IIncrementalGenerator
         public int Line { get; }
         public Signature Signature { get; }
 
+        /// <summary>
+        /// Arguments of this call that need stamping in place before the real factory
+        /// runs. Empty for the overwhelming majority of call sites.
+        /// </summary>
+        public ImmutableArray<ArgumentStamp> ArgumentStamps { get; }
+
         public bool Equals(CallSite? other)
             => other is not null
                && Attribute == other.Attribute
                && FilePath == other.FilePath
                && Line == other.Line
-               && Signature.Equals(other.Signature);
+               && Signature.Equals(other.Signature)
+               && ArgumentStamps.SequenceEqual(other.ArgumentStamps);
 
         public override bool Equals(object? obj) => Equals(obj as CallSite);
 
@@ -407,7 +879,91 @@ public sealed class SourceMapInterceptorGenerator : IIncrementalGenerator
                 int h = Attribute.GetHashCode();
                 h = (h * 397) ^ FilePath.GetHashCode();
                 h = (h * 397) ^ Line;
-                return (h * 397) ^ Signature.GetHashCode();
+                h = (h * 397) ^ Signature.GetHashCode();
+                foreach (var stamp in ArgumentStamps) h = (h * 397) ^ stamp.GetHashCode();
+                return h;
+            }
+        }
+    }
+
+    /// <summary>
+    /// One argument of an intercepted call that reached its <c>Element</c> parameter
+    /// through an implicit user-defined conversion, plus the position it was written at.
+    ///
+    /// <para><see cref="ArrayIndex"/> is <c>-1</c> for an ordinary parameter and a slot
+    /// index for a <c>params</c> argument in expanded form; the two render as
+    /// <c>__a2</c> and <c>__a0[1]</c> respectively.</para>
+    /// </summary>
+    private sealed class ArgumentStamp : IEquatable<ArgumentStamp>
+    {
+        public ArgumentStamp(int parameterOrdinal, int arrayIndex, string filePath, int line)
+        {
+            ParameterOrdinal = parameterOrdinal;
+            ArrayIndex = arrayIndex;
+            FilePath = filePath;
+            Line = line;
+        }
+
+        public int ParameterOrdinal { get; }
+        public int ArrayIndex { get; }
+        public string FilePath { get; }
+        public int Line { get; }
+
+        public bool Equals(ArgumentStamp? other)
+            => other is not null
+               && ParameterOrdinal == other.ParameterOrdinal
+               && ArrayIndex == other.ArrayIndex
+               && FilePath == other.FilePath
+               && Line == other.Line;
+
+        public override bool Equals(object? obj) => Equals(obj as ArgumentStamp);
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                int h = ParameterOrdinal;
+                h = (h * 397) ^ ArrayIndex;
+                h = (h * 397) ^ FilePath.GetHashCode();
+                return (h * 397) ^ Line;
+            }
+        }
+    }
+
+    /// <summary>
+    /// A <c>[ReactorSourceTransparent]</c> annotation the generator cannot honour.
+    /// </summary>
+    private sealed class AnnotationProblem : IEquatable<AnnotationProblem>
+    {
+        public AnnotationProblem(Location location, string methodName, string reason)
+        {
+            Location = location;
+            MethodName = methodName;
+            Reason = reason;
+        }
+
+        public Location Location { get; }
+        public string MethodName { get; }
+        public string Reason { get; }
+
+        public Diagnostic ToDiagnostic()
+            => Diagnostic.Create(UnusableTransparentAnnotation, Location, MethodName, Reason);
+
+        public bool Equals(AnnotationProblem? other)
+            => other is not null
+               && Location.Equals(other.Location)
+               && MethodName == other.MethodName
+               && Reason == other.Reason;
+
+        public override bool Equals(object? obj) => Equals(obj as AnnotationProblem);
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                int h = Location.GetHashCode();
+                h = (h * 397) ^ MethodName.GetHashCode();
+                return (h * 397) ^ Reason.GetHashCode();
             }
         }
     }
@@ -474,7 +1030,8 @@ public sealed class SourceMapInterceptorGenerator : IIncrementalGenerator
         /// <summary>One rendered <c>where …</c> clause per constrained type parameter.</summary>
         public ImmutableArray<string> ConstraintClauses { get; }
 
-        public static Signature From(IMethodSymbol method)
+        public static Signature From(
+            IMethodSymbol method, INamedTypeSymbol elementSymbol, INamedTypeSymbol? emptyElementSymbol)
         {
             var parameters = new List<string>(method.Parameters.Length);
             var arguments = new List<string>(method.Parameters.Length);
@@ -504,9 +1061,15 @@ public sealed class SourceMapInterceptorGenerator : IIncrementalGenerator
             // Only the base Element (or EmptyElement itself) can hold an EmptyElement at
             // runtime; a concrete element record provably cannot, and testing for it is
             // CS0184 — a warning that Release turns into a build error.
-            var returnName = method.ReturnType.OriginalDefinition.ToDisplayString();
-            var canReturnEmpty = returnName == ElementMetadataName
-                || returnName == "Microsoft.UI.Reactor.Core.EmptyElement";
+            //
+            // Symbol comparison, for the same reason ReturnsElement uses it: a return type
+            // of exactly `Element?` renders as "…Element?" and would miss a name match, so
+            // a nullable-Element-returning factory would lose its EmptyElement guard and
+            // clone the shared singleton.
+            var returnType = method.ReturnType.OriginalDefinition;
+            var canReturnEmpty = SymbolEqualityComparer.Default.Equals(returnType, elementSymbol)
+                || (emptyElementSymbol is not null
+                    && SymbolEqualityComparer.Default.Equals(returnType, emptyElementSymbol));
 
             return new Signature(
                 method.ContainingType.ToDisplayString(s_typeFormat),

--- a/src/Reactor.SourceMap.Generator/SourceMapInterceptorGenerator.cs
+++ b/src/Reactor.SourceMap.Generator/SourceMapInterceptorGenerator.cs
@@ -374,10 +374,10 @@ public sealed class SourceMapInterceptorGenerator : IIncrementalGenerator
 
         ImmutableArray<ArgumentStamp>.Builder? builder = null;
 
-        foreach (var argument in operation.Arguments)
+        foreach (var argument in operation.Arguments.Where(static a => a.Parameter is not null))
         {
-            if (argument.Parameter is null) continue;
-            var ordinal = argument.Parameter.Ordinal;
+            // Non-null by the filter above; the compiler cannot see through Where.
+            var ordinal = argument.Parameter!.Ordinal;
 
             if (argument.ArgumentKind == ArgumentKind.ParamArray)
             {
@@ -484,14 +484,8 @@ public sealed class SourceMapInterceptorGenerator : IIncrementalGenerator
     // ── Mechanism 1: transparent helpers ──────────────────────────────────
 
     private static bool IsTransparent(IMethodSymbol method)
-    {
-        foreach (var attribute in method.GetAttributes())
-        {
-            if (attribute.AttributeClass?.ToDisplayString() == TransparentAttributeMetadataName)
-                return true;
-        }
-        return false;
-    }
+        => method.GetAttributes()
+            .Any(static a => a.AttributeClass?.ToDisplayString() == TransparentAttributeMetadataName);
 
     private static bool IsForwardable(IMethodSymbol method, Compilation compilation, INamedTypeSymbol elementSymbol)
         => ForwardabilityProblem(method, compilation, elementSymbol) is null;

--- a/src/Reactor.SourceMap.Generator/SourceMapInterceptorGenerator.cs
+++ b/src/Reactor.SourceMap.Generator/SourceMapInterceptorGenerator.cs
@@ -172,6 +172,17 @@ public sealed class SourceMapInterceptorGenerator : IIncrementalGenerator
         // one of them is a private nested type). Everything about the SIGNATURE
         // must come from the open definition; only the call site comes from the
         // constructed symbol.
+        //
+        // Argument stamping is bound to the SIGNATURE, not to the call, and therefore
+        // also uses the open definition — see CouldHaveConvertedArguments. A reviewer
+        // read that as a missed case (`Wrap<Element>("x")` really does have a constructed
+        // `Element` parameter and a genuine user-defined conversion, both confirmed
+        // against Roslyn 5.9) and it is not: the emitted interceptor declares that
+        // parameter as `T __a0`, so writing an `Element?` back into it is
+        // `CS1503: cannot convert from 'T' to 'Element?'`. Measured — switching the
+        // filter to the constructed method makes the consumer's build fail. Declining
+        // to stamp is what keeps the emitted code compiling; the element still gets a
+        // location from the interceptor's own return-path stamp.
         method = method.OriginalDefinition;
 
         // Only the Reactor DSL surface, plus (spec 010 mechanism 1) any static
@@ -405,6 +416,13 @@ public sealed class SourceMapInterceptorGenerator : IIncrementalGenerator
     /// <c>Element</c>. Purely a cost filter for
     /// <see cref="DescribeArgumentStamps"/> — the per-argument analysis re-checks
     /// everything it depends on.
+    ///
+    /// <para>Deliberately asked of the OPEN definition. The emitted interceptor declares
+    /// its parameters from the open signature, so a generic parameter is rendered as
+    /// <c>T __a0</c> even when the call substitutes <c>T = Element</c>; stamping it would
+    /// emit <c>CS1503: cannot convert from 'T' to 'Element?'</c> into the consumer's
+    /// build. Answering from the constructed method therefore looks more thorough and is
+    /// actively wrong — verified by building the suite with it switched over.</para>
     /// </summary>
     private static bool CouldHaveConvertedArguments(IMethodSymbol method, INamedTypeSymbol elementSymbol)
     {

--- a/src/Reactor/Diagnostics/ReactorSourceTransparentAttribute.cs
+++ b/src/Reactor/Diagnostics/ReactorSourceTransparentAttribute.cs
@@ -50,7 +50,7 @@ namespace Microsoft.UI.Reactor.Diagnostics;
 /// <see langword="internal"/> (never <see langword="private"/>), not declared in
 /// a <c>file</c>-local or generic type, and not a local function (C# interceptors
 /// cannot intercept those). An annotation the generator cannot honour is reported
-/// as <c>REACTOR_SOURCEMAP001</c> rather than silently doing nothing, and
+/// as <c>REACTOR_SOURCEMAP_001</c> rather than silently doing nothing, and
 /// attribution falls back to today's behaviour — the helper's own line — so a bad
 /// annotation never makes attribution worse than no annotation.
 /// </para>

--- a/src/Reactor/Diagnostics/ReactorSourceTransparentAttribute.cs
+++ b/src/Reactor/Diagnostics/ReactorSourceTransparentAttribute.cs
@@ -1,0 +1,74 @@
+using System;
+
+namespace Microsoft.UI.Reactor.Diagnostics;
+
+/// <summary>
+/// Spec 010 — marks a helper method as <em>source-transparent</em>: elements it
+/// returns are attributed to the line that CALLED it, not to the line inside it
+/// that ran the DSL factory.
+///
+/// <para>Without this, a thin forwarding helper collapses every one of its call
+/// sites onto a single line, because an interceptor replaces the <em>call
+/// site</em> and the call site of <c>TextBlock(...)</c> in
+/// <c>static Element MyHeader() =&gt; TextBlock("header");</c> is inside
+/// <c>MyHeader</c>. Annotating <c>MyHeader</c> flips the attribution outward:
+/// the source-map generator emits no interceptor for the factory calls in its
+/// body, and instead intercepts calls <em>to</em> <c>MyHeader</c> and stamps the
+/// caller's line.</para>
+///
+/// <para><b>Deliberately opt-in.</b> It is not a blanket rule for helpers,
+/// because for most element-returning methods the body line is the RIGHT answer
+/// — a <c>Component.Render()</c> body is where the author actually wrote the UI,
+/// and deferring it to the reconciler's call site would be a regression. Only a
+/// thin forwarder, whose own line carries no information a reader wants, benefits.
+/// This attribute is how that intent is expressed.</para>
+///
+/// <para><b>Nesting.</b> Annotated methods compose: a transparent helper calling
+/// another transparent helper keeps deferring outward until it reaches a caller
+/// that is not annotated, and that caller's line is what gets stamped.</para>
+///
+/// <example>
+/// <code>
+/// [ReactorSourceTransparent]
+/// internal static Element Field(string label, string value)
+///     =&gt; HStack(TextBlock(label), TextBlock(value));
+///
+/// // Both rows report THEIR OWN line, instead of both reporting the
+/// // `HStack(` line inside Field.
+/// var form = VStack(
+///     Field("Name", name),
+///     Field("Email", email));
+/// </code>
+/// </example>
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Requirements.</b> The generator has to be able to emit an interceptor that
+/// forwards to the annotated method, so it must be <see langword="static"/>,
+/// return an <c>Element</c>, and be reachable by name from a generated file in
+/// the same compilation — i.e. <see langword="public"/> or
+/// <see langword="internal"/> (never <see langword="private"/>), not declared in
+/// a <c>file</c>-local or generic type, and not a local function (C# interceptors
+/// cannot intercept those). An annotation the generator cannot honour is reported
+/// as <c>REACTOR_SOURCEMAP001</c> rather than silently doing nothing, and
+/// attribution falls back to today's behaviour — the helper's own line — so a bad
+/// annotation never makes attribution worse than no annotation.
+/// </para>
+/// <para>
+/// <b>Where it takes effect.</b> Rule 1 (suppressing stamps inside the body)
+/// applies in the compilation that <em>declares</em> the method; rule 2 (stamping
+/// at the call site) applies in the compilation that <em>calls</em> it. Both need
+/// the source-map generator loaded, so annotating a method in a library whose
+/// consumer has not enabled <c>ReactorSourceMap</c> simply leaves those elements
+/// unstamped.
+/// </para>
+/// <para>
+/// A plain marker attribute with no members and no reflection surface, so it is
+/// trim- and AOT-safe. It is read by the generator from metadata, which is why it
+/// must be <see langword="public"/>.
+/// </para>
+/// </remarks>
+[AttributeUsage(AttributeTargets.Method, Inherited = false)]
+public sealed class ReactorSourceTransparentAttribute : Attribute
+{
+}

--- a/src/Reactor/Hooks/Pending.cs
+++ b/src/Reactor/Hooks/Pending.cs
@@ -26,7 +26,8 @@ public static class PendingFactory
     /// element simply chooses which rendered tree to show — there is no unwinding
     /// of rendering, and no reconciler involvement.
     /// <para>
-    /// Marked <see cref="ReactorSourceTransparentAttribute"/> (spec 010) because it is a
+    /// Marked <c>[ReactorSourceTransparent]</c> (see
+    /// <see cref="ReactorSourceTransparentAttribute"/>, spec 010) because it is a
     /// pure forwarder: the element is really built by the <c>Component&lt;,&gt;</c> call
     /// on the next line, inside Reactor's own assembly, where no consumer call site
     /// exists to intercept. Without the annotation a <c>Pending(...)</c> element reports

--- a/src/Reactor/Hooks/Pending.cs
+++ b/src/Reactor/Hooks/Pending.cs
@@ -1,4 +1,5 @@
 using Microsoft.UI.Reactor.Core;
+using Microsoft.UI.Reactor.Diagnostics;
 
 namespace Microsoft.UI.Reactor.Hooks;
 
@@ -24,7 +25,16 @@ public static class PendingFactory
     /// The child subtree is always mounted so its hooks register with the scope. The
     /// element simply chooses which rendered tree to show — there is no unwinding
     /// of rendering, and no reconciler involvement.
+    /// <para>
+    /// Marked <see cref="ReactorSourceTransparentAttribute"/> (spec 010) because it is a
+    /// pure forwarder: the element is really built by the <c>Component&lt;,&gt;</c> call
+    /// on the next line, inside Reactor's own assembly, where no consumer call site
+    /// exists to intercept. Without the annotation a <c>Pending(...)</c> element reports
+    /// no location at all. With it, the interceptor in the consumer's compilation stamps
+    /// the line they wrote <c>Pending(</c> on, which is the answer they were looking for.
+    /// </para>
     /// </remarks>
+    [ReactorSourceTransparent]
     public static Element Pending(Element fallback, Element child)
         => Microsoft.UI.Reactor.Factories.Component<PendingComponent, PendingProps>(new PendingProps(fallback, child));
 }

--- a/tests/Reactor.DocPipeline.Tests/InlineSnippetLedgerTests.cs
+++ b/tests/Reactor.DocPipeline.Tests/InlineSnippetLedgerTests.cs
@@ -183,6 +183,33 @@ public class InlineSnippetLedgerTests
     private static readonly Dictionary<string, Dictionary<string, string>> AllowedInlineExamples =
         new(StringComparer.OrdinalIgnoreCase)
         {
+            ["source-mapping"] = new(StringComparer.Ordinal)
+            {
+                // The "before" half of the [ReactorSourceTransparent] explanation: a helper
+                // WITHOUT the attribute, shown so the prose can say why its callers collapse
+                // onto one line. Snippet-backing it would mean shipping a deliberately
+                // badly-attributed helper in a sample purely so the docs can point at it; the
+                // "after" half IS snippet-backed, against the real annotated helper in
+                // samples/apps/source-map-explorer/App.cs#transparent-helper.
+                ["""
+                 static Element MyHeader() => TextBlock("header");
+                 """] =
+                    "One-line illustration of the UNannotated default; its annotated counterpart is snippet-backed.",
+
+                // Line-number attribution cannot be shown by a compiled snippet: the whole
+                // point is which physical line each argument sits on, and the trailing
+                // comments ARE the assertion. A snippet would render the same three lines
+                // while making the comments look like output rather than the claim.
+                // The behaviour itself is covered by
+                // ImplicitConversionArgumentTests.EachConvertedArgument_TakesItsOwnLine.
+                ["""
+                 VStack(
+                     "a",   // reports this line
+                     "b");  // and this one
+                 """] =
+                    "Per-argument line attribution; the comments are the claim, and it is tested by EachConvertedArgument_TakesItsOwnLine.",
+            },
+
             ["dialogs-and-flyouts"] = new(StringComparer.Ordinal)
             {
                 // A two-line syntax illustration of the `with { IsOpen = ... }` edge trigger.

--- a/tests/Reactor.SourceMap.Tests/ImplicitConversionArgumentTests.cs
+++ b/tests/Reactor.SourceMap.Tests/ImplicitConversionArgumentTests.cs
@@ -1,0 +1,343 @@
+using System.Runtime.CompilerServices;
+using Microsoft.UI.Reactor.Core;
+using Microsoft.UI.Reactor.Diagnostics;
+using Xunit;
+using static Microsoft.UI.Reactor.Factories;
+
+namespace Microsoft.UI.Reactor.SourceMap.Tests;
+
+/// <summary>
+/// Spec 010 — argument-position stamping (mechanism 2).
+///
+/// <para>An argument that reaches an <c>Element</c> parameter through an implicit
+/// <em>user-defined</em> conversion is built by the conversion operator, whose body is
+/// framework (or library) code. That call site is unreachable on purpose: per the
+/// interceptors specification, "interception can only occur for calls to ordinary member
+/// methods — not constructors, delegates, properties, local functions, <em>operators</em>",
+/// and the operator's body is already compiled into the referenced assembly. The
+/// enclosing factory call is intercepted, though, so its interceptor stamps the converted
+/// argument on the way past — using the argument expression's own line, not the
+/// container's.</para>
+///
+/// <para><b>Oracles.</b> Every line assertion here is checked against
+/// <see cref="At(string, out int, int)"/>, which captures <c>[CallerLineNumber]</c> at the
+/// argument's own physical line. That is an independent measurement rather than an offset
+/// from the container's line, so a mechanism that silently collapsed every argument onto
+/// the <c>VStack(</c> line could not pass.</para>
+///
+/// <para>Shares the "SourceMap" collection because
+/// <see cref="ReactorSourceMap.Enabled"/> is process-global mutable state.</para>
+/// </summary>
+[Collection("SourceMap")]
+public sealed class ImplicitConversionArgumentTests : IDisposable
+{
+    public ImplicitConversionArgumentTests() => ReactorSourceMap.Enabled = true;
+
+    public void Dispose() => ReactorSourceMap.Enabled = false;
+
+    private static int Line([CallerLineNumber] int line = 0) => line;
+
+    /// <summary>
+    /// Passes <paramref name="value"/> through unchanged while reporting the line it was
+    /// written on. Lets a per-argument oracle live INSIDE an argument list, where a bare
+    /// <c>Line()</c> statement cannot go — so a multi-argument call can be checked
+    /// argument by argument without hard-coding offsets.
+    /// </summary>
+    private static string At(string value, out int line, [CallerLineNumber] int captured = 0)
+    {
+        line = captured;
+        return value;
+    }
+
+    /// <summary>
+    /// The same idea as <see cref="At(string, out int, int)"/> for a non-string
+    /// conversion source, so the "any user-defined operator" test gets a real
+    /// per-argument oracle instead of an offset from a nearby line.
+    /// </summary>
+    private static RawBadge Raw(string text, out int line, [CallerLineNumber] int captured = 0)
+    {
+        line = captured;
+        return new RawBadge(text);
+    }
+
+    // ── params, expanded form ─────────────────────────────────────────────
+
+    [Fact]
+    public void BareStringChild_TakesTheStringsOwnLine()
+    {
+        var stack = VStack(At("only", out var stringLine));
+
+        var child = global::System.Linq.Enumerable.Single(stack.Children);
+
+        Assert.Equal(stringLine, child.CallSite!.Value.LineNumber);
+        Assert.EndsWith(
+            "ImplicitConversionArgumentTests.cs", child.CallSite!.Value.FilePath, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void EachConvertedArgument_TakesItsOwnLine()
+    {
+        // The whole point of stamping per ARGUMENT rather than per call: two children of
+        // one container, written on different lines, must not collapse together.
+        var stack = VStack(
+            At("first", out var firstLine),
+            At("second", out var secondLine));
+
+        var children = global::System.Linq.Enumerable.ToList(stack.Children);
+
+        // Guards the oracle itself: if At() ever reported the call's line instead of the
+        // argument's, both expectations would be the same number and the two assertions
+        // below would agree no matter what the product did.
+        Assert.NotEqual(firstLine, secondLine);
+
+        Assert.Equal(firstLine, children[0].CallSite!.Value.LineNumber);
+        Assert.Equal(secondLine, children[1].CallSite!.Value.LineNumber);
+    }
+
+    [Fact]
+    public void ConvertedArgument_DoesNotTakeTheContainersLine()
+    {
+        // Stated separately from the test above, because "each argument differs from the
+        // other" and "neither is the container's line" are independent failures: an
+        // implementation that stamped argument i with the container line + i would pass
+        // the first and fail this one.
+        var containerLine = Line();
+        var stack = VStack(
+            At("below the container", out var argumentLine));
+
+        var child = global::System.Linq.Enumerable.Single(stack.Children);
+
+        Assert.NotEqual(containerLine, argumentLine);
+        Assert.Equal(argumentLine, child.CallSite!.Value.LineNumber);
+        Assert.NotEqual(containerLine, child.CallSite!.Value.LineNumber);
+    }
+
+    [Fact]
+    public void MixedChildren_StampConvertedOnesWithoutDisturbingExplicitOnes()
+    {
+        var stack = VStack(
+            TextBlock(At("explicit", out var explicitLine)), // its own interceptor stamps this
+            At("converted", out var convertedLine));
+
+        var children = global::System.Linq.Enumerable.ToList(stack.Children);
+
+        Assert.NotEqual(explicitLine, convertedLine);
+        Assert.Equal(explicitLine, children[0].CallSite!.Value.LineNumber);
+        Assert.Equal(convertedLine, children[1].CallSite!.Value.LineNumber);
+    }
+
+    [Fact]
+    public void NullChildAmongConvertedOnes_IsStillFilteredOut()
+    {
+        // Behaviour preservation. The interceptor writes into the compiler-built params
+        // array before forwarding it, so a bug there would show up as a changed child
+        // count or a reordering rather than as a wrong line.
+        var stack = VStack(At("a", out var aLine), null, At("b", out var bLine));
+
+        var children = global::System.Linq.Enumerable.ToList(stack.Children);
+
+        Assert.Equal(2, children.Count);
+        Assert.Equal(aLine, children[0].CallSite!.Value.LineNumber);
+        Assert.Equal(bLine, children[1].CallSite!.Value.LineNumber);
+    }
+
+    // ── params, normal form: the caller's array must not be touched ───────
+
+    [Fact]
+    public void ParamsInNormalForm_LeavesTheCallersArrayAlone()
+    {
+        // `VStack(array)` passes an array the CALLER owns. Its elements were converted
+        // where the array was built, not at this call, so there is nothing here to
+        // attribute — and writing into it would be a visible side effect on someone
+        // else's object. The generator emits no stamping for this shape at all.
+        var array = new Element?[] { "built elsewhere" };
+        var before = array[0];
+
+        var stack = VStack(array);
+
+        Assert.Same(before, array[0]);
+        Assert.Null(array[0]!.CallSite);
+        Assert.Same(before, global::System.Linq.Enumerable.Single(stack.Children));
+    }
+
+    [Fact]
+    public void ExplicitlyWrittenArrayArgument_IsAlsoLeftAlone()
+    {
+        // The same protection as above, but with the array written INLINE at the call
+        // site, where the conversions really are lexically part of this call. It is still
+        // normal form — an `Element?[]` argument binding to an `Element?[]` parameter — so
+        // the compiler never synthesizes a params array and the generator must not treat
+        // the one it can see as its own to write into. Distinct from the test above in
+        // what it can catch: a generator that keyed off "the argument is an array
+        // creation" instead of "the compiler built this array" would pass that test and
+        // fail this one.
+        var stack = VStack(new Element?[] { "inline", "array" });
+
+        var children = global::System.Linq.Enumerable.ToList(stack.Children);
+
+        Assert.Equal(2, children.Count);
+        Assert.Null(children[0].CallSite);
+        Assert.Null(children[1].CallSite);
+    }
+
+    [Fact]
+    public void ExpandedFormOnTheSameLinesStillStamps_PositiveControlForNormalForm()
+    {
+        // Positive control for the nulls above: same file, same flag, same factory. Without
+        // it, a generator that had silently stopped emitting argument stamps entirely would
+        // make ParamsInNormalForm_LeavesTheCallersArrayAlone pass for the wrong reason.
+        var stack = VStack(At("expanded", out var argumentLine));
+
+        Assert.Equal(argumentLine, global::System.Linq.Enumerable.Single(stack.Children).CallSite!.Value.LineNumber);
+    }
+
+    // ── Ordinary (non-params) Element parameters ──────────────────────────
+
+    [Fact]
+    public void NullableElementParameter_IsStamped()
+    {
+        var border = Border(At("in a border", out var argumentLine));
+
+        Assert.Equal(argumentLine, border.Child!.CallSite!.Value.LineNumber);
+    }
+
+    [Fact]
+    public void NonNullableElementParameter_IsStamped()
+    {
+        // Distinct from the nullable case in the EMITTED code: writing an `Element?` back
+        // into a non-nullable `Element` parameter needs the null-forgiving operator, and
+        // getting that wrong is a Release build break (warnings are errors there) rather
+        // than a test failure. Covered so the shape is exercised at all.
+        var scroller = ScrollViewer(At("in a scroll viewer", out var argumentLine));
+
+        Assert.Equal(argumentLine, scroller.Child.CallSite!.Value.LineNumber);
+    }
+
+    // ── Precedence: first stamp wins ──────────────────────────────────────
+
+    [Fact]
+    public void AlreadyStampedArgument_KeepsItsOriginalLocation()
+    {
+        // An element created on one line and passed to a container on another must keep
+        // the line that CREATED it. Argument stamping is a fallback for elements nothing
+        // else could reach, never a relabelling pass.
+        var child = TextBlock("created here"); var creationLine = Line();
+
+        var stack = VStack(child);
+
+        Assert.Same(child, global::System.Linq.Enumerable.Single(stack.Children));
+        Assert.Equal(creationLine, child.CallSite!.Value.LineNumber);
+    }
+
+    [Fact]
+    public void OperatorThatReturnsAStampedElement_KeepsTheOperatorsLine()
+    {
+        // StampedBadge's operator builds its element with a Factories call, and that call
+        // site is in THIS assembly, so it is intercepted and stamped with the operator's
+        // own line. First-stamp-wins then leaves the argument path with nothing to do.
+        //
+        // Differential oracle: run the SAME conversion twice, from two different lines —
+        // once outside any argument position, once inside one. Both must report the
+        // operator's line, so they must agree with each other. If the argument path had
+        // relabelled the second one it would report the `Border(` line instead, and these
+        // two would differ. No literal line number is written down, so the test cannot be
+        // repaired by editing a magic number.
+        Element converted = new StampedBadge("outside");
+
+        var border = Border(new StampedBadge("inside"));
+
+        Assert.Equal(converted.CallSite!.Value.LineNumber, border.Child!.CallSite!.Value.LineNumber);
+
+        // Guards the oracle: the two conversions really are on different source lines, so
+        // "they agree" is a claim about the operator winning rather than a tautology.
+        Assert.NotEqual(Line(), border.Child!.CallSite!.Value.LineNumber);
+        Assert.NotEqual(Line(), converted.CallSite!.Value.LineNumber);
+    }
+
+    // ── Not string-specific ───────────────────────────────────────────────
+
+    [Fact]
+    public void AnyUserDefinedConversionToElement_IsStamped()
+    {
+        // The conversion set is open: any consumer type may declare
+        // `implicit operator Element`. RawBadge's operator constructs its element
+        // directly, so nothing else can have stamped it, and the argument path is the
+        // only thing that could produce a location here.
+        var border = Border(Raw("raw", out var badgeLine));
+
+        Assert.Equal(badgeLine, border.Child!.CallSite!.Value.LineNumber);
+    }
+
+    [Fact]
+    public void ConversionThatYieldsTheEmptySingleton_IsNotCloned()
+    {
+        // EmptyElement.Instance is shared process-wide. Stamping it would hand a DIFFERENT
+        // instance to code that compares by reference, and would materialize an extras
+        // bucket on a sentinel whose location can never be read back (Mount filters it out
+        // before it becomes a control). Reachable from consumer code precisely because the
+        // conversion set is open, which is what makes the guard worth having.
+        var border = Border(new BlankBadge());
+
+        Assert.Same(Empty(), border.Child);
+        Assert.Null(border.Child!.CallSite);
+        Assert.Null(border.Child!.Extensions);
+    }
+
+    // ── The runtime flag gates argument stamping too ──────────────────────
+
+    [Fact]
+    public void FlagOff_LeavesConvertedArgumentsUnstamped()
+    {
+        ReactorSourceMap.Enabled = false;
+        try
+        {
+            var stack = VStack(At("while off", out _));
+            Assert.Null(global::System.Linq.Enumerable.Single(stack.Children).CallSite);
+        }
+        finally
+        {
+            ReactorSourceMap.Enabled = true;
+        }
+
+        // Positive control: the same probe with the flag on DOES stamp, so the null above
+        // cannot be the generator having emitted nothing for this file.
+        var control = VStack(At("while on", out var onLine));
+        Assert.Equal(onLine, global::System.Linq.Enumerable.Single(control.Children).CallSite!.Value.LineNumber);
+    }
+}
+
+/// <summary>
+/// A conversion whose operator builds its element with a <c>Factories</c> call, so the
+/// element arrives at the argument position ALREADY stamped with the operator's line.
+/// </summary>
+internal sealed class StampedBadge
+{
+    public StampedBadge(string text) => Text = text;
+
+    public string Text { get; }
+
+    public static implicit operator Element(StampedBadge badge) => Factories.TextBlock(badge.Text);
+}
+
+/// <summary>
+/// A conversion whose operator constructs its element directly. A constructor is never
+/// intercepted, so the result reaches the argument position with no location and the
+/// argument path is the only thing that can supply one.
+/// </summary>
+internal sealed class RawBadge
+{
+    public RawBadge(string text) => Text = text;
+
+    public string Text { get; }
+
+    public static implicit operator Element(RawBadge badge) => new TextBlockElement(badge.Text);
+}
+
+/// <summary>
+/// A conversion that yields the shared empty sentinel, which the argument path must hand
+/// through untouched rather than clone.
+/// </summary>
+internal sealed class BlankBadge
+{
+    public static implicit operator Element(BlankBadge _) => Factories.Empty();
+}

--- a/tests/Reactor.SourceMap.Tests/NonFactoriesEntryPointTests.cs
+++ b/tests/Reactor.SourceMap.Tests/NonFactoriesEntryPointTests.cs
@@ -39,7 +39,7 @@ public sealed class NonFactoriesEntryPointTests : IDisposable
     private static int Line([CallerLineNumber] int line = 0) => line;
 
     /// <summary>
-    /// The documented gap. Meaningful only because
+    /// The remaining gap. Meaningful only because
     /// <see cref="AFactoriesCallOnTheSameLinesIsStamped"/> proves the generator is
     /// alive and stamping in this very file — otherwise a null here could equally mean
     /// interception was off, and the test would pass while proving nothing.
@@ -47,14 +47,34 @@ public sealed class NonFactoriesEntryPointTests : IDisposable
     [Fact]
     public void EntryPointOutsideFactoriesIsNotStamped()
     {
-        var el = PendingFactory.Pending(Microsoft.UI.Reactor.Factories.TextBlock("fallback"), Microsoft.UI.Reactor.Factories.TextBlock("child"));
+        var el = OutsideFactories.Build();
 
         Assert.True(el.CallSite is null,
-            "An element-producing entry point outside Factories now carries a source " +
-            "location. That is an improvement, not a regression - but it means the " +
+            "An unannotated element-producing entry point outside Factories now carries a " +
+            "source location. That is an improvement, not a regression - but it means the " +
             "limitation documented in docs/guide/source-mapping.md is stale and must be " +
             "updated alongside this test.");
     }
+
+    /// <summary>
+    /// The half of the gap that <c>[ReactorSourceTransparent]</c> closes.
+    /// <c>PendingFactory.Pending</c> is a pure forwarder, so it is annotated and its
+    /// callers now get a location; the entry points that genuinely BUILD something of
+    /// their own are the ones that stay unstamped, above.
+    /// </summary>
+    [Fact]
+    public void AnnotatedEntryPointOutsideFactoriesIsStampedAtTheCallSite()
+    {
+        // Deliberately on ONE line: the stamp is taken from the argument list's opening
+        // paren (matching what [CallerLineNumber] reports), so a call split across lines
+        // reports the paren's line and not the last one. MultilineCallSiteTests owns that
+        // behaviour; here it would only make the oracle wrong.
+        var el = PendingFactory.Pending(TB("fallback"), TB("child")); int expected = Line();
+
+        Assert.Equal(expected, el.CallSite!.Value.LineNumber);
+    }
+
+    private static Element TB(string text) => Microsoft.UI.Reactor.Factories.TextBlock(text);
 
     /// <summary>
     /// Positive control for the oracle above: same file, same flag, same physical-line
@@ -79,10 +99,35 @@ public sealed class NonFactoriesEntryPointTests : IDisposable
     [Fact]
     public void UnstampedEntryPointElementIsStillUsable()
     {
-        var el = PendingFactory.Pending(Microsoft.UI.Reactor.Factories.TextBlock("fallback"), Microsoft.UI.Reactor.Factories.TextBlock("child"));
+        var el = OutsideFactories.Build();
 
         Assert.NotNull(el);
         Assert.Null(el.CallSite);
     }
+}
+
+/// <summary>
+/// Stands in for a third-party element-producing entry point that lives outside
+/// <c>Factories</c> and carries no <c>[ReactorSourceTransparent]</c> annotation.
+///
+/// <para>Wraps <c>PropertyGridDefaults.PropertyLabelTemplate</c>, a real public API in
+/// <c>Microsoft.UI.Reactor.Controls</c> whose element is built by a <c>TextBlock</c> call
+/// inside Reactor's own assembly. The suite previously used
+/// <c>PendingFactory.Pending</c> for this, but that method is now annotated and IS
+/// stamped, so continuing to use it would have quietly turned these "not stamped"
+/// assertions into tests of the wrong thing.</para>
+/// </summary>
+internal static class OutsideFactories
+{
+    internal static Element Build()
+        => Microsoft.UI.Reactor.Controls.PropertyGridDefaults.PropertyLabelTemplate(
+            new Microsoft.UI.Reactor.Data.FieldDescriptor
+            {
+                Name = "probe",
+                DisplayName = "Probe",
+                FieldType = typeof(string),
+                GetValue = static _ => "probe",
+            },
+            indentLevel: 0);
 }
 

--- a/tests/Reactor.SourceMap.Tests/SourceMapInterceptorTests.cs
+++ b/tests/Reactor.SourceMap.Tests/SourceMapInterceptorTests.cs
@@ -118,37 +118,40 @@ public sealed class SourceMapInterceptorTests : IDisposable
         Assert.NotNull(control.CallSite);
     }
 
-    // ── Route-independent coverage hole: the string → Element operator ────
+    // ── Route-independent coverage hole: CLOSED by argument-position stamping ──
 
     [Fact]
-    public void BareStringChild_IsNotAttributedToUserCode()
+    public void BareStringChild_IsAttributedToTheStringsOwnLine()
     {
-        // Element.cs:383 declares
+        // Element.cs declares
         //     public static implicit operator Element(string text) => Factories.TextBlock(text);
-        // so a bare-string child's TextBlock call site lives inside Element.cs,
-        // in the Reactor assembly, NOT in user code. The generator only sees
-        // invocations in the CONSUMER's syntax trees, so that call site is never
-        // intercepted at all.
+        // so a bare-string child's TextBlock call site lives inside Element.cs, in the
+        // Reactor assembly, NOT in user code — and it is structurally unreachable:
+        // interceptors cannot intercept operators, and the operator's body is already
+        // compiled into Reactor.dll. Layer 1 therefore left these children null.
+        //
+        // Argument-position stamping closes it from the other side: the enclosing
+        // VStack call IS intercepted, and its interceptor stamps the converted argument
+        // on the way past, using the argument expression's own line.
         var stack = VStack("bare string child"); var thisLine = Line();
 
         var child = global::System.Linq.Enumerable.Single(stack.Children);
 
-        // Positive control: the VStack call site itself IS attributed here, so a
-        // null child stamp is a real hole and not the generator having silently
-        // emitted nothing for this file.
-        Assert.Equal(thisLine, stack.CallSite!.Value.LineNumber);
+        Assert.Equal(thisLine, child.CallSite!.Value.LineNumber);
+        Assert.EndsWith("SourceMapInterceptorTests.cs", child.CallSite!.Value.FilePath, StringComparison.Ordinal);
 
-        // The hole: no stamp at all. Route B yields null rather than a
-        // confidently-wrong location inside framework source.
-        Assert.Null(child.CallSite);
+        // The container still reports its own call site, so the child's stamp is an
+        // addition rather than the outer stamp leaking downwards.
+        Assert.Equal(thisLine, stack.CallSite!.Value.LineNumber);
     }
 
     [Fact]
     public void ExplicitTextBlockChild_IsAttributed_PositiveControlForTheHole()
     {
-        // Same shape, but the child is written explicitly. This is the control
-        // that proves the null above is caused by the implicit operator and not
-        // by children being unreachable in general.
+        // Same shape, but the child is written explicitly. This is the control that
+        // proves the stamp above did not come from the argument path taking over
+        // children in general — an explicit child is stamped by its OWN interceptor,
+        // and first-stamp-wins keeps the argument path from relabelling it.
         var stack = VStack(TextBlock("explicit child")); var thisLine = Line();
 
         var child = global::System.Linq.Enumerable.Single(stack.Children);
@@ -292,18 +295,24 @@ public sealed class SourceMapInterceptorTests : IDisposable
         Assert.Equal(stackLine, stack.CallSite!.Value.LineNumber);
     }
 
-    // ── Helper-method attribution (reported, not aspirational) ────────────
+    // ── Helper-method attribution: the UNANNOTATED default ────────────────
 
     private static TextBlockElement MyHeader() => TextBlock("header");
 
     [Fact]
-    public void HelperMethod_AttributesToTheHelperNotItsCaller()
+    public void UnannotatedHelperMethod_StillAttributesToTheHelperNotItsCaller()
     {
         var element = MyHeader(); var callerLine = Line();
 
-        // Interceptors replace the CALL SITE, and the call site of TextBlock is
-        // inside MyHeader. So Route B reports the helper's own line — exactly the
-        // same limitation CallerInfo has. Asserted rather than assumed.
+        // Interceptors replace the CALL SITE, and the call site of TextBlock is inside
+        // MyHeader. So an ordinary helper reports the helper's own line — exactly the
+        // same limitation CallerInfo has.
+        //
+        // This is the NEGATIVE CONTROL for [ReactorSourceTransparent] (see
+        // TransparentHelperTests): deferring to the caller is opt-in, not the default,
+        // because for most element-returning methods — a Component.Render() body above
+        // all — the body line is the correct answer. If the attribute ever became a
+        // blanket rule for helpers, this test reddens.
         Assert.NotEqual(callerLine, element.CallSite!.Value.LineNumber);
         Assert.True(element.CallSite!.Value.LineNumber < callerLine);
     }

--- a/tests/Reactor.SourceMap.Tests/TransparentHelperTests.cs
+++ b/tests/Reactor.SourceMap.Tests/TransparentHelperTests.cs
@@ -1,0 +1,271 @@
+using System.Runtime.CompilerServices;
+using Microsoft.UI.Reactor.Core;
+using Microsoft.UI.Reactor.Diagnostics;
+using Microsoft.UI.Reactor.Hooks;
+using Xunit;
+using static Microsoft.UI.Reactor.Factories;
+
+namespace Microsoft.UI.Reactor.SourceMap.Tests;
+
+/// <summary>
+/// Spec 010 — <c>[ReactorSourceTransparent]</c> helper attribution (mechanism 1).
+///
+/// <para>An interceptor replaces a CALL SITE, so a helper that forwards to a factory is
+/// attributed to its own body and every one of its call sites collapses onto one line.
+/// The attribute flips that: the generator emits no interceptor for factory calls inside
+/// an annotated method (rule 1), and instead intercepts calls TO it (rule 2). Annotated
+/// calling annotated keeps deferring outward (rule 3).</para>
+///
+/// <para><b>The controls matter more than usual here</b>, because both halves of this
+/// feature can fail silently in opposite directions. If rule 2 stopped working, elements
+/// would go from "the helper's line" to "no line" — so every positive test is paired
+/// against <see cref="PlainField"/>, an identically-shaped helper WITHOUT the attribute,
+/// which must keep reporting its own body line. And if the attribute had accidentally
+/// become a blanket rule for helpers, that control reddens.</para>
+///
+/// <para>Shares the "SourceMap" collection because
+/// <see cref="ReactorSourceMap.Enabled"/> is process-global mutable state.</para>
+/// </summary>
+[Collection("SourceMap")]
+public sealed class TransparentHelperTests : IDisposable
+{
+    public TransparentHelperTests() => ReactorSourceMap.Enabled = true;
+
+    public void Dispose() => ReactorSourceMap.Enabled = false;
+
+    private static int Line([CallerLineNumber] int line = 0) => line;
+
+    // ── Helpers under test ────────────────────────────────────────────────
+    //
+    // `internal`, not `private`: the emitted interceptor lives in a generated file and
+    // has to be able to name the method it forwards to. A private helper is unreachable
+    // from there, which is what PrivateField below is for.
+
+    [ReactorSourceTransparent]
+    internal static Element TransparentField(string label) => HStack(TextBlock(label));
+
+    /// <summary>The control. Identical body, no attribute.</summary>
+    private static Element PlainField(string label) => HStack(TextBlock(label));
+
+    [ReactorSourceTransparent]
+    internal static Element TransparentInner(string label) => TextBlock(label);
+
+    [ReactorSourceTransparent]
+    internal static Element TransparentOuter(string label) => TransparentInner(label);
+
+    /// <summary>
+    /// A conditional helper declared to return <c>Element?</c> — the shape that exposed a
+    /// latent bug in the shared "does this return an Element" test. See
+    /// <see cref="NullableElementReturningHelper_IsStillDeferredToTheCaller"/>.
+    /// </summary>
+    [ReactorSourceTransparent]
+    internal static Element? TransparentMaybeField(bool show, string label)
+        => show ? TextBlock(label) : null;
+
+    /// <summary>Returns whatever it is handed, so first-stamp-wins can be observed.</summary>
+    [ReactorSourceTransparent]
+    internal static Element TransparentPassThrough(Element given) => given;
+
+    /// <summary>Builds its element inside a lambda, to check the rule-1 walk crosses one.</summary>
+    [ReactorSourceTransparent]
+    internal static Element TransparentViaLambda(string label)
+    {
+        global::System.Func<Element> build = () => TextBlock(label);
+        return build();
+    }
+
+    // Deliberately unusable: a private method cannot be named from a generated file, so
+    // the generator reports REACTOR_SOURCEMAP_001 and leaves attribution exactly as it
+    // would be with no attribute at all. Suppressed locally because this file is compiled
+    // in Release too, where warnings are errors — and suppressibility is itself part of
+    // the contract being tested.
+#pragma warning disable REACTOR_SOURCEMAP_001
+    [ReactorSourceTransparent]
+    private static Element PrivateField(string label) => HStack(TextBlock(label));
+#pragma warning restore REACTOR_SOURCEMAP_001
+
+    // ── Rule 2: the caller's line ─────────────────────────────────────────
+
+    [Fact]
+    public void TransparentHelper_IsAttributedToItsCaller()
+    {
+        var element = TransparentField("Name"); var callerLine = Line();
+
+        Assert.Equal(callerLine, element.CallSite!.Value.LineNumber);
+        Assert.EndsWith("TransparentHelperTests.cs", element.CallSite!.Value.FilePath, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void UnannotatedHelper_StillReportsItsOwnBodyLine()
+    {
+        // The control for every test in this file, in the same file and the same run.
+        // Without it, a generator that had stopped emitting anything at all would make
+        // "the transparent helper reports the caller's line" unfalsifiable.
+        var element = PlainField("Name"); var callerLine = Line();
+
+        Assert.NotEqual(callerLine, element.CallSite!.Value.LineNumber);
+        Assert.True(element.CallSite!.Value.LineNumber < callerLine);
+    }
+
+    [Fact]
+    public void TwoCallSitesOfOneTransparentHelper_DoNotCollapse()
+    {
+        // The payoff. Two calls, two lines.
+        var first = TransparentField("Name"); var firstLine = Line();
+        var second = TransparentField("Email"); var secondLine = Line();
+
+        Assert.NotEqual(firstLine, secondLine);
+        Assert.Equal(firstLine, first.CallSite!.Value.LineNumber);
+        Assert.Equal(secondLine, second.CallSite!.Value.LineNumber);
+    }
+
+    [Fact]
+    public void TwoCallSitesOfTheUnannotatedHelper_DoCollapse()
+    {
+        // The differential control for the test above: same two-call shape, attribute
+        // removed. These two MUST land on the same line, which is exactly the problem the
+        // attribute exists to solve. Together the pair proves the attribute is what moves
+        // attribution — not the file, the flag, or the factory.
+        var first = PlainField("Name");
+        var second = PlainField("Email");
+
+        Assert.Equal(first.CallSite!.Value.LineNumber, second.CallSite!.Value.LineNumber);
+    }
+
+    // ── Rule 3: recursion ─────────────────────────────────────────────────
+
+    [Fact]
+    public void NestedTransparentHelpers_DeferToTheOutermostNonTransparentCaller()
+    {
+        // TransparentOuter calls TransparentInner calls TextBlock. Every link is either
+        // annotated or inside something annotated, so the walk keeps going outward until
+        // it reaches this test method, which is not annotated.
+        var element = TransparentOuter("Nested"); var callerLine = Line();
+
+        Assert.Equal(callerLine, element.CallSite!.Value.LineNumber);
+    }
+
+    [Fact]
+    public void InnerTransparentHelper_IsAlsoTransparentWhenCalledDirectly()
+    {
+        // Proves the nested result above came from deferral at each level rather than
+        // TransparentInner happening to be unreachable: called directly, it also reports
+        // its caller.
+        var element = TransparentInner("Direct"); var callerLine = Line();
+
+        Assert.Equal(callerLine, element.CallSite!.Value.LineNumber);
+    }
+
+    [Fact]
+    public void FactoryCallInsideALambdaInATransparentHelper_IsAlsoDeferred()
+    {
+        // Rule 1 walks the enclosing SYMBOL chain, so a factory call nested inside a
+        // lambda still counts as "inside" the transparent method. A syntax-only walk that
+        // stopped at the lambda would stamp the helper's body line here.
+        var element = TransparentViaLambda("Lambda"); var callerLine = Line();
+
+        Assert.Equal(callerLine, element.CallSite!.Value.LineNumber);
+    }
+
+    // ── The Element? return shape ─────────────────────────────────────────
+
+    [Fact]
+    public void NullableElementReturningHelper_IsStillDeferredToTheCaller()
+    {
+        // Regression test for a latent bug in the shared Element-returning check. It
+        // compared rendered type names, and the default display format renders
+        // nullability — so a method declared to return exactly `Element?` rendered as
+        // "…Element?", failed the comparison, and (because Element's base is object) the
+        // base-type walk went straight past the answer. Such a helper was silently
+        // skipped: not intercepted, and not suppressed either, so it reported its own body
+        // line. A conditional helper returning Element? is an entirely natural shape, so
+        // this had to be fixed before the attribute could be trusted.
+        var element = TransparentMaybeField(true, "Maybe"); var callerLine = Line();
+
+        Assert.NotNull(element);
+        Assert.Equal(callerLine, element!.CallSite!.Value.LineNumber);
+    }
+
+    [Fact]
+    public void NullableElementReturningHelper_StillReturnsNullWhenItShould()
+    {
+        // Behaviour preservation: the interceptor forwards, it does not change what the
+        // helper decides. Also exercises the emitted null guard for a nullable return.
+        Assert.Null(TransparentMaybeField(false, "Maybe"));
+    }
+
+    // ── Precedence and gating ─────────────────────────────────────────────
+
+    [Fact]
+    public void TransparentHelper_DoesNotRelabelAnElementItWasGiven()
+    {
+        // First stamp wins. The element was created on its own line and merely passed
+        // through, so the creating line is the right answer and the helper's call site is
+        // not. The same rule that keeps pass-through factories honest.
+        var given = TextBlock("created here"); var creationLine = Line();
+
+        var returned = TransparentPassThrough(given);
+
+        Assert.Same(given, returned);
+        Assert.Equal(creationLine, returned.CallSite!.Value.LineNumber);
+    }
+
+    [Fact]
+    public void PrivateAnnotatedHelper_BehavesExactlyLikeAnUnannotatedOne()
+    {
+        // An annotation the generator cannot honour must never make attribution WORSE
+        // than no annotation. Rule 1 is therefore conditioned on the enclosing method
+        // being forwardable, not merely annotated: suppressing the body stamp with no
+        // rule-2 interceptor to replace it would trade "the helper's line" for nothing at
+        // all. The generator warns (REACTOR_SOURCEMAP_001, suppressed at the declaration
+        // above) instead of failing silently.
+        var element = PrivateField("Name"); var callerLine = Line();
+
+        Assert.NotNull(element.CallSite);
+        Assert.NotEqual(callerLine, element.CallSite!.Value.LineNumber);
+        Assert.True(element.CallSite!.Value.LineNumber < callerLine);
+    }
+
+    [Fact]
+    public void FlagOff_LeavesTransparentHelperResultsUnstamped()
+    {
+        ReactorSourceMap.Enabled = false;
+        try
+        {
+            Assert.Null(TransparentField("off").CallSite);
+        }
+        finally
+        {
+            ReactorSourceMap.Enabled = true;
+        }
+
+        // Positive control: same probe, flag on.
+        var control = TransparentField("on"); var controlLine = Line();
+        Assert.Equal(controlLine, control.CallSite!.Value.LineNumber);
+    }
+
+    // ── The metadata path: an annotation in a REFERENCED assembly ─────────
+
+    [Fact]
+    public void TransparentAnnotationInAReferencedAssembly_IsHonoured()
+    {
+        // `PendingFactory.Pending` is annotated inside Reactor itself, which this suite
+        // consumes as a compiled reference. That is the shipping shape — a consumer
+        // calling an annotated framework method — and it is the only case here that
+        // proves the generator reads the attribute from METADATA rather than from source
+        // in its own compilation. It also requires the attribute type to be public;
+        // an internal one would be invisible across the boundary and every in-compilation
+        // test here would still pass.
+        //
+        // Before this annotation, Pending's element carried no location at all: it builds
+        // itself by calling Factories.Component<,> from inside Reactor's assembly, where
+        // there is no consumer call site to intercept.
+        var element = PendingFactory.Pending(TextBlock("fallback"), TextBlock("child")); var callerLine = Line();
+
+        // The LINE, not merely non-null. A null check alone would also pass if the inner
+        // Component<,> call had stamped it — which is precisely what rule 1 prevents, and
+        // which would point into Reactor's own source rather than at this line.
+        Assert.Equal(callerLine, element.CallSite!.Value.LineNumber);
+        Assert.EndsWith("TransparentHelperTests.cs", element.CallSite!.Value.FilePath, StringComparison.Ordinal);
+    }
+}

--- a/tests/Reactor.SourceMap.Tests/TransparentHelperTests.cs
+++ b/tests/Reactor.SourceMap.Tests/TransparentHelperTests.cs
@@ -74,6 +74,34 @@ public sealed class TransparentHelperTests : IDisposable
         return build();
     }
 
+    /// <summary>
+    /// A generic transparent helper, explicitly instantiated at <c>Element</c> so its
+    /// constructed parameter is an <c>Element</c> a <c>string</c> converts to.
+    /// </summary>
+    [ReactorSourceTransparent]
+    internal static Element TransparentWrap<T>(T value) => (Element)(object)value!;
+
+    [Fact]
+    public void GenericHelperInstantiatedAtElement_IsStampedAtTheCallerAndStillCompiles()
+    {
+        // A PR reviewer read the argument-stamp filter's use of the OPEN definition as a
+        // missed case: `TransparentWrap<Element>("converted")` genuinely does have a
+        // constructed `Element` parameter and a genuine user-defined conversion. Switching
+        // the filter to the constructed method was measured, and it makes the consumer's
+        // build fail — the emitted interceptor declares the parameter as `T __a0`, so
+        // writing an `Element?` into it is CS1503. Declining to stamp the argument is what
+        // keeps generated code compiling.
+        //
+        // The fact that this test COMPILES AT ALL is therefore half its value: this file is
+        // compiled with interception on, so a generator that stamped here would break the
+        // build rather than fail an assertion. The other half is that the element still
+        // gets a location — from rule 2's return-path stamp — so the guard costs nothing
+        // an author can observe here.
+        var element = TransparentWrap<Element>("converted"); var callerLine = Line();
+
+        Assert.Equal(callerLine, element.CallSite!.Value.LineNumber);
+    }
+
     // Deliberately unusable: a private method cannot be named from a generated file, so
     // the generator reports REACTOR_SOURCEMAP_001 and leaves attribution exactly as it
     // would be with no attribute at all. Suppressed locally because this file is compiled
@@ -192,6 +220,45 @@ public sealed class TransparentHelperTests : IDisposable
         // Behaviour preservation: the interceptor forwards, it does not change what the
         // helper decides. Also exercises the emitted null guard for a nullable return.
         Assert.Null(TransparentMaybeField(false, "Maybe"));
+    }
+
+    /// <summary>
+    /// A transparent helper whose body uses a bare-string child, so rule 1's reach over
+    /// argument-position stamping is observable.
+    /// </summary>
+    [ReactorSourceTransparent]
+    internal static Element TransparentWithConvertedChild(string label) => VStack(label);
+
+    [Fact]
+    public void RuleOne_AlsoSuppressesArgumentStampsInsideATransparentHelper()
+    {
+        // Rule 1 returns before argument analysis runs, so a converted child written inside
+        // an annotated helper gets no location at all — not the helper's line, and not the
+        // caller's. That follows from the model rather than being an oversight: the element
+        // belongs to whoever called the helper, and stamping the helper's own line is
+        // exactly what the attribute exists to stop. The RESULT still defers to the caller.
+        //
+        // Pinned because it is the one place the two mechanisms interact, and because
+        // silence here is otherwise indistinguishable from argument stamping being broken.
+        var stack = TransparentWithConvertedChild("child"); var callerLine = Line();
+
+        Assert.Equal(callerLine, stack.CallSite!.Value.LineNumber);
+
+        var child = global::System.Linq.Enumerable.Single(((StackElement)stack).Children);
+        Assert.Null(child.CallSite);
+    }
+
+    [Fact]
+    public void ConvertedChildOutsideATransparentHelper_IsStamped_ControlForRuleOneReach()
+    {
+        // The control that makes the null above mean something: the identical bare-string
+        // child, written at an ordinary call site in the same file, IS stamped. Without
+        // this, a generator that had stopped emitting argument stamps entirely would make
+        // the test above pass for the wrong reason.
+        var stack = VStack("child"); var line = Line();
+
+        var child = global::System.Linq.Enumerable.Single(stack.Children);
+        Assert.Equal(line, child.CallSite!.Value.LineNumber);
     }
 
     // ── Precedence and gating ─────────────────────────────────────────────

--- a/tests/Reactor.Tests/SourceMapTransparentGeneratorTests.cs
+++ b/tests/Reactor.Tests/SourceMapTransparentGeneratorTests.cs
@@ -1,0 +1,452 @@
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.UI.Reactor.Diagnostics;
+using Microsoft.UI.Reactor.SourceMap.Generator;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests;
+
+/// <summary>
+/// Spec 010 — drives <see cref="SourceMapInterceptorGenerator"/> directly to cover the
+/// <c>[ReactorSourceTransparent]</c> shapes that cannot be exercised from a live
+/// interception suite.
+///
+/// <para><b>Why a driver and not more live tests.</b> Every unusable annotation reports
+/// <c>REACTOR_SOURCEMAP_001</c>, and Release builds this repo with warnings as errors — so
+/// a suite containing one annotated instance method, one annotated local function, one
+/// annotated generic-type member and so on would need a <c>#pragma</c> for each just to
+/// compile, and would still only prove that a warning appeared somewhere. Running the
+/// generator over a synthetic compilation asserts the exact id, the exact target, and the
+/// exact reason.</para>
+///
+/// <para><b>The snippet declares its own Reactor surface</b> rather than referencing the
+/// real assembly: the generator matches types by metadata name, so a self-contained
+/// snippet exercises the same code paths without dragging WinUI into a headless suite.
+/// <see cref="AttributeMetadataName_MatchesTheRealAttribute"/> is the drift guard that
+/// makes that safe — if the shipping attribute is ever renamed or moved, these hermetic
+/// tests would otherwise keep passing against a name nothing uses.</para>
+/// </summary>
+public sealed class SourceMapTransparentGeneratorTests
+{
+    /// <summary>
+    /// A minimal stand-in for the Reactor DSL surface the generator keys off. Only the
+    /// metadata names matter.
+    /// </summary>
+    private const string ReactorSurface = """
+        namespace Microsoft.UI.Reactor.Core
+        {
+            public abstract record Element
+            {
+                public SourceLocation? CallSite { get; init; }
+            }
+            public record TextBlockElement(string Content) : Element;
+            public record EmptyElement : Element;
+            public readonly record struct SourceLocation(string FilePath, int LineNumber);
+        }
+        namespace Microsoft.UI.Reactor
+        {
+            public static class Factories
+            {
+                public static Microsoft.UI.Reactor.Core.TextBlockElement TextBlock(string content)
+                    => new(content);
+            }
+        }
+        namespace Microsoft.UI.Reactor.Diagnostics
+        {
+            [global::System.AttributeUsage(global::System.AttributeTargets.Method, Inherited = false)]
+            public sealed class ReactorSourceTransparentAttribute : global::System.Attribute { }
+            public static class ReactorSourceMap { public static bool Enabled { get; set; } }
+        }
+        """;
+
+    private static readonly ImmutableArray<MetadataReference> s_references = BuildReferences();
+
+    private static ImmutableArray<MetadataReference> BuildReferences()
+    {
+        var tpa = (string?)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") ?? string.Empty;
+        return tpa
+            .Split(global::System.IO.Path.PathSeparator)
+            .Where(static p => p.EndsWith(".dll", StringComparison.OrdinalIgnoreCase) && global::System.IO.File.Exists(p))
+            .Select(static p => (MetadataReference)MetadataReference.CreateFromFile(p))
+            .ToImmutableArray();
+    }
+
+    /// <summary>
+    /// Runs the generator over <paramref name="userCode"/> plus the stand-in surface and
+    /// returns what it produced.
+    /// </summary>
+    private static (ImmutableArray<Diagnostic> Diagnostics, string GeneratedSource) Run(
+        string userCode, bool enabled = true)
+    {
+        var compilation = CSharpCompilation.Create(
+            "SourceMapDriverProbe",
+            new[]
+            {
+                CSharpSyntaxTree.ParseText(ReactorSurface, path: "Surface.cs"),
+                CSharpSyntaxTree.ParseText(userCode, path: "User.cs"),
+            },
+            s_references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary,
+                nullableContextOptions: NullableContextOptions.Enable));
+
+        // The snippet must bind, or an "expected diagnostic missing" result would just be
+        // measuring a broken probe. Binding errors are a test bug, not a product signal.
+        var bindErrors = compilation.GetDiagnostics()
+            .Where(static d => d.Severity == DiagnosticSeverity.Error)
+            .ToList();
+        Assert.True(bindErrors.Count == 0, "probe snippet failed to compile: " + string.Join("; ", bindErrors));
+
+        var driver = CSharpGeneratorDriver.Create(
+            new[] { new SourceMapInterceptorGenerator().AsSourceGenerator() },
+            optionsProvider: new StubOptions(enabled));
+
+        driver = (CSharpGeneratorDriver)driver.RunGeneratorsAndUpdateCompilation(compilation, out _, out _);
+        var result = driver.GetRunResult();
+
+        var generated = string.Concat(result.GeneratedTrees.Select(static t => t.ToString()));
+        return (result.Diagnostics, generated);
+    }
+
+    /// <summary>
+    /// Counts attribute APPLICATIONS, not every mention of the name. The generated file
+    /// also declares a file-local <c>InterceptsLocationAttribute</c> polyfill (the .NET 10
+    /// BCL has none), whose class header and constructor would otherwise be counted as two
+    /// phantom interceptors and make every expectation here off by two.
+    /// </summary>
+    private static int InterceptorCount(string generated)
+        => generated.Split(
+            new[] { "[global::System.Runtime.CompilerServices.InterceptsLocationAttribute(" },
+            StringSplitOptions.None).Length - 1;
+
+    // ── Drift guard ───────────────────────────────────────────────────────
+
+    [Fact]
+    public void AttributeMetadataName_MatchesTheRealAttribute()
+    {
+        // Everything in this file is hermetic, so a rename of the shipping attribute would
+        // leave these tests green while the feature silently stopped working for every
+        // real consumer. This is the one assertion that ties the two together.
+        Assert.Equal(
+            SourceMapInterceptorGenerator.TransparentAttributeMetadataName,
+            typeof(ReactorSourceTransparentAttribute).FullName);
+    }
+
+    // ── Unusable annotations report REACTOR_SOURCEMAP_001 ─────────────────
+
+    [Theory]
+    [InlineData("private", "generated code cannot reach it")]
+    [InlineData("protected", "generated code cannot reach it")]
+    public void InaccessibleHelper_IsReported(string accessibility, string expectedReason)
+    {
+        var (diagnostics, _) = Run($$"""
+            using Microsoft.UI.Reactor.Core;
+            using Microsoft.UI.Reactor.Diagnostics;
+            using static Microsoft.UI.Reactor.Factories;
+
+            public class Host
+            {
+                [ReactorSourceTransparent]
+                {{accessibility}} static Element Helper(string s) => TextBlock(s);
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("REACTOR_SOURCEMAP_001", diagnostic.Id);
+        Assert.Equal(DiagnosticSeverity.Warning, diagnostic.DefaultSeverity);
+        Assert.Contains(expectedReason, diagnostic.GetMessage(), StringComparison.Ordinal);
+        Assert.Contains("Helper", diagnostic.GetMessage(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void InstanceHelper_IsReported()
+    {
+        var (diagnostics, _) = Run("""
+            using Microsoft.UI.Reactor.Core;
+            using Microsoft.UI.Reactor.Diagnostics;
+            using static Microsoft.UI.Reactor.Factories;
+
+            public class Host
+            {
+                [ReactorSourceTransparent]
+                public Element Helper(string s) => TextBlock(s);
+            }
+            """);
+
+        Assert.Contains("instance method", Assert.Single(diagnostics).GetMessage(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void LocalFunction_IsReported()
+    {
+        // C# interceptors cannot intercept local functions at all, so the annotation can
+        // never be honoured there however it is written.
+        var (diagnostics, _) = Run("""
+            using Microsoft.UI.Reactor.Core;
+            using Microsoft.UI.Reactor.Diagnostics;
+            using static Microsoft.UI.Reactor.Factories;
+
+            public class Host
+            {
+                public static Element Render()
+                {
+                    [ReactorSourceTransparent]
+                    static Element Helper(string s) => TextBlock(s);
+                    return Helper("x");
+                }
+            }
+            """);
+
+        Assert.Contains("local function", Assert.Single(diagnostics).GetMessage(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void HelperInAGenericType_IsReported()
+    {
+        // "Interceptors cannot be declared in generic types at any level of nesting", and
+        // an interceptor for a member of one would additionally have to restate the
+        // containing type's arity.
+        var (diagnostics, _) = Run("""
+            using Microsoft.UI.Reactor.Core;
+            using Microsoft.UI.Reactor.Diagnostics;
+            using static Microsoft.UI.Reactor.Factories;
+
+            public class Host<T>
+            {
+                [ReactorSourceTransparent]
+                public static Element Helper(string s) => TextBlock(s);
+            }
+            """);
+
+        Assert.Contains("generic type", Assert.Single(diagnostics).GetMessage(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void HelperInAFileLocalType_IsReported()
+    {
+        var (diagnostics, _) = Run("""
+            using Microsoft.UI.Reactor.Core;
+            using Microsoft.UI.Reactor.Diagnostics;
+            using static Microsoft.UI.Reactor.Factories;
+
+            file class Host
+            {
+                [ReactorSourceTransparent]
+                public static Element Helper(string s) => TextBlock(s);
+            }
+            """);
+
+        Assert.Contains("file-local type", Assert.Single(diagnostics).GetMessage(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void NonElementReturningHelper_IsReported()
+    {
+        var (diagnostics, _) = Run("""
+            using Microsoft.UI.Reactor.Diagnostics;
+
+            public class Host
+            {
+                [ReactorSourceTransparent]
+                public static string Helper(string s) => s;
+            }
+            """);
+
+        Assert.Contains("does not return", Assert.Single(diagnostics).GetMessage(), StringComparison.Ordinal);
+    }
+
+    // ── Usable annotations report nothing ─────────────────────────────────
+
+    [Fact]
+    public void UsableHelper_IsNotReported()
+    {
+        // The positive control for every assertion above. Without it, a generator that
+        // reported REACTOR_SOURCEMAP_001 unconditionally — or one whose reason strings had
+        // drifted into always matching — would look identical.
+        var (diagnostics, generated) = Run("""
+            using Microsoft.UI.Reactor.Core;
+            using Microsoft.UI.Reactor.Diagnostics;
+            using static Microsoft.UI.Reactor.Factories;
+
+            public class Host
+            {
+                [ReactorSourceTransparent]
+                internal static Element Helper(string s) => TextBlock(s);
+
+                public static Element Render() => Helper("x");
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+
+        // And it really was honoured: the call TO the helper is intercepted, the call
+        // inside it is not. One interceptor, not two, and not zero.
+        Assert.Equal(1, InterceptorCount(generated));
+        Assert.Contains("Host.Helper", generated, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void NullableElementReturningHelper_IsNotReported()
+    {
+        // Regression guard for the display-string comparison that used to back the
+        // "returns an Element" test: `Element?` rendered as "…Element?", never matched the
+        // metadata name, and the base-type walk went straight past Element to object. A
+        // conditional helper declared to return Element? was therefore reported as not
+        // returning an Element, and silently skipped.
+        var (diagnostics, generated) = Run("""
+            using Microsoft.UI.Reactor.Core;
+            using Microsoft.UI.Reactor.Diagnostics;
+            using static Microsoft.UI.Reactor.Factories;
+
+            public class Host
+            {
+                [ReactorSourceTransparent]
+                internal static Element? Helper(bool show, string s) => show ? TextBlock(s) : null;
+
+                public static Element? Render() => Helper(true, "x");
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+        Assert.Equal(1, InterceptorCount(generated));
+    }
+
+    // ── Rule 1 is conditioned on forwardability ───────────────────────────
+
+    [Fact]
+    public void ForwardableTransparentHelper_SuppressesTheInterceptorInsideItsBody()
+    {
+        var (_, generated) = Run("""
+            using Microsoft.UI.Reactor.Core;
+            using Microsoft.UI.Reactor.Diagnostics;
+            using static Microsoft.UI.Reactor.Factories;
+
+            public class Host
+            {
+                [ReactorSourceTransparent]
+                internal static Element Helper(string s) => TextBlock(s);
+            }
+            """);
+
+        // The helper is never called here, so the ONLY candidate call site in the file is
+        // the TextBlock inside its body — and rule 1 removes it.
+        Assert.Equal(0, InterceptorCount(generated));
+    }
+
+    [Fact]
+    public void NonForwardableTransparentHelper_KeepsTheInterceptorInsideItsBody()
+    {
+        // The asymmetry that makes a bad annotation harmless. Same body, same attribute,
+        // only the accessibility differs — and because no rule-2 interceptor can exist to
+        // re-stamp at the caller, suppressing here would trade "the helper's line" for no
+        // line at all. Paired with the test above, this is a differential oracle: one
+        // input character apart, opposite expected outputs.
+        var (diagnostics, generated) = Run("""
+            using Microsoft.UI.Reactor.Core;
+            using Microsoft.UI.Reactor.Diagnostics;
+            using static Microsoft.UI.Reactor.Factories;
+
+            public class Host
+            {
+                [ReactorSourceTransparent]
+                private static Element Helper(string s) => TextBlock(s);
+            }
+            """);
+
+        Assert.Equal(1, InterceptorCount(generated));
+        Assert.Single(diagnostics);
+    }
+
+    [Fact]
+    public void NestedTransparentHelpers_EmitOnlyTheOutermostInterceptor()
+    {
+        var (_, generated) = Run("""
+            using Microsoft.UI.Reactor.Core;
+            using Microsoft.UI.Reactor.Diagnostics;
+            using static Microsoft.UI.Reactor.Factories;
+
+            public class Host
+            {
+                [ReactorSourceTransparent]
+                internal static Element Inner(string s) => TextBlock(s);
+
+                [ReactorSourceTransparent]
+                internal static Element Outer(string s) => Inner(s);
+
+                public static Element Render() => Outer("x");
+            }
+            """);
+
+        // Three candidate calls — TextBlock inside Inner, Inner inside Outer, Outer inside
+        // Render — and only the last one survives, because the first two are inside a
+        // transparent method. That is rule 3 in one number.
+        Assert.Equal(1, InterceptorCount(generated));
+        Assert.Contains("Host.Outer", generated, StringComparison.Ordinal);
+        Assert.DoesNotContain("Host.Inner", generated, StringComparison.Ordinal);
+    }
+
+    // ── The opt-in gate covers diagnostics too ────────────────────────────
+
+    [Fact]
+    public void DisabledGenerator_ReportsNothingAndEmitsNothing()
+    {
+        // In a compilation where no interceptors are generated the attribute is inert by
+        // design, so warning about it would be pure noise.
+        var (diagnostics, generated) = Run("""
+            using Microsoft.UI.Reactor.Core;
+            using Microsoft.UI.Reactor.Diagnostics;
+            using static Microsoft.UI.Reactor.Factories;
+
+            public class Host
+            {
+                [ReactorSourceTransparent]
+                private static Element Helper(string s) => TextBlock(s);
+            }
+            """, enabled: false);
+
+        Assert.Empty(diagnostics);
+        Assert.Equal(string.Empty, generated);
+    }
+
+    /// <summary>
+    /// Supplies <c>build_property.ReactorSourceMap</c>, which is normally provided by
+    /// <c>CompilerVisibleProperty</c> in the consuming project.
+    /// </summary>
+    private sealed class StubOptions : AnalyzerConfigOptionsProvider
+    {
+        private readonly AnalyzerConfigOptions _global;
+
+        public StubOptions(bool enabled) => _global = new Options(enabled);
+
+        public override AnalyzerConfigOptions GlobalOptions => _global;
+
+        public override AnalyzerConfigOptions GetOptions(SyntaxTree tree) => Options.Empty;
+
+        public override AnalyzerConfigOptions GetOptions(AdditionalText textFile) => Options.Empty;
+
+        private sealed class Options : AnalyzerConfigOptions
+        {
+            internal static readonly Options Empty = new(null);
+
+            private readonly string? _reactorSourceMap;
+
+            internal Options(bool enabled) => _reactorSourceMap = enabled ? "true" : "false";
+
+            private Options(string? value) => _reactorSourceMap = value;
+
+            public override bool TryGetValue(string key, out string value)
+            {
+                if (key == "build_property.ReactorSourceMap" && _reactorSourceMap is not null)
+                {
+                    value = _reactorSourceMap;
+                    return true;
+                }
+
+                value = string.Empty;
+                return false;
+            }
+        }
+    }
+}

--- a/tests/Reactor.Tests/SourceMapTransparentGeneratorTests.cs
+++ b/tests/Reactor.Tests/SourceMapTransparentGeneratorTests.cs
@@ -41,6 +41,19 @@ public sealed class SourceMapTransparentGeneratorTests
             public abstract record Element
             {
                 public SourceLocation? CallSite { get; init; }
+
+                // The conversion argument-position stamping exists for. Without it the
+                // stand-in cannot express a convertible argument at all, and every
+                // driver test that thinks it is exercising one is really exercising
+                // a compile error.
+                //
+                // Built with a CONSTRUCTOR, not `Factories.TextBlock`, to stay faithful to
+                // the real thing: `Element.cs`'s operator lives in Reactor.dll, a different
+                // compilation, so its body is never intercepted and the converted element
+                // arrives unstamped. Calling a factory here would put an extra
+                // interceptable call site inside this compilation and inflate every
+                // interceptor count in this file.
+                public static implicit operator Element(string text) => new TextBlockElement(text);
             }
             public record TextBlockElement(string Content) : Element;
             public record EmptyElement : Element;
@@ -52,6 +65,12 @@ public sealed class SourceMapTransparentGeneratorTests
             {
                 public static Microsoft.UI.Reactor.Core.TextBlockElement TextBlock(string content)
                     => new(content);
+
+                public static Microsoft.UI.Reactor.Core.Element VStack(
+                    params Microsoft.UI.Reactor.Core.Element?[] children)
+                    => children.Length > 0 && children[0] is { } first
+                        ? first
+                        : new Microsoft.UI.Reactor.Core.EmptyElement();
             }
         }
         namespace Microsoft.UI.Reactor.Diagnostics
@@ -77,16 +96,30 @@ public sealed class SourceMapTransparentGeneratorTests
     /// <summary>
     /// Runs the generator over <paramref name="userCode"/> plus the stand-in surface and
     /// returns what it produced.
+    ///
+    /// <para>Asserts the snippet binds BEFORE generation and that the compilation still
+    /// binds AFTER it. The second half is the one that matters: this generator's whole
+    /// job is emitting C# that forwards to arbitrary consumer methods, and every failure
+    /// mode worth catching — an unnameable type, a parameter whose open and constructed
+    /// forms differ, a `params` slot written with the wrong type — shows up as a compile
+    /// error in the emitted file rather than as a wrong string in it.</para>
     /// </summary>
     private static (ImmutableArray<Diagnostic> Diagnostics, string GeneratedSource) Run(
         string userCode, bool enabled = true)
     {
+        // Interceptors are opt-in per namespace; without this the emitted
+        // [InterceptsLocation] attributes are CS9137 and the post-generation check below
+        // would fail for a reason that has nothing to do with the code under test.
+        var parseOptions = new CSharpParseOptions(LanguageVersion.Preview)
+            .WithFeatures([new KeyValuePair<string, string>(
+                "InterceptorsNamespaces", SourceMapInterceptorGenerator.InterceptorNamespace)]);
+
         var compilation = CSharpCompilation.Create(
             "SourceMapDriverProbe",
             new[]
             {
-                CSharpSyntaxTree.ParseText(ReactorSurface, path: "Surface.cs"),
-                CSharpSyntaxTree.ParseText(userCode, path: "User.cs"),
+                CSharpSyntaxTree.ParseText(ReactorSurface, parseOptions, path: "Surface.cs"),
+                CSharpSyntaxTree.ParseText(userCode, parseOptions, path: "User.cs"),
             },
             s_references,
             new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary,
@@ -100,11 +133,20 @@ public sealed class SourceMapTransparentGeneratorTests
         Assert.True(bindErrors.Count == 0, "probe snippet failed to compile: " + string.Join("; ", bindErrors));
 
         var driver = CSharpGeneratorDriver.Create(
-            new[] { new SourceMapInterceptorGenerator().AsSourceGenerator() },
-            optionsProvider: new StubOptions(enabled));
+            [new SourceMapInterceptorGenerator().AsSourceGenerator()],
+            optionsProvider: new StubOptions(enabled),
+            parseOptions: parseOptions);
 
-        driver = (CSharpGeneratorDriver)driver.RunGeneratorsAndUpdateCompilation(compilation, out _, out _);
+        driver = (CSharpGeneratorDriver)driver.RunGeneratorsAndUpdateCompilation(
+            compilation, out var outputCompilation, out _);
         var result = driver.GetRunResult();
+
+        var emitErrors = outputCompilation.GetDiagnostics()
+            .Where(static d => d.Severity == DiagnosticSeverity.Error)
+            .ToList();
+        Assert.True(
+            emitErrors.Count == 0,
+            "the GENERATED code does not compile: " + string.Join("; ", emitErrors));
 
         var generated = string.Concat(result.GeneratedTrees.Select(static t => t.ToString()));
         return (result.Diagnostics, generated);
@@ -255,6 +297,111 @@ public sealed class SourceMapTransparentGeneratorTests
             """);
 
         Assert.Contains("does not return", Assert.Single(diagnostics).GetMessage(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ByRefParameterHelper_IsReported()
+    {
+        // The interceptor must call the original with exactly the arguments it received,
+        // which needs matching ref kinds on both sides.
+        var (diagnostics, _) = Run("""
+            using Microsoft.UI.Reactor.Core;
+            using Microsoft.UI.Reactor.Diagnostics;
+            using static Microsoft.UI.Reactor.Factories;
+
+            public class Host
+            {
+                [ReactorSourceTransparent]
+                public static Element Helper(string s, out int len)
+                {
+                    len = s.Length;
+                    return TextBlock(s);
+                }
+            }
+            """);
+
+        Assert.Contains("by-ref parameter", Assert.Single(diagnostics).GetMessage(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void NonOrdinaryMethodHelper_IsReported()
+    {
+        // A conversion operator is a method as far as `AttributeTargets.Method` is
+        // concerned, but interceptors reach only ordinary methods.
+        var (diagnostics, _) = Run("""
+            using Microsoft.UI.Reactor.Core;
+            using Microsoft.UI.Reactor.Diagnostics;
+            using static Microsoft.UI.Reactor.Factories;
+
+            public class Badge
+            {
+                [ReactorSourceTransparent]
+                public static implicit operator Element(Badge b) => TextBlock("badge");
+            }
+            """);
+
+        Assert.Contains("ordinary methods", Assert.Single(diagnostics).GetMessage(), StringComparison.Ordinal);
+    }
+
+    // ── The post-generation compile check earns its place ─────────────────
+
+    [Fact]
+    public void GenericHelperInstantiatedAtElement_EmitsCompilingCode()
+    {
+        // The shape that makes `Run`'s post-generation compile assertion load-bearing.
+        // `Wrap<Element>("x")` has a constructed parameter of exactly `Element` and a real
+        // implicit user-defined conversion, so it looks like it should get an argument
+        // stamp — but the emitted interceptor declares that parameter from the OPEN
+        // definition as `T __a0`, and writing an `Element?` into it is
+        // CS1503. The generator therefore declines, and this test fails the moment someone
+        // "improves" CouldHaveConvertedArguments to consult the constructed method.
+        //
+        // Verified to be a real tripwire rather than a hopeful one: switching that filter
+        // over makes this assertion fail with the CS1503 quoted above.
+        var (diagnostics, generated) = Run("""
+            using Microsoft.UI.Reactor.Core;
+            using Microsoft.UI.Reactor.Diagnostics;
+            using static Microsoft.UI.Reactor.Factories;
+
+            public class Host
+            {
+                [ReactorSourceTransparent]
+                internal static Element Wrap<T>(T value) => (Element)(object)value!;
+
+                public static Element Render() => Wrap<Element>("x");
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+
+        // The call IS intercepted — the guard is specific to the argument slot, not a
+        // blanket refusal to touch generic helpers.
+        Assert.Equal(1, InterceptorCount(generated));
+        Assert.DoesNotContain("__ReactorStampArgument(__a0", generated, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ConvertedArgumentOnANonGenericFactory_IsStamped_ControlForTheGenericGuard()
+    {
+        // The positive control for the test above: the same converted-string argument on a
+        // NON-generic params factory does get an argument stamp. Without it, the
+        // DoesNotContain assertion above would also pass if argument stamping had stopped
+        // working entirely, or if the stand-in surface could not express a conversion at
+        // all — which was in fact true until this suite's `Element` gained the implicit
+        // operator, and is exactly how that omission was found.
+        var (diagnostics, generated) = Run("""
+            using Microsoft.UI.Reactor.Core;
+            using static Microsoft.UI.Reactor.Factories;
+
+            public class Host
+            {
+                public static Element Render() => VStack("a", "b");
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+        Assert.Contains("__ReactorStampArgument(__a0[0]", generated, StringComparison.Ordinal);
+        Assert.Contains("__ReactorStampArgument(__a0[1]", generated, StringComparison.Ordinal);
     }
 
     // ── Usable annotations report nothing ─────────────────────────────────


### PR DESCRIPTION
Layer 2 of spec 010. Builds on the per-element source mapping merged in #1147, and closes the two attribution gaps that drop documented.

Base is `main` - layer 1 was squash-merged as `33a35999`, so this branch was rebased onto `main` and the diff is only this work.

## The gaps

Measured on `main` with interception on:

| Expression | Outer element | Child element |
|---|---|---|
| `VStack("hi")` | correct | **`null`** |
| `VStack(TextBlock("hi"))` | correct | correct |
| helper `MyHeader() => TextBlock("header")` | n/a | **helper''s body line**, not the caller''s |

Neither is fixable the obvious way. Interceptors "can only occur for calls to ordinary member methods - not constructors, delegates, properties, local functions, **operators**", and the `implicit operator Element(string)` body is already compiled into `Reactor.dll`, so the bare-string child is structurally unreachable. And a helper''s body genuinely *is* the call site of `TextBlock`, so there is nothing incorrect to fix - only an intent the compiler cannot infer.

## Mechanism 1 - `[ReactorSourceTransparent]`

A public marker attribute meaning "attribute my results to my caller". The generator emits no interceptor for DSL calls lexically inside an annotated method (rule 1), and intercepts calls *to* it instead (rule 2). Recursion falls out: annotated calling annotated keeps deferring outward until a caller that is not annotated (rule 3).

```csharp
[ReactorSourceTransparent]
internal static Element Field(string label, string value)
    => HStack(TextBlock(label), TextBlock(value));

var form = VStack(
    Field("Name", name),    // reports THIS line
    Field("Email", email)); // and this one
```

**Deliberately opt-in.** For a `Component.Render()` body the body line is the correct answer, so this is never a blanket rule for helpers. `UnannotatedHelper_StillReportsItsOwnBodyLine` and `TwoCallSitesOfTheUnannotatedHelper_DoCollapse` pin that default in the same file, one attribute apart from the positive tests.

**A bad annotation is never worse than none.** Rule 1 is conditioned on the helper actually being *forwardable* (static, `Element`-returning, nameable from a generated file - so `public`/`internal`, not a local function, not in a `file`-local or generic type), not merely on it being annotated. Suppressing the body stamp with no rule-2 interceptor to replace it would trade "the helper''s line" for no line at all. Unusable annotations report **`REACTOR_SOURCEMAP_001`** rather than doing nothing silently, and are `#pragma`-suppressible.

Instance-method helpers are an explicit, documented gap: intercepting one requires an extension-method interceptor, a different shape.

## Mechanism 2 - argument-position stamping

The enclosing factory call *is* intercepted, so its interceptor stamps arguments that arrived via an implicit user-defined conversion to `Element`, using **each argument''s own line**:

```csharp
VStack(
    "a",   // reports this line
    "b");  // and this one
```

Works for any user-defined conversion, not just `string`. Respects first-stamp-wins, hands `EmptyElement.Instance` through without cloning it, and only ever writes into a `params` array the **compiler** synthesized for that call site - `VStack(myArray)` is left completely alone.

## Bonus: a latent layer-1 bug, fixed centrally

`ReturnsElement` compared `ToDisplayString()` against the metadata name. I measured with a standalone Roslyn 5.9 probe that **the default display format renders nullability**: a method returning exactly `Element?` renders as `...Element?`, misses the comparison, and - since `Element`''s base is `object` - the base-type walk goes straight past the answer. Such a method was silently skipped entirely.

Latent today (no factory returns bare `Element?`; a nullable *derived* return is unaffected, because `TextBlockElement?.BaseType` is unannotated). It stops being latent here, where a conditional `Element?` helper is a natural shape. Fixed at the root by comparing symbols - verified `SymbolEqualityComparer.Default.Equals(Element?, Element)` is `true` while `IncludeNullability` is `false`, which is the pair that proves Default ignores annotations rather than the two simply being the same symbol. `Signature.CanReturnEmpty` had the identical defect and is fixed with it, which matters now that `Element?`-returning methods are reachable at all.

**No behaviour change:** the generated interceptor file for `Reactor.SourceMap.Tests` is **byte-identical** before and after this fix (79,946 bytes, same 90 attribute applications) - a direct measurement rather than an argument from counting declarations.

## `PendingFactory.Pending` is now annotated

It is the textbook thin forwarder, and it is the **only** end-to-end proof that rule 2 reads the attribute from *metadata* rather than same-compilation source - the shipping shape. `TransparentAnnotationInAReferencedAssembly_IsHonoured` asserts the stamped **line**, not merely non-null: a null check alone would also pass if the inner `Component<,>` call had stamped it, pointing into Reactor''s own source. It also depends on the attribute being `public`; an internal one would be invisible across the boundary while every in-compilation test stayed green.

`NonFactoriesEntryPointTests` (which explicitly anticipated this change) now pins the gap against `PropertyGridDefaults.PropertyLabelTemplate` instead - still a real, unannotated, public entry point whose element is built inside Reactor. Docs updated in the same commit.

## Mutation evidence

Every mechanism was mutated in the generator and the suites re-run. No mutation was accepted until it reddened something.

| Mutation | Tests reddened |
|---|---|
| Rule 1 disabled | **7** |
| Rule 2 disabled (`isTransparentTarget` dropped) | **9** |
| Rule 1 applied unconditionally (ignore forwardability) | **1** - `PrivateAnnotatedHelper_BehavesExactlyLikeAnUnannotatedOne` |
| Argument stamping not emitted | **11** |
| Argument first-stamp-wins guard removed | **1** - `OperatorThatReturnsAStampedElement_KeepsTheOperatorsLine` |
| Argument `EmptyElement` guard removed | **1** - `ConversionThatYieldsTheEmptySingleton_IsNotCloned` |
| Argument line -> container''s line | **3** |
| `ParamArray` widened to `Explicit` | **3** |
| Normal-form guards dropped | **1** - `ExplicitlyWrittenArrayArgument_IsAlsoLeftAlone` |
| `ReturnsElement` reverted to name comparison | **2** (one live, one driver) |

Two things this process caught in my own work, both worth stating because they are the failure mode this repo warns about:

- My **first attempt at the argument-line mutation survived**, and the mutation was wrong, not the tests: `FirstAncestorOrSelf<InvocationExpressionSyntax>()` returns the argument''s *own* invocation for `At("x", out var l)`. Re-run against the enclosing `ArgumentListSyntax` it reddens 3 tests.
- `ExplicitlyWrittenArrayArgument_IsAlsoLeftAlone` was **added because the original normal-form test proved nothing under mutation** - its array is built in a separate statement, so no plausible mutation reaches it. The inline-array form is what actually distinguishes "the compiler built this array" from "the argument is an array creation".

The `REACTOR_SOURCEMAP_001` diagnostic got the same treatment: removing the `#pragma` produces the warning at the attribute (`TransparentHelperTests.cs(83,6)`) with the full message, so the green build is suppression working rather than the diagnostic never firing.

## Vacuity controls

- Every line assertion is checked against a `[CallerLineNumber]` oracle captured at the relevant physical line. `At(value, out int line)` puts that oracle *inside* an argument list, so multi-argument calls are checked argument-by-argument with no hard-coded offsets.
- `EachConvertedArgument_TakesItsOwnLine` asserts `firstLine != secondLine` before using them, so a degenerate oracle cannot make the comparison a tautology.
- `OperatorThatReturnsAStampedElement_KeepsTheOperatorsLine` is a differential oracle - the same conversion from two different lines must agree with each other - so no literal line number is written down.
- The driver suite is hermetic, so `AttributeMetadataName_MatchesTheRealAttribute` ties it to the shipping type; a rename would otherwise leave it green while the feature broke for every consumer.
- The driver harness asserts its own probe snippet compiles. That caught the `Microsoft.UI.System` shadowing trap immediately instead of as a mysterious "expected diagnostic missing".
- My `InterceptorCount` helper was itself wrong at first - it counted the emitted `InterceptsLocationAttribute` polyfill''s own declaration. Exact-count assertions caught it.

## Numbers

| | Baseline (`main`) | This branch |
|---|---|---|
| `Reactor.Tests` | 13754 total, 0 failed, 64 skipped | **13768 total, 0 failed, 64 skipped** (+14) |
| `Reactor.SourceMap.Tests` | 42 / 42 | **71 / 71** (+29) |
| `dotnet build Reactor.slnx -c Release` | 0 warnings, 3 `NU1301` | **0 warnings, 3 `NU1301`** (unchanged - nuget.org unreachable here, pre-existing in the `vs-reactor` projects) |

`Reactor.SourceMap.Tests` also builds clean in Release specifically (`0 warnings, 0 errors`), where warnings are errors - and its Release-generated file contains 106 interceptors and 16 argument stamps, so that clean build is the generator running and the pragma suppressing, not the generator being off.

## Also included

- Docs: `docs/_pipeline/templates/source-mapping.md.dt` (the source) recompiled via `mur docs compile --topic source-mapping`. The stale "bare-string children are not stamped" and "helper methods attribute to themselves" limitations are replaced with the new sections; `Pending.md` regenerates from the new XML doc.
- Public API index regenerated into both byte-identical copies.
- `CHANGELOG.md` entry under `Unreleased`/`Added`, cross-referencing spec 010 and ordered by spec number.
- A symbol-only pre-check gates the `GetOperation` call so only factories with an `Element`-typed parameter build an operation tree, keeping per-call-site generation cost where layer 1 measured it.

## Not addressed

`sig.ReturnsNullable`''s emitted `if (__e is null)` arm could previously only be reached through a nullable *derived* return type, for the same root cause fixed here. No machinery added for it.
