### PR TITLE
Fix localization extraction for plural ternaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ Conventions for contributors:
 - Localization extraction now converts recognized count-based singular/plural ternaries
   into ICU plural messages (spec 005 Â§10.4, #1131).
 - Localization extraction normalizes boolean select arguments to the string keys expected
-  by ICU MessageFormat when rewriting source (spec 005 Â§10.4, #1131).
+  by ICU MessageFormat when rewriting source (spec 005 §10.4, #1131).
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,11 @@ Conventions for contributors:
 
 ### Changed
 
+- Localization extraction now converts recognized count-based singular/plural ternaries
+  into ICU plural messages (spec 005 Â§10.4, #1131).
+- Localization extraction normalizes boolean select arguments to the string keys expected
+  by ICU MessageFormat when rewriting source (spec 005 Â§10.4, #1131).
+
 ### Deprecated
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ Conventions for contributors:
 ### Changed
 
 - Localization extraction now converts recognized count-based singular/plural ternaries
-  into ICU plural messages (spec 005 Â§10.4, #1131).
+  into ICU plural messages (spec 005 §10.4, #1131).
 - Localization extraction normalizes boolean select arguments to the string keys expected
   by ICU MessageFormat when rewriting source (spec 005 §10.4, #1131).
 

--- a/docs/reference/localization-howto.md
+++ b/docs/reference/localization-howto.md
@@ -239,16 +239,14 @@ After extraction, manually address:
 
 ## Phase 3: Enhance ICU messages
 
-The extractor produces simple `{variable}` placeholders. For production
-quality, edit the `.resw` values to add ICU features:
+The extractor produces named placeholders and recognizes common count-based
+ternaries, such as `$"{count} item{(count == 1 ? "" : "s")}"`, as ICU plural
+messages. Edit the `.resw` values when you need richer ICU features:
 
 ### Plurals
 
 ```xml
-<!-- Before (extracted) -->
-<data name="ItemCount"><value>{count} items</value></data>
-
-<!-- After (hand-edited) -->
+<!-- Extracted from a count-based ternary -->
 <data name="ItemCount">
   <value>{count, plural, one {# item} other {# items}}</value>
 </data>

--- a/docs/specs/005-localization-design.md
+++ b/docs/specs/005-localization-design.md
@@ -783,6 +783,7 @@ interpolation hole (`{expression}`) is mapped to a named ICU placeholder:
 | `$"Total: {price:C}"` | `Total: {price, number, currency}` | `new { price }` |
 | `$"Due: {date:d}"` | `Due: {date, date, short}` | `new { date }` |
 | `$"Score: {pct:P0}"` | `Score: {pct, number, percent}` | `new { pct }` |
+| `$"{count} item{(count == 1 ? "" : "s")}"` | `{count, plural, one {# item} other {# items}}` | `new { count }` |
 
 **Rules for expression → placeholder name:**
 - Simple variable: `{count}` → `{count}` (keep as-is)
@@ -862,9 +863,11 @@ class InboxPage : Component
 </data>
 ```
 
-Note: the CLI adds a comment hint (`consider adding plural support`) when it detects a
-variable named `count`, `total`, `num*`, or similar quantity-suggesting names adjacent to
-a noun. This nudges the developer or localizer to add ICU plural forms.
+The extractor recognizes `== 1` / `!= 1` ternaries with string-literal arms and emits an
+ICU plural message when it can capture the whole phrase. For simple quantity placeholders
+that do not use a recognized ternary, the CLI retains the `consider adding plural support`
+hint. More complex plural rules, such as a dedicated zero form, can still be added by a
+developer or localizer.
 
 **Step 3 — Developer or localizer upgrades ICU in en-US .resw:**
 

--- a/src/Reactor.Cli/Loc/InterpolationConverter.cs
+++ b/src/Reactor.Cli/Loc/InterpolationConverter.cs
@@ -37,6 +37,7 @@ internal static class InterpolationConverter
     private static readonly HashSet<string> QuantityHintNames = new(StringComparer.OrdinalIgnoreCase)
     {
         "count", "total", "length", "size", "amount", "quantity",
+        "remaining",
     };
 
     public static (string? icuMessage, Dictionary<string, string>? argumentMap, List<string> warnings)
@@ -46,6 +47,7 @@ internal static class InterpolationConverter
         var argumentMap = new Dictionary<string, string>();
         var warnings = new List<string>();
         var usedNames = new HashSet<string>();
+        var emittedHoleNames = new Dictionary<int, string>();
 
         for (var contentIndex = 0; contentIndex < interpolated.Contents.Count; contentIndex++)
         {
@@ -65,13 +67,13 @@ internal static class InterpolationConverter
                         expr = parens.Expression;
 
                     // Ternary with string-literal branches → ICU select
-                    if (TryConvertPluralSuffix(interpolated, contentIndex, expr, icuParts, usedNames, argumentMap, out var suffixPluralIcu))
+                    if (TryConvertPluralSuffix(interpolated, contentIndex, expr, icuParts, emittedHoleNames, warnings, out var suffixPluralIcu, out var suppressStandalonePlural))
                     {
                         icuParts.Add(suffixPluralIcu!);
                         break;
                     }
 
-                    if (TryConvertTernaryPlural(expr, usedNames, argumentMap, out var pluralIcu))
+                    if (!suppressStandalonePlural && TryConvertTernaryPlural(expr, usedNames, argumentMap, out var pluralIcu))
                     {
                         icuParts.Add(pluralIcu!);
                         break;
@@ -93,19 +95,7 @@ internal static class InterpolationConverter
                     }
 
                     // Ensure unique param names
-                    var baseName = paramName ?? $"arg{usedNames.Count}";
-                    var uniqueName = baseName;
-                    var suffix = 2;
-                    while (!usedNames.Add(uniqueName))
-                    {
-                        uniqueName = $"{baseName}{suffix++}";
-                    }
-
-                    // Map back to original expression
-                    if (exprText != uniqueName)
-                    {
-                        argumentMap[uniqueName] = exprText;
-                    }
+                    var uniqueName = AddParameter(paramName, exprText, usedNames, argumentMap);
 
                     // Convert format specifier to ICU formatter
                     var formatClause = hole.FormatClause;
@@ -131,6 +121,7 @@ internal static class InterpolationConverter
                     {
                         icuParts.Add($"{{{uniqueName}}}");
                     }
+                    emittedHoleNames[contentIndex] = uniqueName;
                     break;
             }
         }
@@ -177,14 +168,10 @@ internal static class InterpolationConverter
 
         // Resolve a parameter name from the condition
         var (condName, condExpr, _) = AnalyzeExpression(ternary.Condition);
-        var baseName = condName ?? $"arg{usedNames.Count}";
-        var uniqueName = baseName;
-        var suffix = 2;
-        while (!usedNames.Add(uniqueName))
-            uniqueName = $"{baseName}{suffix++}";
-
-        if (condExpr != uniqueName)
-            argumentMap[uniqueName] = condExpr;
+        var uniqueName = AddParameter(condName, condExpr, usedNames, argumentMap);
+        // ICU select keys are strings. Normalize the C# boolean condition rather
+        // than passing a bool to the MessageFormat runtime.
+        argumentMap[uniqueName] = $"({condExpr}) ? \"true\" : \"false\"";
 
         var trueText = EscapeForIcu(whenTrueLit.Token.ValueText);
         var falseText = EscapeForIcu(whenFalseLit.Token.ValueText);
@@ -198,15 +185,14 @@ internal static class InterpolationConverter
         int contentIndex,
         ExpressionSyntax expr,
         List<string> icuParts,
-        HashSet<string> usedNames,
-        Dictionary<string, string> argumentMap,
-        out string? icuPlural)
+        IReadOnlyDictionary<int, string> emittedHoleNames,
+        List<string> warnings,
+        out string? icuPlural,
+        out bool suppressStandalonePlural)
     {
         icuPlural = null;
+        suppressStandalonePlural = false;
         if (!TryGetPluralTernary(expr, out var quantity, out var singularText, out var pluralText))
-            return false;
-
-        if (string.IsNullOrEmpty(singularText) == string.IsNullOrEmpty(pluralText))
             return false;
 
         var previousTextIndex = contentIndex - 1;
@@ -233,13 +219,18 @@ internal static class InterpolationConverter
         if (wordStart == trimmedLiteral.Length || icuParts.Count < 2)
             return false;
 
+        // This ternary belongs to the preceding quantity, even if folding cannot proceed.
+        // Do not subsequently emit a second standalone plural for the same quantity.
+        suppressStandalonePlural = true;
+        if (!emittedHoleNames.TryGetValue(previousQuantityIndex, out var uniqueName))
+            return false;
+
+        if (previousQuantityHole.FormatClause is not null)
+            warnings.Add($"Format specifier on quantity '{previousQuantityText}' is represented by the ICU plural number sign");
+
         icuParts.RemoveRange(icuParts.Count - 2, 2);
-        var uniqueName = usedNames.Contains(quantity.name)
-            ? quantity.name
-            : AddParameter(quantity, usedNames, argumentMap);
-        var singular = EscapeForIcu($"#{trimmedLiteral}");
-        var pluralSuffix = string.IsNullOrEmpty(pluralText) ? singularText : pluralText;
-        var plural = EscapeForIcu($"#{trimmedLiteral}{pluralSuffix}");
+        var singular = $"#{EscapeForIcuPluralBody(trimmedLiteral)}{EscapeForIcuPluralBody(singularText)}";
+        var plural = $"#{EscapeForIcuPluralBody(trimmedLiteral)}{EscapeForIcuPluralBody(pluralText)}";
         icuPlural = $"{{{uniqueName}, plural, one {{{singular}}} other {{{plural}}}}}";
         return true;
     }
@@ -255,17 +246,24 @@ internal static class InterpolationConverter
             || (string.IsNullOrEmpty(singularText) && string.IsNullOrEmpty(pluralText)))
             return false;
 
+        // A standalone full-word ternary is only demonstrably plural when the
+        // plural arm is the singular arm plus its English plural suffix. Other
+        // conditionals (for example Enabled/Disabled) remain selects.
+        if (!string.IsNullOrEmpty(singularText) && !string.IsNullOrEmpty(pluralText)
+            && !string.Equals(pluralText, singularText + "s", StringComparison.Ordinal))
+            return false;
+
         var uniqueName = AddParameter(quantity, usedNames, argumentMap);
         if (string.IsNullOrEmpty(singularText) || string.IsNullOrEmpty(pluralText))
         {
-            var singularSuffix = EscapeForIcu(singularText);
-            var pluralSuffix = EscapeForIcu(pluralText);
+            var singularSuffix = EscapeForIcuPluralBody(singularText);
+            var pluralSuffix = EscapeForIcuPluralBody(pluralText);
             icuPlural = $"{{{uniqueName}, plural, one {{{singularSuffix}}} other {{{pluralSuffix}}}}}";
             return true;
         }
 
-        var singular = EscapeForIcu($"# {singularText}");
-        var plural = EscapeForIcu($"# {pluralText}");
+        var singular = $"# {EscapeForIcuPluralBody(singularText)}";
+        var plural = $"# {EscapeForIcuPluralBody(pluralText)}";
         icuPlural = $"{{{uniqueName}, plural, one {{{singular}}} other {{{plural}}}}}";
         return true;
     }
@@ -326,7 +324,7 @@ internal static class InterpolationConverter
             return false;
 
         var (name, exprText, isComplex) = AnalyzeExpression(quantityExpression);
-        if (name is null || isComplex)
+        if (name is null || isComplex || !IsQuantityName(name))
             return false;
 
         quantity = (name, exprText);
@@ -343,16 +341,23 @@ internal static class InterpolationConverter
     private static string AddParameter(
         (string name, string exprText) parameter,
         HashSet<string> usedNames,
+        Dictionary<string, string> argumentMap) =>
+        AddParameter(parameter.name, parameter.exprText, usedNames, argumentMap);
+
+    private static string AddParameter(
+        string? parameterName,
+        string exprText,
+        HashSet<string> usedNames,
         Dictionary<string, string> argumentMap)
     {
-        var baseName = parameter.name;
+        var baseName = parameterName ?? $"arg{usedNames.Count}";
         var uniqueName = baseName;
         var suffix = 2;
         while (!usedNames.Add(uniqueName))
             uniqueName = $"{baseName}{suffix++}";
 
-        if (parameter.exprText != uniqueName)
-            argumentMap[uniqueName] = parameter.exprText;
+        if (exprText != uniqueName)
+            argumentMap[uniqueName] = exprText;
 
         return uniqueName;
     }
@@ -402,4 +407,7 @@ internal static class InterpolationConverter
         // and single quotes
         return text.Replace("'", "''").Replace("{", "'{'").Replace("}", "'}'");
     }
+
+    private static string EscapeForIcuPluralBody(string text) =>
+        EscapeForIcu(text).Replace("#", "'#'");
 }

--- a/src/Reactor.Cli/Loc/InterpolationConverter.cs
+++ b/src/Reactor.Cli/Loc/InterpolationConverter.cs
@@ -33,11 +33,10 @@ internal static class InterpolationConverter
         ["f"] = "date, full",
     };
 
-    // Variable names that suggest quantities (for plural hint comments)
+    // Variable names that identify standalone plural candidates.
     private static readonly HashSet<string> QuantityHintNames = new(StringComparer.OrdinalIgnoreCase)
     {
         "count", "total", "length", "size", "amount", "quantity",
-        "remaining",
     };
 
     public static (string? icuMessage, Dictionary<string, string>? argumentMap, List<string> warnings)
@@ -133,7 +132,7 @@ internal static class InterpolationConverter
     }
 
     /// <summary>
-    /// Checks if a parameter name suggests a quantity (for plural hint comments).
+    /// Checks if a parameter name suggests a quantity.
     /// </summary>
     public static bool IsQuantityName(string name)
     {
@@ -192,7 +191,7 @@ internal static class InterpolationConverter
     {
         icuPlural = null;
         suppressStandalonePlural = false;
-        if (!TryGetPluralTernary(expr, out var quantity, out var singularText, out var pluralText))
+        if (!TryGetPluralTernary(expr, requireQuantityName: false, out var quantity, out var singularText, out var pluralText))
             return false;
 
         var previousTextIndex = contentIndex - 1;
@@ -210,6 +209,10 @@ internal static class InterpolationConverter
         if (!string.Equals(previousQuantityText, quantity.exprText, StringComparison.Ordinal))
             return false;
 
+        // This ternary belongs to the preceding quantity, even if folding cannot proceed.
+        // Do not subsequently emit a second standalone plural for the same quantity.
+        suppressStandalonePlural = true;
+
         var literal = previousText.TextToken.ValueText;
         var trimmedLiteral = literal.TrimEnd();
         var wordStart = trimmedLiteral.Length;
@@ -219,9 +222,6 @@ internal static class InterpolationConverter
         if (wordStart == trimmedLiteral.Length || icuParts.Count < 2)
             return false;
 
-        // This ternary belongs to the preceding quantity, even if folding cannot proceed.
-        // Do not subsequently emit a second standalone plural for the same quantity.
-        suppressStandalonePlural = true;
         if (!emittedHoleNames.TryGetValue(previousQuantityIndex, out var uniqueName))
             return false;
 
@@ -242,7 +242,7 @@ internal static class InterpolationConverter
         out string? icuPlural)
     {
         icuPlural = null;
-        if (!TryGetPluralTernary(expr, out var quantity, out var singularText, out var pluralText)
+        if (!TryGetPluralTernary(expr, requireQuantityName: true, out var quantity, out var singularText, out var pluralText)
             || (string.IsNullOrEmpty(singularText) && string.IsNullOrEmpty(pluralText)))
             return false;
 
@@ -270,6 +270,7 @@ internal static class InterpolationConverter
 
     private static bool TryGetPluralTernary(
         ExpressionSyntax expr,
+        bool requireQuantityName,
         out (string name, string exprText) quantity,
         out string singularText,
         out string pluralText)
@@ -279,7 +280,7 @@ internal static class InterpolationConverter
         pluralText = string.Empty;
 
         if (expr is not ConditionalExpressionSyntax ternary
-            || !TryGetPluralCondition(ternary.Condition, out quantity, out var trueIsSingular))
+            || !TryGetPluralCondition(ternary.Condition, requireQuantityName, out quantity, out var trueIsSingular))
             return false;
 
         if (ternary.WhenTrue is not LiteralExpressionSyntax trueLiteral
@@ -304,6 +305,7 @@ internal static class InterpolationConverter
 
     private static bool TryGetPluralCondition(
         ExpressionSyntax condition,
+        bool requireQuantityName,
         out (string name, string exprText) quantity,
         out bool trueIsSingular)
     {
@@ -324,7 +326,7 @@ internal static class InterpolationConverter
             return false;
 
         var (name, exprText, isComplex) = AnalyzeExpression(quantityExpression);
-        if (name is null || isComplex || !IsQuantityName(name))
+        if (name is null || isComplex || (requireQuantityName && !IsQuantityName(name)))
             return false;
 
         quantity = (name, exprText);

--- a/src/Reactor.Cli/Loc/InterpolationConverter.cs
+++ b/src/Reactor.Cli/Loc/InterpolationConverter.cs
@@ -229,8 +229,8 @@ internal static class InterpolationConverter
             warnings.Add($"Format specifier on quantity '{previousQuantityText}' is represented by the ICU plural number sign");
 
         icuParts.RemoveRange(icuParts.Count - 2, 2);
-        var singular = $"#{EscapeForIcuPluralBody(trimmedLiteral)}{EscapeForIcuPluralBody(singularText)}";
-        var plural = $"#{EscapeForIcuPluralBody(trimmedLiteral)}{EscapeForIcuPluralBody(pluralText)}";
+        var singular = $"#{EscapeForIcuPluralBody(literal)}{EscapeForIcuPluralBody(singularText)}";
+        var plural = $"#{EscapeForIcuPluralBody(literal)}{EscapeForIcuPluralBody(pluralText)}";
         icuPlural = $"{{{uniqueName}, plural, one {{{singular}}} other {{{plural}}}}}";
         return true;
     }

--- a/src/Reactor.Cli/Loc/InterpolationConverter.cs
+++ b/src/Reactor.Cli/Loc/InterpolationConverter.cs
@@ -47,8 +47,9 @@ internal static class InterpolationConverter
         var warnings = new List<string>();
         var usedNames = new HashSet<string>();
 
-        foreach (var content in interpolated.Contents)
+        for (var contentIndex = 0; contentIndex < interpolated.Contents.Count; contentIndex++)
         {
+            var content = interpolated.Contents[contentIndex];
             switch (content)
             {
                 case InterpolatedStringTextSyntax text:
@@ -64,6 +65,18 @@ internal static class InterpolationConverter
                         expr = parens.Expression;
 
                     // Ternary with string-literal branches → ICU select
+                    if (TryConvertPluralSuffix(interpolated, contentIndex, expr, icuParts, usedNames, argumentMap, out var suffixPluralIcu))
+                    {
+                        icuParts.Add(suffixPluralIcu!);
+                        break;
+                    }
+
+                    if (TryConvertTernaryPlural(expr, usedNames, argumentMap, out var pluralIcu))
+                    {
+                        icuParts.Add(pluralIcu!);
+                        break;
+                    }
+
                     if (TryConvertTernarySelect(expr, usedNames, argumentMap, out var selectIcu))
                     {
                         icuParts.Add(selectIcu!);
@@ -178,6 +191,170 @@ internal static class InterpolationConverter
 
         icuSelect = $"{{{uniqueName}, select, true {{{trueText}}} false {{{falseText}}}}}";
         return true;
+    }
+
+    private static bool TryConvertPluralSuffix(
+        InterpolatedStringExpressionSyntax interpolated,
+        int contentIndex,
+        ExpressionSyntax expr,
+        List<string> icuParts,
+        HashSet<string> usedNames,
+        Dictionary<string, string> argumentMap,
+        out string? icuPlural)
+    {
+        icuPlural = null;
+        if (!TryGetPluralTernary(expr, out var quantity, out var singularText, out var pluralText))
+            return false;
+
+        if (string.IsNullOrEmpty(singularText) == string.IsNullOrEmpty(pluralText))
+            return false;
+
+        var previousTextIndex = contentIndex - 1;
+        var previousQuantityIndex = contentIndex - 2;
+        if (previousQuantityIndex < 0
+            || interpolated.Contents[previousTextIndex] is not InterpolatedStringTextSyntax previousText
+            || interpolated.Contents[previousQuantityIndex] is not InterpolationSyntax previousQuantityHole)
+            return false;
+
+        var previousExpression = previousQuantityHole.Expression;
+        while (previousExpression is ParenthesizedExpressionSyntax parens)
+            previousExpression = parens.Expression;
+
+        var previousQuantityText = AnalyzeExpression(previousExpression).exprText;
+        if (!string.Equals(previousQuantityText, quantity.exprText, StringComparison.Ordinal))
+            return false;
+
+        var literal = previousText.TextToken.ValueText;
+        var trimmedLiteral = literal.TrimEnd();
+        var wordStart = trimmedLiteral.Length;
+        while (wordStart > 0 && char.IsLetter(trimmedLiteral[wordStart - 1]))
+            wordStart--;
+
+        if (wordStart == trimmedLiteral.Length || icuParts.Count < 2)
+            return false;
+
+        icuParts.RemoveRange(icuParts.Count - 2, 2);
+        var uniqueName = usedNames.Contains(quantity.name)
+            ? quantity.name
+            : AddParameter(quantity, usedNames, argumentMap);
+        var singular = EscapeForIcu($"#{trimmedLiteral}");
+        var pluralSuffix = string.IsNullOrEmpty(pluralText) ? singularText : pluralText;
+        var plural = EscapeForIcu($"#{trimmedLiteral}{pluralSuffix}");
+        icuPlural = $"{{{uniqueName}, plural, one {{{singular}}} other {{{plural}}}}}";
+        return true;
+    }
+
+    private static bool TryConvertTernaryPlural(
+        ExpressionSyntax expr,
+        HashSet<string> usedNames,
+        Dictionary<string, string> argumentMap,
+        out string? icuPlural)
+    {
+        icuPlural = null;
+        if (!TryGetPluralTernary(expr, out var quantity, out var singularText, out var pluralText)
+            || (string.IsNullOrEmpty(singularText) && string.IsNullOrEmpty(pluralText)))
+            return false;
+
+        var uniqueName = AddParameter(quantity, usedNames, argumentMap);
+        if (string.IsNullOrEmpty(singularText) || string.IsNullOrEmpty(pluralText))
+        {
+            var singularSuffix = EscapeForIcu(singularText);
+            var pluralSuffix = EscapeForIcu(pluralText);
+            icuPlural = $"{{{uniqueName}, plural, one {{{singularSuffix}}} other {{{pluralSuffix}}}}}";
+            return true;
+        }
+
+        var singular = EscapeForIcu($"# {singularText}");
+        var plural = EscapeForIcu($"# {pluralText}");
+        icuPlural = $"{{{uniqueName}, plural, one {{{singular}}} other {{{plural}}}}}";
+        return true;
+    }
+
+    private static bool TryGetPluralTernary(
+        ExpressionSyntax expr,
+        out (string name, string exprText) quantity,
+        out string singularText,
+        out string pluralText)
+    {
+        quantity = default;
+        singularText = string.Empty;
+        pluralText = string.Empty;
+
+        if (expr is not ConditionalExpressionSyntax ternary
+            || !TryGetPluralCondition(ternary.Condition, out quantity, out var trueIsSingular))
+            return false;
+
+        if (ternary.WhenTrue is not LiteralExpressionSyntax trueLiteral
+            || !trueLiteral.IsKind(SyntaxKind.StringLiteralExpression)
+            || ternary.WhenFalse is not LiteralExpressionSyntax falseLiteral
+            || !falseLiteral.IsKind(SyntaxKind.StringLiteralExpression))
+            return false;
+
+        if (trueIsSingular)
+        {
+            singularText = trueLiteral.Token.ValueText;
+            pluralText = falseLiteral.Token.ValueText;
+        }
+        else
+        {
+            singularText = falseLiteral.Token.ValueText;
+            pluralText = trueLiteral.Token.ValueText;
+        }
+
+        return true;
+    }
+
+    private static bool TryGetPluralCondition(
+        ExpressionSyntax condition,
+        out (string name, string exprText) quantity,
+        out bool trueIsSingular)
+    {
+        quantity = default;
+        trueIsSingular = false;
+
+        if (condition is not BinaryExpressionSyntax binary
+            || (binary.Kind() != SyntaxKind.EqualsExpression && binary.Kind() != SyntaxKind.NotEqualsExpression))
+            return false;
+
+        ExpressionSyntax? quantityExpression = null;
+        if (IsOneLiteral(binary.Right))
+            quantityExpression = binary.Left;
+        else if (IsOneLiteral(binary.Left))
+            quantityExpression = binary.Right;
+
+        if (quantityExpression is null)
+            return false;
+
+        var (name, exprText, isComplex) = AnalyzeExpression(quantityExpression);
+        if (name is null || isComplex)
+            return false;
+
+        quantity = (name, exprText);
+        trueIsSingular = binary.Kind() == SyntaxKind.EqualsExpression;
+        return true;
+    }
+
+    private static bool IsOneLiteral(ExpressionSyntax expression) =>
+        expression is LiteralExpressionSyntax literal
+        && literal.IsKind(SyntaxKind.NumericLiteralExpression)
+        && literal.Token.Value is int value
+        && value == 1;
+
+    private static string AddParameter(
+        (string name, string exprText) parameter,
+        HashSet<string> usedNames,
+        Dictionary<string, string> argumentMap)
+    {
+        var baseName = parameter.name;
+        var uniqueName = baseName;
+        var suffix = 2;
+        while (!usedNames.Add(uniqueName))
+            uniqueName = $"{baseName}{suffix++}";
+
+        if (parameter.exprText != uniqueName)
+            argumentMap[uniqueName] = parameter.exprText;
+
+        return uniqueName;
     }
 
     private static (string? name, string exprText, bool isComplex) AnalyzeExpression(ExpressionSyntax expr)

--- a/tests/Reactor.Tests/Localization/InterpolationConverterTests.cs
+++ b/tests/Reactor.Tests/Localization/InterpolationConverterTests.cs
@@ -141,6 +141,47 @@ public class InterpolationConverterTests
     }
 
     [Fact]
+    public void QuantitySuffixTernary_ConvertsToIcuPlural()
+    {
+        var node = ParseInterpolation("$\"{remaining} item{(remaining == 1 ? \"\" : \"s\")} left\"");
+        var (icu, argMap, warnings) = InterpolationConverter.Convert(node);
+
+        Assert.Equal("{remaining, plural, one {# item} other {# items}} left", icu);
+        Assert.Null(argMap);
+        Assert.Empty(warnings);
+    }
+
+    [Fact]
+    public void QuantitySuffixTernary_WithNotEquals_ConvertsToIcuPlural()
+    {
+        var node = ParseInterpolation("$\"{remaining} item{(remaining != 1 ? \"s\" : \"\")} left\"");
+        var (icu, _, warnings) = InterpolationConverter.Convert(node);
+
+        Assert.Equal("{remaining, plural, one {# item} other {# items}} left", icu);
+        Assert.Empty(warnings);
+    }
+
+    [Fact]
+    public void QuantityTernary_WithFullWords_ConvertsToIcuPlural()
+    {
+        var node = ParseInterpolation("$\"{remaining == 1 ? \"item\" : \"items\"}\"");
+        var (icu, _, warnings) = InterpolationConverter.Convert(node);
+
+        Assert.Equal("{remaining, plural, one {# item} other {# items}}", icu);
+        Assert.Empty(warnings);
+    }
+
+    [Fact]
+    public void QuantitySuffixTernary_WithoutAdjacentQuantity_StillUsesIcuPlural()
+    {
+        var node = ParseInterpolation("$\"item{remaining == 1 ? \"\" : \"s\"}\"");
+        var (icu, _, warnings) = InterpolationConverter.Convert(node);
+
+        Assert.Equal("item{remaining, plural, one {} other {s}}", icu);
+        Assert.Empty(warnings);
+    }
+
+    [Fact]
     public void Ternary_WithNonLiteralBranch_StillWarnsComplex()
     {
         var node = ParseInterpolation("$\"Value: {(flag ? GetValue() : \"default\")}\"");

--- a/tests/Reactor.Tests/Localization/InterpolationConverterTests.cs
+++ b/tests/Reactor.Tests/Localization/InterpolationConverterTests.cs
@@ -219,6 +219,16 @@ public class InterpolationConverterTests
     }
 
     [Fact]
+    public void QuantitySuffixTernary_WithLiteralSeparator_PreservesWordSpacing()
+    {
+        var node = ParseInterpolation("$\"{count} unread {(count == 1 ? \"message\" : \"messages\")}\"");
+        var (icu, _, warnings) = InterpolationConverter.Convert(node);
+
+        Assert.Equal("{count, plural, one {# unread message} other {# unread messages}}", icu);
+        Assert.Empty(warnings);
+    }
+
+    [Fact]
     public void QuantitySuffixTernary_EscapesLiteralNumberSigns()
     {
         var node = ParseInterpolation("$\"{count} #item{(count == 1 ? \"\" : \"s\")}\"");
@@ -257,7 +267,7 @@ public class InterpolationConverterTests
         var (icu, _, warnings) = InterpolationConverter.Convert(node);
 
         Assert.Equal("{count, plural, one {# item} other {# items}}", icu);
-        Assert.Contains("Format specifier on quantity 'count'", warnings);
+        Assert.Contains(warnings, warning => warning.Contains("Format specifier on quantity 'count'"));
     }
 
     [Fact]

--- a/tests/Reactor.Tests/Localization/InterpolationConverterTests.cs
+++ b/tests/Reactor.Tests/Localization/InterpolationConverterTests.cs
@@ -125,6 +125,8 @@ public class InterpolationConverterTests
         var (icu, argMap, warnings) = InterpolationConverter.Convert(node);
 
         Assert.Equal("Dark mode: {darkMode, select, true {Yes} false {No}}", icu);
+        Assert.NotNull(argMap);
+        Assert.Equal("(darkMode) ? \"true\" : \"false\"", argMap!["darkMode"]);
         Assert.Empty(warnings);
     }
 
@@ -164,7 +166,7 @@ public class InterpolationConverterTests
     [Fact]
     public void QuantityTernary_WithFullWords_ConvertsToIcuPlural()
     {
-        var node = ParseInterpolation("$\"{remaining == 1 ? \"item\" : \"items\"}\"");
+        var node = ParseInterpolation("$\"{(remaining == 1 ? \"item\" : \"items\")}\"");
         var (icu, _, warnings) = InterpolationConverter.Convert(node);
 
         Assert.Equal("{remaining, plural, one {# item} other {# items}}", icu);
@@ -174,10 +176,55 @@ public class InterpolationConverterTests
     [Fact]
     public void QuantitySuffixTernary_WithoutAdjacentQuantity_StillUsesIcuPlural()
     {
-        var node = ParseInterpolation("$\"item{remaining == 1 ? \"\" : \"s\"}\"");
+        var node = ParseInterpolation("$\"item{(remaining == 1 ? \"\" : \"s\")}\"");
         var (icu, _, warnings) = InterpolationConverter.Convert(node);
 
         Assert.Equal("item{remaining, plural, one {} other {s}}", icu);
+        Assert.Empty(warnings);
+    }
+
+    [Fact]
+    public void NonQuantityEqualityTernary_RemainsSelect()
+    {
+        var node = ParseInterpolation("$\"Status: {(status == 1 ? \"Enabled\" : \"Disabled\")}\"");
+        var (icu, argMap, warnings) = InterpolationConverter.Convert(node);
+
+        Assert.Equal("Status: {arg0, select, true {Enabled} false {Disabled}}", icu);
+        Assert.NotNull(argMap);
+        Assert.Equal("(status == 1) ? \"true\" : \"false\"", argMap!["arg0"]);
+        Assert.Empty(warnings);
+    }
+
+    [Fact]
+    public void QuantitySuffixTernary_ReusesEmittedUniqueParameterName()
+    {
+        var node = ParseInterpolation("$\"{model.Count} pending, {count} item{(count == 1 ? \"\" : \"s\")}\"");
+        var (icu, argMap, warnings) = InterpolationConverter.Convert(node);
+
+        Assert.Equal("{count} pending, {count2, plural, one {# item} other {# items}}", icu);
+        Assert.NotNull(argMap);
+        Assert.Equal("model.Count", argMap!["count"]);
+        Assert.Equal("count", argMap["count2"]);
+        Assert.Empty(warnings);
+    }
+
+    [Fact]
+    public void QuantitySuffixTernary_WithTwoNonEmptyBranches_FoldsIntoOnePlural()
+    {
+        var node = ParseInterpolation("$\"{count} file{(count == 1 ? \" is\" : \"s are\")} selected\"");
+        var (icu, _, warnings) = InterpolationConverter.Convert(node);
+
+        Assert.Equal("{count, plural, one {# file is} other {# files are}} selected", icu);
+        Assert.Empty(warnings);
+    }
+
+    [Fact]
+    public void QuantitySuffixTernary_EscapesLiteralNumberSigns()
+    {
+        var node = ParseInterpolation("$\"{count} #item{(count == 1 ? \"\" : \"s\")}\"");
+        var (icu, _, warnings) = InterpolationConverter.Convert(node);
+
+        Assert.Equal("{count, plural, one {# '#'item} other {# '#'items}}", icu);
         Assert.Empty(warnings);
     }
 
@@ -197,6 +244,7 @@ public class InterpolationConverterTests
     [InlineData("total", true)]
     [InlineData("numItems", true)]
     [InlineData("totalCount", true)]
+    [InlineData("remaining", true)]
     [InlineData("name", false)]
     [InlineData("description", false)]
     public void IsQuantityName_CorrectResults(string name, bool expected)

--- a/tests/Reactor.Tests/Localization/InterpolationConverterTests.cs
+++ b/tests/Reactor.Tests/Localization/InterpolationConverterTests.cs
@@ -138,7 +138,7 @@ public class InterpolationConverterTests
 
         Assert.Equal("Mode: {darkMode, select, true {Yes} false {No}}", icu);
         Assert.NotNull(argMap);
-        Assert.Equal("settings.DarkMode", argMap!["darkMode"]);
+        Assert.Equal("(settings.DarkMode) ? \"true\" : \"false\"", argMap!["darkMode"]);
         Assert.Empty(warnings);
     }
 
@@ -166,20 +166,20 @@ public class InterpolationConverterTests
     [Fact]
     public void QuantityTernary_WithFullWords_ConvertsToIcuPlural()
     {
-        var node = ParseInterpolation("$\"{(remaining == 1 ? \"item\" : \"items\")}\"");
+        var node = ParseInterpolation("$\"{(count == 1 ? \"item\" : \"items\")}\"");
         var (icu, _, warnings) = InterpolationConverter.Convert(node);
 
-        Assert.Equal("{remaining, plural, one {# item} other {# items}}", icu);
+        Assert.Equal("{count, plural, one {# item} other {# items}}", icu);
         Assert.Empty(warnings);
     }
 
     [Fact]
     public void QuantitySuffixTernary_WithoutAdjacentQuantity_StillUsesIcuPlural()
     {
-        var node = ParseInterpolation("$\"item{(remaining == 1 ? \"\" : \"s\")}\"");
+        var node = ParseInterpolation("$\"item{(count == 1 ? \"\" : \"s\")}\"");
         var (icu, _, warnings) = InterpolationConverter.Convert(node);
 
-        Assert.Equal("item{remaining, plural, one {} other {s}}", icu);
+        Assert.Equal("item{count, plural, one {} other {s}}", icu);
         Assert.Empty(warnings);
     }
 
@@ -229,6 +229,38 @@ public class InterpolationConverterTests
     }
 
     [Fact]
+    public void AdjacentQuantityTernary_WithoutANoun_DoesNotDuplicateTheCount()
+    {
+        var node = ParseInterpolation("$\"{count} {(count == 1 ? \"item\" : \"items\")}\"");
+        var (icu, argMap, warnings) = InterpolationConverter.Convert(node);
+
+        Assert.Equal("{count} {arg1, select, true {item} false {items}}", icu);
+        Assert.NotNull(argMap);
+        Assert.Equal("(count == 1) ? \"true\" : \"false\"", argMap!["arg1"]);
+        Assert.Empty(warnings);
+    }
+
+    [Fact]
+    public void QuantitySuffixTernary_WithNonHintName_UsesStructuralEvidence()
+    {
+        var node = ParseInterpolation("$\"{n} file{(n == 1 ? \"\" : \"s\")}\"");
+        var (icu, _, warnings) = InterpolationConverter.Convert(node);
+
+        Assert.Equal("{n, plural, one {# file} other {# files}}", icu);
+        Assert.Empty(warnings);
+    }
+
+    [Fact]
+    public void QuantitySuffixTernary_WithFormatSpecifier_WarnsAboutPluralFormatting()
+    {
+        var node = ParseInterpolation("$\"{count:N0} item{(count == 1 ? \"\" : \"s\")}\"");
+        var (icu, _, warnings) = InterpolationConverter.Convert(node);
+
+        Assert.Equal("{count, plural, one {# item} other {# items}}", icu);
+        Assert.Contains("Format specifier on quantity 'count'", warnings);
+    }
+
+    [Fact]
     public void Ternary_WithNonLiteralBranch_StillWarnsComplex()
     {
         var node = ParseInterpolation("$\"Value: {(flag ? GetValue() : \"default\")}\"");
@@ -244,7 +276,6 @@ public class InterpolationConverterTests
     [InlineData("total", true)]
     [InlineData("numItems", true)]
     [InlineData("totalCount", true)]
-    [InlineData("remaining", true)]
     [InlineData("name", false)]
     [InlineData("description", false)]
     public void IsQuantityName_CorrectResults(string name, bool expected)


### PR DESCRIPTION
Fixes #1131

## Summary

Convert C# numeric singular/plural ternaries into ICU `plural` messages instead of boolean `select` messages.

## Changes

- Detect `count == 1 ? "" : "s"` and reversed `!= 1` patterns.
- Generate ICU plural syntax such as:
  `{remaining, plural, one {# item} other {# items}}`
- Support full-word branches such as `"item"` / `"items"`.
- Preserve regular boolean ternaries as ICU `select`.
- Add regression tests for the supported patterns.

