### PR TITLE
Fix Markdown list content wrapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,12 @@ Conventions for contributors:
 
 ### Changed
 
+- **Markdown list-item defaults now use `GridElement` rather than `StackElement`
+  ([openclaw/openclaw-windows-node#1362](https://github.com/openclaw/openclaw-windows-node/issues/1362)).**
+  `MarkdownOptions.ListItem` still receives an `Element` after default construction
+  and may wrap or replace it. Callbacks that cast the default to `StackElement`
+  must adapt to the Auto/Star Grid.
+
 - **`PoolResetSetCodeFix` now fixes struct-typed `.Set(...)` writes it previously left
   alone (issue #1192).** It could only rewrite a literal `new Thickness(uniform)` or
   `new Thickness(l, t, r, b)`, so every other right-hand side — an opaque local, a
@@ -106,6 +112,13 @@ Conventions for contributors:
 ### Removed
 
 ### Fixed
+
+- **Long Markdown list content wraps within finite available width
+  ([openclaw/openclaw-windows-node#1362](https://github.com/openclaw/openclaw-windows-node/issues/1362)).**
+  Default list rows now measure content in a Star column beside an Auto-sized marker
+  instead of a horizontal StackPanel's infinite-width measure. Plain, formatted,
+  ordered, nested, task-list and multi-block content keep their markers, spacing
+  and selection, including in unified rich-text mode.
 
 - `REACTOR_MOD_002` now covers four properties `ElementPool.CleanElement` resets that no
   diagnostic mentioned at all: `IsHitTestVisible`, `Stretch`, `StretchDirection` and `IsActive`.

--- a/docs/_pipeline/templates/text-and-media.md.dt
+++ b/docs/_pipeline/templates/text-and-media.md.dt
@@ -215,7 +215,8 @@ Markdown(string markdown, MarkdownOptions options)
 `Markdown` is the largest Reactor-original control on this page. It
 parses GitHub-flavored Markdown with the embedded `md4c` parser and
 emits a Reactor element tree: headings become `TextBlock` with the
-heading variant, list items become `HStack`s, links become inline
+heading variant, list items become two-column `Grid`s (`Auto` marker / `*`
+content), links become inline
 hyperlinks, code spans become monospace `TextBlock`. No WebView, no HTML
 round-trip — the output composes with every other modifier on this page
 (`.Padding`, `.Width`, `.TextWrapping`).

--- a/docs/guide/text-and-media.md
+++ b/docs/guide/text-and-media.md
@@ -277,7 +277,8 @@ class MarkdownDemo : Component
 `Markdown` is the largest Reactor-original control on this page. It
 parses GitHub-flavored Markdown with the embedded `md4c` parser and
 emits a Reactor element tree: headings become `TextBlock` with the
-heading variant, list items become `HStack`s, links become inline
+heading variant, list items become two-column `Grid`s (`Auto` marker / `*`
+content), links become inline
 hyperlinks, code spans become monospace `TextBlock`. No WebView, no HTML
 round-trip — the output composes with every other modifier on this page
 (`.Padding`, `.Width`, `.TextWrapping`).

--- a/src/Reactor.Advanced/Markdown/MarkdownBuilder.cs
+++ b/src/Reactor.Advanced/Markdown/MarkdownBuilder.cs
@@ -29,7 +29,10 @@ public record MarkdownOptions
     public Func<Element[], Element>? UnorderedList { get; init; }
     /// <summary>Override ordered list rendering. (startNumber, items)</summary>
     public Func<int, Element[], Element>? OrderedList { get; init; }
-    /// <summary>Override list item rendering. (defaultElement)</summary>
+    /// <summary>
+    /// Override list item rendering. Receives the default Auto/Star Grid containing
+    /// the marker and content. Content wraps when the document has a finite available width.
+    /// </summary>
     public Func<Element, Element>? ListItem { get; init; }
     /// <summary>Override code block rendering. (code, language)</summary>
     public Func<string, string?, Element>? CodeBlock { get; init; }
@@ -531,10 +534,11 @@ internal sealed class MarkdownBuilder
         else
             content = TextBlock(""); // empty fallback
 
-        Element element = HStack(4,
+        // A horizontal StackPanel measures content with infinite width, preventing wrapping.
+        Element element = Grid([GridSize.Auto, GridSize.Star()], [],
             TextBlock(marker).VAlign(VerticalAlignment.Top),
-            content
-        );
+            content.Grid(column: 1)
+        ) with { ColumnSpacing = 4 };
 
         if (_options.ListItem is not null)
             element = _options.ListItem(element);

--- a/src/Reactor.Advanced/Markdown/MarkdownBuilder.cs
+++ b/src/Reactor.Advanced/Markdown/MarkdownBuilder.cs
@@ -534,7 +534,8 @@ internal sealed class MarkdownBuilder
         else
             content = TextBlock(""); // empty fallback
 
-        // A horizontal StackPanel measures content with infinite width, preventing wrapping.
+        // The Star column hands the content the finite width left over beside the marker, which is
+        // what lets long text wrap onto additional lines.
         Element element = Grid([GridSize.Auto, GridSize.Star()], [],
             TextBlock(marker).VAlign(VerticalAlignment.Top),
             content.Grid(column: 1)

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/MarkdownFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/MarkdownFixtures.cs
@@ -275,10 +275,11 @@ internal static class MarkdownFixtures
             }
             H.Check("Md_UL_HasAlpha", hasAlpha);
 
-            // Each item is an HStack (StackPanel horizontal)
-            var hstacks = H.FindAllControls<StackPanel>(sp =>
-                sp.Orientation == Orientation.Horizontal);
-            H.Check("Md_UL_HasHStacks", hstacks.Count >= 3);
+            var rows = H.FindAllControls<WinGrid>(grid =>
+                grid.ColumnDefinitions.Count == 2
+                && grid.ColumnDefinitions[0].Width.IsAuto
+                && grid.ColumnDefinitions[1].Width.IsStar);
+            H.Check("Md_UL_HasAutoStarRows", rows.Count == 3);
         }
     }
 
@@ -682,7 +683,8 @@ internal static class MarkdownFixtures
             H.Check("Md_Complex_HasManyBlocks", rtbs.Count >= 5);
 
             // Table grid
-            var grid = H.FindControl<WinGrid>(g => g.ColumnDefinitions.Count >= 2);
+            var grid = H.FindControl<WinGrid>(g => g.ColumnDefinitions.Count >= 2
+                && g.RowDefinitions.Count >= 2);
             H.Check("Md_Complex_HasTable", grid is not null);
 
             // Bullets

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/MarkdownListLayoutFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/MarkdownListLayoutFixtures.cs
@@ -1,0 +1,264 @@
+using Microsoft.UI.Reactor.Core;
+using Microsoft.UI.Reactor.Markdown;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Documents;
+using Microsoft.UI.Xaml.Media;
+using Windows.Foundation;
+using static Microsoft.UI.Reactor.Factories;
+
+namespace Microsoft.UI.Reactor.AppTests.Host.SelfTest.Fixtures;
+
+internal static class MarkdownListLayoutFixtures
+{
+    private const string LongText =
+        "This list item must remain completely readable when the available width changes. " +
+        "Long plain and formatted text should wrap onto additional lines instead of disappearing " +
+        "beyond the right edge of the containing document.";
+    private const string Following = "The paragraph after the list must remain visible.";
+
+    internal class Plain(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override Task RunAsync() =>
+            CheckWrapping(H, $"- {LongText}", [LongText], ["\u2022 "]);
+    }
+
+    internal class Bold(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override Task RunAsync() =>
+            CheckWrapping(H, $"- **{LongText}**", [LongText], ["\u2022 "], bold: true);
+    }
+
+    internal class Ordered(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override Task RunAsync() =>
+            CheckWrapping(H, $"9. {LongText}\n10. Next item", [LongText, "Next item"], ["9. ", "10. "]);
+    }
+
+    internal class Loose(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override Task RunAsync() =>
+            CheckWrapping(H, $"- {LongText}\n\n  Second paragraph in the same item.\n\n- Last item",
+                [LongText, "Second paragraph in the same item.", "Last item"], ["\u2022 ", "\u2022 "]);
+    }
+
+    internal class Nested(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override Task RunAsync() =>
+            CheckWrapping(H, $"- Parent item\n\n  - {LongText}\n\n- Last item",
+                ["Parent item", LongText, "Last item"], ["\u2022 ", "\u2022 ", "\u2022 "]);
+    }
+
+    internal class Code(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override Task RunAsync() =>
+            CheckWrapping(H, $"- {LongText}\n\n  ```text\n  {LongText}\n  ```",
+                [LongText, LongText], ["\u2022 "]);
+    }
+
+    internal class Tasks(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override Task RunAsync() =>
+            CheckWrapping(H, $"- [x] {LongText}\n- [ ] Pending\n- [X] Done",
+                [LongText, "Pending", "Done"], ["\u2611 ", "\u2610 ", "\u2611 "]);
+    }
+
+    internal class Unified(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override Task RunAsync() =>
+            CheckWrapping(H, $"- {LongText}", [LongText], ["\u2022 "], unified: true);
+    }
+
+    internal class Short(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            using var host = H.CreateHost();
+            host.Mount(_ => Border(
+                Microsoft.UI.Reactor.Advanced.Factories.Markdown("- Yes\n- No")
+                    .HAlign(HorizontalAlignment.Left))
+                .Width(1000).HAlign(HorizontalAlignment.Left).VAlign(VerticalAlignment.Top));
+            await Harness.Render();
+
+            var viewport = H.FindControl<Border>(b => b.Width == 1000)
+                ?? throw new InvalidOperationException("Missing Markdown viewport.");
+            var document = (FrameworkElement)viewport.Child;
+            var text = H.FindAllControls<RichTextBlock>(_ => true);
+            H.Check("Short_FullText", text.Select(Text).SequenceEqual(["Yes", "No"]));
+            H.Check("Short_IntrinsicWidth", document.ActualWidth > 0 && document.ActualWidth < 100);
+            Console.WriteLine($"# Short list: viewport={viewport.ActualWidth:F2}, document={document.ActualWidth:F2}");
+        }
+    }
+
+    internal class RowMeasureEquivalence(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            const string suffix = "\n\n  Second paragraph.\n\n  - Nested item\n\n  ```text\n  code\n  ```";
+            foreach (bool unified in new[] { false, true })
+            {
+                var baseline = new List<(Size Desired, Rect Bounds, Rect End)[]>();
+                foreach (bool explicitRow in new[] { true, false })
+                {
+                    using var host = H.CreateHost();
+                    host.Mount(_ => Border(
+                        Microsoft.UI.Reactor.Advanced.Factories.Markdown(
+                            $"- {LongText}{suffix}\n\n{Following}",
+                            new MarkdownOptions
+                            {
+                                UnifiedRichText = unified,
+                                ListItem = item =>
+                                {
+                                    var grid = (GridElement)item;
+                                    return grid with
+                                    {
+                                        Definition = grid.Definition with
+                                        {
+                                            Rows = explicitRow ? [GridSize.Auto] : [],
+                                        },
+                                    };
+                                },
+                            }))
+                        .Width(686).HAlign(HorizontalAlignment.Left).VAlign(VerticalAlignment.Top));
+                    await Harness.Render();
+
+                    var viewport = H.FindControl<Border>(b => b.Width == 686)
+                        ?? throw new InvalidOperationException("Missing Markdown viewport.");
+                    var rows = H.FindAllControls<Microsoft.UI.Xaml.Controls.Grid>(
+                        g => g.ColumnDefinitions.Count == 2 && g.ColumnSpacing == 4);
+                    H.Check($"RowMode_{unified}_{explicitRow}", rows.Count == 2
+                        && rows.All(g => g.RowDefinitions.Count == (explicitRow ? 1 : 0)));
+                    var blocks = H.FindAllControls<RichTextBlock>(b => Runs(b).Any());
+                    H.Check($"RowModeText_{unified}_{explicitRow}",
+                        blocks.SelectMany(Runs).Select(r => r.Text).OrderBy(t => t)
+                            .SequenceEqual(new[] { LongText, "Second paragraph.", "Nested item", "code", Following }.OrderBy(t => t)));
+
+                    int step = 0;
+                    foreach (double width in new[] { 686.0, 320.0, 686.0 })
+                    {
+                        viewport.Width = width;
+                        viewport.UpdateLayout();
+                        await Harness.Render();
+                        var elements = new FrameworkElement[] { viewport }
+                            .Concat(rows).Concat(blocks).ToArray();
+                        var snapshot = elements.Select(element =>
+                        {
+                            var bounds = element.TransformToVisual(viewport).TransformBounds(
+                                new Rect(0, 0, element.ActualWidth, element.ActualHeight));
+                            var end = element is RichTextBlock block
+                                ? block.TransformToVisual(viewport).TransformBounds(
+                                    Runs(block).Last().ContentEnd.GetCharacterRect(LogicalDirection.Backward))
+                                : new Rect();
+                            return (element.DesiredSize, bounds, end);
+                        }).ToArray();
+                        Console.WriteLine($"# row mode: unified={unified}, explicit={explicitRow}, " +
+                            $"width={width}, desired={viewport.DesiredSize}, height={viewport.ActualHeight}");
+                        if (explicitRow)
+                            baseline.Add(snapshot);
+                        else
+                            H.Check($"ImplicitRowEquivalent_{unified}_{step}", snapshot.SequenceEqual(baseline[step]));
+                        step++;
+                    }
+                }
+            }
+        }
+    }
+
+    private static async Task CheckWrapping(
+        Harness h, string markdown, string[] expectedText, string[] expectedMarkers,
+        bool bold = false, bool unified = false)
+    {
+        using var host = h.CreateHost();
+        host.Mount(_ => Border(
+            Microsoft.UI.Reactor.Advanced.Factories.Markdown(
+                markdown + "\n\n" + Following, new MarkdownOptions { UnifiedRichText = unified }))
+            .Width(686).HAlign(HorizontalAlignment.Left).VAlign(VerticalAlignment.Top));
+        await Harness.Render();
+
+        var viewport = h.FindControl<Border>(b => b.Width == 686)
+            ?? throw new InvalidOperationException("Missing Markdown viewport.");
+        var blocks = h.FindAllControls<RichTextBlock>(b => Runs(b).Any());
+        var listBlocks = blocks.Where(b => Text(b) != Following).ToArray();
+        h.Check("FullTextAndBlockOrder", listBlocks.Select(Text).SequenceEqual(expectedText));
+        var following = blocks.Single(b => Text(b) == Following);
+        var markers = h.FindAllControls<TextBlock>(b => expectedMarkers.Contains(b.Text));
+        h.Check("Markers", markers.Select(b => b.Text).SequenceEqual(expectedMarkers));
+        h.Check("SelectionPreserved", listBlocks.All(b => b.IsTextSelectionEnabled));
+        if (bold)
+            h.Check("BoldPreserved", Runs(listBlocks.Single()).All(r => r.FontWeight.Weight >= 700));
+
+        double wideHeight = 0;
+        foreach (var width in new[] { 686.0, 320.0, 686.0 })
+        {
+            viewport.Width = width;
+            viewport.UpdateLayout();
+            await Harness.Render();
+            h.Check($"Viewport_{width}", Math.Abs(viewport.ActualWidth - width) < 1);
+
+            foreach (var marker in markers)
+            {
+                var row = (Panel)VisualTreeHelper.GetParent(marker);
+                var content = (FrameworkElement)row.Children[1];
+                var contentOrigin = content.TransformToVisual(row).TransformPoint(new Point());
+                h.Check($"Marker_{marker.Text}_{width}_TopAligned", marker.VerticalAlignment == VerticalAlignment.Top);
+                h.Check($"Marker_{marker.Text}_{width}_Spacing",
+                    Math.Abs(contentOrigin.X - marker.ActualWidth - 4) < 1);
+            }
+
+            for (int i = 0; i < listBlocks.Length; i++)
+            {
+                var block = listBlocks[i];
+                var runs = Runs(block).ToArray();
+                var first = runs[0].ContentStart.GetCharacterRect(LogicalDirection.Forward);
+                var last = runs[^1].ContentEnd.GetCharacterRect(LogicalDirection.Backward);
+                var bounds = block.TransformToVisual(viewport).TransformBounds(
+                    new Rect(0, 0, block.ActualWidth, block.ActualHeight));
+                var lastInViewport = block.TransformToVisual(viewport).TransformBounds(last);
+                Console.WriteLine($"# width={width}, block={i}, textLength={Text(block).Length}, " +
+                    $"bounds={bounds}, first={first}, last={last}");
+                h.Check($"Block{i}_{width}_FiniteWidth",
+                    block.ActualWidth > 0 && double.IsFinite(block.ActualWidth)
+                    && bounds.Left >= -1 && bounds.Right <= viewport.ActualWidth + 1);
+                h.Check($"Block{i}_{width}_LastCharacterVisible",
+                    last.Height > 0 && lastInViewport.Left >= -1
+                    && lastInViewport.Right <= viewport.ActualWidth + 1
+                    && last.Top >= 0 && last.Bottom <= block.ActualHeight + 1);
+                if (Text(block) == LongText)
+                    h.Check($"Block{i}_{width}_Wraps", last.Top > first.Top + 1);
+            }
+
+            // In unified mode this paragraph shares its RichTextBlock with the list.
+            // Measure its text positions, not the bounds of the whole document.
+            var followingRuns = Runs(following).ToArray();
+            var followingFirst = following.TransformToVisual(viewport).TransformBounds(
+                followingRuns[0].ContentStart.GetCharacterRect(LogicalDirection.Forward));
+            var followingLast = following.TransformToVisual(viewport).TransformBounds(
+                followingRuns[^1].ContentEnd.GetCharacterRect(LogicalDirection.Backward));
+            double lastBottom = listBlocks.Max(b => b.TransformToVisual(viewport).TransformBounds(
+                new Rect(0, 0, b.ActualWidth, b.ActualHeight)).Bottom);
+            h.Check($"FollowingParagraph_{width}",
+                followingFirst.Top >= lastBottom - 1 && followingLast.Height > 0
+                && followingLast.Right <= viewport.ActualWidth + 1
+                && followingLast.Bottom <= viewport.ActualHeight + 1);
+            if (wideHeight == 0)
+                wideHeight = viewport.ActualHeight;
+            else if (width == 320)
+                h.Check("Narrow_GrowsHeight", viewport.ActualHeight > wideHeight + 1);
+            else
+                h.Check("Wide_RestoresHeight", Math.Abs(viewport.ActualHeight - wideHeight) < 1);
+        }
+    }
+
+    private static IEnumerable<Run> Runs(RichTextBlock block) =>
+        block.Blocks.OfType<Paragraph>().SelectMany(p => Runs(p.Inlines));
+
+    private static IEnumerable<Run> Runs(IEnumerable<Inline> inlines) =>
+        inlines.SelectMany(inline => inline switch
+        {
+            Run run => new[] { run },
+            Span span => Runs(span.Inlines),
+            _ => Enumerable.Empty<Run>(),
+        });
+
+    private static string Text(RichTextBlock block) => string.Concat(Runs(block).Select(r => r.Text));
+}

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/MarkdownListLayoutFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/MarkdownListLayoutFixtures.cs
@@ -149,14 +149,14 @@ internal static class MarkdownListLayoutFixtures
                                 ? block.TransformToVisual(viewport).TransformBounds(
                                     Runs(block).Last().ContentEnd.GetCharacterRect(LogicalDirection.Backward))
                                 : new Rect();
-                            return (element.DesiredSize, bounds, end);
+                            return (Desired: element.DesiredSize, Bounds: bounds, End: end);
                         }).ToArray();
                         Console.WriteLine($"# row mode: unified={unified}, explicit={explicitRow}, " +
                             $"width={width}, desired={viewport.DesiredSize}, height={viewport.ActualHeight}");
                         if (explicitRow)
                             baseline.Add(snapshot);
                         else
