### PR TITLE
fix(tray): avoid duplicate mouse notifications

### DIFF
--- a/src/Reactor/Hosting/Shell/TrayHiddenWindow.cs
+++ b/src/Reactor/Hosting/Shell/TrayHiddenWindow.cs
@@ -190,9 +190,13 @@ internal sealed class TrayHiddenWindow : IDisposable
         {
             try
             {
+                // NOTIFYICON_VERSION_4 wire protocol:
+                // Explorer forwards both the legacy mouse message (WM_LBUTTONUP / WM_RBUTTONUP)
+                // and the version-4 semantic notification (NIN_SELECT / WM_CONTEXTMENU) for each
+                // physical user interaction. Handling both duplicates Click and RightClick (issue #1180).
+                // We handle only the v4 semantic notifications + WM_LBUTTONDBLCLK.
                 switch (mouseMessage)
                 {
-                    case TrayIconComInterop.WM_LBUTTONUP:
                     case TrayIconComInterop.NIN_SELECT:
                     case TrayIconComInterop.NIN_KEYSELECT:
                         hit.OnClick?.Invoke();
@@ -200,7 +204,6 @@ internal sealed class TrayHiddenWindow : IDisposable
                     case TrayIconComInterop.WM_LBUTTONDBLCLK:
                         hit.OnDoubleClick?.Invoke();
                         break;
-                    case TrayIconComInterop.WM_RBUTTONUP:
                     case TrayIconComInterop.WM_CONTEXTMENU:
                         hit.OnRightClick?.Invoke();
                         break;


### PR DESCRIPTION
## Summary

Fixes duplicate tray icon mouse event notifications when using `NOTIFYICON_VERSION_4`.

`TrayHiddenWindow.DispatchCallback` currently handles both legacy mouse messages and the corresponding semantic notifications, causing a single tray interaction to trigger `Click` or `RightClick` more than once. This change removes the duplicate legacy message handling while preserving the existing semantic notifications and double-click behavior.

## Linked issue / spec

Fixes #1180

## Test plan

- Reviewed the tray callback dispatch path and the `NOTIFYICON_VERSION_4` notification handling.
- Removed `WM_LBUTTONUP` from `Click` dispatch and `WM_RBUTTONUP` from `RightClick` dispatch.
- Verified that `NIN_SELECT` and `NIN_KEYSELECT` remain mapped to `Click`.
- Verified that `WM_CONTEXTMENU` remains mapped to `RightClick`.
- Verified that `WM_LBUTTONDBLCLK` remains mapped to `DoubleClick`.
- Confirmed the final change is limited to `src/Reactor/Hosting/Shell/TrayHiddenWindow.cs`.
- Local Windows/.NET tests could not be run because development is being performed on macOS without the .NET SDK and Windows App SDK environment.

## Risk / breaking changes

No public API changes.

This is a localized change to tray icon callback dispatch. Legacy `WM_LBUTTONUP` and `WM_RBUTTONUP` messages are no longer treated as separate event triggers when the corresponding `NOTIFYICON_VERSION_4` semantic notifications are received.

Existing keyboard selection, right-click context-menu, and double-click handling are preserved.