### PR TITLE
Gate compiled-doc drift instead of computing it and throwing it away

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
     outputs:
       non-md: ${{ steps.filter.outputs.non-md }}
       docs-templates: ${{ steps.filter.outputs.docs-templates }}
+      compiled-docs: ${{ steps.filter.outputs.compiled-docs }}
       devtools-trim: ${{ steps.filter.outputs.devtools-trim }}
       audit-ledger: ${{ steps.filter.outputs.audit-ledger }}
     steps:
@@ -45,6 +46,7 @@ jobs:
             echo "No valid diff range; defaulting all change filters to true"
             echo "non-md=true" >> "$GITHUB_OUTPUT"
             echo "docs-templates=true" >> "$GITHUB_OUTPUT"
+            echo "compiled-docs=true" >> "$GITHUB_OUTPUT"
             echo "devtools-trim=true" >> "$GITHUB_OUTPUT"
             echo "audit-ledger=true" >> "$GITHUB_OUTPUT"
             exit 0
@@ -53,6 +55,7 @@ jobs:
             echo "git diff failed; defaulting all change filters to true"
             echo "non-md=true" >> "$GITHUB_OUTPUT"
             echo "docs-templates=true" >> "$GITHUB_OUTPUT"
+            echo "compiled-docs=true" >> "$GITHUB_OUTPUT"
             echo "devtools-trim=true" >> "$GITHUB_OUTPUT"
             echo "audit-ledger=true" >> "$GITHUB_OUTPUT"
             exit 0
@@ -77,6 +80,16 @@ jobs:
             echo "devtools-trim=true" >> "$GITHUB_OUTPUT"
           else
             echo "devtools-trim=false" >> "$GITHUB_OUTPUT"
+          fi
+          # Issue #1052: the compiled-docs freshness gate lives in `docs-build`,
+          # which is armed by non-md. But the likeliest way to introduce the
+          # drift it catches is to hand-edit a generated page under docs/guide —
+          # and that edit is pure .md, so it sets non-md=false and skips the one
+          # job that would have caught it. Same shape as audit-ledger below.
+          if echo "$files" | grep -qE '^docs/guide/'; then
+            echo "compiled-docs=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "compiled-docs=false" >> "$GITHUB_OUTPUT"
           fi
           # Issue #959: the spec 044 swallowed-error audit is a Markdown file
           # whose summary table is derived from its own rows and gated by
@@ -763,7 +776,11 @@ jobs:
   docs-build:
     name: Docs build
     needs: changes
-    if: needs.changes.outputs.non-md == 'true'
+    # `compiled-docs` re-arms this job for a docs/guide-only edit (issue #1052).
+    # Those files are all .md, so non-md alone is false and the job would skip —
+    # and hand-editing a generated page instead of its template is the single
+    # most likely way to introduce the drift the freshness gate below catches.
+    if: needs.changes.outputs.non-md == 'true' || needs.changes.outputs.compiled-docs == 'true'
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -773,8 +790,27 @@ jobs:
         with:
           dotnet-version: 10.0.x
 
+      # Tee'd to a log rather than run bare, because the freshness gate at the
+      # bottom of this job needs to know this compile *fully ran*. A compile
+      # that dies early leaves docs/guide untouched, and an untouched tree is
+      # indistinguishable from a fresh one by `git status` alone — so the log is
+      # what turns "no diff" into a measurement instead of an assumption.
+      #
+      # The exit code is checked explicitly instead of leaning on the runner's
+      # trailing `exit $LASTEXITCODE`: a pipeline's exit code is a subtlety
+      # nobody should have to re-derive when reading a gate. (Measured on
+      # pwsh 7.6: $LASTEXITCODE through `| Tee-Object` reports the native
+      # command's code, 0 and non-zero alike.)
       - name: Compile docs
-        run: dotnet run --project src/Reactor.Cli -- docs compile --no-screenshots --ci
+        shell: pwsh
+        run: |
+          $PSNativeCommandUseErrorActionPreference = $false
+          dotnet run --project src/Reactor.Cli -- docs compile --no-screenshots --ci 2>&1 |
+            Tee-Object -FilePath "$env:RUNNER_TEMP/docs-compile.log"
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "docs compile failed (exit $LASTEXITCODE)."
+            exit 1
+          }
 
       # Non-destructiveness gate for issue #989: a compile with
       # --no-screenshots must never touch a committed screenshot. Phase 3 is
@@ -807,6 +843,16 @@ jobs:
       # both modes against a planted subdirectory — `all` names each PNG, so
       # whoever hits this in CI sees which files appeared instead of a
       # directory they then have to go and inspect.
+      #
+      # Kept, and kept *first*, now that the freshness gate below watches all of
+      # docs/guide. That gate's path set is a superset of this one's, but the two
+      # defend opposite properties: this one says nothing may be written here,
+      # and you fix it by removing the write; that one says whatever was written
+      # must be committed, and you fix it by committing. Fold them together and
+      # a reintroduced screenshot write gets answered with "commit the
+      # regenerated output" — precisely the wrong instruction, and the one that
+      # would have let issue #989 through. Ordering is what keeps the specific
+      # diagnosis in front of the general one.
       - name: Verify --no-screenshots left committed images untouched
         shell: pwsh
         run: |
@@ -822,28 +868,93 @@ jobs:
             exit 1
           }
 
-      # Docs version freshness gate. The compile above substitutes the
-      # {{reactorVersion}} token — whose single source is <ReactorPublicVersion>
-      # in Directory.Build.props — into the guide pages that name the package
-      # version. If a PR bumps that property (or edits these templates) without
-      # recompiling, the committed output goes stale; fail here with a clear fix
-      # instead of shipping docs that disagree with the source of truth.
+      # Compiled-output freshness gate (issue #1052). The compile above
+      # regenerates every generated file under docs/guide — 72 topic pages,
+      # README.md, and ~117 pages under reference/. Until this gate existed, CI
+      # did all of that work and then checked exactly two of those files, so a
+      # source edit that changed a `snippet="source:..."` region left the
+      # published page stale and the job stayed green. The evidence was being
+      # computed and discarded.
       #