-                            H.Check($"ImplicitRowEquivalent_{unified}_{step}", snapshot.SequenceEqual(baseline[step]));
+                            H.Check($"ImplicitRowEquivalent_{unified}_{step}", LayoutMatches(snapshot, baseline[step]));
                         step++;
                     }
                 }
@@ -248,6 +248,29 @@ internal static class MarkdownListLayoutFixtures
                 h.Check("Wide_RestoresHeight", Math.Abs(viewport.ActualHeight - wideHeight) < 1);
         }
     }
+
+    // Two independent mounts can land a fraction of a DIP apart through sub-pixel rounding, so
+    // equivalence is measured within a tolerance rather than by exact floating-point equality.
+    private const double LayoutTolerance = 0.5;
+
+    private static bool LayoutMatches(
+        (Size Desired, Rect Bounds, Rect End)[] actual,
+        (Size Desired, Rect Bounds, Rect End)[] expected) =>
+        actual.Length == expected.Length
+        && actual.Zip(expected).All(pair =>
+            Close(pair.First.Desired, pair.Second.Desired)
+            && Close(pair.First.Bounds, pair.Second.Bounds)
+            && Close(pair.First.End, pair.Second.End));
+
+    private static bool Close(Size a, Size b) =>
+        Close(a.Width, b.Width) && Close(a.Height, b.Height);
+
+    private static bool Close(Rect a, Rect b) =>
+        Close(a.X, b.X) && Close(a.Y, b.Y) && Close(a.Width, b.Width) && Close(a.Height, b.Height);
+
+    // Equals first so the NaN and infinity components of a degenerate Rect match themselves.
+    private static bool Close(double a, double b) =>
+        a.Equals(b) || Math.Abs(a - b) <= LayoutTolerance;
 
     private static IEnumerable<Run> Runs(RichTextBlock block) =>
         block.Blocks.OfType<Paragraph>().SelectMany(p => Runs(p.Inlines));

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -66,6 +66,16 @@ internal static class SelfTestFixtureRegistry
         "Markdown_Links",
         "Markdown_BlockQuotes",
         "Markdown_UnorderedList",
