### PR TITLE
Fix lint and TypeScript errors across the three React Native harness projects

### DIFF
--- a/tests/startup_perf/BlankRNW/.eslintrc.js
+++ b/tests/startup_perf/BlankRNW/.eslintrc.js
@@ -1,4 +1,8 @@
 module.exports = {
   root: true,
   extends: '@react-native',
+  // index.js anchors a wall-clock T0 on `globalThis` before any import. The
+  // shared @react-native config doesn't enable an environment that declares
+  // that ES2020 global, so no-undef flags it.
+  env: {es2020: true},
 };

--- a/tests/startup_perf/BlankRNW/globals.d.ts
+++ b/tests/startup_perf/BlankRNW/globals.d.ts
@@ -1,0 +1,11 @@
+// React Native runtime globals that @react-native/typescript-config's curated
+// `lib` list doesn't declare, so TypeScript reports TS2304 for them.
+//
+// `global` is only ever reached through an explicit `(global as any)` cast to
+// read the `__PERF_T0` anchor that index.js sets before the first import.
+declare const global: typeof globalThis;
+
+declare function requestIdleCallback(
+  callback: (deadline: {timeRemaining(): number; didTimeout: boolean}) => void,
+  options?: {timeout: number},
+): number;

--- a/tests/startup_perf/BlankRNW/package.json
+++ b/tests/startup_perf/BlankRNW/package.json
@@ -6,6 +6,7 @@
     "windows": "npx @react-native-community/cli run-windows",
     "windows-debug": "react-native run-windows --arch x64",
     "lint": "eslint .",
+    "typecheck": "tsc --noEmit",
     "start": "react-native start"
   },
   "dependencies": {

--- a/tests/startup_perf/BlankRNW/tsconfig.json
+++ b/tests/startup_perf/BlankRNW/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "extends": "@react-native/typescript-config",
+  "compilerOptions": {
+    "types": []
+  },
   "include": ["**/*.ts", "**/*.tsx"],
   "exclude": ["**/node_modules", "**/Pods"]
 }

--- a/tests/stress_perf_rn/StocksGrid/App.tsx
+++ b/tests/stress_perf_rn/StocksGrid/App.tsx
@@ -33,7 +33,6 @@ import {
   ROWS,
   TOTAL_ITEMS,
   StockDataSource,
-  formatCell,
 } from './StockDataSource';
 import { PerfTracker } from './PerfTracker';
 
