### PR TITLE
Docs: make the documented pre-push build actually reproduce the `Build solution` CI job

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,11 @@ Thanks for contributing to Reactor! A few notes before you open this PR:
 - Link the issue or spec this PR addresses (Fixes #..., Implements docs/specs/0XX-...).
 - Keep the change focused. Smaller, well-scoped PRs land faster.
 - Include tests. See CONTRIBUTING.md for the unit / selftest / e2e split.
-- Run `dotnet build Reactor.slnx` and `dotnet test tests/Reactor.Tests` locally.
+- Before pushing, reproduce the CI `Build solution` gate: `dotnet restore Reactor.slnx`, then
+  `dotnet build Reactor.slnx --no-restore -c Release`. Then `dotnet test tests/Reactor.Tests`.
+  (`-c Release` matters — `TreatWarningsAsErrors` is Release-only, so a green Debug build does
+  not clear CI. Keep restore separate, as CI does: a combined `-c Release` restore additionally
+  turns NuGet restore warnings into errors CI never sees. See CONTRIBUTING.md.)
 - First-time contributors: the Microsoft CLA bot will comment automatically; sign once and you're set.
 -->
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,8 +7,9 @@ Thanks for contributing to Reactor! A few notes before you open this PR:
 - Before pushing, reproduce the CI `Build solution` gate: `dotnet restore Reactor.slnx`, then
   `dotnet build Reactor.slnx --no-restore -c Release`. Then `dotnet test tests/Reactor.Tests`.
   (`-c Release` matters — `TreatWarningsAsErrors` is Release-only, so a green Debug build does
-  not clear CI. Keep restore separate, as CI does: a combined `-c Release` restore additionally
-  turns NuGet restore warnings into errors CI never sees. See CONTRIBUTING.md.)
+  not clear CI. Keep restore a separate step, as CI does: the one-shot
+  `dotnet build Reactor.slnx -c Release` runs its implicit restore under Release too, which
+  additionally turns NuGet restore warnings into errors CI never sees. See CONTRIBUTING.md.)
 - First-time contributors: the Microsoft CLA bot will comment automatically; sign once and you're set.
 -->
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -223,7 +223,15 @@ Hard-won specifics that repeatedly cost sessions time. Prefer these exact comman
   solution defaults; single app/test projects usually do not.)
 - **A green Debug build does not clear the `Build solution` CI job.**
   `TreatWarningsAsErrors` is Release-only and CI builds Release, so verify with
-  `dotnet build Reactor.slnx -c Release`. If `WMC0110` / `WMC1509` follows a C# error,
+  `dotnet restore Reactor.slnx` followed by `dotnet build Reactor.slnx --no-restore -c Release`.
+  Keep those two steps split, exactly as `ci.yml` has them (L326/L329). The one-shot
+  `dotnet build Reactor.slnx -c Release` also restores under `Configuration=Release`, and NuGet
+  honors `TreatWarningsAsErrors` during restore, so on a proxied or offline feed `NU1900`
+  ("unable to get package vulnerability data") becomes a hard error — measured on this repo, the
+  one-shot form raised NU errors across **127 projects** versus **12** for the split form, burying
+  the real result before a single file compiles. On a healthy feed neither form emits `NU1900` and
+  the distinction is invisible; it only bites behind a TLS-inspecting proxy or offline. CI is
+  immune because it restores without `-c Release`. If `WMC0110` / `WMC1509` follows a C# error,
   treat the markup errors as a likely cascade: fix the earlier error first, then confirm
   they disappear before investigating them independently.
 - **Add `-p:SkipSignaturesGen=true` to local `tests/Reactor.Tests` builds** to avoid the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -224,7 +224,8 @@ Hard-won specifics that repeatedly cost sessions time. Prefer these exact comman
 - **A green Debug build does not clear the `Build solution` CI job.**
   `TreatWarningsAsErrors` is Release-only and CI builds Release, so verify with
   `dotnet restore Reactor.slnx` followed by `dotnet build Reactor.slnx --no-restore -c Release`.
-  Keep those two steps split, exactly as `ci.yml` has them (L326/L329). The one-shot
+  Keep those two steps split, exactly as the `Restore` and `Build` steps of the
+  `build-solution` job in `ci.yml` do. The one-shot
   `dotnet build Reactor.slnx -c Release` also restores under `Configuration=Release`, and NuGet
   honors `TreatWarningsAsErrors` during restore, so on a proxied or offline feed `NU1900`
   ("unable to get package vulnerability data") becomes a hard error — measured on this repo, the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,6 +58,19 @@ dotnet build Reactor.slnx
 dotnet build src/Reactor/Reactor.csproj
 ```
 
+### Reproducing the CI build gate
+
+The plain `dotnet build Reactor.slnx` above is a **Debug** build, and a green Debug build does not clear the `Build solution` CI job. `TreatWarningsAsErrors` is scoped to `Configuration=Release` in `Directory.Build.props`, so Debug stays warning-tolerant for a fast inner loop while the CI PR-gate builds Release and fails on any compiler or analyzer warning.
+
+Before opening a PR, reproduce that job — restore first, then build Release with `--no-restore`:
+
+```bash
+dotnet restore Reactor.slnx
+dotnet build Reactor.slnx --no-restore -c Release
+```
+
+Keep those as two steps, the way [`ci.yml`](.github/workflows/ci.yml) does. A combined `dotnet build Reactor.slnx -c Release` runs its implicit restore under `Configuration=Release` as well, and NuGet honors `TreatWarningsAsErrors` during restore — so `NU`-prefixed restore warnings (an unreachable feed, missing package vulnerability data) become hard errors that CI, which restores without `-c Release`, never hits.
+
 ### From Visual Studio
 
 1. Open `Reactor.slnx` in Visual Studio 2022 (17.8+)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,7 +69,7 @@ dotnet restore Reactor.slnx
 dotnet build Reactor.slnx --no-restore -c Release
 ```
 