+        "Markdown_ListLayout_Plain",
+        "Markdown_ListLayout_Bold",
+        "Markdown_ListLayout_Ordered",
+        "Markdown_ListLayout_Loose",
+        "Markdown_ListLayout_Nested",
+        "Markdown_ListLayout_Code",
+        "Markdown_ListLayout_Tasks",
+        "Markdown_ListLayout_Unified",
+        "Markdown_ListLayout_Short",
+        "Markdown_ListLayout_RowMeasureEquivalence",
         "Markdown_OrderedList",
         "Markdown_TaskList",
         "Markdown_TableWithAlignment",
@@ -1973,6 +1983,16 @@ internal static class SelfTestFixtureRegistry
         "Markdown_Links" => new MarkdownFixtures.Links(harness),
         "Markdown_BlockQuotes" => new MarkdownFixtures.BlockQuotes(harness),
         "Markdown_UnorderedList" => new MarkdownFixtures.UnorderedList(harness),
+        "Markdown_ListLayout_Plain" => new MarkdownListLayoutFixtures.Plain(harness),
+        "Markdown_ListLayout_Bold" => new MarkdownListLayoutFixtures.Bold(harness),
+        "Markdown_ListLayout_Ordered" => new MarkdownListLayoutFixtures.Ordered(harness),
+        "Markdown_ListLayout_Loose" => new MarkdownListLayoutFixtures.Loose(harness),
+        "Markdown_ListLayout_Nested" => new MarkdownListLayoutFixtures.Nested(harness),
+        "Markdown_ListLayout_Code" => new MarkdownListLayoutFixtures.Code(harness),
+        "Markdown_ListLayout_Tasks" => new MarkdownListLayoutFixtures.Tasks(harness),
+        "Markdown_ListLayout_Unified" => new MarkdownListLayoutFixtures.Unified(harness),
+        "Markdown_ListLayout_Short" => new MarkdownListLayoutFixtures.Short(harness),
+        "Markdown_ListLayout_RowMeasureEquivalence" => new MarkdownListLayoutFixtures.RowMeasureEquivalence(harness),
         "Markdown_OrderedList" => new MarkdownFixtures.OrderedList(harness),
         "Markdown_TaskList" => new MarkdownFixtures.TaskList(harness),
         "Markdown_TableWithAlignment" => new MarkdownFixtures.TableWithAlignment(harness),