-      # Scoped to the two version-bearing pages (getting-started, packaging)
-      # rather than all of docs/guide: other committed guide pages currently
-      # carry pre-existing compile drift unrelated to versioning, which a
-      # whole-tree diff would false-fail on. Widen once that drift is
-      # reconciled separately.
-      - name: Verify docs version substitution is committed
+      # This step consumes it. It subsumes the old two-file version check: a
+      # `<ReactorPublicVersion>` bump that wasn't recompiled shows up here as a
+      # diff in getting-started.md / packaging.md like any other staleness,
+      # which is why the fix text still names that case explicitly.
+      #
+      # `git status --porcelain`, not `git diff` — the same reason the images
+      # gate above gives, and it matters more here. `git diff` sees tracked
+      # modifications only, so a *new* topic template or a newly generated
+      # reference page produces an untracked file that `git diff` reports as
+      # nothing at all. `git status` catches both, so it replaces `git diff`
+      # rather than joining it (docs/contributing/doc-pipeline.md §4).
+      #
+      # The precondition is deliberately part of this step rather than a step of
+      # its own. A clean tree only means "fresh" if the compile that was
+      # supposed to rewrite the tree actually rewrote it, so the verdict and the
+      # thing it depends on belong together — a separate step would pass or fail
+      # on its own and leave the reader to connect them. Two ways the compile
+      # can exit 0 without having regenerated what this gate covers:
+      #
+      #   * `RunReferenceGeneration` returns null and only *prints* when there is
+      #     no Reactor.xml (or no reference-map.yaml). Phase 5.7's header still
+      #     appears, the compile still says it succeeded, and ~117 reference
+      #     pages silently go unwritten.
+      #   * a `--skip-*` flag added to the invocation above turns a writing phase
+      #     off. Phases 2 (build) and 3 (capture) are expected to be skipped —
+      #     neither writes a page, and skipping capture is the whole point of
+      #     --no-screenshots — and Phase 5 isn't implemented. Any *other* skipped
+      #     phase silently narrows this gate, so it fails here instead.
+      #
+      # Both are checked against the log rather than assumed away, because each
+      # of them turns this gate into a check that cannot fail — which is the
+      # defect the gate was added to fix, reintroduced one level up.
+      #
+      # Matching avoids the box-drawing characters in the phase banners on
+      # purpose: every pattern here is ASCII, so the gate cannot be defeated by
+      # a console-encoding difference mangling `═══` on some future runner
+      # image.
+      - name: Verify compiled docs are committed
         shell: pwsh
         run: |
-          # git diff --exit-code returns non-zero when the tree differs; opt out
-          # of native-command error mapping so we surface the actionable message
-          # below instead of a bare PowerShell terminating error.
           $PSNativeCommandUseErrorActionPreference = $false
-          git diff --exit-code -- docs/guide/getting-started.md docs/guide/packaging.md
+          $logPath = "$env:RUNNER_TEMP/docs-compile.log"
+          if (-not (Test-Path -LiteralPath $logPath)) {
+            Write-Error "No compile log at $logPath — the gate could not run, so treat this as a failure rather than an all-clear."
+            exit 1
+          }
+          $log = Get-Content -LiteralPath $logPath -Raw
+
+          if ($log -notmatch [regex]::Escape('Documentation compiled successfully.')) {
+            Write-Error 'The docs compile did not report success, so docs/guide was not fully regenerated and a clean tree below would prove nothing. Treating as a failure. See the Compile docs step output.'
+            exit 1
+          }
+
+          foreach ($missing in @('Reactor.xml not found', 'reference-map.yaml not found')) {
+            if ($log -match [regex]::Escape($missing)) {
+              Write-Error "Phase 5.7 skipped reference generation ($missing), so docs/guide/reference was not regenerated and this gate cannot judge it. Treating as a failure."
+              exit 1
+            }
+          }
+
+          # Phase 2 (build), 3 (capture) and 5 (AI author, unimplemented) are the
+          # only skips that leave every generated page still written this run.
+          $unexpected = [regex]::Matches($log, '(?m)Phase (?<n>[0-9.]+):[^\r\n]*\(skipped') |
+            ForEach-Object { $_.Groups['n'].Value } |
+            Where-Object { $_ -notin @('2', '3', '5') } |
+            Sort-Object -Unique
+          if ($unexpected) {
+            Write-Error "Compile skipped phase(s) $($unexpected -join ', '), which write under docs/guide. The tree below was not fully regenerated, so this gate cannot judge it. Treating as a failure."
+            exit 1
+          }
+
+          $dirty = git status --porcelain --untracked-files=all -- docs/guide
           if ($LASTEXITCODE -ne 0) {
-            Write-Error 'docs/guide is out of date with the doc templates and/or ReactorPublicVersion. Run: dotnet run --project src/Reactor.Cli -- docs compile --no-screenshots  then commit the regenerated docs/guide pages (the {{reactorVersion}} token is substituted from <ReactorPublicVersion> in Directory.Build.props).'
+            Write-Error "git status failed (exit $LASTEXITCODE) — the gate could not run, so treat this as a failure rather than an all-clear."
+            exit 1
+          }
+          if ($dirty) {
+            $dirty | ForEach-Object { Write-Host "  $_" }
+            Write-Error 'The files above are generated, and recompiling them produced different output than what is committed. docs/guide is compiled from docs/_pipeline/templates/*.md.dt plus the sources their snippets point at, so editing a page directly does not stick — regenerate instead. Run: dotnet run --project src/Reactor.Cli -- docs compile --no-screenshots  then commit the result. Most often this is a src/ edit that moved a snippet="source:..." region, or a <ReactorPublicVersion> bump in Directory.Build.props that the {{reactorVersion}} pages have not picked up. See docs/contributing/doc-pipeline.md section 10.'
             exit 1
           }
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -892,22 +892,25 @@ jobs:
       # its own. A clean tree only means "fresh" if the compile that was
       # supposed to rewrite the tree actually rewrote it, so the verdict and the
       # thing it depends on belong together — a separate step would pass or fail
-      # on its own and leave the reader to connect them. Two ways the compile
-      # can exit 0 without having regenerated what this gate covers:
+      # on its own and leave the reader to connect them.
       #
-      #   * `RunReferenceGeneration` returns null and only *prints* when there is
-      #     no Reactor.xml (or no reference-map.yaml). Phase 5.7's header still
-      #     appears, the compile still says it succeeded, and ~117 reference
-      #     pages silently go unwritten.
-      #   * a `--skip-*` flag added to the invocation above turns a writing phase
-      #     off. Phases 2 (build) and 3 (capture) are expected to be skipped —
-      #     neither writes a page, and skipping capture is the whole point of
-      #     --no-screenshots — and Phase 5 isn't implemented. Any *other* skipped
-      #     phase silently narrows this gate, so it fails here instead.
+      # Only one class of "exited 0 without regenerating" is checked here, and
+      # it is the one only the workflow can see: a `--skip-*` flag added to the
+      # invocation above turning a writing phase off. Phases 2 (build) and 3
+      # (capture) are expected to be skipped — neither writes a page, and
+      # skipping capture is the whole point of --no-screenshots — and Phase 5
+      # isn't implemented. Any *other* skipped phase silently narrows this gate,
+      # so it fails here instead.
       #