@@ -83,8 +82,8 @@ const StockCell = React.memo(function StockCell({
 // Precomputed text styles — picked by isUp instead of an inline {color: ...}
 // object that would allocate per render and defeat downstream caching.
 const cellTextStyles = StyleSheet.create({
-  up:   { color: '#008000', fontSize: 8, paddingHorizontal: 2, paddingVertical: 1 },
-  down: { color: '#FF0000', fontSize: 8, paddingHorizontal: 2, paddingVertical: 1 },
+  up:   { color: GREEN, fontSize: 8, paddingHorizontal: 2, paddingVertical: 1 },
+  down: { color: RED, fontSize: 8, paddingHorizontal: 2, paddingVertical: 1 },
 });
 
 // ── App ─────────────────────────────────────────────────────────────────────

--- a/tests/stress_perf_rn/StocksGrid/globals.d.ts
+++ b/tests/stress_perf_rn/StocksGrid/globals.d.ts
@@ -1,0 +1,10 @@
+// `performance` is supplied by the React Native runtime (Hermes), but
+// @react-native/typescript-config pins a curated `lib` list that has no DOM
+// entry, so TypeScript cannot see the global and reports TS2304 on every
+// `performance.now()` in PerfTracker.
+//
+// Only `now()` is declared: the `memory` reading is non-standard and already
+// goes through an explicit `(performance as any).memory` cast.
+declare const performance: {
+  now(): number;
+};

--- a/tests/stress_perf_rn/StocksGrid/package.json
+++ b/tests/stress_perf_rn/StocksGrid/package.json
@@ -6,6 +6,7 @@
     "windows": "npx @react-native-community/cli run-windows",
     "windows-debug": "react-native run-windows --arch x64",
     "lint": "eslint .",
+    "typecheck": "tsc --noEmit",
     "start": "react-native start",
     "test": "jest",
     "test:windows": "jest --config jest.config.windows.js"

--- a/tests/stress_perf_rn/VirtualList/App.tsx
+++ b/tests/stress_perf_rn/VirtualList/App.tsx
@@ -114,6 +114,12 @@ export default function App(props: AppProps) {
       }
     });
     return stop;
+    // The frame loop must be installed exactly once for the component's
+    // lifetime — re-running it would restart the tween mid-benchmark and
+    // corrupt the measurements. `finishBenchmark` is also declared below this
+    // effect, so listing it here would throw on first render (TDZ); it is
+    // reached through the always-current closure instead.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const finishBenchmark = useCallback(() => {

--- a/tests/stress_perf_rn/VirtualList/globals.d.ts
+++ b/tests/stress_perf_rn/VirtualList/globals.d.ts
@@ -1,0 +1,10 @@
+// `performance` is supplied by the React Native runtime (Hermes), but
+// @react-native/typescript-config pins a curated `lib` list that has no DOM
+// entry, so TypeScript cannot see the global and reports TS2304 on every
+// `performance.now()` in PerfTracker.
+//
+// Only `now()` is declared: the `memory` reading is non-standard and already
+// goes through an explicit `(performance as any).memory` cast.
+declare const performance: {
+  now(): number;
+};

--- a/tests/stress_perf_rn/VirtualList/package.json
+++ b/tests/stress_perf_rn/VirtualList/package.json
@@ -6,6 +6,7 @@
     "windows": "npx @react-native-community/cli run-windows",
     "windows-debug": "react-native run-windows --arch x64",
     "lint": "eslint .",
+    "typecheck": "tsc --noEmit",
     "start": "react-native start",
     "test": "jest",
     "test:windows": "jest --config jest.config.windows.js"


### PR DESCRIPTION
Follow-up to #1175. That PR fixed the HeadTrax sample server; this one audits **every** Node project in the repo and fixes what's broken in the three React Native harnesses.

## Audit results

| Project | `npm ci` | build / compile | `lint` | typecheck |
|---|---|---|---|---|
| `samples/apps/headtrax/service` | pass | pass | – | – |
| `tools/figma-plugin` | pass | pass (`tsc && build-ui.mjs`) | – | pass |
| `src/vscode-reactor` | pass | pass (`tsc -p ./`, TS 7.0.2) | – | pass |
| `tests/stress_perf_rn/StocksGrid` | pass (857 pkgs) | – | **fail (3 errors)** | **fail (6× TS2304)** |
| `tests/stress_perf_rn/VirtualList` | pass | – | **fail (1 error)** | **fail (5× TS2304)** |
| `tests/startup_perf/BlankRNW` | pass (786 pkgs) | – | **fail (1 error)** | **fail (TS2688)** |

The two TypeScript projects and the (now-fixed) HeadTrax service are healthy. The three RN projects all fail their declared `lint` script and none of them type-check.

**Why this rotted:** no workflow in `.github/workflows` has a `setup-node` or `npm` step — there is zero CI coverage for any Node project in this repo. (Verified with a positive control: the same search finds 41 `runs-on` and 169 `dotnet` matches in those files.)

## Lint fixes

- **StocksGrid** — removed the unused `formatCell` import, and pointed the precomputed cell styles at the existing `GREEN`/`RED` constants instead of re-inlining the same two hex literals. The values are byte-identical, so rendering is unchanged; this resolves the unused-variable errors without deleting the named constants.
- **VirtualList** — the always-on frame loop deliberately uses `[]` deps. Satisfying `react-hooks/exhaustive-deps` here would be actively wrong: re-running the effect restarts the tween mid-benchmark and corrupts the measurement, and `finishBenchmark` is declared *below* the effect, so naming it in the dep array throws a TDZ `ReferenceError` on first render. Documented and disabled at that single site rather than changing behavior.
- **BlankRNW** — `index.js` anchors `__PERF_T0` on `globalThis`, which the shared `@react-native` eslint environment doesn't declare. Enabled `env: es2020`.

## TypeScript fixes

`@react-native/typescript-config` pins `types: ["jest"]` and a curated `lib` list with no DOM entry, so RN runtime globals are invisible to `tsc`.

- **StocksGrid / VirtualList** — `performance.now()` raised TS2304 eleven times. Added a `globals.d.ts` declaring only `now()`; the non-standard `memory` read already goes through an explicit `(performance as any)` cast, so nothing more is needed.
- **BlankRNW** — it has no jest and no `@types/jest`, so the inherited `types: ["jest"]` failed with TS2688 *before checking anything*. Overriding it to `[]` then surfaced two genuine errors the fatal config error had been masking (`global`, `requestIdleCallback`), both now declared in its `globals.d.ts`. Overriding beat adding an unused `@types/jest` dependency to a project with no tests.

Each project also gains a `typecheck` script, so this is verifiable rather than latent.

## Verification

Per project, `npm run lint` and `npm run typecheck` both exit 0 — run against the exact committed dependency state. StocksGrid additionally still Metro-bundles (1,021,436 bytes).

Because a green run proves little on its own, I mutation-checked both guards:

| Mutation | Expected | Actual |
|---|---|---|
| delete `globals.d.ts` | typecheck fails | exit **2**, `TS2304: Cannot find name 'performance'` |
| restore it | passes | exit **0** |
| re-add unused `formatCell` import | lint fails | exit **1**, `'formatCell' is defined but never used` |
| remove it again | passes | exit **0** |

(My first mutation attempt reported a false pass — `Select-Object -First N` truncates the PowerShell pipeline and discards the real exit code, and a CRLF mismatch meant the edit never applied. Both were harness bugs; the numbers above are from the corrected run.)

No lockfile, `.npmrc`, or dependency changes in this PR.

## Found but deliberately NOT fixed here — the RN apps cannot build at all

While auditing I found a more serious, separate problem, filed as its own issue rather than bundled in here.

All three RN projects depend on **`react-native-windows@1.0.0`, which is a placeholder package containing only a `package.json`** — no code. The real react-native-windows ships on the `0.x` line (`latest` is `0.84.0`; `v0.82-stable` is `0.82.8`). Dependabot bumped `^0.82.5` → `^1.0.0` in #127/#123/#156 because `1.0.0` sorts above every `0.x`, deleting 1,869 lines of dependency subtree in the process.

Consequences, all measured:

- the CLI resolves platforms as `['ios', 'android']` — no `windows`, so `npm run windows` cannot work
- `Microsoft.ReactNative.Composition.CppApp.props`, which the checked-in `.vcxproj` imports from `node_modules\react-native-windows\`, does not exist — and the project has an explicit `<Error>` for exactly that missing file
- `scripts/rnw-dependencies.ps1` and `@react-native-windows/cli`, both referenced by `tests/stress_perf_rn/README.md`, do not exist

Installing the real `0.82.5` flips every one of those (`windows` platform appears, the PropertySheets resolve, `react-native bundle --platform windows` succeeds) and matches the checked-in native project, which says `<!-- This project was created with react-native-windows 0.82.5 -->` and pins `Microsoft.ReactNative 0.82.5`.

I did not include that fix because it is **not a clean one-line revert**: restoring RNW 0.82.5 also restores `@xmldom/xmldom@0.7.13` (deprecated, "critical issues") via `@react-native-windows/cli`, which is precisely what #127/#156 and #1169 ("Clear all 17 Component Governance alerts") were removing. Choosing between a buildable harness and those alerts is a Component Governance policy call that belongs to the maintainers, and I can't validate the native build in this environment. Details and evidence are in the issue.

I'd also suggest adding a small CI job running `npm ci && npm run lint && npm run typecheck` for these projects — it would have caught every issue in this PR, and the HeadTrax crash in #1175.