@@ -3619,8 +3639,6 @@ internal static class SelfTestFixtureRegistry
         _ => null,
     };
 }
-
-
 
 
 

--- a/tests/Reactor.Tests/LayoutFootgunDetectorTests.cs
+++ b/tests/Reactor.Tests/LayoutFootgunDetectorTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.UI.Reactor.Core;
 using Microsoft.UI.Reactor.Diagnostics;
+using Microsoft.UI.Reactor.Markdown;
 using Xunit;
 using static Microsoft.UI.Reactor.Factories;
 
@@ -87,6 +88,33 @@ public sealed class LayoutFootgunDetectorTests : IDisposable
     }
 
     // ── Should NOT warn ────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("- First\n\n  Second")]
+    [InlineData("- Parent\n\n  - Child\n\n- Last")]
+    [InlineData("- Intro\n\n  ```text\n  code\n  ```")]
+    public void MarkdownMultiBlockItems_DoNotConsumeLayoutWarning(string markdown)
+    {
+        var rows = new List<GridElement>();
+        Microsoft.UI.Reactor.Advanced.Factories.Markdown(markdown, new MarkdownOptions
+        {
+            CodeBlock = (code, _) => TextBlock(code),
+            ListItem = item =>
+            {
+                rows.Add(Assert.IsType<GridElement>(item));
+                return item;
+            },
+        });
+        Assert.NotEmpty(rows);
+        foreach (var row in rows)
+            LayoutFootgunDetector.InspectGrid(row);
+        Assert.Empty(_warnings);
+
+        var offender = Grid([GridSize.Auto, GridSize.Star()], [GridSize.Auto],
+            VStack(Border(VStack())).Grid(column: 1));
+        LayoutFootgunDetector.InspectGrid(offender);
+        Assert.Contains("row 0 (Auto)", Assert.Single(_warnings));
+    }
 
     [Fact]
     public void HStack_InStarColumn_DoesNotWarn()

