### PR TITLE
Fix HeadTrax sample server: use @as-integrations/express4 for Apollo Server 5

### DIFF
--- a/samples/apps/headtrax/service/package-lock.json
+++ b/samples/apps/headtrax/service/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@apollo/server": "^5.5.1",
+        "@as-integrations/express4": "^1.1.2",
         "better-sqlite3": "^11.7.0",
         "cors": "^2.8.5",
         "express": "^4.22.2"
@@ -429,6 +430,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/@as-integrations/express4": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@as-integrations/express4/-/express4-1.1.2.tgz",
+      "integrity": "sha512-PGeMcwoOKdYnZ4LtsmM7aLNoel3tbK8wKnfyahdRau1qb7wLbuaXB35zg3w34Ov4bm3WJtO3yzd8Bw5jVE+aIQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@apollo/server": "^4.0.0 || ^5.0.0",
+        "express": "^4.0.0"
       }
     },
     "node_modules/@faker-js/faker": {

--- a/samples/apps/headtrax/service/package.json
+++ b/samples/apps/headtrax/service/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@apollo/server": "^5.5.1",
+    "@as-integrations/express4": "^1.1.2",
     "better-sqlite3": "^11.7.0",
     "cors": "^2.8.5",
     "express": "^4.22.2"

--- a/samples/apps/headtrax/service/server.js
+++ b/samples/apps/headtrax/service/server.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 // HeadTrax GraphQL Service
-// Serves employee data from SQLite via Apollo Server 4 + Express.
+// Serves employee data from SQLite via Apollo Server 5 + Express.
 //
 // Usage:
 //   npm start              # default port 4000, db = ./headtrax.db
@@ -12,7 +12,7 @@ import { fileURLToPath } from "url";
 import express from "express";
 import cors from "cors";
 import { ApolloServer } from "@apollo/server";
-import { expressMiddleware } from "@apollo/server/express4";
+import { expressMiddleware } from "@as-integrations/express4";
 import Database from "better-sqlite3";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));


### PR DESCRIPTION
## Problem

`samples/apps/headtrax/service/server.js` crashed immediately on `npm start`:

```
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './express4' is not defined
by "exports" in .../node_modules/@apollo/server/package.json imported from .../server.js
```

**Apollo Server 5 moved the Express integration out of the core package**, so the `@apollo/server/express4` subpath no longer exists. The installed 5.5.1 exports only `.`, `./errors`, `./plugin/*`, and `./standalone`. The sample declares `"@apollo/server": "^5.5.1"` but `server.js` still imported the removed subpath, so the sample server has been unrunnable on `main`.

## Fix

Switch to the standalone integration package:

```diff
-import { expressMiddleware } from "@apollo/server/express4";
+import { expressMiddleware } from "@as-integrations/express4";
```

- Adds `@as-integrations/express4` (1.1.2) to `dependencies`.
- The sample uses `express ^4.22.2`, so **express4** is the correct integration — not `@as-integrations/express5`. The package's peer range is `@apollo/server: ^4.0.0 || ^5.0.0`, `express: ^4.0.0`.
- The middleware keeps the same `expressMiddleware(server, { context })` signature, so **the call site is unchanged** — verified at runtime, not just by reading.
- The file's header comment said "Apollo Server 4"; corrected to 5 to match the declared dependency.

Scope is limited to `server.js`, `package.json`, and `package-lock.json`. `.npmrc` is untouched and the lockfile was regenerated by an install rather than hand-edited.

## Verification

Ran end to end against a real server, not just a startup banner:

| Check | Result |
|---|---|
| `npm ci` from clean | exit 0, 179 packages |
| `npm run generate:small` | 500 employees generated |
| `node server.js` | startup banner, no crash |
| `GET /health` | `{"ok":true,...}` |
| GraphQL `stats` / `departments` / `employees` | real rows returned |
| FTS `searchQuery` | known surname → exactly 1 hit |
| FTS negative control | nonsense term → `totalCount: 0` |
| Nested `manager` / `directReports` | hierarchy resolves correctly |

The FTS negative control matters: without it, "rows came back" would be consistent with the search argument being ignored entirely. Getting exactly 1 hit for a known surname and 0 for a nonsense term shows the filter is genuinely applied.

The `manager` field returns `null` unless `managerId` is included in `select` — that is the existing select-projection behavior, not a regression; with `managerId` selected the full reporting chain resolves.

Lockfile integrity was independently cross-checked: the registry proxy used in my environment records a legacy `sha1-` hash, so the new entry's `resolved`/`integrity` were normalized to the canonical `registry.npmjs.org` URL and `sha512-` value. That hash is confirmed two ways — the upstream `dist.shasum` matches the downloaded tarball, and `npm ci` verifies integrity on install and passed. All 179 `resolved` URLs in the lockfile point at `registry.npmjs.org`.

## Known limitation (not fixed here)

**The sample requires Node 22.** `better-sqlite3 ^11.7.0` (resolves to 11.10.0) cannot compile on Node 26 — it uses V8 APIs removed there (`v8::Object::GetPrototype`, `v8::Context::GetIsolate`, `v8::PropertyCallbackInfo::This`), producing `error C2039`. On Node 22 a prebuilt binary is downloaded and `npm ci` just works. Deliberately left alone to keep this PR focused on the crash; upgrading `better-sqlite3` is a separate change.