-      # Both are checked against the log rather than assumed away, because each
-      # of them turns this gate into a check that cannot fail — which is the
-      # defect the gate was added to fix, reintroduced one level up.
+      # The other class — Phase 5.7 bailing on a missing Reactor.xml or
+      # reference-map.yaml and leaving ~117 reference pages unwritten — used to
+      # be checked here too, by grepping stdout for those two "not found"
+      # strings. That was the wrong owner and the wrong direction of failure: a
+      # reword in CompileCommand.cs would have made the check silently stop
+      # matching, i.e. fail *open*, which is the defect this whole job exists to
+      # fix reintroduced one level up. `docs compile --ci` now returns non-zero
+      # for it, so the exit-code check in the Compile docs step catches it and
+      # this gate does not need to re-derive it from prose.
       #
       # Matching avoids the box-drawing characters in the phase banners on
       # purpose: every pattern here is ASCII, so the gate cannot be defeated by
@@ -927,13 +930,6 @@ jobs:
           if ($log -notmatch [regex]::Escape('Documentation compiled successfully.')) {
             Write-Error 'The docs compile did not report success, so docs/guide was not fully regenerated and a clean tree below would prove nothing. Treating as a failure. See the Compile docs step output.'
             exit 1
-          }
-
-          foreach ($missing in @('Reactor.xml not found', 'reference-map.yaml not found')) {
-            if ($log -match [regex]::Escape($missing)) {
-              Write-Error "Phase 5.7 skipped reference generation ($missing), so docs/guide/reference was not regenerated and this gate cannot judge it. Treating as a failure."
-              exit 1
-            }
           }
 
           # Phase 2 (build), 3 (capture) and 5 (AI author, unimplemented) are the

