### PR TITLE
Clear all 17 Component Governance alerts in the RN harness lockfiles

### DIFF
--- a/tests/startup_perf/BlankRNW/package-lock.json
+++ b/tests/startup_perf/BlankRNW/package-lock.json
@@ -6439,21 +6439,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/image-size": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.2.1.tgz",
-      "integrity": "sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==",
-      "license": "MIT",
-      "dependencies": {
-        "queue": "6.0.2"
-      },
-      "bin": {
-        "image-size": "bin/image-size.js"
-      },
-      "engines": {
-        "node": ">=16.x"
-      }
-    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -7733,9 +7718,9 @@
       }
     },
     "node_modules/metro": {
-      "version": "0.83.7",
-      "resolved": "https://registry.npmjs.org/metro/-/metro-0.83.7.tgz",
-      "integrity": "sha512-SPaPEyvTsTmd0LpT7RaZciQyDw2i/JB7+iY9L5VfBo72+psescFxBqpI1TL9dnL+pmnfkU+l/J1mEEGLeF65EQ==",
+      "version": "0.83.8",
+      "resolved": "https://registry.npmjs.org/metro/-/metro-0.83.8.tgz",
+      "integrity": "sha512-ZbJDJCDlvv0O3QHVbhZkyP2/DtebfEoDZ3wVyYHgu6Uoy6DmmE/bis6lIDBYh+kWPuaueJDegyutPjkIBLtZDQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
@@ -7753,23 +7738,22 @@
         "flow-enums-runtime": "^0.0.6",
         "graceful-fs": "^4.2.4",
         "hermes-parser": "0.35.0",
-        "image-size": "^1.0.2",
         "invariant": "^2.2.4",
         "jest-worker": "^29.7.0",
         "jsc-safe-url": "^0.2.2",
         "lodash.throttle": "^4.1.1",
-        "metro-babel-transformer": "0.83.7",
-        "metro-cache": "0.83.7",
-        "metro-cache-key": "0.83.7",
-        "metro-config": "0.83.7",
-        "metro-core": "0.83.7",
-        "metro-file-map": "0.83.7",
-        "metro-resolver": "0.83.7",
-        "metro-runtime": "0.83.7",
-        "metro-source-map": "0.83.7",
-        "metro-symbolicate": "0.83.7",
-        "metro-transform-plugins": "0.83.7",
-        "metro-transform-worker": "0.83.7",
+        "metro-babel-transformer": "0.83.8",
+        "metro-cache": "0.83.8",
+        "metro-cache-key": "0.83.8",
+        "metro-config": "0.83.8",
+        "metro-core": "0.83.8",
+        "metro-file-map": "0.83.8",
+        "metro-resolver": "0.83.8",
+        "metro-runtime": "0.83.8",
+        "metro-source-map": "0.83.8",
+        "metro-symbolicate": "0.83.8",
+        "metro-transform-plugins": "0.83.8",
+        "metro-transform-worker": "0.83.8",
         "mime-types": "^3.0.1",
         "nullthrows": "^1.1.1",
         "serialize-error": "^2.1.0",
@@ -7786,15 +7770,15 @@
       }
     },
     "node_modules/metro-babel-transformer": {
-      "version": "0.83.7",
-      "resolved": "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.83.7.tgz",
-      "integrity": "sha512-sBqBkt6kNut/88bv+Ucvm4yqdPetbvAEsHzi3MAgJEifOSYYzX5Z5Kgw3TFOrwf/mHJTOBG2ONlaMHoyfP15TA==",
+      "version": "0.83.8",
+      "resolved": "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.83.8.tgz",
+      "integrity": "sha512-tnn0J5wzgTgTx2OJy3Cwr1y79bJz4eNgFQd+2HENOs5Vz6QOMnt05z7J+BedIo9wIbpEa0iN9U1nerxyvMRE9g==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.25.2",
         "flow-enums-runtime": "^0.0.6",
         "hermes-parser": "0.35.0",
-        "metro-cache-key": "0.83.7",
+        "metro-cache-key": "0.83.8",
         "nullthrows": "^1.1.1"
       },
       "engines": {
@@ -7817,24 +7801,24 @@
       }
     },
     "node_modules/metro-cache": {
-      "version": "0.83.7",
-      "resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.83.7.tgz",
-      "integrity": "sha512-E9SRePXQ1Zvlj79VcOk57q7VC7rMHMFQ+jhmPHBiq+dJ0bJB5BL87lWZF6oh5X76Cci5tpDuQNaDwwuSCToEeg==",
+      "version": "0.83.8",
+      "resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.83.8.tgz",
+      "integrity": "sha512-aogMG5WbKzW5000otNjYrS9hIoORzkCI1faPJK+vxQLaf2BorJKBBFe/jl2Tfsi1mZUglS2EBuBt8B3JB7MYDQ==",
       "license": "MIT",
       "dependencies": {
         "exponential-backoff": "^3.1.1",
         "flow-enums-runtime": "^0.0.6",
         "https-proxy-agent": "^7.0.5",
-        "metro-core": "0.83.7"
+        "metro-core": "0.83.8"
       },
       "engines": {
         "node": ">=20.19.4"
       }
     },
     "node_modules/metro-cache-key": {
-      "version": "0.83.7",
-      "resolved": "https://registry.npmjs.org/metro-cache-key/-/metro-cache-key-0.83.7.tgz",
-      "integrity": "sha512-W1c2Nmx8MiJTJt+eWhMO08z9VKi3kZOaz99IYGdqeqDgY9j+yZjXl62rUav4Di0heZfh4/n2s722PqRL1OODeg==",
+      "version": "0.83.8",
+      "resolved": "https://registry.npmjs.org/metro-cache-key/-/metro-cache-key-0.83.8.tgz",
+      "integrity": "sha512-I38PtcjT4crS5HY9UQ8i6z8S7tJ2WewtPGr/OwS6FcLKfy5T/1hlTaFw+wozUZkEtNpR6Gc0oJuvuKCbSoSN5A==",
       "license": "MIT",
       "dependencies": {
         "flow-enums-runtime": "^0.0.6"
@@ -7844,18 +7828,18 @@
       }
     },
     "node_modules/metro-config": {
-      "version": "0.83.7",
-      "resolved": "https://registry.npmjs.org/metro-config/-/metro-config-0.83.7.tgz",
-      "integrity": "sha512-83mjWFbFOt2GeJ6pFIum5mSnc1uTsZJAtD8o4ej0s4NVsYsA7fB+pHvTfHhFrpeMONaobu2riKavkPei05Er/Q==",
+      "version": "0.83.8",
+      "resolved": "https://registry.npmjs.org/metro-config/-/metro-config-0.83.8.tgz",
+      "integrity": "sha512-crNbNy+/B4tCne2+HjUshwvC57gNBQj+V9fFSy3lHH2RlKcLHib3Mil/SfTX8Pfh2fCY5pPuSu2OKa7YiadB+Q==",
       "license": "MIT",
       "dependencies": {
         "connect": "^3.6.5",
         "flow-enums-runtime": "^0.0.6",
         "jest-validate": "^29.7.0",
-        "metro": "0.83.7",
-        "metro-cache": "0.83.7",
-        "metro-core": "0.83.7",
-        "metro-runtime": "0.83.7",
+        "metro": "0.83.8",
+        "metro-cache": "0.83.8",
+        "metro-core": "0.83.8",
+        "metro-runtime": "0.83.8",
         "yaml": "^2.6.1"
       },
       "engines": {
@@ -7863,23 +7847,23 @@
       }
     },
     "node_modules/metro-core": {
-      "version": "0.83.7",
-      "resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.83.7.tgz",
-      "integrity": "sha512-6yn3w1wnltT6RQl7p7YES2l95ArC+mWrOssEiH8p5/DDrJS65/szf9LsC9JrBv8c5DdvSY3V3f0GRYg0Ox7hCg==",
+      "version": "0.83.8",
+      "resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.83.8.tgz",
+      "integrity": "sha512-NTyOUOQaQKvQgJG9VI2ymN6KTM7gHEqkVFhkPc9bK4BsHSTz/EaXuFBXtC+wtwINLeH9tbusL/jfsSmdEmuU7A==",
       "license": "MIT",
       "dependencies": {
         "flow-enums-runtime": "^0.0.6",
         "lodash.throttle": "^4.1.1",
-        "metro-resolver": "0.83.7"
+        "metro-resolver": "0.83.8"
       },
       "engines": {
         "node": ">=20.19.4"
       }
     },
     "node_modules/metro-file-map": {
-      "version": "0.83.7",
-      "resolved": "https://registry.npmjs.org/metro-file-map/-/metro-file-map-0.83.7.tgz",
-      "integrity": "sha512-+j0F1m+FQYVAQ6syf+mwhIPV5GoFQrkInX8bppuc50IzNsZbMrp8R5H/Sx/K2daQ3YEa9F/XwkeZT8gzJfgeCw==",
+      "version": "0.83.8",
+      "resolved": "https://registry.npmjs.org/metro-file-map/-/metro-file-map-0.83.8.tgz",
+      "integrity": "sha512-+W++EUuzEXIfWQEFTWQMVThzhWbnJL4gRNJ9WSHzIAM5pT7gsprUxo9+2hrfirURm/TLvrKwhq37oCECJcDSyQ==",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.0",
@@ -7897,9 +7881,9 @@
       }
     },
     "node_modules/metro-minify-terser": {
-      "version": "0.83.7",
-      "resolved": "https://registry.npmjs.org/metro-minify-terser/-/metro-minify-terser-0.83.7.tgz",
-      "integrity": "sha512-MfJar2IS4tBRuLb9svwb0Gu5l9BsH+pcRm8eGcEi/wy8MzZinfinh5dFLt2nWkocnulIgtGB5NkFDdbXqMXKhQ==",
+      "version": "0.83.8",
+      "resolved": "https://registry.npmjs.org/metro-minify-terser/-/metro-minify-terser-0.83.8.tgz",
+      "integrity": "sha512-7tU0J5/c7LZaZJwTlOb1xq0NepTFvGzRxigDhZOq4jSE6g0BRHmBqe7XvLH3WcRiJNGy+eshcZr34RpMjb6mmg==",
       "license": "MIT",
       "dependencies": {
         "flow-enums-runtime": "^0.0.6",
@@ -7910,9 +7894,9 @@
       }
     },
     "node_modules/metro-resolver": {
-      "version": "0.83.7",
-      "resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.83.7.tgz",
-      "integrity": "sha512-WSJIENlMcoSsuz66IfBHOkgfp3KJt2UW2TnEHPf1b8pIG2eEXNOVmo2+03A0H17WY2XGXWgxL0CG7FAopqgB1A==",
+      "version": "0.83.8",
+      "resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.83.8.tgz",
+      "integrity": "sha512-piU0NVTI9i37YztDVF5rtn9uxP3NebVT0xZM9NKJ9z0jbigrctUQksi3NoYIeJMvL6Wn2dgAehpcmmnfn+gUwA==",
       "license": "MIT",
       "dependencies": {
         "flow-enums-runtime": "^0.0.6"
@@ -7922,9 +7906,9 @@
       }
     },
     "node_modules/metro-runtime": {
-      "version": "0.83.7",
-      "resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.83.7.tgz",
-      "integrity": "sha512-9GKkJURaB2iyYoEExKnedzAHzxmKtSi+k0tsZUvMoU27tBZJElchYt7JH/Ai/XzYAI9lCAaV7u5HZSI8J5Z+wQ==",
+      "version": "0.83.8",
+      "resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.83.8.tgz",
+      "integrity": "sha512-f7FfeM0pamq8vrvs8aO9KvIUabbUKe0WkHFpLt6Q9yIIIsORqNFwlgJeHGraOFPU7Cxqj5yLXkJu5bT1uwDXvw==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.25.0",
@@ -7935,18 +7919,18 @@
       }
     },
     "node_modules/metro-source-map": {
-      "version": "0.83.7",
-      "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.83.7.tgz",
-      "integrity": "sha512-JgA1h7oc1a1jydBe1GhVFsUoMYo3wLPk7oRA32rjlDsq+sP2JLt9x2p2lWbNSxTm/u8NV4VRid3hvEJgcX8tKw==",
+      "version": "0.83.8",
+      "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.83.8.tgz",
+      "integrity": "sha512-60Uor7bM+KsVewLkLCcZfkPFCbqjPDdoSmeBuT3+ye+ac80BuLWbbR8DpyxWpUqQeZPdaAT5ZqFgDIs8BNEcVA==",
       "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.29.0",
         "@babel/types": "^7.29.0",
         "flow-enums-runtime": "^0.0.6",
         "invariant": "^2.2.4",
-        "metro-symbolicate": "0.83.7",
+        "metro-symbolicate": "0.83.8",
         "nullthrows": "^1.1.1",
-        "ob1": "0.83.7",
+        "ob1": "0.83.8",
         "source-map": "^0.5.6",
         "vlq": "^1.0.0"
       },