--- a/tests/Reactor.Tests/LayoutFootgunDetectorTests.cs
+++ b/tests/Reactor.Tests/LayoutFootgunDetectorTests.cs
@@ -107,7 +107,13 @@ public sealed class LayoutFootgunDetectorTests : IDisposable
         });
         Assert.NotEmpty(rows);
         foreach (var row in rows)
+        {
+            // The detector only warns on an explicit Auto track, so the absence of a warning below
+            // is only meaningful while the rows stay implicit — an implicit row is Star, and Star
+            // stretches instead of collapsing.
+            Assert.Empty(row.Definition.Rows);
             LayoutFootgunDetector.InspectGrid(row);
+        }
         Assert.Empty(_warnings);
 
         var offender = Grid([GridSize.Auto, GridSize.Star()], [GridSize.Auto],

--- a/tests/Reactor.Tests/MarkdownBuilderTests.cs
+++ b/tests/Reactor.Tests/MarkdownBuilderTests.cs
@@ -657,17 +657,23 @@ public class MarkdownBuilderTests
     }
 
     [Fact]
-    public void UnorderedList_ItemsAreHStacksWithBulletMarker()
+    public void UnorderedList_ItemsUseAutoStarGridWithBulletMarker()
     {
         var result = Md("- Item one");
         var stack = AsVStack(result);
         var listStack = Child<StackElement>(stack, 0);
-        var item = Assert.IsType<StackElement>(listStack.Children[0]);
-        Assert.Equal(Orientation.Horizontal, item.Orientation);
-        Assert.Equal(4.0, item.Spacing);
+        var item = Assert.IsType<GridElement>(listStack.Children[0]);
+        Assert.Equal([GridSize.Auto, GridSize.Star()], item.Definition.Columns);
+        Assert.Empty(item.Definition.Rows);
+        Assert.Equal(4.0, item.ColumnSpacing);
+        Assert.Equal(2, item.Children.Length);
 
         var marker = Assert.IsType<TextBlockElement>(item.Children[0]);
-        Assert.Contains("\u2022", marker.Content);
+        Assert.Equal("\u2022 ", marker.Content);
+        Assert.Equal(VerticalAlignment.Top, marker.Modifiers!.VerticalAlignment);
+        Assert.Equal(1, item.Children[1].GetAttached<GridAttached>()!.Column);
+        Assert.Equal("Item one", Inline<RichTextRun>(
+            Assert.IsType<RichTextBlockElement>(item.Children[1]), 0).Text);
     }
 
     [Fact]