--- a/docs/contributing/doc-pipeline.md
+++ b/docs/contributing/doc-pipeline.md
@@ -179,12 +179,20 @@ separately: the phase compares the chosen XML against the newest `.cs` under
 with [`REACTOR_DOC_REFGEN_W002`](#6-snippet--image--diagram-error-codes) when the
 source is newer. Run `dotnet build src/Reactor` and compile again.
 
-If no `Reactor.xml` exists at all the phase skips reference generation rather
-than failing, printing:
+If no `Reactor.xml` exists at all, **a local compile** skips reference generation
+rather than failing, printing:
 
 ```
   (Reactor.xml not found — run `dotnet build src/Reactor` first)
 ```
+
+That degradation is deliberate: on a first compile you should still get your
+guide pages. Under `--ci` the same condition **exits 1** instead. CI always
+builds, so a missing input there means the run is not the run that was asked
+for, and skipping the phase would leave the ~117 pages under
+`docs/guide/reference/` silently at whatever was committed. The same applies to
+a missing `reference-map.yaml`. `ReferenceStalenessWiringTests` pins both
+directions.
 
 CI does build it. The `docs-build` job runs `docs compile --no-screenshots --ci`
 *without* `--no-build`, so Phase 2 builds every doc app, each of which
@@ -194,9 +202,10 @@ an ordering reason rather than a missing-build one: `actions/checkout` writes th
 sources before that build runs, so the emitted XML always postdates every `.cs`.
 
 That is no longer left as a property of how the job happens to be spelled. The
-freshness gate ([§10](#10-compiled-output-freshness-gate)) reads the compile log
-and fails if this phase reported `Reactor.xml not found`, because the ~117 pages
-it would have skipped are pages that gate is judging.
+freshness gate ([§10](#10-compiled-output-freshness-gate)) reads a clean
+`git status -- docs/guide` as proof the committed output matches a fresh
+compile, and that reading is only sound if every page was actually written — so
+the non-zero exit above is what the gate stands on.
 
 [i1068]: https://github.com/microsoft/microsoft-ui-reactor/issues/1068
 
@@ -696,16 +705,31 @@ the gate refuses to return a verdict unless the log shows the run completed:
   case: `--ci` builds Release, `TreatWarningsAsErrors` promotes `NU1900`, and the
   run dies before assembling anything. Pass `-p:WarningsNotAsErrors=NU1900` when
   measuring from a machine that cannot reach the NuGet vulnerability API.
-- `Reactor.xml not found` / `reference-map.yaml not found` must be **absent**.
-  Phase 5.7 prints its header, skips generation, and the compile still exits 0
-  (§ *Which `Reactor.xml` the reference phase reads*) — leaving ~117 reference
-  pages unwritten and scoring clean.
 - No phase other than 2 (build), 3 (capture) and 5 (AI author) may report
   `(skipped)`. Those three write no page; anything else does, so a `--skip-*`
   added to the invocation would silently narrow the gate instead of failing it.
+  Only the workflow can see this one — the CLI cannot know that a flag it was
+  handed was a mistake.
 
 Each of those is a way for the gate to become a check that cannot fail — which
 is the defect it was added to fix, one level up.
+
+There is a third way a compile can exit 0 without regenerating, and it is
+**not** checked here on purpose. Phase 5.7 prints its header and then bails when
+`Reactor.xml` or `reference-map.yaml` is missing (see *Which `Reactor.xml` the
+reference phase reads*), leaving ~117 reference pages unwritten. `mur docs
+compile --ci` now **returns non-zero** for that, so the compile step catches it
+and the gate never sees it. The first version of this gate grepped stdout for
+`Reactor.xml not found` instead, which was both the wrong owner and the wrong
+direction of failure: reword the message in `CompileCommand.cs` and the grep
+silently stops matching — it fails *open*. `ReferenceStalenessWiringTests` pins
+the exit code, in both the `--ci` and the local direction, so the contract is a
+test rather than a string.
+
+Note the asymmetry that makes this correct rather than merely stricter: locally,
+a missing `Reactor.xml` is the first-compile case and still just skips with a
+message, because an author who hasn't built yet should still get their guide
+pages. Under `--ci` there is no such case — CI always builds.
 
 ### Why `git status` and not `git diff`
 

--- a/docs/contributing/doc-pipeline.md
+++ b/docs/contributing/doc-pipeline.md
@@ -193,6 +193,11 @@ runs for real on every PR. `REACTOR_DOC_REFGEN_W002` still stays quiet there, fo
 an ordering reason rather than a missing-build one: `actions/checkout` writes the
 sources before that build runs, so the emitted XML always postdates every `.cs`.
 
+That is no longer left as a property of how the job happens to be spelled. The
+freshness gate ([§10](#10-compiled-output-freshness-gate)) reads the compile log
+and fails if this phase reported `Reactor.xml not found`, because the ~117 pages
+it would have skipped are pages that gate is judging.
+
 [i1068]: https://github.com/microsoft/microsoft-ui-reactor/issues/1068
 
 ### Screenshots and committed images
@@ -651,7 +656,101 @@ dotnet build docs/_pipeline/apps/<topic>/<topic>.csproj -c Debug -p:Platform=x64
 `-p:BuildProjectReferences=false` keeps several single-app builds from racing
 on `src/Reactor`'s `obj/bin`.
 
-## 10. Inline C# in templates
+## 10. Compiled-output freshness gate
+
+`docs/guide/**` is generated. The `docs-build` job recompiles all of it on every
+PR — 72 topic pages, `README.md`, and ~117 pages under `reference/` — and then
+asserts that recompiling changed nothing:
+
+```pwsh
+git status --porcelain --untracked-files=all -- docs/guide
+```
+
+Non-empty output fails the PR. The fix is never to edit the reported file:
+
+```powershell
+dotnet run --project src/Reactor.Cli -- docs compile --no-screenshots
+```
+
+then commit the result.
+
+Until [issue #1052][i1052] this check covered **two** of those files. CI ran the
+full compile, produced a complete answer about all of them, and threw it away —
+so a `src/` edit that moved a `snippet="source:..."` region left the published
+page stale with the job green. It bit twice in a month: `architecture-overview.md`
+published a `GetElement` body that no longer existed, and [PR #1157][p1157]
+would have shipped an analyzer alongside ten guide pages that the analyzer
+itself rejects. The doc-app snippet gate (§9) does not catch that second one —
+it checks the *source* a page is generated from, not the generated page.
+
+### Why the gate reads the compile log first
+
+A clean tree only means *fresh* if the compile that was supposed to rewrite the
+tree actually rewrote it. An empty diff produced by a compile that never wrote
+anything looks exactly like an empty diff produced by an up-to-date corpus, so
+the gate refuses to return a verdict unless the log shows the run completed:
+
+- `Documentation compiled successfully.` must be present. A compile that dies in
+  Phase 2 prints `✗ build failed` and returns 1 — and locally that is easy to
+  miss, because the tree it leaves behind is clean. Offline this is the common
+  case: `--ci` builds Release, `TreatWarningsAsErrors` promotes `NU1900`, and the
+  run dies before assembling anything. Pass `-p:WarningsNotAsErrors=NU1900` when
+  measuring from a machine that cannot reach the NuGet vulnerability API.
+- `Reactor.xml not found` / `reference-map.yaml not found` must be **absent**.
+  Phase 5.7 prints its header, skips generation, and the compile still exits 0
+  (§ *Which `Reactor.xml` the reference phase reads*) — leaving ~117 reference
+  pages unwritten and scoring clean.
+- No phase other than 2 (build), 3 (capture) and 5 (AI author) may report
+  `(skipped)`. Those three write no page; anything else does, so a `--skip-*`
+  added to the invocation would silently narrow the gate instead of failing it.
+
+Each of those is a way for the gate to become a check that cannot fail — which
+is the defect it was added to fix, one level up.
+
+### Why `git status` and not `git diff`
+
+The same reason given for the images gate above, and it bites harder here:
+`git diff` reports tracked modifications only. A new topic template or a newly
+generated reference page lands as an *untracked* file, which `git diff` reports
+as nothing at all. Measured against a planted
+`docs/guide/reference/hooks/PlantedProbe.md`: `git status` reports
+`?? docs/guide/reference/hooks/PlantedProbe.md`, `git diff --name-only` reports
+an empty string.
+
+### It does not replace the images gate
+
+The freshness gate watches a superset of `docs/guide/images`, but the two say
+opposite things. The images gate says *nothing may be written here* and you fix
+it by removing the write; the freshness gate says *what was written must be
+committed* and you fix it by committing. Merged, a reintroduced screenshot write
+would be answered with "commit the regenerated output" — the exact wrong
+instruction, and the one [issue #989][i989] exists to prevent. The images gate
+therefore runs **first**, so the specific diagnosis lands before the general one.
+
+### Consequence for ordinary PRs
+
+Any `src/` change that alters a region a guide page snippets from now turns
+`docs-build` red until the page is recompiled. That is the point, but it means a
+red docs job is a routine outcome of framework work rather than a sign something
+is broken — recompile and commit, and check the diff belongs to your change.
+
+### The job has to be armed for a docs-only edit
+
+`docs-build` runs on the `non-md` change filter, which is false when every
+changed file ends in `.md`. Hand-editing a generated page under `docs/guide` is
+exactly that shape — and it is the likeliest way to introduce the drift this
+gate catches, so the gate would have skipped the change it exists for. A
+separate `compiled-docs` filter (`^docs/guide/`) re-arms the job, ORed into its
+`if:`. Unrelated pure-Markdown edits still skip it, so this costs nothing
+elsewhere. Same fix as the `audit-ledger` filter beside it
+([issue #959][i959]). `VersionSingleSourceTests` pins both halves.
+
+[i959]: https://github.com/microsoft/microsoft-ui-reactor/issues/959
+
+[i1052]: https://github.com/microsoft/microsoft-ui-reactor/issues/1052
+[p1157]: https://github.com/microsoft/microsoft-ui-reactor/pull/1157
+
+## 11. Inline C# in templates
 
 A ` ```csharp snippet="topic/id" ` block is extracted from a real doc app, so CI compiles it and
 the `docs-snippet-gate` job holds it to the same analyzer rules a reader's own project uses.

--- a/docs/contributing/release-runbook.md
+++ b/docs/contributing/release-runbook.md
@@ -106,8 +106,11 @@ current is free now, since you bump the one property anyway.
 
 Two guards keep the bump honest so it can't silently go stale:
 
-- **Docs freshness gate** (CI `docs-build` job) fails the PR if `<ReactorPublicVersion>`
-  changed but `docs/guide/{getting-started,packaging}.md` weren't recompiled.
+- **Docs freshness gate** (CI `docs-build` job) recompiles the whole guide and fails the
+  PR if any generated file under `docs/guide` differs from what is committed — so a
+  `<ReactorPublicVersion>` bump that skipped a recompile is caught along with every other
+  kind of compiled-doc drift. See
+  [doc-pipeline.md §10](doc-pipeline.md#10-compiled-output-freshness-gate).
 - **Tag-vs-property guard** (`release.yml`, tag pushes only) fails the release if
   `<ReactorPublicVersion>` doesn't equal the MinVer-resolved tag version — so the tag, the
   docs, and the stamped template pack are provably one version.

--- a/docs/guide/analyzer-architecture.md
+++ b/docs/guide/analyzer-architecture.md
@@ -211,11 +211,10 @@ flags an `async`-void `UseEffect` body (spec 060 §4.1).
 ## Symbol-grounded matching — the WithKey case
 
 ```csharp
-static void AnalyzeMissingKey(SyntaxNodeAnalysisContext ctx, InvocationExpressionSyntax inv)
+static void AnalyzeMissingKey(SyntaxNodeAnalysisContext ctx, InvocationExpressionSyntax inv, int lambdaIndex)
 {
-    // Single lambda argument with an invocation body.
-    if (inv.ArgumentList.Arguments.Count != 1) return;
-    if (inv.ArgumentList.Arguments[0].Expression is not LambdaExpressionSyntax lambda) return;
+    if (inv.ArgumentList.Arguments.Count <= lambdaIndex) return;
+    if (inv.ArgumentList.Arguments[lambdaIndex].Expression is not LambdaExpressionSyntax lambda) return;
 
     var body = lambda.Body;
     if (body is BlockSyntax block) body = ExtractReturnExpression(block) ?? body;

--- a/docs/guide/architecture-overview.md
+++ b/docs/guide/architecture-overview.md
@@ -189,6 +189,11 @@ public UIElement GetElement(ElementFactoryGetArgs args)
                 && _reconciler.TryAdoptRealizedReplacement(reused, replacement))
             {
                 control = reused;
+                // Same as the adopt path above: refresh the back-pointer the
+                // adoption itself does not move, so the reported source
+                // location follows the row that is actually live (spec 010).
+                if (reused is FrameworkElement adoptedFe)
+                    Reconciler.SetElementTagIfNeeded(adoptedFe, element);
             }
             else
             {

--- a/docs/guide/collections.md
+++ b/docs/guide/collections.md
@@ -875,7 +875,8 @@ class LetterJump : Component<IReadOnlyList<Person>>
                     {
                         if (groupStarts.TryGetValue(letter, out var start))
                             listRef.Current?.ScrollToIndex(start);
-                    }).AutomationName($"Jump to {letter}")))
+                    }).AutomationName($"Jump to {letter}")
+                        .WithKey(letter.ToString())))
         );
     }
 }

--- a/docs/guide/commanding.md
+++ b/docs/guide/commanding.md
@@ -454,7 +454,8 @@ class ParameterizedCommandExample : Component
                     // by design, so call .Execute(arg) directly from the click handler.
                     Button(delete.Label, () => delete.Execute?.Invoke(item))
                         .AutomationName($"Delete {item.Title}")
-                        .IsEnabled(delete.IsEnabled)))
+                        .IsEnabled(delete.IsEnabled))
+                    .WithKey(item.Id.ToString()))
         ).Padding(24);
     }
 }