@@ -7955,14 +7939,14 @@
       }
     },
     "node_modules/metro-symbolicate": {
-      "version": "0.83.7",
-      "resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.83.7.tgz",
-      "integrity": "sha512-g4suyxw20WOHWI680c+Kq4wC/NF+Hx5pRH9afrMp+sMTxqLeKcPR1Xf4wMhsjlbvx7LbIREdke6q928jEjvJWw==",
+      "version": "0.83.8",
+      "resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.83.8.tgz",
+      "integrity": "sha512-ZLrbqOqQ+m+Mpv7zo65XEXkNqVYvgUbY7tIsb9e1zSSmU/4C3D6DjaJvRHqcAdl0mkg8TI/csKooAEa5xcZNwg==",
       "license": "MIT",
       "dependencies": {
         "flow-enums-runtime": "^0.0.6",
         "invariant": "^2.2.4",
-        "metro-source-map": "0.83.7",
+        "metro-source-map": "0.83.8",
         "nullthrows": "^1.1.1",
         "source-map": "^0.5.6",
         "vlq": "^1.0.0"
@@ -7975,9 +7959,9 @@
       }
     },
     "node_modules/metro-transform-plugins": {
-      "version": "0.83.7",
-      "resolved": "https://registry.npmjs.org/metro-transform-plugins/-/metro-transform-plugins-0.83.7.tgz",
-      "integrity": "sha512-Ss0FpBiZDjX2kwhukMDl5sNdYK8T/06IPqxNE4H6PTlRlfs9q11cef13c/xESY/Pm4VCkp1yJUZO3kXzvMxQFA==",
+      "version": "0.83.8",
+      "resolved": "https://registry.npmjs.org/metro-transform-plugins/-/metro-transform-plugins-0.83.8.tgz",
+      "integrity": "sha512-9JRPkvi+m0QH2Y/w5RjCF9mHqOUNFpMFLDDLhKUjhcKESh8Wm3HKDdHXHVldTN1lTToCIabv81nF0zyJzKEJ5g==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.25.2",
@@ -7992,9 +7976,9 @@
       }
     },
     "node_modules/metro-transform-worker": {
-      "version": "0.83.7",
-      "resolved": "https://registry.npmjs.org/metro-transform-worker/-/metro-transform-worker-0.83.7.tgz",
-      "integrity": "sha512-UegCo7ygB2fT64mRK2nbAjQVJ1zSwIIHy8d96jJv2nKZFDaViYBiughEdu5HM/Ceq0WN3LZrZk3zhl9aoiLYFw==",
+      "version": "0.83.8",
+      "resolved": "https://registry.npmjs.org/metro-transform-worker/-/metro-transform-worker-0.83.8.tgz",
+      "integrity": "sha512-Pa2hOfhUmWpI/dmkhsLq8uGyFHK2opoEK7j/YCiRtqNSe0YzzxYguXTNgg8AMiuZfc9LPcB1AhGENS10O5wcIw==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.25.2",
@@ -8002,13 +7986,13 @@
         "@babel/parser": "^7.29.0",
         "@babel/types": "^7.29.0",
         "flow-enums-runtime": "^0.0.6",
-        "metro": "0.83.7",
-        "metro-babel-transformer": "0.83.7",
-        "metro-cache": "0.83.7",
-        "metro-cache-key": "0.83.7",
-        "metro-minify-terser": "0.83.7",
-        "metro-source-map": "0.83.7",
-        "metro-transform-plugins": "0.83.7",
+        "metro": "0.83.8",
+        "metro-babel-transformer": "0.83.8",
+        "metro-cache": "0.83.8",
+        "metro-cache-key": "0.83.8",
+        "metro-minify-terser": "0.83.8",
+        "metro-source-map": "0.83.8",
+        "metro-transform-plugins": "0.83.8",
         "nullthrows": "^1.1.1"
       },
       "engines": {
@@ -8292,9 +8276,9 @@
       "license": "MIT"
     },
     "node_modules/ob1": {
-      "version": "0.83.7",
-      "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.83.7.tgz",
-      "integrity": "sha512-9M5kpuOLyTPogMtZiQUIxdAZxl7Dxs6tVBbJErSumsqGMuhVSoUbkfeZ3XNPpLpwBBtqY5QDUzGwggLHX3slQg==",
+      "version": "0.83.8",
+      "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.83.8.tgz",
+      "integrity": "sha512-pk7el+eTOzfSKMAY4QBiiwKzegXn633JQj13y+pW5E5IdS+yV2CfDJ9Hf20K/LKy8nCrP9dAmd7XOk52OJxifA==",
       "license": "MIT",
       "dependencies": {
         "flow-enums-runtime": "^0.0.6"
@@ -8818,15 +8802,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/queue": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
-      "integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "~2.0.3"
       }
     },
     "node_modules/queue-microtask": {

--- a/tests/startup_perf/BlankRNW/package-lock.json
+++ b/tests/startup_perf/BlankRNW/package-lock.json
@@ -54,17 +54,17 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "version": "7.29.6",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.6.tgz",
+      "integrity": "sha512-QdxmAo/ikZqqRGA8s43ww8lcql6naWRvEz0FFrl6MIlc7Gi6TroXnSdWa5U/kq6fzcpqpHesicQxFZIieZbyIA==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
+        "@babel/generator": "^7.29.6",
         "@babel/helper-compilation-targets": "^7.28.6",
         "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.29.0",
+        "@babel/helpers": "^7.29.2",
+        "@babel/parser": "^7.29.3",
         "@babel/template": "^7.28.6",
         "@babel/traverse": "^7.29.0",
         "@babel/types": "^7.29.0",
@@ -103,13 +103,13 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -330,18 +330,18 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -385,12 +385,12 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
-      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -1970,13 +1970,13 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"

--- a/tests/stress_perf_rn/StocksGrid/package-lock.json
+++ b/tests/stress_perf_rn/StocksGrid/package-lock.json
@@ -6893,21 +6893,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/image-size": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.2.1.tgz",
-      "integrity": "sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==",
-      "license": "MIT",
-      "dependencies": {
-        "queue": "6.0.2"
-      },
-      "bin": {
-        "image-size": "bin/image-size.js"
-      },
-      "engines": {
-        "node": ">=16.x"
-      }
-    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -8696,9 +8681,9 @@
       }
     },
     "node_modules/metro": {
-      "version": "0.83.7",
-      "resolved": "https://registry.npmjs.org/metro/-/metro-0.83.7.tgz",
-      "integrity": "sha512-SPaPEyvTsTmd0LpT7RaZciQyDw2i/JB7+iY9L5VfBo72+psescFxBqpI1TL9dnL+pmnfkU+l/J1mEEGLeF65EQ==",
+      "version": "0.83.8",
+      "resolved": "https://registry.npmjs.org/metro/-/metro-0.83.8.tgz",
+      "integrity": "sha512-ZbJDJCDlvv0O3QHVbhZkyP2/DtebfEoDZ3wVyYHgu6Uoy6DmmE/bis6lIDBYh+kWPuaueJDegyutPjkIBLtZDQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
@@ -8716,23 +8701,22 @@
         "flow-enums-runtime": "^0.0.6",
         "graceful-fs": "^4.2.4",
         "hermes-parser": "0.35.0",
-        "image-size": "^1.0.2",
         "invariant": "^2.2.4",
         "jest-worker": "^29.7.0",
         "jsc-safe-url": "^0.2.2",
         "lodash.throttle": "^4.1.1",
-        "metro-babel-transformer": "0.83.7",
-        "metro-cache": "0.83.7",
-        "metro-cache-key": "0.83.7",
-        "metro-config": "0.83.7",
-        "metro-core": "0.83.7",
-        "metro-file-map": "0.83.7",
-        "metro-resolver": "0.83.7",
-        "metro-runtime": "0.83.7",
-        "metro-source-map": "0.83.7",
-        "metro-symbolicate": "0.83.7",
-        "metro-transform-plugins": "0.83.7",
-        "metro-transform-worker": "0.83.7",
+        "metro-babel-transformer": "0.83.8",
+        "metro-cache": "0.83.8",
+        "metro-cache-key": "0.83.8",
+        "metro-config": "0.83.8",
+        "metro-core": "0.83.8",
+        "metro-file-map": "0.83.8",
+        "metro-resolver": "0.83.8",
+        "metro-runtime": "0.83.8",
+        "metro-source-map": "0.83.8",
+        "metro-symbolicate": "0.83.8",
+        "metro-transform-plugins": "0.83.8",
+        "metro-transform-worker": "0.83.8",
         "mime-types": "^3.0.1",
         "nullthrows": "^1.1.1",
         "serialize-error": "^2.1.0",
@@ -8749,15 +8733,15 @@
       }
     },
     "node_modules/metro-babel-transformer": {
-      "version": "0.83.7",
-      "resolved": "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.83.7.tgz",
-      "integrity": "sha512-sBqBkt6kNut/88bv+Ucvm4yqdPetbvAEsHzi3MAgJEifOSYYzX5Z5Kgw3TFOrwf/mHJTOBG2ONlaMHoyfP15TA==",
+      "version": "0.83.8",
+      "resolved": "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.83.8.tgz",
+      "integrity": "sha512-tnn0J5wzgTgTx2OJy3Cwr1y79bJz4eNgFQd+2HENOs5Vz6QOMnt05z7J+BedIo9wIbpEa0iN9U1nerxyvMRE9g==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.25.2",
         "flow-enums-runtime": "^0.0.6",
         "hermes-parser": "0.35.0",
-        "metro-cache-key": "0.83.7",
+        "metro-cache-key": "0.83.8",
         "nullthrows": "^1.1.1"
       },
       "engines": {
@@ -8780,24 +8764,24 @@
       }
     },
     "node_modules/metro-cache": {
-      "version": "0.83.7",
-      "resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.83.7.tgz",
-      "integrity": "sha512-E9SRePXQ1Zvlj79VcOk57q7VC7rMHMFQ+jhmPHBiq+dJ0bJB5BL87lWZF6oh5X76Cci5tpDuQNaDwwuSCToEeg==",
+      "version": "0.83.8",
+      "resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.83.8.tgz",
+      "integrity": "sha512-aogMG5WbKzW5000otNjYrS9hIoORzkCI1faPJK+vxQLaf2BorJKBBFe/jl2Tfsi1mZUglS2EBuBt8B3JB7MYDQ==",
       "license": "MIT",
       "dependencies": {
         "exponential-backoff": "^3.1.1",
         "flow-enums-runtime": "^0.0.6",
         "https-proxy-agent": "^7.0.5",
-        "metro-core": "0.83.7"
+        "metro-core": "0.83.8"
       },
       "engines": {
         "node": ">=20.19.4"
       }
     },
     "node_modules/metro-cache-key": {
-      "version": "0.83.7",
-      "resolved": "https://registry.npmjs.org/metro-cache-key/-/metro-cache-key-0.83.7.tgz",
-      "integrity": "sha512-W1c2Nmx8MiJTJt+eWhMO08z9VKi3kZOaz99IYGdqeqDgY9j+yZjXl62rUav4Di0heZfh4/n2s722PqRL1OODeg==",
+      "version": "0.83.8",
+      "resolved": "https://registry.npmjs.org/metro-cache-key/-/metro-cache-key-0.83.8.tgz",
+      "integrity": "sha512-I38PtcjT4crS5HY9UQ8i6z8S7tJ2WewtPGr/OwS6FcLKfy5T/1hlTaFw+wozUZkEtNpR6Gc0oJuvuKCbSoSN5A==",
       "license": "MIT",
       "dependencies": {
         "flow-enums-runtime": "^0.0.6"
@@ -8807,18 +8791,18 @@
       }
     },
     "node_modules/metro-config": {
-      "version": "0.83.7",
-      "resolved": "https://registry.npmjs.org/metro-config/-/metro-config-0.83.7.tgz",
-      "integrity": "sha512-83mjWFbFOt2GeJ6pFIum5mSnc1uTsZJAtD8o4ej0s4NVsYsA7fB+pHvTfHhFrpeMONaobu2riKavkPei05Er/Q==",
+      "version": "0.83.8",
+      "resolved": "https://registry.npmjs.org/metro-config/-/metro-config-0.83.8.tgz",
+      "integrity": "sha512-crNbNy+/B4tCne2+HjUshwvC57gNBQj+V9fFSy3lHH2RlKcLHib3Mil/SfTX8Pfh2fCY5pPuSu2OKa7YiadB+Q==",
       "license": "MIT",
       "dependencies": {
         "connect": "^3.6.5",
         "flow-enums-runtime": "^0.0.6",
         "jest-validate": "^29.7.0",
-        "metro": "0.83.7",
-        "metro-cache": "0.83.7",
-        "metro-core": "0.83.7",
-        "metro-runtime": "0.83.7",
+        "metro": "0.83.8",
+        "metro-cache": "0.83.8",
+        "metro-core": "0.83.8",
+        "metro-runtime": "0.83.8",
         "yaml": "^2.6.1"
       },
       "engines": {
@@ -8826,23 +8810,23 @@
       }
     },
     "node_modules/metro-core": {
-      "version": "0.83.7",
-      "resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.83.7.tgz",
-      "integrity": "sha512-6yn3w1wnltT6RQl7p7YES2l95ArC+mWrOssEiH8p5/DDrJS65/szf9LsC9JrBv8c5DdvSY3V3f0GRYg0Ox7hCg==",
+      "version": "0.83.8",
+      "resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.83.8.tgz",
+      "integrity": "sha512-NTyOUOQaQKvQgJG9VI2ymN6KTM7gHEqkVFhkPc9bK4BsHSTz/EaXuFBXtC+wtwINLeH9tbusL/jfsSmdEmuU7A==",
       "license": "MIT",
       "dependencies": {
         "flow-enums-runtime": "^0.0.6",
         "lodash.throttle": "^4.1.1",
-        "metro-resolver": "0.83.7"
+        "metro-resolver": "0.83.8"
       },
       "engines": {
         "node": ">=20.19.4"
       }
     },
     "node_modules/metro-file-map": {
-      "version": "0.83.7",
-      "resolved": "https://registry.npmjs.org/metro-file-map/-/metro-file-map-0.83.7.tgz",
-      "integrity": "sha512-+j0F1m+FQYVAQ6syf+mwhIPV5GoFQrkInX8bppuc50IzNsZbMrp8R5H/Sx/K2daQ3YEa9F/XwkeZT8gzJfgeCw==",
+      "version": "0.83.8",
+      "resolved": "https://registry.npmjs.org/metro-file-map/-/metro-file-map-0.83.8.tgz",
+      "integrity": "sha512-+W++EUuzEXIfWQEFTWQMVThzhWbnJL4gRNJ9WSHzIAM5pT7gsprUxo9+2hrfirURm/TLvrKwhq37oCECJcDSyQ==",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.0",
@@ -8860,9 +8844,9 @@
       }
     },
     "node_modules/metro-minify-terser": {
-      "version": "0.83.7",
-      "resolved": "https://registry.npmjs.org/metro-minify-terser/-/metro-minify-terser-0.83.7.tgz",
-      "integrity": "sha512-MfJar2IS4tBRuLb9svwb0Gu5l9BsH+pcRm8eGcEi/wy8MzZinfinh5dFLt2nWkocnulIgtGB5NkFDdbXqMXKhQ==",
+      "version": "0.83.8",
+      "resolved": "https://registry.npmjs.org/metro-minify-terser/-/metro-minify-terser-0.83.8.tgz",
+      "integrity": "sha512-7tU0J5/c7LZaZJwTlOb1xq0NepTFvGzRxigDhZOq4jSE6g0BRHmBqe7XvLH3WcRiJNGy+eshcZr34RpMjb6mmg==",
       "license": "MIT",
       "dependencies": {
         "flow-enums-runtime": "^0.0.6",
@@ -8873,9 +8857,9 @@
       }
     },
     "node_modules/metro-resolver": {
-      "version": "0.83.7",
-      "resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.83.7.tgz",
-      "integrity": "sha512-WSJIENlMcoSsuz66IfBHOkgfp3KJt2UW2TnEHPf1b8pIG2eEXNOVmo2+03A0H17WY2XGXWgxL0CG7FAopqgB1A==",
+      "version": "0.83.8",
+      "resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.83.8.tgz",
+      "integrity": "sha512-piU0NVTI9i37YztDVF5rtn9uxP3NebVT0xZM9NKJ9z0jbigrctUQksi3NoYIeJMvL6Wn2dgAehpcmmnfn+gUwA==",
       "license": "MIT",
       "dependencies": {
         "flow-enums-runtime": "^0.0.6"
@@ -8885,9 +8869,9 @@
       }
     },
     "node_modules/metro-runtime": {
-      "version": "0.83.7",
-      "resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.83.7.tgz",
-      "integrity": "sha512-9GKkJURaB2iyYoEExKnedzAHzxmKtSi+k0tsZUvMoU27tBZJElchYt7JH/Ai/XzYAI9lCAaV7u5HZSI8J5Z+wQ==",
+      "version": "0.83.8",
+      "resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.83.8.tgz",
+      "integrity": "sha512-f7FfeM0pamq8vrvs8aO9KvIUabbUKe0WkHFpLt6Q9yIIIsORqNFwlgJeHGraOFPU7Cxqj5yLXkJu5bT1uwDXvw==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.25.0",
@@ -8898,18 +8882,18 @@
       }
     },
     "node_modules/metro-source-map": {
-      "version": "0.83.7",
-      "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.83.7.tgz",
-      "integrity": "sha512-JgA1h7oc1a1jydBe1GhVFsUoMYo3wLPk7oRA32rjlDsq+sP2JLt9x2p2lWbNSxTm/u8NV4VRid3hvEJgcX8tKw==",
+      "version": "0.83.8",
+      "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.83.8.tgz",
+      "integrity": "sha512-60Uor7bM+KsVewLkLCcZfkPFCbqjPDdoSmeBuT3+ye+ac80BuLWbbR8DpyxWpUqQeZPdaAT5ZqFgDIs8BNEcVA==",
       "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.29.0",
         "@babel/types": "^7.29.0",
         "flow-enums-runtime": "^0.0.6",
         "invariant": "^2.2.4",
-        "metro-symbolicate": "0.83.7",
+        "metro-symbolicate": "0.83.8",
         "nullthrows": "^1.1.1",
-        "ob1": "0.83.7",
+        "ob1": "0.83.8",
         "source-map": "^0.5.6",
         "vlq": "^1.0.0"
       },