@@ -678,11 +684,11 @@ public class MarkdownBuilderTests
         var listStack = Child<StackElement>(stack, 0);
         Assert.Equal(3, listStack.Children.Length);
 
-        var item1 = Assert.IsType<StackElement>(listStack.Children[0]);
+        var item1 = Assert.IsType<GridElement>(listStack.Children[0]);
         var marker1 = Assert.IsType<TextBlockElement>(item1.Children[0]);
         Assert.Contains("1.", marker1.Content);
 
-        var item3 = Assert.IsType<StackElement>(listStack.Children[2]);
+        var item3 = Assert.IsType<GridElement>(listStack.Children[2]);
         var marker3 = Assert.IsType<TextBlockElement>(item3.Children[0]);
         Assert.Contains("3.", marker3.Content);
     }
@@ -694,11 +700,11 @@ public class MarkdownBuilderTests
         var stack = AsVStack(result);
         var listStack = Child<StackElement>(stack, 0);
 
-        var item1 = Assert.IsType<StackElement>(listStack.Children[0]);
+        var item1 = Assert.IsType<GridElement>(listStack.Children[0]);
         var marker1 = Assert.IsType<TextBlockElement>(item1.Children[0]);
         Assert.Contains("5.", marker1.Content);
 
-        var item2 = Assert.IsType<StackElement>(listStack.Children[1]);
+        var item2 = Assert.IsType<GridElement>(listStack.Children[1]);
         var marker2 = Assert.IsType<TextBlockElement>(item2.Children[0]);
         Assert.Contains("6.", marker2.Content);
     }