--- a/docs/guide/components.md
+++ b/docs/guide/components.md
@@ -474,7 +474,7 @@ class MutatingPropsDont : Component<ItemsProps>
         // Don't — this mutates the parent's collection, so the parent never
         // sees the change and doesn't re-render.
         Props.Items.Add("new item");
-        return VStack(4, ForEach(Props.Items, i => TextBlock(i)));
+        return VStack(4, ForEach(Props.Items, (item, i) => TextBlock(item).WithKey($"{i}-{item}")));
     }
 }
 ```

--- a/docs/guide/controls.md
+++ b/docs/guide/controls.md
@@ -138,7 +138,7 @@ class CollectionsGroup : Component
         var items = new[] { "Alpha", "Bravo", "Charlie", "Delta" };
         return VStack(4,
             TextBlock("Items").Bold(),
-            ForEach(items, item => TextBlock($"  • {item}"))
+            ForEach(items, item => TextBlock($"  • {item}").WithKey(item))
         ).Padding(16);
     }
 }
@@ -407,7 +407,7 @@ class DataSystemGroup : Component
             ForEach(rows, r => HStack(16,
                 TextBlock(r.Item1),
                 TextBlock(r.Item2.ToString())
-            ))
+            ).WithKey(r.Item1))
         ).Padding(16);
     }
 }

--- a/docs/guide/dev-tooling.md
+++ b/docs/guide/dev-tooling.md
@@ -443,7 +443,7 @@ class IterationDemo : Component
                     }
                 })
             ),
-            ForEach(items, item => TextBlock($"  - {item}"))
+            ForEach(items, (item, i) => TextBlock($"  - {item}").WithKey($"{i}-{item}"))
         ).Padding(24);
     }
 }

--- a/docs/guide/effects.md
+++ b/docs/guide/effects.md
@@ -293,7 +293,7 @@ class FetchCancellationExample : Component
 
         return VStack(8,
             TextBox(query, setQuery, header: "Search query").Width(250),
-            ForEach(items, i => TextBlock(i))
+            ForEach(items, item => TextBlock(item).WithKey(item))
         ).Padding(24);
     }
 }

--- a/docs/guide/forms.md
+++ b/docs/guide/forms.md
@@ -524,7 +524,7 @@ class AutoSuggestDemo : Component
             When(matches.Length > 0, () =>
                 VStack(2,
                     ForEach(matches, m =>
-                        TextBlock(m).Padding(8, 4))
+                        TextBlock(m).Padding(8, 4).WithKey(m))
                 ).Background(Theme.CardBackground).Width(280))
         ).Padding(24);
     }

--- a/docs/guide/hooks.md
+++ b/docs/guide/hooks.md
@@ -109,7 +109,7 @@ class ReducerDemo : Component
                 Button("Clear", () =>
                     updateItems(_ => new List<string>()))
             ),
-            ForEach(items, item => TextBlock($"  - {item}"))
+            ForEach(items, (item, i) => TextBlock($"  - {item}").WithKey($"{i}-{item}"))
         );
     }
 }

--- a/docs/guide/layout.md
+++ b/docs/guide/layout.md
@@ -208,7 +208,7 @@ class ScrollBorderDemo : Component
                     VStack(4,
                         ForEach(
                             Enumerable.Range(1, 20),
-                            i => TextBlock($"Scrollable item {i}"))
+                            i => TextBlock($"Scrollable item {i}").WithKey(i.ToString()))
                     ).Padding(8)
                 ).Height(120)
             ).CornerRadius(4).Background(Theme.CardBackground)

--- a/src/Reactor.Cli/Docs/CompileCommand.cs
+++ b/src/Reactor.Cli/Docs/CompileCommand.cs
@@ -560,6 +560,32 @@ internal static partial class CompileCommand
                 }
                 Console.WriteLine($"  Generated: {phaseRefResult.Pages.Count} page(s)");
             }
+            else if (ci)
+            {
+                // A null result means RunReferenceGeneration bailed on a missing
+                // input — no Reactor.xml, or no reference-map.yaml — having
+                // already said so on stdout. Locally that is a reasonable
+                // degradation: an author who hasn't built yet still gets their
+                // guide pages. Under --ci it is not. CI always builds, so a
+                // missing input means the run is not the run that was asked
+                // for, and the ~117 pages under docs/guide/reference/ are
+                // silently left at whatever was committed.
+                //
+                // Exiting 0 there is what let the freshness gate in
+                // .github/workflows/ci.yml be lied to: a compile that wrote no
+                // reference page leaves a clean tree, which is indistinguishable
+                // from an up-to-date one by `git status`. The gate used to
+                // re-derive this by grepping stdout for the two "not found"
+                // strings, which fails *open* the moment either string is
+                // reworded here. Owning the verdict where the state lives makes
+                // it a typed exit code instead (issue #1052).
+                Console.Error.WriteLine(
+                    "Reference generation was skipped for want of an input (see above), so no page " +
+                    "under docs/guide/reference was written. That is a failure in --ci mode: pass " +
+                    "--skip-reference to skip the phase deliberately, or build src/Reactor so " +
+                    "Reactor.xml exists.");
+                return 1;
+            }
             if (hasErrors && ci)
             {
                 Console.Error.WriteLine("Reference generation failed.");

--- a/tests/Reactor.DocPipeline.Tests/ReferenceStalenessWiringTests.cs
+++ b/tests/Reactor.DocPipeline.Tests/ReferenceStalenessWiringTests.cs
@@ -111,19 +111,102 @@ public class ReferenceStalenessWiringTests
 
     /// <summary>
     /// No build at all is a skip, not a failure — the first-compile case, and
-    /// the one the "not found" message exists for.
+    /// the one the "not found" message exists for. Scoped to a local run: see
+    /// the <c>--ci</c> pair below, which must fail on the same fixture.
     /// </summary>
     [Fact]
-    public void No_build_at_all_skips_reference_generation_without_failing()
+    public void No_build_at_all_skips_reference_generation_without_failing_locally()
+    {
+        using var repo = new FakeRepo();
+        repo.PlantSource("Core/Widget.cs", Base);
+
+        var (exitCode, output) = repo.CompileWithReferenceLocally();
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("Reactor.xml not found", output);
+        Assert.DoesNotContain("REACTOR_DOC_REFGEN_W002", output);
+    }
+
+    /// <summary>
+    /// Issue #1052. Under <c>--ci</c> the same missing input is a failure, not a
+    /// degradation: CI always builds, so no <c>Reactor.xml</c> means the run is
+    /// not the run that was asked for, and the ~117 pages under
+    /// <c>docs/guide/reference/</c> are silently left at whatever was committed.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is what the <c>docs-build</c> freshness gate stands on. That gate
+    /// reads a clean <c>git status -- docs/guide</c> as "the committed output
+    /// matches a fresh compile" — a reading that is only true if the compile
+    /// wrote every page it was supposed to. A skipped Phase 5.7 leaves the tree
+    /// clean for the wrong reason, and exiting 0 there made the gate
+    /// unfailable for that whole class of drift.
+    /// </para>
+    /// <para>
+    /// The gate used to re-derive this by grepping stdout for
+    /// <c>Reactor.xml not found</c>. That failed <em>open</em>: reword the
+    /// message in <c>CompileCommand</c> and the grep silently stops matching.
+    /// The exit code is the contract now, and this test is what pins it — the
+    /// pair with the local case above is what shows it is <c>--ci</c> doing the
+    /// work and not the fixture.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public void No_build_at_all_fails_reference_generation_under_ci()
     {
         using var repo = new FakeRepo();
         repo.PlantSource("Core/Widget.cs", Base);
 
         var (exitCode, output) = repo.CompileWithReference();
 
-        Assert.Equal(0, exitCode);
+        Assert.Equal(1, exitCode);
         Assert.Contains("Reactor.xml not found", output);
-        Assert.DoesNotContain("REACTOR_DOC_REFGEN_W002", output);
+        Assert.Contains("Reference generation was skipped for want of an input", output);
+        // The compile must not claim success on the way out — that string is
+        // the freshness gate's own precondition.
+        Assert.DoesNotContain("Documentation compiled successfully.", output);
+    }
+
+    /// <summary>
+    /// The second missing input Phase 5.7 bails on. Same contract, different
+    /// cause — asserting only the <c>Reactor.xml</c> case would leave this one
+    /// free to regress back to a silent exit 0.
+    /// </summary>
+    [Fact]
+    public void Missing_reference_map_fails_under_ci_but_not_locally()
+    {
+        using var repo = new FakeRepo();
+        repo.PlantXml("x64/Release/net10.0-windows10.0.22621.0", Base.AddMinutes(30));
+        repo.PlantSource("Core/Widget.cs", Base);
+        repo.RemoveReferenceMap();
+
+        var (ciExit, ciOutput) = repo.CompileWithReference();
+        var (localExit, localOutput) = repo.CompileWithReferenceLocally();
+
+        Assert.Contains("reference-map.yaml not found", ciOutput);
+        Assert.Equal(1, ciExit);
+
+        Assert.Contains("reference-map.yaml not found", localOutput);
+        Assert.Equal(0, localExit);
+    }
+
+    /// <summary>
+    /// The non-vacuity control for the two <c>--ci</c> failures above: with both
+    /// inputs present, <c>--ci</c> passes. Without this, those tests would look
+    /// identical against a build that failed <c>--ci</c> for any reason at all.
+    /// </summary>
+    [Fact]
+    public void Both_inputs_present_passes_under_ci()
+    {
+        using var repo = new FakeRepo();
+        repo.PlantXml("x64/Release/net10.0-windows10.0.22621.0", Base.AddMinutes(30));
+        repo.PlantSource("Core/Widget.cs", Base);
+
+        var (exitCode, output) = repo.CompileWithReference();
+
+        Assert.Equal(0, exitCode);
+        Assert.DoesNotContain("Reference generation was skipped for want of an input", output);
+        Assert.Contains("Documentation compiled successfully.", output);
     }
 
     /// <summary>
@@ -251,6 +334,20 @@ public class ReferenceStalenessWiringTests
         /// </summary>
         public (int ExitCode, string Output) CompileWithReference() =>
             Compile("--no-screenshots", "--no-build", "--skip-diagrams", "--no-ai", "--ci");
+
+        /// <summary>
+        /// Same, minus <c>--ci</c>. The pair is what shows a missing-input
+        /// failure is scoped to CI rather than being a blanket hard error.
+        /// </summary>
+        public (int ExitCode, string Output) CompileWithReferenceLocally() =>
+            Compile("--no-screenshots", "--no-build", "--skip-diagrams", "--no-ai");
+
+        /// <summary>
+        /// Removes the fixture's <c>reference-map.yaml</c>, the other input
+        /// whose absence makes Phase 5.7 bail.
+        /// </summary>
+        public void RemoveReferenceMap() =>
+            File.Delete(Path.Join(_root, "docs", "_pipeline", "reference-map.yaml"));
 
         private (int ExitCode, string Output) Compile(params string[] args)
         {

--- a/tests/Reactor.Tests/VersionSingleSourceTests.cs
+++ b/tests/Reactor.Tests/VersionSingleSourceTests.cs
@@ -279,8 +279,9 @@ public sealed class VersionSingleSourceTests
     }
 
     /// <summary>
-    /// Returns the lines of the named job (a 4-space-indented `&lt;name&gt;:` key
-    /// under `jobs:`) up to the next job at the same indent, or null.
+    /// Returns the lines of the named job (a two-space-indented
+    /// <c>&lt;name&gt;:</c> key under <c>jobs:</c>) up to the next job at the
+    /// same indent, or null.
     /// </summary>
     static string? ExtractYamlJob(string yaml, string jobName)
     {

--- a/tests/Reactor.Tests/VersionSingleSourceTests.cs
+++ b/tests/Reactor.Tests/VersionSingleSourceTests.cs
@@ -126,24 +126,89 @@ public sealed class VersionSingleSourceTests
             "$(ReactorPublicVersion) instead so the repo has exactly one framework-version literal.");
     }
 
-    // ── Guard 3: CI docs-freshness gate is wired ──────────────────────────
+    // ── Guard 3: CI compiled-docs freshness gate is wired ─────────────────
+    //
+    // Widened for issue #1052. This guard used to pin a two-file
+    // `git diff --exit-code`, which was the whole defect: the `docs-build` job
+    // recompiles ~190 generated files under docs/guide and then judged two of
+    // them. Version freshness is now a *subset* of what the gate covers — a
+    // ReactorPublicVersion bump that skipped a recompile shows up as drift in
+    // getting-started.md / packaging.md like any other staleness — so this test
+    // pins the general gate rather than the version-specific one it replaced.
 
     [Fact]
-    public void CiWorkflow_gates_docs_version_freshness()
+    public void CiWorkflow_gates_compiled_docs_freshness()
     {
         var (path, text) = ReadRepoFile(Path.Join(".github", "workflows", "ci.yml"));
-        var step = ExtractYamlStep(text, "Verify docs version substitution is committed");
+        var step = ExtractYamlStep(text, "Verify compiled docs are committed");
         Assert.False(step is null,
-            $"'{path}' has no docs version freshness step — the gate that fails a PR which bumps " +
-            "ReactorPublicVersion / edits a template without recompiling the guide.");
+            $"'{path}' has no compiled-docs freshness step — the gate that fails a PR whose committed " +
+            "docs/guide output differs from a fresh compile (a moved snippet=\"source:...\" region, an " +
+            "edited template, or a ReactorPublicVersion bump that was never recompiled).");
+
+        // The trailing newline is load-bearing: it pins the pathspec to the whole
+        // tree. Narrowing it back to a hand-picked subset (`-- docs/guide/foo.md`)
+        // is the exact regression this guard exists to catch, and it would still
+        // satisfy a substring match without the newline.
         Assert.Contains(
-            "git diff --exit-code -- docs/guide/getting-started.md docs/guide/packaging.md",
+            "git status --porcelain --untracked-files=all -- docs/guide\n",
             step!, global::System.StringComparison.Ordinal);
-        // Non-vacuous: also require the failure path. Leaving the diff command in
-        // a comment/echo while making the step succeed (exit 0) would defeat the
-        // gate but keep the substring above — these assertions catch that.
-        Assert.Contains("if ($LASTEXITCODE -ne 0)", step!, global::System.StringComparison.Ordinal);
+
+        // Non-vacuous: also require the failure path. Leaving the status command
+        // in place while making the step succeed (exit 0) would defeat the gate
+        // but keep the substring above — these assertions catch that.
+        Assert.Contains("if ($dirty)", step!, global::System.StringComparison.Ordinal);
         Assert.Contains("exit 1", step!, global::System.StringComparison.Ordinal);
+
+        // A clean tree only means "fresh" if the compile actually rewrote the
+        // tree. Both ways a compile can exit 0 without doing so must stay
+        // checked, or the gate silently becomes a check that cannot fail.
+        Assert.Contains("Documentation compiled successfully.", step!, global::System.StringComparison.Ordinal);
+        Assert.Contains("Reactor.xml not found", step!, global::System.StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void CiWorkflow_compile_step_writes_the_log_the_freshness_gate_reads()
+    {
+        // The gate above reads its precondition out of a log the compile step
+        // tees. If the two ever name different paths the gate fails closed
+        // ("No compile log at ..."), which is safe but reports a missing file
+        // rather than the decoupling that caused it — so bind them here.
+        var (path, text) = ReadRepoFile(Path.Join(".github", "workflows", "ci.yml"));
+        var compile = ExtractYamlStep(text, "Compile docs");
+        var gate = ExtractYamlStep(text, "Verify compiled docs are committed");
+
+        Assert.False(compile is null, $"'{path}' has no 'Compile docs' step.");
+        Assert.False(gate is null, $"'{path}' has no 'Verify compiled docs are committed' step.");
+
+        const string logPath = "$env:RUNNER_TEMP/docs-compile.log";
+        Assert.Contains("Tee-Object", compile!, global::System.StringComparison.Ordinal);
+        Assert.Contains(logPath, compile!, global::System.StringComparison.Ordinal);
+        Assert.Contains(logPath, gate!, global::System.StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void CiWorkflow_arms_docs_build_for_a_docs_guide_only_edit()
+    {
+        // The freshness gate lives in `docs-build`, which is armed by `non-md`.
+        // Hand-editing a generated page under docs/guide — the likeliest way to
+        // introduce the drift the gate catches — is a pure-.md change, so
+        // non-md is false and the job would skip the one check that change type
+        // exists for. A dedicated `compiled-docs` filter re-arms it.
+        var (path, text) = ReadRepoFile(Path.Join(".github", "workflows", "ci.yml"));
+
+        Assert.Contains(
+            "compiled-docs: ${{ steps.filter.outputs.compiled-docs }}",
+            text, global::System.StringComparison.Ordinal);
+        Assert.Contains(
+            @"grep -qE '^docs/guide/'",
+            text, global::System.StringComparison.Ordinal);
+
+        var job = ExtractYamlJob(text, "docs-build");
+        Assert.False(job is null, $"'{path}' no longer defines a `docs-build` job.");
+        Assert.Contains(
+            "needs.changes.outputs.compiled-docs == 'true'",
+            job!, global::System.StringComparison.Ordinal);
     }
 
     // ── Guard 4: release-time tag-vs-property consistency guard ────────────
@@ -190,6 +255,39 @@ public sealed class VersionSingleSourceTests
         for (int i = start + 1; i < lines.Length; i++)
         {
             if (lines[i].TrimStart().StartsWith("- name:", global::System.StringComparison.Ordinal))
+            {
+                end = i;
+                break;
+            }
+        }
+        return string.Join("\n", lines[start..end]);
+    }
+
+    /// <summary>
+    /// Returns the lines of the named job (a 4-space-indented `&lt;name&gt;:` key
+    /// under `jobs:`) up to the next job at the same indent, or null.
+    /// </summary>
+    static string? ExtractYamlJob(string yaml, string jobName)
+    {
+        var lines = yaml.Replace("\r\n", "\n").Split('\n');
+        int start = -1;
+        for (int i = 0; i < lines.Length; i++)
+        {
+            if (lines[i] == $"  {jobName}:")
+            {
+                start = i;
+                break;
+            }
+        }
+        if (start < 0) return null;
+
+        int end = lines.Length;
+        for (int i = start + 1; i < lines.Length; i++)
+        {
+            var line = lines[i];
+            // A sibling job: exactly two leading spaces, then a key.
+            if (line.Length > 2 && line[0] == ' ' && line[1] == ' ' && line[2] != ' ' &&
+                line.TrimEnd().EndsWith(":", global::System.StringComparison.Ordinal))
             {
                 end = i;
                 break;

--- a/tests/Reactor.Tests/VersionSingleSourceTests.cs
+++ b/tests/Reactor.Tests/VersionSingleSourceTests.cs
@@ -161,10 +161,25 @@ public sealed class VersionSingleSourceTests
         Assert.Contains("exit 1", step!, global::System.StringComparison.Ordinal);
 
         // A clean tree only means "fresh" if the compile actually rewrote the
-        // tree. Both ways a compile can exit 0 without doing so must stay
-        // checked, or the gate silently becomes a check that cannot fail.
+        // tree, so the gate's own precondition must stay.
         Assert.Contains("Documentation compiled successfully.", step!, global::System.StringComparison.Ordinal);
-        Assert.Contains("Reactor.xml not found", step!, global::System.StringComparison.Ordinal);
+
+        // The skipped-phase detector, and the allow-list that keeps it from
+        // firing on the skips this invocation legitimately produces (Phase 3
+        // capture, via --no-screenshots) plus the unimplemented Phase 5 and the
+        // build phase. Assert the allow-list contents, not just that a regex
+        // exists: widening it to include 5.5 (diagrams) or 5.7 (reference)
+        // would silently stop the gate covering those pages.
+        //
+        // The other way a compile can exit 0 without regenerating — Phase 5.7
+        // bailing on a missing Reactor.xml / reference-map.yaml — is deliberately
+        // NOT pinned here. It moved into `docs compile --ci` itself, where the
+        // state lives, and is covered by ReferenceStalenessWiringTests. Grepping
+        // the log for those messages failed open on a reword; the exit code does
+        // not.
+        Assert.Contains(@"Phase (?<n>[0-9.]+):", step!, global::System.StringComparison.Ordinal);
+        Assert.Contains(@"-notin @('2', '3', '5')", step!, global::System.StringComparison.Ordinal);
+        Assert.Contains("$unexpected", step!, global::System.StringComparison.Ordinal);
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #1052.

## The defect

`docs-build` runs a real `mur docs compile --no-screenshots --ci` on every PR, regenerating **~190** files under `docs/guide` — 72 topic pages, `README.md`, and ~117 pages under `reference/`. It then asserted freshness on **two** of them:

```yaml
- name: Verify docs version substitution is committed
  run: git diff --exit-code -- docs/guide/getting-started.md docs/guide/packaging.md
