### PR TITLE
Fix localization extraction of icon glyphs

### DIFF
--- a/src/Reactor.Cli/Loc/LocalizableStringScanner.cs
+++ b/src/Reactor.Cli/Loc/LocalizableStringScanner.cs
@@ -220,7 +220,7 @@ internal static class LocalizableStringScanner
         private void ProcessStringLiteral(LiteralExpressionSyntax literal, string className, string context)
         {
             var value = literal.Token.ValueText;
-            if (string.IsNullOrWhiteSpace(value)) return;
+            if (string.IsNullOrWhiteSpace(value) || IsPrivateUseOnly(value)) return;
 
             _results.Add(new LocalizableString
             {
@@ -231,6 +231,28 @@ internal static class LocalizableStringScanner
                 SpanStart = literal.SpanStart,
                 SpanLength = literal.Span.Length,
             });
+        }
+
+        private static bool IsPrivateUseOnly(string value)
+        {
+            if (value.Length == 0) return false;
+
+            for (var i = 0; i < value.Length; i++)
+            {
+                var codePoint = (int)value[i];
+                if (char.IsHighSurrogate(value[i]) && i + 1 < value.Length && char.IsLowSurrogate(value[i + 1]))
+                {
+                    codePoint = char.ConvertToUtf32(value[i], value[++i]);
+                }
+
+                var isPrivateUse = (codePoint >= 0xE000 && codePoint <= 0xF8FF)
+                    || (codePoint >= 0xF0000 && codePoint <= 0xFFFFD)
+                    || (codePoint >= 0x100000 && codePoint <= 0x10FFFD);
+                if (!isPrivateUse)
+                    return false;
+            }
+
+            return true;
         }
 
         private void ProcessInterpolatedString(InterpolatedStringExpressionSyntax interpolated, string className, string context)

--- a/tests/Reactor.Tests/Localization/LocalizableStringScannerTests.cs
+++ b/tests/Reactor.Tests/Localization/LocalizableStringScannerTests.cs
@@ -293,6 +293,27 @@ public class LocalizableStringScannerTests
     }
 
     [Fact]
+    public void PrivateUseOnlyString_Skipped()
+    {
+        var source = """
+            class App : Component {
+                public override Element Render() {
+                    return VStack(
+                        TextBlock("\uE74D"),
+                        TextBlock("\uE73A"),
+                        TextBlock("\U000F0000"),
+                        TextBlock("\uE74D Delete"));
+                }
+            }
+            """;
+
+        var results = Scan(source);
+
+        Assert.Single(results);
+        Assert.Equal("\uE74D Delete", results[0].Value);
+    }
+
+    [Fact]
     public void MultipleElementsInMethod_AllDetected()
     {
         var source = """


### PR DESCRIPTION
## Summary
Fixes #1132

Fixes localization extraction of Segoe Fluent icon glyphs.

## Changes

- Skip string literals containing only Private Use Area code points.
- Support BMP and supplementary Private Use Area ranges.
- Preserve mixed icon and text strings for translation.
- Add regression coverage for icon-only literals.

This prevents `mur loc extract --rewrite` from routing decorative icon glyphs through `t.Message(...)`.
