### PR TITLE
Prepare the 0.1.0-preview.15 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,20 @@ Conventions for contributors:
 
 ### Added
 
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+## [0.1.0-preview.15] — 2026-09-11
+
+### Added
+
 - **Binary icon sources on `WindowIcon` (spec 036 §4.1, issue #1185).**
   `WindowIcon.FromBytes(ReadOnlySpan<byte>)` takes encoded `.ico` or PNG data and
   `WindowIcon.FromRgba(ReadOnlySpan<byte>, int, int)` takes a raw straight-alpha RGBA8

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -48,7 +48,7 @@
       a floating range like 0.1.* matches nothing and fails restore (NU1103) —
       pin a real version here and substitute it, never float.
     -->
-    <ReactorPublicVersion>0.1.0-preview.14</ReactorPublicVersion>
+    <ReactorPublicVersion>0.1.0-preview.15</ReactorPublicVersion>
   </PropertyGroup>
 
   <!--

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -231,7 +231,7 @@ project and edit the `.csproj`:
     <RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == '' And ('$(Platform)' == '' Or '$(Platform)' == 'AnyCPU')">$(NETCoreSdkPortableRuntimeIdentifier)</RuntimeIdentifier>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.UI.Reactor" Version="0.1.0-preview.14" />
+    <PackageReference Include="Microsoft.UI.Reactor" Version="0.1.0-preview.15" />
   </ItemGroup>
 </Project>
 ```

--- a/docs/guide/charting.md
+++ b/docs/guide/charting.md
@@ -29,7 +29,7 @@ optional `Microsoft.UI.Reactor.Advanced` package (spec 062 §7), so add its
 package reference first:
 
 ```xml
-<PackageReference Include="Microsoft.UI.Reactor.Advanced" Version="0.1.0-preview.14" />
+<PackageReference Include="Microsoft.UI.Reactor.Advanced" Version="0.1.0-preview.15" />
 ```
 
 ```csharp

--- a/docs/guide/data-system.md
+++ b/docs/guide/data-system.md
@@ -105,7 +105,7 @@ optional `Microsoft.UI.Reactor.Advanced` package (spec 062 §7). Add the
 package reference and a second `using static`:
 
 ```xml
-<PackageReference Include="Microsoft.UI.Reactor.Advanced" Version="0.1.0-preview.14" />
+<PackageReference Include="Microsoft.UI.Reactor.Advanced" Version="0.1.0-preview.15" />
 ```
 
 ```csharp

--- a/docs/guide/docking.md
+++ b/docs/guide/docking.md
@@ -18,7 +18,7 @@ Docking ships in the optional `Microsoft.UI.Reactor.Advanced` package
 (spec 062 §7). Add its package reference:
 
 ```xml
-<PackageReference Include="Microsoft.UI.Reactor.Advanced" Version="0.1.0-preview.14" />
+<PackageReference Include="Microsoft.UI.Reactor.Advanced" Version="0.1.0-preview.15" />
 ```
 
 Docking is an opt-in element type — register it at host construction

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -19,7 +19,7 @@ the rest of the docset elaborates.
 <!-- /ai:lock -->
 
 > **Public preview package available.** Reactor ships `Microsoft.UI.Reactor`
-> `0.1.0-preview.14` on NuGet.org. The project template package is still
+> `0.1.0-preview.15` on NuGet.org. The project template package is still
 > installed from source for now; `bootstrap.ps1` installs `mur`, packs/registers
 > the local `reactorapp` template, and stamps generated apps to reference the
 > public preview package by default. Broader signed distribution is tracked in
@@ -43,7 +43,7 @@ install (so it's on PATH cross-shell with no manual `$env:Path` edits), runs
 matching `ProjectTemplates` nupkg, registers the `dotnet new reactorapp`
 template, and drops the Reactor agent plugin under `~/.claude/plugins/reactor`
 (symlink when allowed, copy otherwise). Apps created from that template reference
-`Microsoft.UI.Reactor` version `0.1.0-preview.14` from NuGet.org by default.
+`Microsoft.UI.Reactor` version `0.1.0-preview.15` from NuGet.org by default.
 
 When it finishes you can immediately run:
 
@@ -81,7 +81,7 @@ with a one-line remediation for anything broken.
 > **What this gets you.** A globally-resolvable `mur` (via `~/.dotnet/tools`),
 > a locally installed `reactorapp` template that references
 > `<PackageReference Include="Microsoft.UI.Reactor"
-> Version="0.1.0-preview.14" />`, a local NuGet feed at `<repo>/local-nupkgs/`
+> Version="0.1.0-preview.15" />`, a local NuGet feed at `<repo>/local-nupkgs/`
 > for source-built smoke tests, and an agent plugin so AI assistants generate
 > against the real factories (`mur --skill` / `mur --api` print the same
 > content). Run `mur upgrade` whenever you pull new template, CLI, plugin, or
@@ -171,7 +171,7 @@ New PowerShell windows pick up the user-PATH change on their own.
 **5. Pack local framework snapshots and project templates.** This produces the
 source-built `0.0.0-local` framework nupkgs for smoke tests plus the local
 `ProjectTemplates` nupkg that installs `dotnet new reactorapp`. The template's
-normal default references the public `Microsoft.UI.Reactor` `0.1.0-preview.14`
+normal default references the public `Microsoft.UI.Reactor` `0.1.0-preview.15`
 package.
 
 ```powershell
@@ -268,7 +268,7 @@ Reactor component. No `App.xaml`, no `MainWindow.xaml.cs` — just one C#
 file.
 
 By default that package reference is
-`<PackageReference Include="Microsoft.UI.Reactor" Version="0.1.0-preview.14" />`.
+`<PackageReference Include="Microsoft.UI.Reactor" Version="0.1.0-preview.15" />`.
 For local framework smoke tests, generate with
 `dotnet new reactorapp -n MyLocalApp --MSUIReactorVersion 0.0.0-local` and run
 from inside the source checkout or another folder that has the local feed

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -231,7 +231,7 @@ project and edit the `.csproj`:
     <RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == '' And ('$(Platform)' == '' Or '$(Platform)' == 'AnyCPU')">$(NETCoreSdkPortableRuntimeIdentifier)</RuntimeIdentifier>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.UI.Reactor" Version="0.1.0-preview.14" />
+    <PackageReference Include="Microsoft.UI.Reactor" Version="0.1.0-preview.15" />
   </ItemGroup>
 </Project>
 ```

--- a/docs/guide/packaging.md
+++ b/docs/guide/packaging.md
@@ -311,7 +311,7 @@ a folder inside `Reactor.dll`.
 
 **`Reactor.dll` is in your publish output as a managed assembly,
 not a tucked-away framework package.** Reactor ships as the public preview
-NuGet package `Microsoft.UI.Reactor` version `0.1.0-preview.14`; local
+NuGet package `Microsoft.UI.Reactor` version `0.1.0-preview.15`; local
 source-built smoke packages still use `0.0.0-local` via `mur pack-local`.
 Trim-friendly deployments don't get any framework-side magic; the same trimmer
 configuration that works for any WinUI 3 app works here.

--- a/docs/guide/text-and-media.md
+++ b/docs/guide/text-and-media.md
@@ -244,7 +244,7 @@ Markdown(string markdown, MarkdownOptions options)
 
 > **Package note.** `Markdown(...)` ships in the optional
 > `Microsoft.UI.Reactor.Advanced` package (spec 062 §7). Add a
-> `<PackageReference Include="Microsoft.UI.Reactor.Advanced" Version="0.1.0-preview.14" />` and import
+> `<PackageReference Include="Microsoft.UI.Reactor.Advanced" Version="0.1.0-preview.15" />` and import
 > its factories alongside the core ones:
 > `using static Microsoft.UI.Reactor.Advanced.Factories;`. Both overloads
 > return the base `Element`, and `MarkdownOptions` stays in


### PR DESCRIPTION
Release-prep PR for **0.1.0-preview.15**, following [`docs/contributing/release-runbook.md`](docs/contributing/release-runbook.md).

## Changelog coverage audit

**21 commits** since `v0.1.0-preview.14` — 6 touched `CHANGELOG.md`, 15 did not. **No entries were missing.**

The decisive probe: *which commits touched shipped product source (`src/Reactor/`, `src/Reactor.Advanced/`, `src/Reactor.Analyzers/`, `src/Reactor.Devtools/`, `src/Reactor.Cli/`, `tools/Templates/`, `Directory.Build.props`) without a changelog entry?* The answer was zero. Because a zero-result is not a measurement, the same probe was re-run with the changelog filter removed as a **positive control** — it matched 5 commits, all of which already carry an entry:

| Commit | PR | Entry present |
| --- | --- | --- |
| `323b7d75b` | #1197 — Markdown list content wrapping | ✅ Fixed |
| `5664a4d98` | #1196 — struct-typed `.Margin`/`.Padding`/`.CornerRadius` | ✅ Added + Changed |
| `d9a92bb17` | #1195 — `CleanElement` resets / `IsTabStop` leak | ✅ Fixed |
| `9cde98a76` | #1194 — `REACTOR_ICON_001` | ✅ Added |
| `c0da12623` | #1191 — binary icon sources | ✅ Added |

(#1199 also touched the changelog but no shipped source — it is docs/CI only, and its entry says so explicitly.)

### Deliberately omitted, with reasons

None of the 15 commits without an entry reaches a published package. Each was checked by file path, and the non-obvious ones by diff:

- **10 Dependabot npm bumps** confined to `tests/` and `samples/` — #1174, #1190, #1189, #1187, #1188, #1171, #1172, #1170, plus #1169 (lockfile-only Component Governance clearance) and #1176 (lint/TypeScript fixes in the React Native harness projects).
- **#1179** — `@types/node` in `src/vscode-reactor`, confirmed by diff to be a `devDependencies` entry only.
- **#1186 + #1198** — the only two commits touching `Directory.Packages.props`. Between them the `GitHub.Copilot.SDK` change is **net zero** (1.0.11 → 1.0.13 → 1.0.11, rolled back because 1.0.13 is absent from the OneBranch feed); the SDK is a `Reactor.Cli` dependency and the CLI is not one of the four published packages. The remaining bumps are MSTest 4.3.3 → 4.4.0 and the MTP TrxReport/HangDump extensions 2.3.3 → 2.4.0, all test-only.
- **#1178** — CI coverage for the repo's npm projects. Its only `src/` file is `src/vscode-reactor/out/extension.js.map`; `extension.js` itself is byte-identical, so the compiled extension behaviour is unchanged.
- **#1175** — HeadTrax sample Node server fix (`samples/apps/headtrax/service/`), not shipped.

### Adjudication: did the two `Fixed` product bugs actually ship broken?

A bug introduced *and* fixed inside the same unreleased window never shipped and needs no entry. Settled by checking whether the buggy code shape exists **at the previous tag**, not by issue filing dates:

- **#1197** — `git show v0.1.0-preview.14:src/Reactor.Advanced/Markdown/MarkdownBuilder.cs` contains `Element element = HStack(4, TextBlock(marker).VAlign(...), content);`. The infinite-width StackPanel measure shipped. **Entry is correct.**
- **#1195** — `v0.1.0-preview.14:src/Reactor.Analyzers/ModifierTable.cs` contains both `["Stretch"] = "Viewbox-only modifier."` and `["IsHitTestVisible"] = "No modifier exists; …"`, and `v0.1.0-preview.14:src/Reactor/Core/ElementPool.cs` contains the `if (fe is Control tabStopControl) tabStopControl.ClearValue(Control.IsTabStopProperty);` gate. Both the analyzer blind spot and the non-`Control` `IsTabStop` leak shipped. **Entries are correct.**

One reviewed-and-kept judgement call: #1195's third `Fixed` bullet (the pool ⇄ analyzer consistency invariants now scanning all of `CleanElement`) describes a test-invariant widening rather than user-facing behaviour. It was left in place because it is the mechanism that explains the two product fixes above it, and deleting a merged, reviewed entry during a release cut loses that context.

Spec cross-references on the existing entries were spot-checked against the specs rather than inferred: `docs/specs/036-window-design.md:228` is `### 4.1 WindowSpec`, and `docs/specs/061-in-build-did-you-mean.md` exists.

## Release cut

1. `## [Unreleased]` → `## [0.1.0-preview.15] — 2026-09-11`, with a fresh empty `## [Unreleased]` above it carrying all six Keep-a-Changelog buckets.
2. `<ReactorPublicVersion>` bumped to `0.1.0-preview.15` in the root `Directory.Build.props` — the single source of truth, so no file sweep. README stays version-agnostic.
3. Guide recompiled with `mur docs compile --skip-screenshots --skip-diagrams`, producing **exactly 12 `{{reactorVersion}}` substitutions across 8 guide pages** and no other churn (verified by reading every changed line of `git diff -- docs/guide`).

## Validation

| Check | Result |
| --- | --- |
| `dotnet build tests/Reactor.Tests -p:Platform=x64 -p:SkipSignaturesGen=true` | ✅ 0 errors |
| `dotnet test … --filter-class "*TemplateMetadataTests*"` | ✅ **6/6 passed**, module label `net10.0\|x64` (handshake-derived, so the run really started) |
| `dotnet pack` the template with `-p:MicrosoftUIReactorVersion=0.1.0-preview.15` | ✅ packed |
| Stamped version inside the `.nupkg` | ✅ `.template.config/template.json` symbol `MSUIReactorVersion` has `defaultValue='0.1.0-preview.15'` |
| Negative control — any `0.1.0-preview.14` left in the package? | ✅ none |

The package was verified by expanding the `.nupkg` rather than via `dotnet new install` / floating restore: that touches no global template state and never restores `Microsoft.UI.Reactor`, so it cannot be fooled by an internal ADO CI build such as `0.1.0-preview.13.30` sitting in the shared local NuGet cache (those sort *above* released previews while predating recent features). `local-nupkgs` and the temp expansion directory were cleaned up.

## Pre-flight

| Check | Result |
| --- | --- |
| `git ls-remote --tags origin v0.1.0-preview.15` | ✅ absent (positive control: `v0.1.0-preview.14` → `456d63e03`) |
| `gh release view v0.1.0-preview.15` | ✅ `release not found` (positive control: preview.14 returns its JSON) |
| Four packages absent from NuGet.org | ⚠️ **UNVERIFIED — not a pass** |

**nuget.org is unreachable from this environment** (`The SSL connection could not be established` against `https://api.nuget.org/v3-flatcontainer/microsoft.ui.reactor/index.json`), which is also why every build in this PR logs `NU1900`. The runbook's "confirm the four packages aren't already published" step therefore could not be completed here and is flagged rather than implied to have passed — a failed lookup is not a measurement. Someone with NuGet.org reachability should confirm `Microsoft.UI.Reactor`, `Microsoft.UI.Reactor.Advanced`, `Microsoft.UI.Reactor.Devtools` and `Microsoft.UI.Reactor.ProjectTemplates` have no `0.1.0-preview.15` before the publish gate is approved.

## After merge (not done in this PR)

Tagging is deliberately left for explicit approval. When approved, tag the **merge commit** (`git tag -a v0.1.0-preview.15 <sha>` then `git push origin v0.1.0-preview.15`, individually — never `git push --tags`). Note that **the tag does not publish to NuGet.org**: publishing requires approving the OneBranch `Production_PublishNuGet` stage, and the **two-person rule** means the approver must be a different person than whoever pushed the tag.