```

CI computed a complete answer about all of them and discarded 188.

## Both predicted instances were real, and the gate caught the second one itself

**`architecture-overview.md`** was stale again at `27ed6662` — its snippet source `ElementFactory.cs` changed in `33a35999` (spec-010) and the page was never recompiled.

**The ten pages #1157 stranded.** #1157 merged while this PR was in review. Its first CI run with the gate enabled went red and named exactly the ten files the issue predicted:

```
M analyzer-architecture.md   M dev-tooling.md
M collections.md             M effects.md
M commanding.md              M forms.md
M components.md              M hooks.md
M controls.md                M layout.md
```

That is the case the issue called out as the nastier one: without the gate, #1157 would have shipped a widened `REACTOR_DSL_001` alongside guide pages still teaching the unkeyed `ForEach` its own analyzer rejects. Both regenerations are separate commits.

## The gate

- **Whole tree, via `git status --porcelain --untracked-files=all`.** Not `git diff` — diff reports tracked modifications only, so a new topic or reference page lands as an untracked file it reports as nothing. Measured against a planted `docs/guide/reference/hooks/PlantedProbe.md`: `git status` reports `??`, `git diff --name-only` reports an empty string.
- **The compile owns its own verdict.** `docs compile --ci` now exits non-zero when Phase 5.7 bails for want of `Reactor.xml` or `reference-map.yaml`. Previously it exited 0 having written none of the ~117 reference pages, leaving a clean tree that is indistinguishable from an up-to-date one. Locally it still just skips — the first-compile case is real — but CI always builds, so there is no such case there.
- **The gate keeps only the check the CLI cannot supply:** that no page-writing phase was skipped. A `--skip-*` added to the workflow invocation is a legitimate exit 0 that silently narrows the gate's scope, and only the workflow can know that was a mistake.
- **Armed for docs-only edits.** `docs-build` runs on `non-md`, false when every changed file ends in `.md` — so hand-editing a generated page, the likeliest way to introduce this drift, would have skipped the gate. A `compiled-docs` filter re-arms it, matching the `audit-ledger` fix beside it.
- **The images gate stays, and stays first.** Its paths are now a subset but its remedy is the opposite — remove the write, not commit the output. Merged, a reintroduced screenshot write would be told to "commit the regenerated output", the instruction #989 exists to prevent.

## Review

The repo's `pr-review` skill found 2 issues (1 medium, 1 low), both fixed:

- **Gate guard pinned only some of the gate's branches** — mutation-proved: deleting two checks left the tests green. Now pins the skipped-phase regex and the `'2','3','5'` allow-list, so widening it to 5.5/5.7 reddens.
- **Gate re-derived compile state by scraping stdout** — and two of those greps failed **open**: reword `Reactor.xml not found` in `CompileCommand.cs` and the gate silently scores a compile that wrote no reference page as clean. That is this PR's own defect one level up, hence the CLI change above.

Three rounds of Copilot review; the third returned no comments. Round 1's three comments were all on generated pages, arguing `.WithKey($"{i}-{item}")` is the pattern the analyzer warns against — it is not: `MissingWithKeyAnalyzer` deliberately exempts composites that reference the item, pinned by `DSL_002_Does_Not_Fire_On_Composite_Index_Key`. Answered on the threads. Round 2 found a real doc-comment error in my helper, fixed.

## Verification

Each gate branch planted against the step scripts extracted from the finished `ci.yml` — tracked edit, untracked reference page, missing success line, unexpected skipped phase, missing log all fail; a clean tree with a real compile log passes. The change filter was replayed over eight file-list shapes. Every new test mutation-checked, including the CLI change (deleting its `return 1` reddens exactly the two `--ci` tests). `Reactor.DocPipeline.Tests` 438/438, `VersionSingleSourceTests` 9/9, Release build clean, full CI green.

## Cost worth knowing

Any `src/` change touching a snippetted region now reddens `docs-build` until recompiled. That is the intent, but it makes a red docs job a routine outcome of framework work — so the failure message names the paths and the exact command.