@@ -8927,14 +8911,14 @@
       }
     },
     "node_modules/metro-symbolicate": {
-      "version": "0.83.7",
-      "resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.83.7.tgz",
-      "integrity": "sha512-g4suyxw20WOHWI680c+Kq4wC/NF+Hx5pRH9afrMp+sMTxqLeKcPR1Xf4wMhsjlbvx7LbIREdke6q928jEjvJWw==",
+      "version": "0.83.8",
+      "resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.83.8.tgz",
+      "integrity": "sha512-ZLrbqOqQ+m+Mpv7zo65XEXkNqVYvgUbY7tIsb9e1zSSmU/4C3D6DjaJvRHqcAdl0mkg8TI/csKooAEa5xcZNwg==",
       "license": "MIT",
       "dependencies": {
         "flow-enums-runtime": "^0.0.6",
         "invariant": "^2.2.4",
-        "metro-source-map": "0.83.7",
+        "metro-source-map": "0.83.8",
         "nullthrows": "^1.1.1",
         "source-map": "^0.5.6",
         "vlq": "^1.0.0"
@@ -8956,9 +8940,9 @@
       }
     },
     "node_modules/metro-transform-plugins": {
-      "version": "0.83.7",
-      "resolved": "https://registry.npmjs.org/metro-transform-plugins/-/metro-transform-plugins-0.83.7.tgz",
-      "integrity": "sha512-Ss0FpBiZDjX2kwhukMDl5sNdYK8T/06IPqxNE4H6PTlRlfs9q11cef13c/xESY/Pm4VCkp1yJUZO3kXzvMxQFA==",
+      "version": "0.83.8",
+      "resolved": "https://registry.npmjs.org/metro-transform-plugins/-/metro-transform-plugins-0.83.8.tgz",
+      "integrity": "sha512-9JRPkvi+m0QH2Y/w5RjCF9mHqOUNFpMFLDDLhKUjhcKESh8Wm3HKDdHXHVldTN1lTToCIabv81nF0zyJzKEJ5g==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.25.2",
@@ -8973,9 +8957,9 @@
       }
     },
     "node_modules/metro-transform-worker": {
-      "version": "0.83.7",
-      "resolved": "https://registry.npmjs.org/metro-transform-worker/-/metro-transform-worker-0.83.7.tgz",
-      "integrity": "sha512-UegCo7ygB2fT64mRK2nbAjQVJ1zSwIIHy8d96jJv2nKZFDaViYBiughEdu5HM/Ceq0WN3LZrZk3zhl9aoiLYFw==",
+      "version": "0.83.8",
+      "resolved": "https://registry.npmjs.org/metro-transform-worker/-/metro-transform-worker-0.83.8.tgz",
+      "integrity": "sha512-Pa2hOfhUmWpI/dmkhsLq8uGyFHK2opoEK7j/YCiRtqNSe0YzzxYguXTNgg8AMiuZfc9LPcB1AhGENS10O5wcIw==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.25.2",
@@ -8983,13 +8967,13 @@
         "@babel/parser": "^7.29.0",
         "@babel/types": "^7.29.0",
         "flow-enums-runtime": "^0.0.6",
-        "metro": "0.83.7",
-        "metro-babel-transformer": "0.83.7",
-        "metro-cache": "0.83.7",
-        "metro-cache-key": "0.83.7",
-        "metro-minify-terser": "0.83.7",
-        "metro-source-map": "0.83.7",
-        "metro-transform-plugins": "0.83.7",
+        "metro": "0.83.8",
+        "metro-babel-transformer": "0.83.8",
+        "metro-cache": "0.83.8",
+        "metro-cache-key": "0.83.8",
+        "metro-minify-terser": "0.83.8",
+        "metro-source-map": "0.83.8",
+        "metro-transform-plugins": "0.83.8",
         "nullthrows": "^1.1.1"
       },
       "engines": {
@@ -9288,9 +9272,9 @@
       "license": "MIT"
     },
     "node_modules/ob1": {
-      "version": "0.83.7",
-      "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.83.7.tgz",
-      "integrity": "sha512-9M5kpuOLyTPogMtZiQUIxdAZxl7Dxs6tVBbJErSumsqGMuhVSoUbkfeZ3XNPpLpwBBtqY5QDUzGwggLHX3slQg==",
+      "version": "0.83.8",
+      "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.83.8.tgz",
+      "integrity": "sha512-pk7el+eTOzfSKMAY4QBiiwKzegXn633JQj13y+pW5E5IdS+yV2CfDJ9Hf20K/LKy8nCrP9dAmd7XOk52OJxifA==",
       "license": "MIT",
       "dependencies": {
         "flow-enums-runtime": "^0.0.6"
@@ -9900,15 +9884,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/queue": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
-      "integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "~2.0.3"
       }
     },
     "node_modules/queue-microtask": {

--- a/tests/stress_perf_rn/StocksGrid/package-lock.json
+++ b/tests/stress_perf_rn/StocksGrid/package-lock.json
@@ -1275,9 +1275,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-systemjs": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.0.tgz",
-      "integrity": "sha512-PrujnVFbOdUpw4UHiVwKvKRLMMic8+eC0CuNlxjsyZUiBjhFdPsewdXCkveh2KqBA9/waD0W1b4hXSOBQJezpQ==",
+      "version": "7.29.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.4.tgz",
+      "integrity": "sha512-N7QmZ0xRZfjHOfZeQLJjwgX2zS9pdGHSVl/cjSGlo4dXMqvurfxXDMKY4RqEKzPozV78VMcd0lxyG13mlbKc4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2088,9 +2088,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2172,9 +2172,9 @@
       "license": "MIT"
     },
     "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4412,16 +4412,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -5779,9 +5779,9 @@
       "license": "MIT"
     },
     "node_modules/eslint-plugin-react/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5881,9 +5881,9 @@
       "license": "MIT"
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6592,9 +6592,9 @@
       "license": "MIT"
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -8321,14 +8321,14 @@
       }
     },
     "node_modules/launch-editor": {
-      "version": "2.13.2",
-      "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.13.2.tgz",
-      "integrity": "sha512-4VVDnbOpLXy/s8rdRCSXb+zfMeFR0WlJWpET1iA9CQdlZDfwyLjUuGQzXU4VeOoey6AicSAluWan7Etga6Kcmg==",
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.14.1.tgz",
+      "integrity": "sha512-QWBrQsMpH7gPr965dsKD/3cKWiNoTjpATQf++Xq63N6sKRGMwlVXz41O1IZTMfZQgBctD/K5Zt06+/I6pP6+HA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "picocolors": "^1.1.1",
-        "shell-quote": "^1.8.3"
+        "shell-quote": "^1.8.4"
       }
     },
     "node_modules/leven": {
@@ -11243,9 +11243,9 @@
       "license": "MIT"
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",

--- a/tests/stress_perf_rn/VirtualList/package-lock.json
+++ b/tests/stress_perf_rn/VirtualList/package-lock.json
@@ -2088,9 +2088,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2172,9 +2172,9 @@
       "license": "MIT"
     },
     "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4412,16 +4412,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -5779,9 +5779,9 @@
       "license": "MIT"
     },
     "node_modules/eslint-plugin-react/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5881,9 +5881,9 @@
       "license": "MIT"
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6592,9 +6592,9 @@
       "license": "MIT"
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -11243,9 +11243,9 @@
       "license": "MIT"
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",

