### PR TITLE
deps: roll GitHub.Copilot.SDK back to 1.0.11

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -47,7 +47,7 @@
          (PrivateAssets=all) — never shipped in the `mur` tool output. Version tracks
          YamlDotNet's major (18.x). -->
     <PackageVersion Include="Vecc.YamlDotNet.Analyzers.StaticGenerator" Version="18.1.0" />
-    <PackageVersion Include="GitHub.Copilot.SDK" Version="1.0.13" />
+    <PackageVersion Include="GitHub.Copilot.SDK" Version="1.0.11" />
     <PackageVersion Include="MessagePack" Version="2.5.301" />
   </ItemGroup>
 


### PR DESCRIPTION
## What

Reverts the `GitHub.Copilot.SDK` version in `Directory.Packages.props` from `1.0.13` back to `1.0.11`. One line, nothing else.

## Why

`1.0.13` (bumped in #1186) is not published to the internal NuGet feed that the OneBranch CI and release pipelines restore from, so restore fails there. `1.0.11` is the last version present on that feed.

## Notes

- `dotnet restore src/Reactor.Cli/Reactor.Cli.csproj` succeeds on `1.0.11`.
- No lock files reference the package, so nothing else needs regenerating.
- We can re-bump once the newer version lands on the internal feed.