@@ -709,7 +715,7 @@ public class MarkdownBuilderTests
         var result = Md("- [x] Done");
         var stack = AsVStack(result);
         var listStack = Child<StackElement>(stack, 0);
-        var item = Assert.IsType<StackElement>(listStack.Children[0]);
+        var item = Assert.IsType<GridElement>(listStack.Children[0]);
         var marker = Assert.IsType<TextBlockElement>(item.Children[0]);
         Assert.Contains("\u2611", marker.Content);
     }
@@ -720,7 +726,7 @@ public class MarkdownBuilderTests
         var result = Md("- [ ] Todo");
         var stack = AsVStack(result);
         var listStack = Child<StackElement>(stack, 0);
-        var item = Assert.IsType<StackElement>(listStack.Children[0]);
+        var item = Assert.IsType<GridElement>(listStack.Children[0]);
         var marker = Assert.IsType<TextBlockElement>(item.Children[0]);
         Assert.Contains("\u2610", marker.Content);
     }
@@ -803,6 +809,30 @@ public class MarkdownBuilderTests
 
         Md("- A\n- B\n- C", options);
         Assert.Equal(3, callCount);
+    }
+
+    [Fact]
+    public void ListItem_CustomCallback_ReceivesDefaultGridAndRetainsReplacement()
+    {
+        var defaults = new List<GridElement>();
+        var result = Md("- A\n- B", new MarkdownOptions
+        {
+            ListItem = item =>
+            {
+                defaults.Add(Assert.IsType<GridElement>(item));
+                return Border(item).Padding(7);
+            },
+        });
+
+        var list = Child<StackElement>(AsVStack(result), 0);
+        Assert.Equal(2, defaults.Count);
+        Assert.Equal(2, list.Children.Length);
+        for (int i = 0; i < defaults.Count; i++)
+        {
+            var wrapper = Assert.IsType<BorderElement>(list.Children[i]);
+            Assert.Same(defaults[i], wrapper.Child);
+            Assert.Equal(new Thickness(7), wrapper.Modifiers!.Padding);
+        }
     }
 
     // ════════════════════════════════════════════════════════════════════
@@ -1199,15 +1229,15 @@ public class MarkdownBuilderTests
         var stack = AsVStack(result);
         var listStack = Child<StackElement>(stack, 0);
 