--- a/tests/stress_perf_rn/VirtualList/package-lock.json
+++ b/tests/stress_perf_rn/VirtualList/package-lock.json
@@ -6893,21 +6893,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/image-size": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.2.1.tgz",
-      "integrity": "sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==",
-      "license": "MIT",
-      "dependencies": {
-        "queue": "6.0.2"
-      },
-      "bin": {
-        "image-size": "bin/image-size.js"
-      },
-      "engines": {
-        "node": ">=16.x"
-      }
-    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -8696,9 +8681,9 @@
       }
     },
     "node_modules/metro": {
-      "version": "0.83.7",
-      "resolved": "https://registry.npmjs.org/metro/-/metro-0.83.7.tgz",
-      "integrity": "sha512-SPaPEyvTsTmd0LpT7RaZciQyDw2i/JB7+iY9L5VfBo72+psescFxBqpI1TL9dnL+pmnfkU+l/J1mEEGLeF65EQ==",
+      "version": "0.83.8",
+      "resolved": "https://registry.npmjs.org/metro/-/metro-0.83.8.tgz",
+      "integrity": "sha512-ZbJDJCDlvv0O3QHVbhZkyP2/DtebfEoDZ3wVyYHgu6Uoy6DmmE/bis6lIDBYh+kWPuaueJDegyutPjkIBLtZDQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
@@ -8716,23 +8701,22 @@
         "flow-enums-runtime": "^0.0.6",
         "graceful-fs": "^4.2.4",
         "hermes-parser": "0.35.0",
-        "image-size": "^1.0.2",
         "invariant": "^2.2.4",
         "jest-worker": "^29.7.0",
         "jsc-safe-url": "^0.2.2",
         "lodash.throttle": "^4.1.1",
-        "metro-babel-transformer": "0.83.7",
-        "metro-cache": "0.83.7",
-        "metro-cache-key": "0.83.7",
-        "metro-config": "0.83.7",
-        "metro-core": "0.83.7",
-        "metro-file-map": "0.83.7",
-        "metro-resolver": "0.83.7",
-        "metro-runtime": "0.83.7",
-        "metro-source-map": "0.83.7",
-        "metro-symbolicate": "0.83.7",
-        "metro-transform-plugins": "0.83.7",
-        "metro-transform-worker": "0.83.7",
+        "metro-babel-transformer": "0.83.8",
+        "metro-cache": "0.83.8",
+        "metro-cache-key": "0.83.8",
+        "metro-config": "0.83.8",
+        "metro-core": "0.83.8",
+        "metro-file-map": "0.83.8",
+        "metro-resolver": "0.83.8",
+        "metro-runtime": "0.83.8",
+        "metro-source-map": "0.83.8",
+        "metro-symbolicate": "0.83.8",
+        "metro-transform-plugins": "0.83.8",
+        "metro-transform-worker": "0.83.8",
         "mime-types": "^3.0.1",
         "nullthrows": "^1.1.1",
         "serialize-error": "^2.1.0",
@@ -8749,15 +8733,15 @@
       }
     },
     "node_modules/metro-babel-transformer": {
-      "version": "0.83.7",
-      "resolved": "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.83.7.tgz",
-      "integrity": "sha512-sBqBkt6kNut/88bv+Ucvm4yqdPetbvAEsHzi3MAgJEifOSYYzX5Z5Kgw3TFOrwf/mHJTOBG2ONlaMHoyfP15TA==",
+      "version": "0.83.8",
+      "resolved": "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.83.8.tgz",
+      "integrity": "sha512-tnn0J5wzgTgTx2OJy3Cwr1y79bJz4eNgFQd+2HENOs5Vz6QOMnt05z7J+BedIo9wIbpEa0iN9U1nerxyvMRE9g==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.25.2",
         "flow-enums-runtime": "^0.0.6",
         "hermes-parser": "0.35.0",
-        "metro-cache-key": "0.83.7",
+        "metro-cache-key": "0.83.8",
         "nullthrows": "^1.1.1"
       },
       "engines": {
@@ -8780,24 +8764,24 @@
       }
     },
     "node_modules/metro-cache": {
-      "version": "0.83.7",
-      "resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.83.7.tgz",
-      "integrity": "sha512-E9SRePXQ1Zvlj79VcOk57q7VC7rMHMFQ+jhmPHBiq+dJ0bJB5BL87lWZF6oh5X76Cci5tpDuQNaDwwuSCToEeg==",
+      "version": "0.83.8",
+      "resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.83.8.tgz",
+      "integrity": "sha512-aogMG5WbKzW5000otNjYrS9hIoORzkCI1faPJK+vxQLaf2BorJKBBFe/jl2Tfsi1mZUglS2EBuBt8B3JB7MYDQ==",
       "license": "MIT",
       "dependencies": {
         "exponential-backoff": "^3.1.1",
         "flow-enums-runtime": "^0.0.6",
         "https-proxy-agent": "^7.0.5",
-        "metro-core": "0.83.7"
+        "metro-core": "0.83.8"
       },
       "engines": {
         "node": ">=20.19.4"
       }
     },
     "node_modules/metro-cache-key": {
-      "version": "0.83.7",
-      "resolved": "https://registry.npmjs.org/metro-cache-key/-/metro-cache-key-0.83.7.tgz",
-      "integrity": "sha512-W1c2Nmx8MiJTJt+eWhMO08z9VKi3kZOaz99IYGdqeqDgY9j+yZjXl62rUav4Di0heZfh4/n2s722PqRL1OODeg==",
+      "version": "0.83.8",
+      "resolved": "https://registry.npmjs.org/metro-cache-key/-/metro-cache-key-0.83.8.tgz",
+      "integrity": "sha512-I38PtcjT4crS5HY9UQ8i6z8S7tJ2WewtPGr/OwS6FcLKfy5T/1hlTaFw+wozUZkEtNpR6Gc0oJuvuKCbSoSN5A==",
       "license": "MIT",
       "dependencies": {
         "flow-enums-runtime": "^0.0.6"
@@ -8807,18 +8791,18 @@
       }
     },
     "node_modules/metro-config": {
-      "version": "0.83.7",
-      "resolved": "https://registry.npmjs.org/metro-config/-/metro-config-0.83.7.tgz",
-      "integrity": "sha512-83mjWFbFOt2GeJ6pFIum5mSnc1uTsZJAtD8o4ej0s4NVsYsA7fB+pHvTfHhFrpeMONaobu2riKavkPei05Er/Q==",
+      "version": "0.83.8",
+      "resolved": "https://registry.npmjs.org/metro-config/-/metro-config-0.83.8.tgz",
+      "integrity": "sha512-crNbNy+/B4tCne2+HjUshwvC57gNBQj+V9fFSy3lHH2RlKcLHib3Mil/SfTX8Pfh2fCY5pPuSu2OKa7YiadB+Q==",
       "license": "MIT",
       "dependencies": {
         "connect": "^3.6.5",
         "flow-enums-runtime": "^0.0.6",
         "jest-validate": "^29.7.0",
-        "metro": "0.83.7",
-        "metro-cache": "0.83.7",
-        "metro-core": "0.83.7",
-        "metro-runtime": "0.83.7",
+        "metro": "0.83.8",
+        "metro-cache": "0.83.8",
+        "metro-core": "0.83.8",
+        "metro-runtime": "0.83.8",
         "yaml": "^2.6.1"
       },
       "engines": {
@@ -8826,23 +8810,23 @@
       }
     },
     "node_modules/metro-core": {
-      "version": "0.83.7",
-      "resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.83.7.tgz",
-      "integrity": "sha512-6yn3w1wnltT6RQl7p7YES2l95ArC+mWrOssEiH8p5/DDrJS65/szf9LsC9JrBv8c5DdvSY3V3f0GRYg0Ox7hCg==",
+      "version": "0.83.8",
+      "resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.83.8.tgz",
+      "integrity": "sha512-NTyOUOQaQKvQgJG9VI2ymN6KTM7gHEqkVFhkPc9bK4BsHSTz/EaXuFBXtC+wtwINLeH9tbusL/jfsSmdEmuU7A==",
       "license": "MIT",
       "dependencies": {
         "flow-enums-runtime": "^0.0.6",
         "lodash.throttle": "^4.1.1",
-        "metro-resolver": "0.83.7"
+        "metro-resolver": "0.83.8"
       },
       "engines": {
         "node": ">=20.19.4"
       }
     },
     "node_modules/metro-file-map": {
-      "version": "0.83.7",
-      "resolved": "https://registry.npmjs.org/metro-file-map/-/metro-file-map-0.83.7.tgz",
-      "integrity": "sha512-+j0F1m+FQYVAQ6syf+mwhIPV5GoFQrkInX8bppuc50IzNsZbMrp8R5H/Sx/K2daQ3YEa9F/XwkeZT8gzJfgeCw==",
+      "version": "0.83.8",
+      "resolved": "https://registry.npmjs.org/metro-file-map/-/metro-file-map-0.83.8.tgz",
+      "integrity": "sha512-+W++EUuzEXIfWQEFTWQMVThzhWbnJL4gRNJ9WSHzIAM5pT7gsprUxo9+2hrfirURm/TLvrKwhq37oCECJcDSyQ==",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.0",
@@ -8860,9 +8844,9 @@
       }
     },
     "node_modules/metro-minify-terser": {
-      "version": "0.83.7",
-      "resolved": "https://registry.npmjs.org/metro-minify-terser/-/metro-minify-terser-0.83.7.tgz",
-      "integrity": "sha512-MfJar2IS4tBRuLb9svwb0Gu5l9BsH+pcRm8eGcEi/wy8MzZinfinh5dFLt2nWkocnulIgtGB5NkFDdbXqMXKhQ==",
+      "version": "0.83.8",
+      "resolved": "https://registry.npmjs.org/metro-minify-terser/-/metro-minify-terser-0.83.8.tgz",
+      "integrity": "sha512-7tU0J5/c7LZaZJwTlOb1xq0NepTFvGzRxigDhZOq4jSE6g0BRHmBqe7XvLH3WcRiJNGy+eshcZr34RpMjb6mmg==",
       "license": "MIT",
       "dependencies": {
         "flow-enums-runtime": "^0.0.6",
@@ -8873,9 +8857,9 @@
       }
     },
     "node_modules/metro-resolver": {
-      "version": "0.83.7",
-      "resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.83.7.tgz",
-      "integrity": "sha512-WSJIENlMcoSsuz66IfBHOkgfp3KJt2UW2TnEHPf1b8pIG2eEXNOVmo2+03A0H17WY2XGXWgxL0CG7FAopqgB1A==",
+      "version": "0.83.8",
+      "resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.83.8.tgz",
+      "integrity": "sha512-piU0NVTI9i37YztDVF5rtn9uxP3NebVT0xZM9NKJ9z0jbigrctUQksi3NoYIeJMvL6Wn2dgAehpcmmnfn+gUwA==",
       "license": "MIT",
       "dependencies": {
         "flow-enums-runtime": "^0.0.6"
@@ -8885,9 +8869,9 @@
       }
     },
     "node_modules/metro-runtime": {
-      "version": "0.83.7",
-      "resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.83.7.tgz",
-      "integrity": "sha512-9GKkJURaB2iyYoEExKnedzAHzxmKtSi+k0tsZUvMoU27tBZJElchYt7JH/Ai/XzYAI9lCAaV7u5HZSI8J5Z+wQ==",
+      "version": "0.83.8",
+      "resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.83.8.tgz",
+      "integrity": "sha512-f7FfeM0pamq8vrvs8aO9KvIUabbUKe0WkHFpLt6Q9yIIIsORqNFwlgJeHGraOFPU7Cxqj5yLXkJu5bT1uwDXvw==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.25.0",
@@ -8898,18 +8882,18 @@
       }
     },
     "node_modules/metro-source-map": {
-      "version": "0.83.7",
-      "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.83.7.tgz",
-      "integrity": "sha512-JgA1h7oc1a1jydBe1GhVFsUoMYo3wLPk7oRA32rjlDsq+sP2JLt9x2p2lWbNSxTm/u8NV4VRid3hvEJgcX8tKw==",
+      "version": "0.83.8",
+      "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.83.8.tgz",
+      "integrity": "sha512-60Uor7bM+KsVewLkLCcZfkPFCbqjPDdoSmeBuT3+ye+ac80BuLWbbR8DpyxWpUqQeZPdaAT5ZqFgDIs8BNEcVA==",
       "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.29.0",
         "@babel/types": "^7.29.0",
         "flow-enums-runtime": "^0.0.6",
         "invariant": "^2.2.4",
-        "metro-symbolicate": "0.83.7",
+        "metro-symbolicate": "0.83.8",
         "nullthrows": "^1.1.1",
-        "ob1": "0.83.7",
+        "ob1": "0.83.8",
         "source-map": "^0.5.6",
         "vlq": "^1.0.0"
       },
