### PR TITLE
Publish the docs site per release with a version selector

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,43 +1,199 @@
 name: Publish docs
 
+# The published site is versioned with mike (https://github.com/jimporter/mike).
+# Every version is rendered once and kept in the `gh-pages` branch; the Pages
+# artifact is that whole branch, so versions stay byte-identical after they are
+# published. Material's version selector reads the `versions.json` that mike
+# maintains at the site root.
 on:
   push:
     branches: [main]
     paths:
       - 'docs/guide/**'
+      - 'docs/_overrides/**'
+      - 'docs/_site-root/**'
       - 'mkdocs.yml'
       - 'docs/requirements.txt'
       - '.github/workflows/docs.yml'
+    # Path filters are not evaluated for tag pushes, so a release tag always
+    # publishes regardless of which files the release commit touched. That is
+    # the behaviour we want here: the tag itself is the trigger.
+    tags:
+      - 'v*'
   workflow_dispatch:
+    inputs:
+      backfill_tags:
+        description: >-
+          Space-separated release tags to publish retroactively, e.g.
+          "v0.1.0-preview.12 v0.1.0-preview.13". Leave empty to just republish
+          the selected branch as the `main` version.
+        required: false
+        default: ''
 
-permissions:
-  contents: read
-  pages: write
-  id-token: write
+permissions: {}
 
+# Serialises Pages deployments *and* the gh-pages pushes below, so two runs can
+# never race for the same branch.
 concurrency:
   group: pages
   cancel-in-progress: false
 
+env:
+  MIKE_BRANCH: gh-pages
+  LATEST_ALIAS: latest
+  MAIN_VERSION: main
+
 jobs:
-  build:
+  publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # mike commits the rendered site to gh-pages
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # mike rewrites the gh-pages branch, and the steps below decide which
+          # release is `latest` by sorting the tag list — both need real history.
+          fetch-depth: 0
+
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.12'
           cache: pip
           cache-dependency-path: docs/requirements.txt
+
       - run: pip install -r docs/requirements.txt
-      - run: mkdocs build --strict
+
+      - name: Configure the identity mike commits under
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Fetch the existing version history
+        # Absent on the very first run; mike creates the branch in that case.
+        run: |
+          git fetch origin "$MIKE_BRANCH:$MIKE_BRANCH" \
+            || echo "No $MIKE_BRANCH branch yet — mike will create it."
+
+      # mike exposes no --strict passthrough, so strictness stays an explicit
+      # gate. The build is deterministic, so passing here means the render mike
+      # performs next is equally clean. Mirrors the PR-side gate in ci.yml.
+      - name: Check the docs build strictly
+        run: python -m mkdocs build --strict --site-dir "$RUNNER_TEMP/strict-check"
+
+      - name: Publish the main version
+        if: github.ref_type == 'branch' && !inputs.backfill_tags
+        run: |
+          mike deploy --branch "$MIKE_BRANCH" --push --alias-type copy \
+            --title 'main (development)' "$MAIN_VERSION"
+
+          # Until a release version exists there is nothing for the site root to
+          # redirect to, which would leave it a 404. Point the root at main for
+          # that window only; publishing any release moves it back to `latest`.
+          if ! mike list --branch "$MIKE_BRANCH" "$LATEST_ALIAS" >/dev/null 2>&1; then
+            mike set-default --branch "$MIKE_BRANCH" --push "$MAIN_VERSION"
+          fi
+
+      - name: Publish the release version
+        # `!inputs.backfill_tags` matters because a workflow_dispatch can be
+        # started from a tag ref: without it, a manual backfill launched from a
+        # tag would run this step and the backfill step in the same run.
+        if: github.ref_type == 'tag' && !inputs.backfill_tags
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          newest="$(git tag --list 'v*' --sort=-v:refname | head -n 1)"
+
+          if [ "$GITHUB_REF_NAME" = "$newest" ]; then
+            mike deploy --branch "$MIKE_BRANCH" --push --alias-type copy \
+              --update-aliases "$version" "$LATEST_ALIAS"
+            mike set-default --branch "$MIKE_BRANCH" --push "$LATEST_ALIAS"
+          else
+            # Tagging an older line (a backport, or a re-cut of a superseded
+            # tag) must publish that version without dragging `latest` backwards.
+            echo "$GITHUB_REF_NAME is older than $newest — publishing without moving $LATEST_ALIAS."
+            mike deploy --branch "$MIKE_BRANCH" --push --alias-type copy "$version"
+          fi
+
+      - name: Backfill release versions
+        if: inputs.backfill_tags
+        env:
+          BACKFILL_TAGS: ${{ inputs.backfill_tags }}
+        run: |
+          # Tags cut before versioning existed carry no version selector in their
+          # own mkdocs.yml, so the config and theme override from this ref are
+          # layered over each tag checkout. That only works while the tag's page
+          # set still satisfies this nav — the strict build below is what turns a
+          # tag that has drifted too far into a loud failure rather than a
+          # silently broken version.
+          overlay="$(mktemp -d)"
+          cp mkdocs.yml "$overlay/mkdocs.yml"
+          cp -r docs/_overrides "$overlay/_overrides"
+
+          newest="$(git tag --list 'v*' --sort=-v:refname | head -n 1)"
+
+          for tag in $BACKFILL_TAGS; do
+            echo "::group::Publishing $tag"
+            git checkout --force --detach "$tag"
+            cp "$overlay/mkdocs.yml" mkdocs.yml
+            rm -rf docs/_overrides
+            cp -r "$overlay/_overrides" docs/_overrides
+
+            python -m mkdocs build --strict --site-dir "$RUNNER_TEMP/strict-check"
+
+            if [ "$tag" = "$newest" ]; then
+              mike deploy --branch "$MIKE_BRANCH" --push --alias-type copy \
+                --update-aliases "${tag#v}" "$LATEST_ALIAS"
+            else
+              mike deploy --branch "$MIKE_BRANCH" --push --alias-type copy "${tag#v}"
+            fi
+            echo "::endgroup::"
+          done
+
+          git checkout --force "$GITHUB_SHA"
+
+          # The loop above only assigns `latest` to the newest tag, so a backfill
+          # that omits it leaves the alias undefined — and `mike set-default`
+          # errors on an identifier that does not exist. Fall back through the
+          # versions that could plausibly anchor the site root instead of failing
+          # after the versions have already been pushed.
+          if mike list --branch "$MIKE_BRANCH" "$LATEST_ALIAS" >/dev/null 2>&1; then
+            mike set-default --branch "$MIKE_BRANCH" --push "$LATEST_ALIAS"
+          elif mike list --branch "$MIKE_BRANCH" "$MAIN_VERSION" >/dev/null 2>&1; then
+            echo "No $LATEST_ALIAS alias yet — pointing the site root at $MAIN_VERSION."
+            mike set-default --branch "$MIKE_BRANCH" --push "$MAIN_VERSION"
+          else
+            echo "Neither $LATEST_ALIAS nor $MAIN_VERSION is published; leaving the site root default unchanged."
+          fi
+
+      - name: Assemble the Pages artifact from every published version
+        # `git archive` rather than a checkout: it materialises the branch
+        # without leaving git metadata in the directory that gets uploaded.
+        run: |
+          rm -rf site && mkdir site
+          git archive "$MIKE_BRANCH" | tar -x -C site
+
+          # Forwards legacy unversioned URLs to the same page under `latest`.
+          # Kept out of the mike branch deliberately: it is a property of how the
+          # site is served, not of any one published version, so it is refreshed
+          # from this ref on every deploy.
+          if [ -f docs/_site-root/404.html ]; then
+            cp docs/_site-root/404.html site/404.html
+          else
+            echo "::warning::docs/_site-root/404.html is missing — legacy unversioned links will 404."
+          fi
+
+          echo "Publishing these versions:"
+          cat site/versions.json
+
       - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: site
 
   deploy:
-    needs: build
+    needs: publish
     runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -118,6 +118,16 @@ jobs:
         env:
           BACKFILL_TAGS: ${{ inputs.backfill_tags }}
         run: |
+          # A typo'd or missing-`v` tag must fail before anything is published:
+          # the loop below pushes as it goes, so discovering a bad tag halfway
+          # would leave the site half-updated.
+          for tag in $BACKFILL_TAGS; do
+            if ! git rev-parse -q --verify "refs/tags/$tag" >/dev/null; then
+              echo "::error::backfill_tags: '$tag' is not a tag in this repository. Use full release tags, including the leading v — for example v0.1.0-preview.14."
+              exit 1
+            fi
+          done
+
           # Tags cut before versioning existed carry no version selector in their
           # own mkdocs.yml, so the config and theme override from this ref are
           # layered over each tag checkout. That only works while the tag's page
@@ -129,6 +139,12 @@ jobs:
           cp -r docs/_overrides "$overlay/_overrides"
 
           newest="$(git tag --list 'v*' --sort=-v:refname | head -n 1)"
+
+          # Highest of the requested tags, ordered by git's version sort rather
+          # than the order the operator happened to type them in.
+          printf '%s\n' $BACKFILL_TAGS > "$RUNNER_TEMP/backfill-tags.txt"
+          highest_backfilled="$(git tag --list 'v*' --sort=-v:refname \
+            | grep -Fxf "$RUNNER_TEMP/backfill-tags.txt" | head -n 1)"
 
           for tag in $BACKFILL_TAGS; do
             echo "::group::Publishing $tag"
@@ -150,18 +166,21 @@ jobs:
 
           git checkout --force "$GITHUB_SHA"
 
-          # The loop above only assigns `latest` to the newest tag, so a backfill
-          # that omits it leaves the alias undefined — and `mike set-default`
-          # errors on an identifier that does not exist. Fall back through the
-          # versions that could plausibly anchor the site root instead of failing
-          # after the versions have already been pushed.
+          # `mike deploy` writes version directories but never the site root's
+          # index.html — only `set-default` does — so the root would 404 unless
+          # something is selected here. `latest` is the goal; main is the
+          # stand-in before any release is published; and failing those, the
+          # newest version this run published is better than no root at all.
+          # (It is transient either way: the next main push or release tag
+          # re-points the root.)
           if mike list --branch "$MIKE_BRANCH" "$LATEST_ALIAS" >/dev/null 2>&1; then
             mike set-default --branch "$MIKE_BRANCH" --push "$LATEST_ALIAS"
           elif mike list --branch "$MIKE_BRANCH" "$MAIN_VERSION" >/dev/null 2>&1; then
             echo "No $LATEST_ALIAS alias yet — pointing the site root at $MAIN_VERSION."
             mike set-default --branch "$MIKE_BRANCH" --push "$MAIN_VERSION"
           else