-Keep those as two steps, the way [`ci.yml`](.github/workflows/ci.yml) does. A combined `dotnet build Reactor.slnx -c Release` runs its implicit restore under `Configuration=Release` as well, and NuGet honors `TreatWarningsAsErrors` during restore — so `NU`-prefixed restore warnings (an unreachable feed, missing package vulnerability data) become hard errors that CI, which restores without `-c Release`, never hits.
+Keep those as two steps, the way the `Restore` and `Build` steps of the `build-solution` job in [`ci.yml`](.github/workflows/ci.yml) do. The one-shot `dotnet build Reactor.slnx -c Release` runs its implicit restore under `Configuration=Release` as well, and NuGet honors `TreatWarningsAsErrors` during restore — so `NU`-prefixed restore warnings (an unreachable feed, missing package vulnerability data) become hard errors that CI, which restores without `-c Release`, never hits.
 
 ### From Visual Studio
 


### PR DESCRIPTION
Fixes #1163

## Summary

`.github/PULL_REQUEST_TEMPLATE.md` presented `dotnet build Reactor.slnx` as the pre-push check, but that's a **Debug** build and cannot reproduce the `Build solution` CI job — `TreatWarningsAsErrors` is scoped to `Configuration=Release` (`Directory.Build.props:70-72`) and CI builds Release (`ci.yml:329`). A contributor followed it, got green, pushed, and CI failed on a warning their local build was configured not to care about.

The Debug/Release split itself is correct and unchanged. Only the contributor-facing surface was wrong.

## The issue's premise, verified

MSBuild property evaluation on three real projects:

| Project | Debug | Release |
|---|---|---|
| `Reactor.csproj` | `false` | `true` |
| `Reactor.Analyzers.csproj` | `false` | `true` |
| `Reactor.Tests.csproj` | `false` | `true` |

## Why this doesn't use the literal fix the issue proposed

The issue suggested `dotnet build Reactor.slnx -c Release`. That one-liner is **not** what CI runs, and the difference is not cosmetic.

CI restores separately and builds `--no-restore` (`ci.yml:326` + `:329`). A one-shot `-c Release` performs its implicit restore under `Configuration=Release` too, and NuGet honors `TreatWarningsAsErrors` **during restore** — a caveat `Directory.Build.props:64-68` already flags.

Measured on this repo, same tree/machine/network, only the restore-splitting varying:

| Run | `NU1900` as error | `NU1900` as warning | Projects with NU errors |
|---|---|---|---|
| `dotnet build -c Release` (one-shot) | 248 | 0 | **127** |
| `dotnet restore` (CI-style) | 0 | 124 | — |
| `dotnet restore` + `build --no-restore -c Release` | — | — | **12** |

Behind a TLS-inspecting proxy the one-shot form turns a transient feed condition into 127 projects' worth of hard errors before a single file compiles — precisely the "your local build says something CI doesn't" confusion this issue is about, just inverted. So this PR documents the two-step form CI actually runs, which reproduces the gate **by construction**.

On a healthy feed no `NU1900` is emitted and both forms behave identically; the distinction only bites offline or behind a proxy.

## Changes

- **`.github/PULL_REQUEST_TEMPLATE.md`** — corrected pre-push line, rationale kept inline so a future shortening pass can't silently drop it (the issue's own concern).
- **`CONTRIBUTING.md`** — new *Reproducing the CI build gate* section under Building; the durable home for the explanation, which the template now points at.
- **`AGENTS.md`** — the field note at L224 recommended the same one-shot command. Corrected, with the measurement recorded.

## Deliberately not changed

- Debug stays warning-tolerant — that's the documented fast-iteration intent.
- `dotnet test` keeps no `-c Release`; it would cost a second full build for no added signal.

## Verification

- `TreatWarningsAsErrors` Debug/Release split confirmed by direct MSBuild property evaluation (table above).
- Documented commands byte-match `ci.yml:326` / `:329` (`-c` ≡ `--configuration`).
- Code fences balanced in all three files; template additions confirmed to stay inside the `<!-- -->` block so nothing leaks into rendered PR bodies.
- Re-grepped every contributor-facing doc: no surface still presents a bare Debug build as the CI gate. Remaining bare occurrences are legitimate (inner-loop build, platform notes, AOT note).

> **Note on CI for this PR:** 12 `ci.yml` jobs — including `Build solution` itself — are gated on `non-md == 'true'`, so this markdown-only PR skips them. A green run here is not evidence; the verification above is.

I could not obtain a clean full-solution Release build locally: this environment's NuGet access is blocked by a TLS-inspecting proxy, and the worktree path is 148 chars, which triggers the documented `PRI175`/`WMC1006` long-path failures (`CONTRIBUTING.md:31-42`). Both are pre-existing environmental limits, unrelated to a markdown-only change.