@@ -8927,14 +8911,14 @@
       }
     },
     "node_modules/metro-symbolicate": {
-      "version": "0.83.7",
-      "resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.83.7.tgz",
-      "integrity": "sha512-g4suyxw20WOHWI680c+Kq4wC/NF+Hx5pRH9afrMp+sMTxqLeKcPR1Xf4wMhsjlbvx7LbIREdke6q928jEjvJWw==",
+      "version": "0.83.8",
+      "resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.83.8.tgz",
+      "integrity": "sha512-ZLrbqOqQ+m+Mpv7zo65XEXkNqVYvgUbY7tIsb9e1zSSmU/4C3D6DjaJvRHqcAdl0mkg8TI/csKooAEa5xcZNwg==",
       "license": "MIT",
       "dependencies": {
         "flow-enums-runtime": "^0.0.6",
         "invariant": "^2.2.4",
-        "metro-source-map": "0.83.7",
+        "metro-source-map": "0.83.8",
         "nullthrows": "^1.1.1",
         "source-map": "^0.5.6",
         "vlq": "^1.0.0"
@@ -8956,9 +8940,9 @@
       }
     },
     "node_modules/metro-transform-plugins": {
-      "version": "0.83.7",
-      "resolved": "https://registry.npmjs.org/metro-transform-plugins/-/metro-transform-plugins-0.83.7.tgz",
-      "integrity": "sha512-Ss0FpBiZDjX2kwhukMDl5sNdYK8T/06IPqxNE4H6PTlRlfs9q11cef13c/xESY/Pm4VCkp1yJUZO3kXzvMxQFA==",
+      "version": "0.83.8",
+      "resolved": "https://registry.npmjs.org/metro-transform-plugins/-/metro-transform-plugins-0.83.8.tgz",
+      "integrity": "sha512-9JRPkvi+m0QH2Y/w5RjCF9mHqOUNFpMFLDDLhKUjhcKESh8Wm3HKDdHXHVldTN1lTToCIabv81nF0zyJzKEJ5g==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.25.2",
@@ -8973,9 +8957,9 @@
       }
     },
     "node_modules/metro-transform-worker": {
-      "version": "0.83.7",
-      "resolved": "https://registry.npmjs.org/metro-transform-worker/-/metro-transform-worker-0.83.7.tgz",
-      "integrity": "sha512-UegCo7ygB2fT64mRK2nbAjQVJ1zSwIIHy8d96jJv2nKZFDaViYBiughEdu5HM/Ceq0WN3LZrZk3zhl9aoiLYFw==",
+      "version": "0.83.8",
+      "resolved": "https://registry.npmjs.org/metro-transform-worker/-/metro-transform-worker-0.83.8.tgz",
+      "integrity": "sha512-Pa2hOfhUmWpI/dmkhsLq8uGyFHK2opoEK7j/YCiRtqNSe0YzzxYguXTNgg8AMiuZfc9LPcB1AhGENS10O5wcIw==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.25.2",
@@ -8983,13 +8967,13 @@
         "@babel/parser": "^7.29.0",
         "@babel/types": "^7.29.0",
         "flow-enums-runtime": "^0.0.6",
-        "metro": "0.83.7",
-        "metro-babel-transformer": "0.83.7",
-        "metro-cache": "0.83.7",
-        "metro-cache-key": "0.83.7",
-        "metro-minify-terser": "0.83.7",
-        "metro-source-map": "0.83.7",
-        "metro-transform-plugins": "0.83.7",
+        "metro": "0.83.8",
+        "metro-babel-transformer": "0.83.8",
+        "metro-cache": "0.83.8",
+        "metro-cache-key": "0.83.8",
+        "metro-minify-terser": "0.83.8",
+        "metro-source-map": "0.83.8",
+        "metro-transform-plugins": "0.83.8",
         "nullthrows": "^1.1.1"
       },
       "engines": {
@@ -9288,9 +9272,9 @@
       "license": "MIT"
     },
     "node_modules/ob1": {
-      "version": "0.83.7",
-      "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.83.7.tgz",
-      "integrity": "sha512-9M5kpuOLyTPogMtZiQUIxdAZxl7Dxs6tVBbJErSumsqGMuhVSoUbkfeZ3XNPpLpwBBtqY5QDUzGwggLHX3slQg==",
+      "version": "0.83.8",
+      "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.83.8.tgz",
+      "integrity": "sha512-pk7el+eTOzfSKMAY4QBiiwKzegXn633JQj13y+pW5E5IdS+yV2CfDJ9Hf20K/LKy8nCrP9dAmd7XOk52OJxifA==",
       "license": "MIT",
       "dependencies": {
         "flow-enums-runtime": "^0.0.6"
@@ -9900,15 +9884,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/queue": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
-      "integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "~2.0.3"
       }
     },
     "node_modules/queue-microtask": {


### PR DESCRIPTION
## Summary

Clears all 17 open Component Governance / Dependabot alerts on this repo. Every one of them lives in the committed `package-lock.json` files of the three React Native comparison harnesses under `tests/`, which means an upstream advisory fix never reaches us until the lockfile is updated by hand.

Two commits, because the two halves have genuinely different reasoning:

**1. The 11 straightforward version bumps.**

| Package | Bump | Advisory |
| --- | --- | --- |
| `brace-expansion` | 1.1.14 -> 1.1.18 (6 nested copies in each of two harnesses) | GHSA-3jxr-9vmj-r5cp, GHSA-mh99-v99m-4gvg, GHSA-rgw5-rvv9-x895 |
| `brace-expansion` | 5.0.6 -> 5.0.9 | GHSA-3jxr-9vmj-r5cp |
| `launch-editor` | 2.13.2 -> 2.14.1 | GHSA-v6wh-96g9-6wx3 |
| `@babel/plugin-transform-modules-systemjs` | 7.29.0 -> 7.29.4 | GHSA-fv7c-fp4j-7gwp |
| `@babel/core` | 7.29.0 -> 7.29.6 | GHSA-4x5r-pxfx-6jf8 |

`@babel/core` 7.29.6 requires `generator ^7.29.6`, which requires `parser`/`types ^7.29.7`, which require the two 7.29.7 helpers, so BlankRNW moves those five along with it. The chain terminates there.

**2. The 6 `image-size` alerts, which look unfixable but are not.**

There is no patched `image-size` to move to: both advisories cover `<= 2.0.2`, 2.0.2 is the latest release, and `image-size/image-size` was archived on 2026-06-03 with issues and PRs disabled. That is why both advisories can only cite PR 439 through a web.archive.org snapshot.

The fix came from the consumer side instead. metro vendored its own image dimension parsing ([react/metro#1860](https://github.com/react/metro/pull/1860), cherry-picked as [#1870](https://github.com/react/metro/pull/1870) / [#1871](https://github.com/react/metro/pull/1871)) and released it in 0.83.8, dropping the dependency outright. These harnesses were pinned at metro 0.83.7. Because `metro-config` and `metro-transform-worker` pin `metro` to an exact version, the whole family moves in lockstep: 15 entries per lockfile (the 14 `metro-*` packages plus `ob1`). Removing `image-size` also orphans `queue`, its only dependant.

No `package.json` changes anywhere. Every declaring range already admitted the patched version, so only the lockfiles held the vulnerable ones.

## Linked issue / spec

No tracking issue in this repo. Upstream context: [react/metro#1607](https://github.com/react/metro/issues/1607) (the Dependabot tracking issue) and [react/metro#1762](https://github.com/react/metro/issues/1762) (image-size unmaintained). Source alerts are the [Component Governance board](https://github-private.visualstudio.com/microsoft/_componentGovernance/238544?_a=alerts&typeId=64394330&alerts-view-option=active) and this repo's Dependabot alerts.

## Test plan

- [x] `npm ci` succeeds in all three harnesses (787 / 858 / 858 packages, exit 0) and leaves the lockfiles unmodified. This is the load-bearing check: it proves every integrity value validates against the real tarball and every dependency range is satisfiable.
- [x] Each tree installs exactly 2 packages fewer than before, matching `image-size` and `queue`.
- [x] All 10 integrity values introduced by the first commit independently confirmed by downloading the published tarballs and recomputing sha512.
- [x] 0 non-sha512 integrity values and 0 non-`registry.npmjs.org` `resolved` URLs remain in any lockfile.
- [x] Swept the installed trees for every package named in all 17 original alerts: 30 copies found, 0 vulnerable. metro on disk is 0.83.8 and `image-size` is absent.

Two notes on making those checks mean something. The tarball verification method was validated first by reproducing four pre-existing untouched integrity values exactly (`balanced-match`, `concat-map`, `picocolors`, `jsesc`), which is what rules out the proxy rewriting tarball bytes. And the "0 vulnerable" sweep is not vacuous: run against the pre-change trees, the same checker flags `@babel/core 7.29.0` and `image-size 1.2.1`.

No .NET gates were run, and none apply. The changed files are npm lockfiles in `tests/stress_perf_rn/` and `tests/startup_perf/BlankRNW/`, which are not in `Reactor.slnx` (the similarly named solution entries are `BlankReactorMsix` and `tests/stress_perf/`, not `stress_perf_rn`) and are not built by any CI workflow. No product code, tests, or docs are touched.

## Risk / breaking changes

No public API change, no behavior change in Reactor itself. Risk is confined to the RN comparison harnesses used for perf benchmarking.

Two things worth a reviewer's attention:

- **This is not fixed on metro 0.85+.** metro 0.85.0, 0.86.0 and 0.87.0 all still declare `image-size ^1.0.2`; the vendoring fix was never forward-ported past the 0.84 line. A future React Native upgrade will reintroduce these two advisories until that is resolved upstream. Happy to file that issue on `react/metro` as a follow-up.
- **The lockfiles were edited surgically rather than regenerated, deliberately.** This environment's proxy registry rewrites both fields that identify an artifact: `resolved` becomes an internal `ms-feed-N.pkgs.visualstudio.com` URL and `integrity` is downgraded from sha512 to sha1. A fresh resolve corrupts every entry that way (measured: 791 of 791), so its output cannot be committed. This follows the precedent set in #1089. For the metro bump I used npm's real resolution as the source of truth for versions and dependency ranges, then restored `resolved` to `registry.npmjs.org` and recomputed `integrity` as sha512 from the actual tarball bytes. Entries where the proxy rewrote `resolved`/`integrity` while the version stood still were excluded as noise, along with a spurious `typescript` `devOptional` -> `dev` flip, which is why the diff is 173 lines per file rather than several thousand.