-            echo "Neither $LATEST_ALIAS nor $MAIN_VERSION is published; leaving the site root default unchanged."
+            echo "Neither $LATEST_ALIAS nor $MAIN_VERSION is published — pointing the site root at ${highest_backfilled#v}."
+            mike set-default --branch "$MIKE_BRANCH" --push "${highest_backfilled#v}"
           fi
 
       - name: Assemble the Pages artifact from every published version
@@ -174,11 +193,17 @@ jobs:
           # Forwards legacy unversioned URLs to the same page under `latest`.
           # Kept out of the mike branch deliberately: it is a property of how the
           # site is served, not of any one published version, so it is refreshed
-          # from this ref on every deploy.
-          if [ -f docs/_site-root/404.html ]; then
-            cp docs/_site-root/404.html site/404.html
-          else
-            echo "::warning::docs/_site-root/404.html is missing — legacy unversioned links will 404."
+          # from this ref on every deploy. It is tracked in the repo, so a
+          # missing file means something is wrong rather than absent by choice.
+          cp docs/_site-root/404.html site/404.html
+
+          # `mike deploy` writes version directories but never the root
+          # index.html; only `set-default` does. Publishing without one leaves
+          # the site root a 404, which is worth catching here rather than in a
+          # bug report.
+          if [ ! -f site/index.html ]; then
+            echo "::error::The assembled site has no root index.html, so the site root would 404. A publish step must run mike set-default."
+            exit 1
           fi
 
           echo "Publishing these versions:"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,23 @@ Conventions for contributors:
 
 ### Changed
 