-        // First item: HStack with marker + content
-        var item1 = Assert.IsType<StackElement>(listStack.Children[0]);
+        // First item: Grid with marker + content
+        var item1 = Assert.IsType<GridElement>(listStack.Children[0]);
         var content1 = item1.Children[1]; // content is second child after marker
         var rtb1 = Assert.IsType<RichTextBlockElement>(content1);
         var run1 = Inline<RichTextRun>(rtb1, 0);
         Assert.True(run1.IsBold);
 
         // Second item
-        var item2 = Assert.IsType<StackElement>(listStack.Children[1]);
+        var item2 = Assert.IsType<GridElement>(listStack.Children[1]);
         var content2 = item2.Children[1];
         var rtb2 = Assert.IsType<RichTextBlockElement>(content2);
         var run2 = Inline<RichTextRun>(rtb2, 0);

--- a/tests/Reactor.Tests/MarkdownUnifiedRichTextTests.cs
+++ b/tests/Reactor.Tests/MarkdownUnifiedRichTextTests.cs
@@ -106,9 +106,14 @@ public class MarkdownUnifiedRichTextTests
 
         var listInline = Assert.IsType<RichTextInlineUIContainer>(rtb.Paragraphs[1].Inlines[0]);
         Assert.NotNull(listInline.Child);
-        // Default list rendering is a VStack of HStack(marker, content) items.
+        // Default list rendering is a VStack of Grid(marker, content) items.
         var listStack = Assert.IsType<StackElement>(listInline.Child);
         Assert.Equal(2, listStack.Children.Length);
+        Assert.All(listStack.Children, item =>
+        {
+            var grid = Assert.IsType<GridElement>(item);
+            Assert.Equal([GridSize.Auto, GridSize.Star()], grid.Definition.Columns);
+        });
 
         Assert.IsType<RichTextRun>(rtb.Paragraphs[2].Inlines[0]);
     }


### PR DESCRIPTION
## Summary

Fix long Markdown list items clipping even though their full text is present and wrapping is enabled. The previous horizontal StackPanel measured content with infinite width; the default list row now uses native Auto/Star Grid columns so the marker keeps its natural width and content receives the finite remainder.

Preserve marker formatting, the four-DIP gap, top alignment, block contents, selection, and the post-construction `ListItem` hook. Keep the single row implicit to avoid triggering the existing layout-footgun heuristic for valid multi-block list content. No parser changes, hardcoded content widths, custom panels, or app-specific workarounds.

## Linked issue / spec

Related to openclaw/openclaw-windows-node#1362. Consumer package adoption and workaround removal are separate from this upstream fix.

## Test plan

- [x] Reproduced the original failure in Reactor's native selftest host. Replacing the fixed row with the original HStack makes the final wrapping oracles fail (89 failed assertions across eight wrapping cases).
- [x] Added native coverage for plain/bold bullets, ordered markers starting at 9, loose and nested lists, code blocks, task lists, unified rich text, and short intrinsic-width lists. Checked complete native text, final-character geometry, marker placement, and 686 -> 320 -> 686 resizing.
- [x] Compared explicit Auto and implicit single rows in native default/unified documents: desired sizes, arranged bounds, and final-character rectangles match.
- [x] Added callback-wrapper and diagnostic regression tests; the latter fail with the explicit Auto row and verify that subsequent real layout offenders still warn. Strengthened the complex-document table assertion so list-item Grids cannot satisfy it.
- [x] Focused Markdown and layout-diagnostic unit suites: **192 passed, 0 failed, 0 skipped**.
- [x] Complete unit suite: **13,901 passed, 0 failed, 64 declared skips**.
- [x] Native Markdown corpus: **36 fixtures, 399 checks, 0 failures, 0 fixture skips**.
- [x] Separate `dotnet restore Reactor.slnx`, followed by `dotnet build Reactor.slnx --no-restore -c Release -p:SkipSignaturesGen=true`: succeeded with 0 errors and 2 WIN2D0001 AnyCPU warnings in Devtools/Chat.UI. Debug native/unit builds also succeeded.
- [x] Regenerated only the affected guide topic through `mur docs compile --topic text-and-media --ci` with build/capture/AI/diagram/reference steps disabled; no lint findings or unrelated snippet changes.
- [ ] Packaged/MSIX, NativeAOT, screenshot, and input-driven E2E runs were not performed locally.

## Risk / breaking changes

`MarkdownOptions.ListItem` retains its `Element -> Element` signature and invocation order, but its default concrete input changes from **`StackElement` to `GridElement`**. Callbacks that explicitly cast the old default must adapt. This is documented in the XML comments, guide, and changelog.

The fix requires a finite available width from the outer host; it does not promise wrapping inside an unbounded horizontal host. No diagnostics algorithm changes or new public API signatures are introduced.