+- **The documentation site is published per release, with a version selector (no
+  product code changed).** <https://microsoft.github.io/microsoft-ui-reactor/> was
+  rebuilt from the tip of `main` on every docs push, so it only ever showed unreleased
+  documentation and there was no way to read the docs matching the release you were
+  running. The site is now versioned with [mike](https://github.com/jimporter/mike):
+  each version renders once into a `gh-pages` branch and stays byte-identical
+  afterwards, a release tag publishes its version and takes the `latest` alias, and
+  `main` is published separately as `main (development)`. The site root redirects to
+  `latest`, and every version that is not `latest` carries a banner saying so.
+
+  Versioning moves every page under a version directory, which would turn already
+  published links into 404s, so the published site root also carries a `404.html` that
+  forwards legacy unversioned paths to the same page under `latest`, preserving the
+  query string and anchor — existing links such as `.../getting-started/#manual-setup`
+  keep working. See
+  [the release runbook](docs/contributing/release-runbook.md#versioned-documentation-site).
+
 - **`PoolResetSetCodeFix` now fixes struct-typed `.Set(...)` writes it previously left
   alone (issue #1192).** It could only rewrite a literal `new Thickness(uniform)` or
   `new Thickness(l, t, r, b)`, so every other right-hand side — an opaque local, a

--- a/docs/_overrides/main.html
+++ b/docs/_overrides/main.html
@@ -1,0 +1,14 @@
+{% extends "base.html" %}
+
+{#-
+  Shown by Material for MkDocs on every deployed version that does not carry the
+  alias named by `extra.version.default` in mkdocs.yml. The link deliberately
+  targets the site root rather than the `latest` alias directly, so that already
+  published versions keep working if the alias is ever renamed.
+-#}
+{% block outdated %}
+  You are viewing the documentation for an older version of Microsoft.UI.Reactor.
+  <a href="{{ '../' ~ base_url }}">
+    <strong>Go to the latest release.</strong>
+  </a>
+{% endblock %}

--- a/docs/_overrides/main.html
+++ b/docs/_overrides/main.html
@@ -2,12 +2,16 @@
 
 {#-
   Shown by Material for MkDocs on every deployed version that does not carry the
-  alias named by `extra.version.default` in mkdocs.yml. The link deliberately
-  targets the site root rather than the `latest` alias directly, so that already
-  published versions keep working if the alias is ever renamed.
+  alias named by `extra.version.default` in mkdocs.yml. That covers two different
+  cases — an older release, and the unreleased `main` build, which is newer than
+  the latest release rather than older — so the wording has to fit both.
+
+  The link deliberately targets the site root rather than the `latest` alias
+  directly, so that already published versions keep working if the alias is ever
+  renamed.
 -#}
 {% block outdated %}
-  You are viewing the documentation for an older version of Microsoft.UI.Reactor.
+  You are not viewing the latest release of Microsoft.UI.Reactor.
   <a href="{{ '../' ~ base_url }}">
     <strong>Go to the latest release.</strong>
   </a>

--- a/docs/_site-root/404.html
+++ b/docs/_site-root/404.html
@@ -43,7 +43,18 @@
           window.location.replace(
             base + "latest/" + rest + window.location.search + window.location.hash
           );
+          return;
         }
+
+        // Not redirecting, so the body below is what the reader sees. Point its
+        // link at the same base the redirect would have used, rather than a
+        // hardcoded project path that would be wrong on a custom domain.
+        document.addEventListener("DOMContentLoaded", function () {
+          var link = document.getElementById("latest-link");
+          if (link) {
+            link.setAttribute("href", base + "latest/");
+          }
+        });
       })();
     </script>
   </head>
@@ -52,7 +63,7 @@
     <p>
       This page may have moved. The documentation is now published per release —
       try the
-      <a href="/microsoft-ui-reactor/latest/">latest release documentation</a>.
+      <a id="latest-link" href="/microsoft-ui-reactor/latest/">latest release documentation</a>.
     </p>
   </body>
 </html>

--- a/docs/_site-root/404.html
+++ b/docs/_site-root/404.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="robots" content="noindex" />
+    <title>Redirecting — Microsoft.UI.Reactor</title>
+    <!--
+      Served by GitHub Pages for any unmatched path under the project site.
+
+      The docs site used to be unversioned, so pages lived at paths like
+      /microsoft-ui-reactor/getting-started/. Versioning moved every page under a
+      version directory, which would turn every previously published link — the
+      ones in README.md, in search results, and in other people's bookmarks —
+      into a hard 404. This forwards those legacy paths to the same page in the
+      `latest` release.
+
+      Copied to the published site root by .github/workflows/docs.yml; it is not
+      part of the MkDocs build, so it must not rely on the theme.
+    -->
+    <script>
+      (function () {
+        // The published version directories are named after release versions
+        // ("0.1.0-preview.14"), plus the "main" and "latest" aliases. A path that
+        // already starts with one of those is a genuine 404 inside a published
+        // version, so forwarding it would only produce a nonsense path such as
+        // /latest/main/foo/ — and forwarding a /latest/ path would loop.
+        function isPublishedVersion(segment) {
+          return segment === "latest" || segment === "main" || /^\d/.test(segment);
+        }
+
+        var projectPrefix = "/microsoft-ui-reactor/";
+        var path = window.location.pathname;
+        // Falls back to "/" so this keeps working if the site ever moves to a
+        // custom domain, where there is no repository-name prefix.
+        var base = path.indexOf(projectPrefix) === 0 ? projectPrefix : "/";
+        var rest = path.slice(base.length).replace(/^\/+/, "");
+        var firstSegment = rest.split("/")[0];
+
+        if (rest !== "" && !isPublishedVersion(firstSegment)) {
+          // location.hash survives the failed request, so a deep link such as
+          // /getting-started/#manual-setup keeps its anchor.
+          window.location.replace(
+            base + "latest/" + rest + window.location.search + window.location.hash
+          );
+        }
+      })();
+    </script>
+  </head>
+  <body>
+    <h1>Page not found</h1>
+    <p>
+      This page may have moved. The documentation is now published per release —
+      try the
+      <a href="/microsoft-ui-reactor/latest/">latest release documentation</a>.
+    </p>
+  </body>
+</html>

--- a/docs/_site-root/404.redirect.test.js
+++ b/docs/_site-root/404.redirect.test.js
@@ -1,0 +1,152 @@
+// Regression tests for the redirect logic in 404.html.
+//
+// Run directly with `node docs/_site-root/404.redirect.test.js`, or let CI run it
+// through SiteRootRedirectTests in tests/Reactor.DocPipeline.Tests.
+//
+// The script under test is extracted from 404.html rather than duplicated here,
+// so these cases cannot pass against a copy that has drifted from the file the
+// workflow actually publishes.
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const vm = require("vm");
+
+const htmlPath = path.join(__dirname, "404.html");
+const html = fs.readFileSync(htmlPath, "utf8");
+
+const match = html.match(/<script>([\s\S]*?)<\/script>/);
+if (!match) {
+  console.error(`FATAL: no <script> block found in ${htmlPath}`);
+  process.exit(2);
+}
+const redirectScript = match[1];
+
+// Minimal stand-ins for the two browser APIs the script touches. `replace` and
+// the resolved link href are the observable outputs; everything else is inert.
+function evaluate(href) {
+  const url = new URL(href);
+  const result = { replacedWith: null, linkHref: null };
+
+  const link = {
+    setAttribute(name, value) {
+      if (name === "href") result.linkHref = value;
+    },
+  };
+
+  const sandbox = {
+    window: {
+      location: {
+        pathname: url.pathname,
+        search: url.search,
+        hash: url.hash,
+        replace(to) {
+          result.replacedWith = to;
+        },
+      },
+    },
+    document: {
+      _handlers: [],
+      addEventListener(type, handler) {
+        if (type === "DOMContentLoaded") this._handlers.push(handler);
+      },
+      getElementById(id) {
+        return id === "latest-link" ? link : null;
+      },
+    },
+  };
+  sandbox.window.window = sandbox.window;
+  sandbox.window.document = sandbox.document;
+
+  vm.createContext(sandbox);
+  vm.runInContext(redirectScript, sandbox);
+
+  // The script defers the link fix-up to DOMContentLoaded; fire it so the
+  // no-redirect cases can assert what the reader actually ends up seeing.
+  for (const handler of sandbox.document._handlers) handler();
+
+  return result;
+}
+
+const PAGES = "https://microsoft.github.io";
+const CUSTOM = "https://reactor.example.com";
+
+// [description, input URL, expected redirect target (null = no redirect),
+//  expected fallback-link href (null = not asserted)]
+const cases = [
+  ["legacy top-level page redirects into latest",
+    `${PAGES}/microsoft-ui-reactor/getting-started/`,
+    "/microsoft-ui-reactor/latest/getting-started/", null],
+
+  ["legacy deep link keeps its anchor (the README link)",
+    `${PAGES}/microsoft-ui-reactor/getting-started/#manual-setup`,
+    "/microsoft-ui-reactor/latest/getting-started/#manual-setup", null],
+
+  ["legacy nested page redirects",
+    `${PAGES}/microsoft-ui-reactor/recipes/login/`,
+    "/microsoft-ui-reactor/latest/recipes/login/", null],
+
+  ["legacy page keeps its query string",
+    `${PAGES}/microsoft-ui-reactor/controls/?q=button`,
+    "/microsoft-ui-reactor/latest/controls/?q=button", null],
+
+  ["a miss inside latest does not redirect, so it cannot loop",
+    `${PAGES}/microsoft-ui-reactor/latest/nope/`,
+    null, "/microsoft-ui-reactor/latest/"],
+
+  ["a miss inside main does not gain a second version prefix",
+    `${PAGES}/microsoft-ui-reactor/main/nope/`,
+    null, "/microsoft-ui-reactor/latest/"],
+
+  ["a miss inside a release version does not gain a second version prefix",
+    `${PAGES}/microsoft-ui-reactor/0.1.0-preview.14/nope/`,
+    null, "/microsoft-ui-reactor/latest/"],
+
+  ["the site root itself is left alone",
+    `${PAGES}/microsoft-ui-reactor/`,
+    null, "/microsoft-ui-reactor/latest/"],
+
+  ["a custom domain redirects without the project prefix",
+    `${CUSTOM}/getting-started/`,
+    "/latest/getting-started/", null],
+
+  ["a custom domain miss inside latest does not loop",
+    `${CUSTOM}/latest/nope/`,
+    null, "/latest/"],
+];
+
+let failures = 0;
+
+for (const [description, href, expectedRedirect, expectedLink] of cases) {
+  let actual;
+  try {
+    actual = evaluate(href);
+  } catch (error) {
+    console.log(`not ok  ${description}\n        threw: ${error.message}`);
+    failures++;
+    continue;
+  }
+
+  const redirectOk = actual.replacedWith === expectedRedirect;
+  const linkOk = expectedLink === null || actual.linkHref === expectedLink;
+
+  if (redirectOk && linkOk) {
+    console.log(`ok      ${description}`);
+    continue;
+  }
+
+  failures++;
+  console.log(`not ok  ${description}`);
+  console.log(`        url:      ${href}`);
+  if (!redirectOk) {
+    console.log(`        redirect expected: ${expectedRedirect}`);
+    console.log(`        redirect actual:   ${actual.replacedWith}`);
+  }
+  if (!linkOk) {
+    console.log(`        link href expected: ${expectedLink}`);
+    console.log(`        link href actual:   ${actual.linkHref}`);
+  }
+}
+
+console.log(`\n${cases.length - failures}/${cases.length} passed`);
+process.exit(failures === 0 ? 0 : 1);

--- a/docs/contributing/release-runbook.md
+++ b/docs/contributing/release-runbook.md
@@ -214,20 +214,27 @@ backwards.
 
 Before versioning, pages lived at unversioned paths such as
 `https://microsoft.github.io/microsoft-ui-reactor/getting-started/`. Those paths no longer
-exist — every page now sits under a version directory — so `docs/_site-root/404.html` is
-copied to the published site root and forwards them to the same page under `latest`,
-preserving any query string and anchor. GitHub Pages serves that file for any unmatched path
-under the project site.
+exist — every page now sits under a version directory — so the publish workflow copies
+`docs/_site-root/404.html` to the published site root, where GitHub Pages serves it for
+unmatched paths. It forwards those legacy paths to the same page under `latest`, preserving
+any query string and anchor.
 
 It deliberately does **not** forward a path that already starts with a published version or
 alias (`latest`, `main`, or anything beginning with a digit): those are genuine 404s inside a
 published version, and forwarding them would produce nonsense paths or a redirect loop. If
 version identifiers ever stop matching that shape, update the guard in that file.
 
+MkDocs never sees this file, so `mkdocs build --strict` cannot catch a mistake in it. Its
+behaviour is covered by `docs/_site-root/404.redirect.test.js` instead — run it with
+`node docs/_site-root/404.redirect.test.js`, or let CI run it via `SiteRootRedirectTests` in
+`tests/Reactor.DocPipeline.Tests`.
+
 ### Publishing a version retroactively
 
 Run the `Publish docs` workflow manually and set **backfill_tags** to a space-separated tag
-list, e.g. `v0.1.0-preview.12 v0.1.0-preview.13`. Each tag is checked out and built in turn.
+list, e.g. `v0.1.0-preview.12 v0.1.0-preview.13`. Every tag is verified to exist before
+anything is published — a typo or a missing leading `v` fails the run up front rather than
+halfway through — and each tag is then checked out and built in turn.
 
 Tags cut before versioning existed carry no version selector in their own `mkdocs.yml`, so
 the backfill layers the `mkdocs.yml` and `docs/_overrides/` from the ref you dispatch from

--- a/docs/contributing/release-runbook.md
+++ b/docs/contributing/release-runbook.md
@@ -8,7 +8,7 @@ Releases are **tag-driven**, but pushing a tag only *starts* the pipelines — i
 
 1. **Pre-flight** — pick the next `v0.1.0-preview.N` and confirm the tag, GitHub release, and the four NuGet packages don't already exist (`git tag --list`, `gh release view`, NuGet.org).
 2. **Prep PR (bump one property + recompile docs)** — bump `<ReactorPublicVersion>` in the root `Directory.Build.props` to the version you're about to tag, run `mur docs compile --skip-screenshots --skip-diagrams`, and commit the regenerated `docs/guide` pages. That single property is the source of truth: the guide's `{{reactorVersion}}` token and the template's `MicrosoftUIReactorVersion` fallback both derive from it, and `README.md` is version-agnostic (no sweep needed). CI's docs freshness gate fails the PR if you bump the property without recompiling. Land a PR, merge to `main`.
-3. **Tag `main`** — `git checkout main && git pull`, then `git tag -a v<version> -m "Release <version>"` and `git push origin v<version>`. This starts the GitHub `Package` workflow and the OneBranch official pipeline.
+3. **Tag `main`** — `git checkout main && git pull`, then `git tag -a v<version> -m "Release <version>"` and `git push origin v<version>`. This starts the GitHub `Package` workflow and the OneBranch official pipeline, and publishes the versioned docs site (see [Versioned documentation site](#versioned-documentation-site)).
 4. **Publish (gated)** — the tag push does **not** publish to NuGet.org. Approve the OneBranch `Production_PublishNuGet` stage, then verify the packages appear on NuGet.org.
 5. **Two-person rule** — the publish approver **must be a different person than whoever pushed the tag** (a self-approval is rejected by the compliance gate). Line up a second approver *before* you tag.
 6. **Smoke-test** — scaffold from the published template and restore against NuGet.org.
@@ -179,11 +179,61 @@ After pushing the tag:
 
 1. Confirm the GitHub `Package` workflow runs for the tag and creates a GitHub Release.
 2. Confirm the OneBranch official pipeline starts for the tag.
-3. Approve the `Production_PublishNuGet` stage when ready to publish to NuGet.org.
-4. Verify the packages appear on NuGet.org.
-5. Install the released template package or a locally packed template and create a smoke app that restores against NuGet.org.
+3. Confirm the `Publish docs` workflow runs for the tag and that the new version is selectable at <https://microsoft.github.io/microsoft-ui-reactor/> (see [Versioned documentation site](#versioned-documentation-site)).
+4. Approve the `Production_PublishNuGet` stage when ready to publish to NuGet.org.
+5. Verify the packages appear on NuGet.org.
+6. Install the released template package or a locally packed template and create a smoke app that restores against NuGet.org.
 
 > **Two-person rule (submitter ≠ approver).** Publishing passes through two distinct gates, not one: the ADO Environment approval *and* the OneBranch ApprovalService / ServiceTree compliance check. The OneBranch approver **must be a different person than whoever pushed the release tag** — a self-approval by the tag pusher will be rejected by the compliance gate (and has bitten past release cycles). Line up a second approver before tagging so the publish is not blocked.
+
+## Versioned documentation site
+
+<https://microsoft.github.io/microsoft-ui-reactor/> is versioned with
+[mike](https://github.com/jimporter/mike). Every published version is rendered once and
+kept as its own directory in the `gh-pages` branch, and the Pages artifact is that whole
+branch — so a version's pages stay byte-identical after it ships. Material's version
+selector in the site header reads the `versions.json` mike maintains at the site root.
+
+Nothing about this is manual on the happy path. `.github/workflows/docs.yml` handles it:
+
+| Trigger | Result |
+| --- | --- |
+| Push to `main` touching the docs | Republishes the `main (development)` version |
+| Push of a `v*` tag | Publishes `<version>`, moves the `latest` alias to it, and repoints the site root |
+
+The site root redirects to whichever version holds the `latest` alias, so readers landing
+on the bare URL always get the newest release rather than unreleased `main`. Every version
+that does *not* hold `latest` renders the outdated-version banner defined in
+`docs/_overrides/main.html`.
+
+A tag only takes the `latest` alias if it is the highest tag by version sort. Re-cutting or
+backporting an older tag therefore publishes that version without dragging `latest`
+backwards.
+
+### Legacy unversioned links
+
+Before versioning, pages lived at unversioned paths such as
+`https://microsoft.github.io/microsoft-ui-reactor/getting-started/`. Those paths no longer
+exist — every page now sits under a version directory — so `docs/_site-root/404.html` is
+copied to the published site root and forwards them to the same page under `latest`,
+preserving any query string and anchor. GitHub Pages serves that file for any unmatched path
+under the project site.
+
+It deliberately does **not** forward a path that already starts with a published version or
+alias (`latest`, `main`, or anything beginning with a digit): those are genuine 404s inside a
+published version, and forwarding them would produce nonsense paths or a redirect loop. If
+version identifiers ever stop matching that shape, update the guard in that file.
+
+### Publishing a version retroactively
+
+Run the `Publish docs` workflow manually and set **backfill_tags** to a space-separated tag
+list, e.g. `v0.1.0-preview.12 v0.1.0-preview.13`. Each tag is checked out and built in turn.
+
+Tags cut before versioning existed carry no version selector in their own `mkdocs.yml`, so
+the backfill layers the `mkdocs.yml` and `docs/_overrides/` from the ref you dispatch from
+over each tag checkout. That only holds while the tag's page set still satisfies the current
+`nav`; the workflow's `mkdocs build --strict` step fails loudly if a tag has drifted too far,
+rather than publishing a broken version.
 
 ## If a release tag is wrong
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,3 +2,4 @@ mkdocs==1.6.1
 mkdocs-material==9.7.7
 pymdown-extensions==11.0.1
 pygments==2.20.0
+mike==2.2.0

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,6 +18,9 @@ exclude_docs: |
 
 theme:
   name: material
+  # Supplies the `outdated` block that warns readers when they are viewing a
+  # released version older than `latest`. Must stay outside docs_dir.
+  custom_dir: docs/_overrides
   features:
     - navigation.instant
     - navigation.tracking
@@ -46,6 +49,16 @@ theme:
         name: Switch to light mode
   icon:
     repo: fontawesome/brands/github
+
+# Renders the version selector in the header. Versions themselves live in the
+# gh-pages branch and are published by .github/workflows/docs.yml; `default`
+# names the alias the site root redirects to, and every version not carrying
+# that alias shows the outdated-version warning.
+extra:
+  version:
+    provider: mike
+    default: latest
+    alias: true
 
 markdown_extensions:
   - admonition

--- a/tests/Reactor.DocPipeline.Tests/SiteRootRedirectTests.cs
+++ b/tests/Reactor.DocPipeline.Tests/SiteRootRedirectTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Microsoft.UI.Reactor.Cli.Docs.Tests;
@@ -24,7 +25,7 @@ namespace Microsoft.UI.Reactor.Cli.Docs.Tests;
 public sealed class SiteRootRedirectTests
 {
     [Fact]
-    public void Site_root_404_redirect_cases_pass()
+    public async Task Site_root_404_redirect_cases_pass()
     {
         var repoRoot = FindRepoRoot();
         var testScript = Path.Join(repoRoot, "docs", "_site-root", "404.redirect.test.js");
@@ -44,15 +45,17 @@ public sealed class SiteRootRedirectTests
             CreateNoWindow = true,
         })!;
 
-        // Start both reads before waiting: a child that fills one pipe buffer
-        // blocks on the write while the parent blocks in WaitForExit.
-        var stdout = process.StandardOutput.ReadToEndAsync();
-        var stderr = process.StandardError.ReadToEndAsync();
-        process.WaitForExit();
+        var cancellationToken = TestContext.Current.CancellationToken;
+
+        // Start both reads before awaiting exit: a child that fills one pipe
+        // buffer blocks on the write while the parent waits for it to exit.
+        var stdoutTask = process.StandardOutput.ReadToEndAsync(cancellationToken);
+        var stderrTask = process.StandardError.ReadToEndAsync(cancellationToken);
+        await process.WaitForExitAsync(cancellationToken);
 
         var output = string.Join(
             Environment.NewLine,
-            new[] { stdout.Result, stderr.Result }.Where(s => !string.IsNullOrWhiteSpace(s)));
+            new[] { await stdoutTask, await stderrTask }.Where(s => !string.IsNullOrWhiteSpace(s)));
 
         // Fails rather than skips when node is absent. Every GitHub-hosted
         // runner ships node, and the repo already has npm projects, so a

--- a/tests/Reactor.DocPipeline.Tests/SiteRootRedirectTests.cs
+++ b/tests/Reactor.DocPipeline.Tests/SiteRootRedirectTests.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Cli.Docs.Tests;
+
+/// <summary>
+/// Runs the redirect regression suite for <c>docs/_site-root/404.html</c>.
+///
+/// That file is the only part of the published docs site that MkDocs never
+/// sees: the publish workflow copies it straight into the Pages artifact, so
+/// <c>mkdocs build --strict</c> cannot catch a mistake in it. Without this test
+/// the branching inside it — the loop guard that stops a miss under
+/// <c>latest/</c> redirecting to itself, and the query/anchor preservation that
+/// keeps deep links like the one in README.md intact — would ship unverified.
+///
+/// The cases live in JavaScript next to the file they cover so a docs author can
+/// run them with plain <c>node</c>; this test exists so CI runs them too. It is
+/// wired into the <c>docs-build</c> job, which is armed whenever a non-Markdown
+/// file changes, and both the HTML and the test script qualify.
+/// </summary>
+public sealed class SiteRootRedirectTests
+{
+    [Fact]
+    public void Site_root_404_redirect_cases_pass()
+    {
+        var repoRoot = FindRepoRoot();
+        var testScript = Path.Join(repoRoot, "docs", "_site-root", "404.redirect.test.js");
+
+        Assert.True(
+            File.Exists(testScript),
+            $"Missing {testScript}. The published site's 404 redirect is unverified without it.");
+
+        using var process = Process.Start(new ProcessStartInfo
+        {
+            FileName = "node",
+            ArgumentList = { testScript },
+            WorkingDirectory = repoRoot,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        })!;
+
+        // Start both reads before waiting: a child that fills one pipe buffer
+        // blocks on the write while the parent blocks in WaitForExit.
+        var stdout = process.StandardOutput.ReadToEndAsync();
+        var stderr = process.StandardError.ReadToEndAsync();
+        process.WaitForExit();
+
+        var output = string.Join(
+            Environment.NewLine,
+            new[] { stdout.Result, stderr.Result }.Where(s => !string.IsNullOrWhiteSpace(s)));
+
+        // Fails rather than skips when node is absent. Every GitHub-hosted
+        // runner ships node, and the repo already has npm projects, so a
+        // missing interpreter is a broken environment — and a test that quietly
+        // opts out when its fixture fails is a test that cannot fail.
+        Assert.True(
+            process.ExitCode == 0,
+            $"docs/_site-root/404.redirect.test.js failed (exit {process.ExitCode}):{Environment.NewLine}{output}");
+    }
+
+    private static string FindRepoRoot()
+    {
+        var dir = Directory.GetCurrentDirectory();
+        while (dir is not null)
+        {
+            if (File.Exists(Path.Join(dir, "Reactor.slnx")) || Directory.Exists(Path.Join(dir, ".git")))
+                return dir;
+            dir = Path.GetDirectoryName(dir);
+        }
+        throw new InvalidOperationException("Reactor repo root not found from test cwd.");
+    }
+}


### PR DESCRIPTION
## Summary

The docs site at https://microsoft.github.io/microsoft-ui-reactor/ was rebuilt from the tip of `main` on every docs push, so it only ever showed unreleased documentation. There was no way to read the docs matching the release you were actually running. This versions the site with [mike](https://github.com/jimporter/mike) plus Material for MkDocs' native version selector.

The model worth understanding before reviewing: `gh-pages` is a store of **rendered HTML**, one directory per version, not something derived from tags. A version exists on the site only because a build was run for it and the output filed there. That is what makes published versions stay byte-identical after they ship.

| Trigger | Result |
| --- | --- |
| Push to `main` (docs paths) | Republishes `main (development)` |
| Push a `v*` tag | Publishes that version, moves the `latest` alias, repoints the site root |
| Manual dispatch with `backfill_tags` | Publishes older tags retroactively |

The site root redirects to `latest`, so readers landing on the bare URL get the newest release rather than unreleased `main`. A tag only takes `latest` if it is the highest by version sort, so re-cutting or backporting an older tag cannot drag it backwards.

Versioning moves every page under a version directory, which would turn already published links (including the two in `README.md`) into hard 404s. The published site root therefore carries a `404.html` that forwards legacy unversioned paths to the same page under `latest`, preserving the query string and anchor, and skipping paths already under a published version so it cannot loop.

## Linked issue / spec

N/A. No issue or spec; this came from a direct request for a version selector on the docs site.

## Test plan

- [x] `dotnet test tests/Reactor.DocPipeline.Tests --filter-class "*SiteRootRedirectTests*"` passes (`succeeded: 1`).
- [x] Mutation-checked that test through the real runner rather than trusting a green run: breaking the loop guard in `404.html` turns it red (`failed: 1`), and the C# assertion surfaces the exact failing cases. Breaking the hash handling gives 9/10 and the fallback link 5/10 under `node`.
- [x] Rehearsed all three publish paths (main, release tag, backfill) locally against scratch branches with real mike 2.2.0, and checked the resulting `versions.json`, `latest` alias, root redirect and artifact assembly. `latest/` and `0.1.0-preview.14/` resolve to the same git tree OID, so `--alias-type copy` costs no extra storage.
- [x] Confirmed an older tag builds clean under the new config: `v0.1.0-preview.12` pins mkdocs-material 9.5.49 and passes `mkdocs build --strict`. This is what the backfill depends on.
- [x] Proved the new root-index guard both ways: a rootless site fails the assembly step with exit 1, a healthy one passes with exit 0.
- [x] `python -m mkdocs build --strict` clean, and verified `docs/_site-root/` does not leak into the built site.

`docs/_site-root/404.html` is the one part of the published site MkDocs never parses, so `mkdocs build --strict` cannot cover it. Its cases live in `docs/_site-root/404.redirect.test.js` (runnable with plain `node`), and `SiteRootRedirectTests` in `tests/Reactor.DocPipeline.Tests` is what makes CI run them. That suite is already in the `docs-build` job, which is armed by any non-Markdown change, and both files qualify.

## Risk / breaking changes

No product code and no public API change. The risks are all in the published site:

- **URL layout changes.** Every page moves under a version directory. The root `404.html` is the mitigation and is covered by the tests above. Worth a careful look, since it is the piece protecting existing links and search results.
- **A one-time manual step is needed after merge.** Merging publishes only `main`. To seed the releases, dispatch `Publish docs` once with `backfill_tags` set to `v0.1.0-preview.12 v0.1.0-preview.13 v0.1.0-preview.14`. Until then the site root points at `main` rather than 404ing, but the dropdown will not look right.
- **Creates a new long-lived `gh-pages` branch.** I checked that no other workflow, branch-glob trigger, or CODEOWNERS rule fires on pushes to it.
- **Permissions were narrowed,** not widened: workflow scope is now `permissions: {}`, with `contents: write` only on the publish job and `pages: write` + `id-token: write` only on deploy.
- **The backfill overlays this branch's `mkdocs.yml` and theme override onto each old tag,** since those tags predate the versioning config. That holds only while a tag's page set still satisfies the current `nav`; the per-tag `mkdocs build --strict` is what makes a tag that has drifted too far fail loudly instead of publishing broken.

Two commits, kept separate so the review history stays legible: the first is the feature, the second is exactly what a `pr-review` pass changed. That pass found a real one, confirmed by a reproduction against mike: `mike deploy` writes version directories and `versions.json` but never the root `index.html`, so a backfill omitting the newest tag would have published a site whose landing page 404s.
