### PR TITLE
Make ShutdownPolicy govern process lifetime (#1204)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,13 @@ Conventions for contributors:
 
 ### Fixed
 
+- `ShutdownPolicy.Explicit` and `ShutdownPolicy.OnLastSurfaceClosed` now actually keep the process
+  running: Reactor projects the policy onto `Application.DispatcherShutdownMode`, so WinUI no longer
+  quits the event loop on last-window-close before `EvaluateShutdownPolicy` can veto it. Closing the
+  last window of a tray-backed app used to exit with code 0 as if the policy were
+  `OnPrimaryWindowClosed`. The default policy is unchanged, and apps that embed `ReactorHostControl`
+  in their own `Application` are left alone. (spec 036 §6.2, issue #1204)
+
 ### Security
 
 ## [0.1.0-preview.15] — 2026-09-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,11 +37,14 @@ Conventions for contributors:
 ### Fixed
 
 - `ShutdownPolicy.Explicit` and `ShutdownPolicy.OnLastSurfaceClosed` now actually keep the process
-  running: Reactor projects the policy onto `Application.DispatcherShutdownMode`, so WinUI no longer
-  quits the event loop on last-window-close before `EvaluateShutdownPolicy` can veto it. Closing the
-  last window of a tray-backed app used to exit with code 0 as if the policy were
-  `OnPrimaryWindowClosed`. The default policy is unchanged, and apps that embed `ReactorHostControl`
-  in their own `Application` are left alone. (spec 036 §6.2, issue #1204)
+  running. Reactor takes ownership of the WinUI dispatcher loop at startup
+  (`Application.DispatcherShutdownMode = OnExplicitShutdown`), so the platform no longer ends the
+  process on last-window-close without consulting `EvaluateShutdownPolicy`. Closing the last window
+  of a tray-backed app used to exit with code 0 as if the policy were `OnPrimaryWindowClosed`.
+  Ownership is unconditional, which also makes the documented issue-#647 guarantee real: under the
+  default policy, closing an auxiliary window that opted out via `ExcludeFromShutdownPolicy` no
+  longer ends the app even when it was the last window on screen. Apps that embed
+  `ReactorHostControl` in their own `Application` are left alone. (spec 036 §6.2, issue #1204)
 
 ### Security
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -264,7 +264,7 @@ Two Host modes serve it:
 
 | Mode | Question | Exit codes |
 |---|---|---|
-| `--shutdown-policy-probe <policy> [--with-tray] [--no-window] [--reopen] [--excluded-window] [--close-tray]` | Does the event loop outlive its last window (or a zero-surface startup)? | `42` still alive, `1` loop unwound, `45` reopen failed |
+| `--shutdown-policy-probe <policy> [--with-tray] [--no-window] [--reopen] [--excluded-window] [--close-tray] [--legacy-run]` | Does the event loop outlive its last window (or a zero-surface startup)? | `42` still alive, `1` loop unwound, `45` reopen failed |
 | `--shutdown-policy-gate-probe` | Does Reactor leave a *non*-Reactor `Application`'s lifetime alone? | `43` gate held, `44` gate violated, `46` inconclusive |
 
 Every arm has a counterpart asserting the opposite outcome, so a "still alive" or "gate

--- a/TESTING.md
+++ b/TESTING.md
@@ -250,6 +250,33 @@ dotnet run --project tests/Reactor.AppTests.Host -- --self-test
 dotnet run --project tests/Reactor.AppTests.Host -- --self-test --filter "Flex"
 ```
 
+### Not every test here wraps a TAP fixture
+
+`SelfTestBatch` is the TAP wrapper, but the project also holds tests that drive the Host in
+*different* modes because the thing under test is the process itself.
+`ShutdownPolicyProcessLifetimeTests` is the current example: `--self-test` cannot answer
+"did the process survive its last window closing?", because that Host terminates itself
+when the run ends — and it cannot reach a code path guarded by
+`Application.Current is ReactorApplication` at all, because inside the selftest Host that
+is always true.
+
+Two Host modes serve it:
+
+| Mode | Question | Exit codes |
+|---|---|---|
+| `--shutdown-policy-probe <policy> [--with-tray] [--no-window] [--reopen]` | Does the event loop outlive its last window (or a zero-surface startup)? | `42` still alive, `1` loop unwound, `45` reopen failed |
+| `--shutdown-policy-gate-probe` | Does Reactor leave a *non*-Reactor `Application`'s lifetime alone? | `43` gate held, `44` gate violated, `46` inconclusive |
+
+Every arm has a counterpart asserting the opposite outcome, so a "still alive" or "gate
+held" result is a measurement rather than a probe that can only report one thing.
+
+Reach for this shape only when in-process observation is structurally impossible — process
+lifetime, startup ordering, a branch that depends on who owns the `Application`. Anything
+you can see from inside a live window belongs in a fixture. Share `HostProcess` for
+locating and running the Host so every mode agrees on where the binary lives; it reads the
+configuration and TFM stamped into the test assembly by `Reactor.SelfTests.csproj`, so
+`dotnet test -c Release` finds the Release Host rather than a stale Debug one.
+
 ### Fixture registration is two-place — and what that does to name searches
 
 Selftest: add the fixture to `AllFixtures` **and** to the `Create()` switch in

--- a/TESTING.md
+++ b/TESTING.md
@@ -264,7 +264,7 @@ Two Host modes serve it:
 
 | Mode | Question | Exit codes |
 |---|---|---|
-| `--shutdown-policy-probe <policy> [--with-tray] [--no-window] [--reopen]` | Does the event loop outlive its last window (or a zero-surface startup)? | `42` still alive, `1` loop unwound, `45` reopen failed |
+| `--shutdown-policy-probe <policy> [--with-tray] [--no-window] [--reopen] [--excluded-window]` | Does the event loop outlive its last window (or a zero-surface startup)? | `42` still alive, `1` loop unwound, `45` reopen failed |
 | `--shutdown-policy-gate-probe` | Does Reactor leave a *non*-Reactor `Application`'s lifetime alone? | `43` gate held, `44` gate violated, `46` inconclusive |
 
 Every arm has a counterpart asserting the opposite outcome, so a "still alive" or "gate

--- a/TESTING.md
+++ b/TESTING.md
@@ -264,7 +264,7 @@ Two Host modes serve it:
 
 | Mode | Question | Exit codes |
 |---|---|---|
-| `--shutdown-policy-probe <policy> [--with-tray] [--no-window] [--reopen] [--excluded-window]` | Does the event loop outlive its last window (or a zero-surface startup)? | `42` still alive, `1` loop unwound, `45` reopen failed |
+| `--shutdown-policy-probe <policy> [--with-tray] [--no-window] [--reopen] [--excluded-window] [--close-tray]` | Does the event loop outlive its last window (or a zero-surface startup)? | `42` still alive, `1` loop unwound, `45` reopen failed |
 | `--shutdown-policy-gate-probe` | Does Reactor leave a *non*-Reactor `Application`'s lifetime alone? | `43` gate held, `44` gate violated, `46` inconclusive |
 
 Every arm has a counterpart asserting the opposite outcome, so a "still alive" or "gate

--- a/docs/_pipeline/templates/windows.md.dt
+++ b/docs/_pipeline/templates/windows.md.dt
@@ -564,17 +564,20 @@ exit. Auxiliary windows that opt out of the shutdown policy (such as docking
 tear-off floating windows) are never elected primary, so closing one of them
 never exits the app even when it is the last *visible* window.
 
-Reactor drives WinUI's `Application.DispatcherShutdownMode` from the policy, so
-picking one is all you need. At startup Reactor switches the platform to
-`OnExplicitShutdown` — otherwise WinUI ends the process when the last window
-closes, without consulting the policy, a tray icon, or `ExcludeFromShutdownPolicy`.
-From then on the table above is exhaustive: every exit is Reactor's decision.
+Reactor takes ownership of WinUI's `Application.DispatcherShutdownMode` at
+startup, switching the platform to `OnExplicitShutdown`. Otherwise WinUI ends the
+process when the last window closes, without consulting the policy, a tray icon,
+or `ExcludeFromShutdownPolicy`. Ownership is unconditional — it does not vary with
+the policy — so the table above is exhaustive: every exit is Reactor's decision,
+made by evaluating the policy when a surface closes.
 
 Set the policy before `ReactorApp.Run` or at any point afterwards, from any
 thread; it is read when a surface closes, so there is no ordering to get right.
+Changing it does not move `DispatcherShutdownMode`.
 
-Reactor only takes that ownership when it owns the `Application`, so a host app
-that embeds `ReactorHostControl` in its own `Application` keeps its own lifetime.
+Reactor only takes that ownership when it owns the `Application`. A WinUI app that
+embeds `ReactorHostControl` runs its own `Application` and manages its own
+windows, so Reactor leaves its shutdown mode — and its lifetime — alone.
 
 ## Tips
 

--- a/docs/_pipeline/templates/windows.md.dt
+++ b/docs/_pipeline/templates/windows.md.dt
@@ -568,8 +568,11 @@ Reactor takes ownership of WinUI's `Application.DispatcherShutdownMode` at
 startup, switching the platform to `OnExplicitShutdown`. Otherwise WinUI ends the
 process when the last window closes, without consulting the policy, a tray icon,
 or `ExcludeFromShutdownPolicy`. Ownership is unconditional — it does not vary with
-the policy — so the table above is exhaustive: every exit is Reactor's decision,
-made by evaluating the policy when a surface closes.
+the policy — so the table above is exhaustive for surface closes: when a window or
+tray icon closes, the policy alone decides. The process can also end in two other
+ways, neither of which involves the platform: a startup callback that opens no
+surface at all exits immediately under `OnPrimaryWindowClosed`, and
+`ReactorApp.Exit()` always works.
 
 Set the policy before `ReactorApp.Run` or at any point afterwards, from any
 thread; it is read when a surface closes, so there is no ordering to get right.

--- a/docs/_pipeline/templates/windows.md.dt
+++ b/docs/_pipeline/templates/windows.md.dt
@@ -564,6 +564,25 @@ exit. Auxiliary windows that opt out of the shutdown policy (such as docking
 tear-off floating windows) are never elected primary, so closing one of them
 never exits the app even when it is the last *visible* window.
 
+Reactor drives WinUI's `Application.DispatcherShutdownMode` from the policy, so
+picking one is all you need — the two non-default policies switch the platform to
+`OnExplicitShutdown` so the event loop outlives the last window, and Reactor
+decides when the process ends. Reactor only touches that property when it owns the
+`Application`, so a host app that embeds `ReactorHostControl` keeps its own lifetime.
+
+Where you set the policy decides when the platform catches up, because
+`DispatcherShutdownMode` is per-thread and cannot be written from another thread:
+
+| Set from | Takes effect |
+| --- | --- |
+| Before `ReactorApp.Run` | Stored, then applied at startup before any window opens |
+| The UI thread (startup callback, event handler, tray command) | Before the setter returns |
+| A background thread | On a following UI-thread turn |
+
+Prefer the first two. A background-thread change is posted rather than awaited —
+blocking would deadlock a UI thread that is waiting on the caller — so a window
+close the UI thread happens to process first is still judged by the previous policy.
+
 ## Tips
 
 **Memoize specs.** A stable `WindowSpec` avoids unnecessary chrome updates.

--- a/docs/_pipeline/templates/windows.md.dt
+++ b/docs/_pipeline/templates/windows.md.dt
@@ -565,23 +565,16 @@ tear-off floating windows) are never elected primary, so closing one of them
 never exits the app even when it is the last *visible* window.
 
 Reactor drives WinUI's `Application.DispatcherShutdownMode` from the policy, so
-picking one is all you need — the two non-default policies switch the platform to
-`OnExplicitShutdown` so the event loop outlives the last window, and Reactor
-decides when the process ends. Reactor only touches that property when it owns the
-`Application`, so a host app that embeds `ReactorHostControl` keeps its own lifetime.
+picking one is all you need. At startup Reactor switches the platform to
+`OnExplicitShutdown` — otherwise WinUI ends the process when the last window
+closes, without consulting the policy, a tray icon, or `ExcludeFromShutdownPolicy`.
+From then on the table above is exhaustive: every exit is Reactor's decision.
 
-Where you set the policy decides when the platform catches up, because
-`DispatcherShutdownMode` is per-thread and cannot be written from another thread:
+Set the policy before `ReactorApp.Run` or at any point afterwards, from any
+thread; it is read when a surface closes, so there is no ordering to get right.
 
-| Set from | Takes effect |
-| --- | --- |
-| Before `ReactorApp.Run` | Stored, then applied at startup before any window opens |
-| The UI thread (startup callback, event handler, tray command) | Before the setter returns |
-| A background thread | On a following UI-thread turn |
-
-Prefer the first two. A background-thread change is posted rather than awaited —
-blocking would deadlock a UI thread that is waiting on the caller — so a window
-close the UI thread happens to process first is still judged by the previous policy.
+Reactor only takes that ownership when it owns the `Application`, so a host app
+that embeds `ReactorHostControl` in its own `Application` keeps its own lifetime.
 
 ## Tips
 

--- a/docs/_pipeline/templates/windows.md.dt
+++ b/docs/_pipeline/templates/windows.md.dt
@@ -569,10 +569,10 @@ startup, switching the platform to `OnExplicitShutdown`. Otherwise WinUI ends th
 process when the last window closes, without consulting the policy, a tray icon,
 or `ExcludeFromShutdownPolicy`. Ownership is unconditional — it does not vary with
 the policy — so the table above is exhaustive for surface closes: when a window or
-tray icon closes, the policy alone decides. The process can also end in two other
-ways, neither of which involves the platform: a startup callback that opens no
-surface at all exits immediately under `OnPrimaryWindowClosed`, and
-`ReactorApp.Exit()` always works.
+tray icon closes, the policy alone decides. The process can also end two other
+ways, both of which ask WinUI to exit outright rather than letting it decide: a
+startup callback that opens no surface at all exits immediately under
+`OnPrimaryWindowClosed`, and `ReactorApp.Exit()` always works.
 
 Set the policy before `ReactorApp.Run` or at any point afterwards, from any
 thread; it is read when a surface closes, so there is no ordering to get right.

--- a/docs/_pipeline/templates/windows.md.dt
+++ b/docs/_pipeline/templates/windows.md.dt
@@ -574,9 +574,12 @@ ways, both of which ask WinUI to exit outright rather than letting it decide: a
 startup callback that opens no surface at all exits immediately under
 `OnPrimaryWindowClosed`, and `ReactorApp.Exit()` always works.
 
-Set the policy before `ReactorApp.Run` or at any point afterwards, from any
-thread; it is read when a surface closes, so there is no ordering to get right.
-Changing it does not move `DispatcherShutdownMode`.
+Set the policy before `ReactorApp.Run`, or on the UI thread before your startup
+callback returns. A surface close reads it at the moment it happens, so a change
+made any time beforehand counts — but a zero-surface startup is judged the instant
+the callback returns, so a write posted from another thread during startup can
+land too late to be seen. Changing the policy never moves
+`DispatcherShutdownMode`.
 
 Reactor only takes that ownership when it owns the `Application`. A WinUI app that
 embeds `ReactorHostControl` runs its own `Application` and manages its own

--- a/docs/guide/windows.md
+++ b/docs/guide/windows.md
@@ -904,10 +904,10 @@ startup, switching the platform to `OnExplicitShutdown`. Otherwise WinUI ends th
 process when the last window closes, without consulting the policy, a tray icon,
 or `ExcludeFromShutdownPolicy`. Ownership is unconditional — it does not vary with
 the policy — so the table above is exhaustive for surface closes: when a window or
-tray icon closes, the policy alone decides. The process can also end in two other
-ways, neither of which involves the platform: a startup callback that opens no
-surface at all exits immediately under `OnPrimaryWindowClosed`, and
-`ReactorApp.Exit()` always works.
+tray icon closes, the policy alone decides. The process can also end two other
+ways, both of which ask WinUI to exit outright rather than letting it decide: a
+startup callback that opens no surface at all exits immediately under
+`OnPrimaryWindowClosed`, and `ReactorApp.Exit()` always works.
 
 Set the policy before `ReactorApp.Run` or at any point afterwards, from any
 thread; it is read when a surface closes, so there is no ordering to get right.

--- a/docs/guide/windows.md
+++ b/docs/guide/windows.md
@@ -909,9 +909,12 @@ ways, both of which ask WinUI to exit outright rather than letting it decide: a
 startup callback that opens no surface at all exits immediately under
 `OnPrimaryWindowClosed`, and `ReactorApp.Exit()` always works.
 
-Set the policy before `ReactorApp.Run` or at any point afterwards, from any
-thread; it is read when a surface closes, so there is no ordering to get right.
-Changing it does not move `DispatcherShutdownMode`.
+Set the policy before `ReactorApp.Run`, or on the UI thread before your startup
+callback returns. A surface close reads it at the moment it happens, so a change
+made any time beforehand counts — but a zero-surface startup is judged the instant
+the callback returns, so a write posted from another thread during startup can
+land too late to be seen. Changing the policy never moves
+`DispatcherShutdownMode`.
 
 Reactor only takes that ownership when it owns the `Application`. A WinUI app that
 embeds `ReactorHostControl` runs its own `Application` and manages its own

--- a/docs/guide/windows.md
+++ b/docs/guide/windows.md
@@ -899,6 +899,25 @@ exit. Auxiliary windows that opt out of the shutdown policy (such as docking
 tear-off floating windows) are never elected primary, so closing one of them
 never exits the app even when it is the last *visible* window.
 
+Reactor drives WinUI's `Application.DispatcherShutdownMode` from the policy, so
+picking one is all you need — the two non-default policies switch the platform to
+`OnExplicitShutdown` so the event loop outlives the last window, and Reactor
+decides when the process ends. Reactor only touches that property when it owns the
+`Application`, so a host app that embeds `ReactorHostControl` keeps its own lifetime.
+
+Where you set the policy decides when the platform catches up, because
+`DispatcherShutdownMode` is per-thread and cannot be written from another thread:
+
+| Set from | Takes effect |
+| --- | --- |
+| Before `ReactorApp.Run` | Stored, then applied at startup before any window opens |
+| The UI thread (startup callback, event handler, tray command) | Before the setter returns |
+| A background thread | On a following UI-thread turn |
+
+Prefer the first two. A background-thread change is posted rather than awaited —
+blocking would deadlock a UI thread that is waiting on the caller — so a window
+close the UI thread happens to process first is still judged by the previous policy.
+
 ## Tips
 
 **Memoize specs.** A stable `WindowSpec` avoids unnecessary chrome updates.

--- a/docs/guide/windows.md
+++ b/docs/guide/windows.md
@@ -903,8 +903,11 @@ Reactor takes ownership of WinUI's `Application.DispatcherShutdownMode` at
 startup, switching the platform to `OnExplicitShutdown`. Otherwise WinUI ends the
 process when the last window closes, without consulting the policy, a tray icon,
 or `ExcludeFromShutdownPolicy`. Ownership is unconditional — it does not vary with
-the policy — so the table above is exhaustive: every exit is Reactor's decision,
-made by evaluating the policy when a surface closes.
+the policy — so the table above is exhaustive for surface closes: when a window or
+tray icon closes, the policy alone decides. The process can also end in two other
+ways, neither of which involves the platform: a startup callback that opens no
+surface at all exits immediately under `OnPrimaryWindowClosed`, and
+`ReactorApp.Exit()` always works.
 
 Set the policy before `ReactorApp.Run` or at any point afterwards, from any
 thread; it is read when a surface closes, so there is no ordering to get right.

--- a/docs/guide/windows.md
+++ b/docs/guide/windows.md
@@ -899,17 +899,20 @@ exit. Auxiliary windows that opt out of the shutdown policy (such as docking
 tear-off floating windows) are never elected primary, so closing one of them
 never exits the app even when it is the last *visible* window.
 
-Reactor drives WinUI's `Application.DispatcherShutdownMode` from the policy, so
-picking one is all you need. At startup Reactor switches the platform to
-`OnExplicitShutdown` — otherwise WinUI ends the process when the last window
-closes, without consulting the policy, a tray icon, or `ExcludeFromShutdownPolicy`.
-From then on the table above is exhaustive: every exit is Reactor's decision.
+Reactor takes ownership of WinUI's `Application.DispatcherShutdownMode` at
+startup, switching the platform to `OnExplicitShutdown`. Otherwise WinUI ends the
+process when the last window closes, without consulting the policy, a tray icon,
+or `ExcludeFromShutdownPolicy`. Ownership is unconditional — it does not vary with
+the policy — so the table above is exhaustive: every exit is Reactor's decision,
+made by evaluating the policy when a surface closes.
 
 Set the policy before `ReactorApp.Run` or at any point afterwards, from any
 thread; it is read when a surface closes, so there is no ordering to get right.
+Changing it does not move `DispatcherShutdownMode`.
 
-Reactor only takes that ownership when it owns the `Application`, so a host app
-that embeds `ReactorHostControl` in its own `Application` keeps its own lifetime.
+Reactor only takes that ownership when it owns the `Application`. A WinUI app that
+embeds `ReactorHostControl` runs its own `Application` and manages its own
+windows, so Reactor leaves its shutdown mode — and its lifetime — alone.
 
 ## Tips
 

--- a/docs/guide/windows.md
+++ b/docs/guide/windows.md
@@ -900,23 +900,16 @@ tear-off floating windows) are never elected primary, so closing one of them
 never exits the app even when it is the last *visible* window.
 
 Reactor drives WinUI's `Application.DispatcherShutdownMode` from the policy, so
-picking one is all you need — the two non-default policies switch the platform to
-`OnExplicitShutdown` so the event loop outlives the last window, and Reactor
-decides when the process ends. Reactor only touches that property when it owns the
-`Application`, so a host app that embeds `ReactorHostControl` keeps its own lifetime.
+picking one is all you need. At startup Reactor switches the platform to
+`OnExplicitShutdown` — otherwise WinUI ends the process when the last window
+closes, without consulting the policy, a tray icon, or `ExcludeFromShutdownPolicy`.
+From then on the table above is exhaustive: every exit is Reactor's decision.
 
-Where you set the policy decides when the platform catches up, because
-`DispatcherShutdownMode` is per-thread and cannot be written from another thread:
+Set the policy before `ReactorApp.Run` or at any point afterwards, from any
+thread; it is read when a surface closes, so there is no ordering to get right.
 
-| Set from | Takes effect |
-| --- | --- |
-| Before `ReactorApp.Run` | Stored, then applied at startup before any window opens |
-| The UI thread (startup callback, event handler, tray command) | Before the setter returns |
-| A background thread | On a following UI-thread turn |
-
-Prefer the first two. A background-thread change is posted rather than awaited —
-blocking would deadlock a UI thread that is waiting on the caller — so a window
-close the UI thread happens to process first is still judged by the previous policy.
+Reactor only takes that ownership when it owns the `Application`, so a host app
+that embeds `ReactorHostControl` in its own `Application` keeps its own lifetime.
 
 ## Tips
 

--- a/docs/specs/036-window-design.md
+++ b/docs/specs/036-window-design.md
@@ -551,10 +551,11 @@ Because the mode no longer depends on the policy, `ShutdownPolicy` stays
 a plain store: settable from any thread, read when a surface closes, with
 no window in which the policy and the platform can disagree.
 
-Reactor only takes ownership when it owns the `Application`: an app
-embedding `ReactorHostControl` never calls `Application.Start`, so its
-mode already defaults to `OnExplicitShutdown` and Reactor must not change
-that app's lifetime.
+Reactor only takes ownership when it owns the `Application` — when
+`Application.Current` is a `ReactorApplication`. A WinUI app that embeds
+`ReactorHostControl` runs its own `Application` and manages its own
+windows, so Reactor does not decide when that process ends and leaves its
+`DispatcherShutdownMode` at whatever the app chose or inherited.
 
 ### 6.3 Per-window teardown
 

--- a/docs/specs/036-window-design.md
+++ b/docs/specs/036-window-design.md
@@ -526,26 +526,35 @@ The startup callback is allowed to open zero surfaces. `ReactorApp.Run`
 does not require at least one `OpenWindow` or `OpenTrayIcon` call —
 only that the selected `ShutdownPolicy` permits the resulting state.
 
-**Platform projection (issue #1204).** WinUI quits the thread's
+**Platform ownership (issue #1204).** WinUI quits the thread's
 `DispatcherQueue` event loop when the last XAML window closes unless
 `Application.DispatcherShutdownMode` is `OnExplicitShutdown`, and
-`Application.Start` resets that property to `OnLastWindowClose`. Reactor
-therefore derives the mode from the policy — `OnExplicitShutdown` for
-`Explicit` and `OnLastSurfaceClosed`, the platform default for
-`OnPrimaryWindowClosed` — so §6.2 is the sole authority on process
-lifetime for the two non-default policies. The write happens in
-`OnLaunched` (for a policy chosen before `Run`) and from the
-`ShutdownPolicy` setter (for a later change). The property is per-thread,
-so a setter call from a background thread posts the write to the UI
-dispatcher instead of performing it inline; it does not block on that hop,
-because a UI thread waiting on the caller would deadlock. The consequence
-is ordering, not loss: a close the UI thread processes before the posted
-write is judged by the previous policy, which is why the documented
-guidance is to set the policy before `Run` or on the UI thread. Reactor
-only writes it when it owns the `Application`: an app embedding
-`ReactorHostControl` never calls `Application.Start`, so its mode already
-defaults to `OnExplicitShutdown` and Reactor must not change that app's
-lifetime.
+`Application.Start` resets that property to `OnLastWindowClose`. Leaving
+it there makes the platform a second, uncoordinated decision-maker: it
+cannot see `Explicit`, a surviving tray icon, or a window that opted out
+via `ExcludeFromShutdownPolicy`, so it ends processes this section says
+should keep running.
+
+`OnLaunched` therefore switches the mode to `OnExplicitShutdown` once,
+before any window exists, for **every** policy — not only the two that
+obviously need it. That unconditional ownership is what makes §6.2
+exhaustive, and in particular what makes §6.4's auxiliary-window
+guarantee real: closing a docking tear-off that was never elected primary
+leaves `closedWasPrimary` false, and now nothing else unwinds the loop
+behind Reactor's back. Every exit flows through one of three places —
+`EvaluateShutdownPolicy` on a surface close, the zero-surface check in
+`OnLaunched`, or an explicit `ReactorApp.Exit`. `ReactorWindow`
+subscribes to the native `Window.Closed`, so a user-initiated close is
+observed exactly like an app-initiated one.
+
+Because the mode no longer depends on the policy, `ShutdownPolicy` stays
+a plain store: settable from any thread, read when a surface closes, with
+no window in which the policy and the platform can disagree.
+
+Reactor only takes ownership when it owns the `Application`: an app
+embedding `ReactorHostControl` never calls `Application.Start`, so its
+mode already defaults to `OnExplicitShutdown` and Reactor must not change
+that app's lifetime.
 
 ### 6.3 Per-window teardown
 

--- a/docs/specs/036-window-design.md
+++ b/docs/specs/036-window-design.md
@@ -526,6 +526,27 @@ The startup callback is allowed to open zero surfaces. `ReactorApp.Run`
 does not require at least one `OpenWindow` or `OpenTrayIcon` call —
 only that the selected `ShutdownPolicy` permits the resulting state.
 
+**Platform projection (issue #1204).** WinUI quits the thread's
+`DispatcherQueue` event loop when the last XAML window closes unless
+`Application.DispatcherShutdownMode` is `OnExplicitShutdown`, and
+`Application.Start` resets that property to `OnLastWindowClose`. Reactor
+therefore derives the mode from the policy — `OnExplicitShutdown` for
+`Explicit` and `OnLastSurfaceClosed`, the platform default for
+`OnPrimaryWindowClosed` — so §6.2 is the sole authority on process
+lifetime for the two non-default policies. The write happens in
+`OnLaunched` (for a policy chosen before `Run`) and from the
+`ShutdownPolicy` setter (for a later change). The property is per-thread,
+so a setter call from a background thread posts the write to the UI
+dispatcher instead of performing it inline; it does not block on that hop,
+because a UI thread waiting on the caller would deadlock. The consequence
+is ordering, not loss: a close the UI thread processes before the posted
+write is judged by the previous policy, which is why the documented
+guidance is to set the policy before `Run` or on the UI thread. Reactor
+only writes it when it owns the `Application`: an app embedding
+`ReactorHostControl` never calls `Application.Start`, so its mode already
+defaults to `OnExplicitShutdown` and Reactor must not change that app's
+lifetime.
+
 ### 6.3 Per-window teardown
 
 - `Window.Closed` → `ReactorWindow.Closed` event

--- a/docs/specs/036-window-design.md
+++ b/docs/specs/036-window-design.md
@@ -532,12 +532,19 @@ only that the selected `ShutdownPolicy` permits the resulting state.
 `Application.Start` resets that property to `OnLastWindowClose`. Leaving
 it there makes the platform a second, uncoordinated decision-maker: it
 cannot see `Explicit`, a surviving tray icon, or a window that opted out
-via `ExcludeFromShutdownPolicy`, so it ends processes this section says
-should keep running.
+via `ExcludeFromShutdownPolicy`, so it ends processes that this section
+says should keep running.
 
 `OnLaunched` therefore switches the mode to `OnExplicitShutdown` once,
 before any window exists, for **every** policy — not only the two that
-obviously need it. That unconditional ownership is what makes §6.2
+obviously need it. It does so on the launch shapes Reactor drives (the
+`Run(startup)` callback and the legacy `Run<TRoot>` bridge) and
+deliberately not when `ReactorApplication` is constructed directly
+without `ReactorApp.Run`: that host owns its own windows, never reaches
+the zero-surface check, and would be left pumping forever once its
+windows closed.
+
+That unconditional-per-policy ownership is what makes §6.2
 exhaustive, and in particular what makes §6.4's auxiliary-window
 guarantee real: closing a docking tear-off that was never elected primary
 leaves `closedWasPrimary` false, and now nothing else unwinds the loop

--- a/docs/specs/036-window-design.md
+++ b/docs/specs/036-window-design.md
@@ -555,8 +555,16 @@ subscribes to the native `Window.Closed`, so a user-initiated close is
 observed exactly like an app-initiated one.
 
 Because the mode no longer depends on the policy, `ShutdownPolicy` stays
-a plain store: settable from any thread, read when a surface closes, with
-no window in which the policy and the platform can disagree.
+a plain store: settable from any thread, with no window in which the
+policy and the platform can disagree. Two moments consult it. A surface
+close reaches `EvaluateShutdownPolicy`, which reads it then, so any
+earlier change counts. Startup is the exception — the zero-surface
+decision runs the instant the launch path finishes, so it sees whatever
+the policy holds at that instant and a write posted from another thread
+during startup can land too late. Both launch paths run that decision
+from a `finally`: once ownership is taken, a startup that throws and is
+marked handled by the app's `OnUnhandledException` would otherwise leave
+the loop pumping with nothing on screen.
 
 Reactor only takes ownership when it owns the `Application` — when
 `Application.Current` is a `ReactorApplication`. A WinUI app that embeds

--- a/src/Reactor/Hosting/ReactorApp.cs
+++ b/src/Reactor/Hosting/ReactorApp.cs
@@ -733,19 +733,21 @@ public static partial class ReactorApp
         }
         catch (Exception)
         {
-            // Unregister BEFORE closing: UnregisterWindow no-ops when the window
-            // was never registered (a configure throw), and doing it first means
-            // the close cascade's own unregister is the no-op instead — so a
-            // failed open cannot run EvaluateShutdownPolicy and decide to exit.
-            // The zero-surface decision on the launch paths owns that call.
-            UnregisterWindow(window);
+            // evaluateShutdownPolicy: false — a failed open is not a surface
+            // close. MountAndActivate can throw after RegisterWindow, and if the
+            // failed window was the elected primary, evaluating here would call
+            // SafeExit while the caller is still unwinding: the app would die
+            // over an OpenWindow failure it may well handle, even with other
+            // windows still open. The launch paths' zero-surface decision owns
+            // the lifetime call instead.
+            UnregisterWindow(window, evaluateShutdownPolicy: false);
             // Dispose alone is not enough: it unsubscribes handlers and tears
             // down the host, but never closes the native Window the
             // ReactorWindow ctor already created. Without this, a failed open
             // leaves a live untracked window on screen — most visibly under
             // ShutdownPolicy.Explicit, where the process keeps running.
-            try { window.Close(); } catch { /* best effort */ }
-            try { window.Dispose(); } catch { /* best effort */ }
+            try { window.Close(); } catch (Exception) { /* best effort */ }
+            try { window.Dispose(); } catch (Exception) { /* best effort */ }
             throw;
         }
         return window;
@@ -854,7 +856,19 @@ public static partial class ReactorApp
     // Copy-on-write remove. Idempotent — removing an already-removed window
     // (Phase 1 path runs Dispose → close cascade twice in some failure modes)
     // is a no-op.
-    internal static void UnregisterWindow(ReactorWindow window)
+    internal static void UnregisterWindow(ReactorWindow window) =>
+        UnregisterWindow(window, evaluateShutdownPolicy: true);
+
+    /// <param name="window">The window to remove from the process-wide registry.</param>
+    /// <param name="evaluateShutdownPolicy">
+    /// <c>false</c> for a window that never successfully opened. A failed open is
+    /// not a surface close, so it must not decide process lifetime: the window
+    /// could have been the elected primary, and running the evaluator here would
+    /// call <see cref="SafeExit"/> while the caller is still unwinding — killing
+    /// the app over an <c>OpenWindow</c> failure the caller may well handle, and
+    /// even when other windows remain.
+    /// </param>
+    internal static void UnregisterWindow(ReactorWindow window, bool evaluateShutdownPolicy)
     {
         var current = Volatile.Read(ref _windows);
         int idx = Array.IndexOf(current, window);
@@ -882,7 +896,8 @@ public static partial class ReactorApp
         try { WindowClosed?.Invoke(null, window); }
         catch (Exception ex) { global::System.Diagnostics.Debug.WriteLine($"[Reactor] WindowClosed threw: {ex.Message}"); }
 
-        EvaluateShutdownPolicy(closedWasPrimary: wasPrimary);
+        if (evaluateShutdownPolicy)
+            EvaluateShutdownPolicy(closedWasPrimary: wasPrimary);
     }
 
     // OnPrimaryWindowClosed: exit when the just-closed window was the primary.
@@ -1010,12 +1025,19 @@ public static partial class ReactorApp
     /// </remarks>
     private static void RequestEventLoopExit()
     {
+        // Deliberately broad, on both attempts. Application.Exit() tears open
+        // windows down synchronously, and ReactorWindow.OnNativeClosed invokes
+        // user Closed callbacks without catching them, so an arbitrary app
+        // exception can surface here. Narrowing to the usual WinRT teardown set
+        // would let one escape before the fallback runs and leave an
+        // OnExplicitShutdown loop pumping with no remaining way out — which is
+        // the exact failure this method exists to prevent. Do not narrow these.
         try
         {
             Application.Current?.Exit();
             return;
         }
-        catch (Exception ex) when (ex is ObjectDisposedException or InvalidOperationException or COMException)
+        catch (Exception ex)
         {
             AppLogger?.LogError(ex, "ReactorApp: Application.Exit() failed; falling back to EnqueueEventLoopExit.");
             global::System.Diagnostics.Debug.WriteLine($"[Reactor] Application.Exit threw: {ex.GetType().Name}: {ex.Message}");
@@ -1025,7 +1047,7 @@ public static partial class ReactorApp
         {
             UIDispatcher?.EnqueueEventLoopExit();
         }
-        catch (Exception ex) when (ex is ObjectDisposedException or InvalidOperationException or COMException)
+        catch (Exception ex)
         {
             AppLogger?.LogError(ex, "ReactorApp: EnqueueEventLoopExit() also failed; the event loop may not terminate.");
             global::System.Diagnostics.Debug.WriteLine($"[Reactor] EnqueueEventLoopExit threw: {ex.GetType().Name}: {ex.Message}");

--- a/src/Reactor/Hosting/ReactorApp.cs
+++ b/src/Reactor/Hosting/ReactorApp.cs
@@ -179,9 +179,17 @@ public static partial class ReactorApp
     /// <para>Settable from any thread and at any point in the process lifetime,
     /// and read back immediately. Reactor takes ownership of the event loop at
     /// startup (see <see cref="TakeOwnershipOfDispatcherLifetime"/>), so this
-    /// value is consulted by <see cref="EvaluateShutdownPolicy"/> when a surface
-    /// closes rather than mirrored into platform state — there is no window in
-    /// which the policy and the platform can disagree.</para>
+    /// value is consulted when a decision is due rather than mirrored into
+    /// platform state — there is no window in which the policy and the platform
+    /// can disagree.</para>
+    /// <para>Two moments consult it. A surface close reaches
+    /// <see cref="EvaluateShutdownPolicy"/>, which reads the value then, so a
+    /// change made any time beforehand counts. Startup is the exception:
+    /// <see cref="ExitIfStartupOpenedNoSurface"/> runs the instant the launch
+    /// path finishes, so a zero-surface startup is judged against whatever the
+    /// policy holds at that instant. Set it before <c>Run</c>, or on the UI
+    /// thread before the startup callback returns — a write posted from another
+    /// thread during startup can land too late to be seen.</para>
     /// </remarks>
     public static ShutdownPolicy ShutdownPolicy
     {
@@ -239,6 +247,15 @@ public static partial class ReactorApp
     /// object, an invalid operation, or a COM fault all mean the XAML runtime is
     /// already broken. Failing at the point it is detectable beats limping into a
     /// lifetime the app did not ask for.</para>
+    /// <para>An app can still override that by returning <c>true</c> from
+    /// <see cref="ReactorApplication.OnUnhandledException"/>, which marks the
+    /// rethrow handled. Reactor does not escalate to
+    /// <see cref="Environment.FailFast(string)"/> to prevent it: an app that
+    /// force-handles every exception has asked to keep running, and the
+    /// resulting state is the pre-fix one — the platform still ends the process
+    /// on last-window-close, so the policy is ignored rather than the process
+    /// hanging. The <see cref="AppLogger"/> error above is what makes that
+    /// visible.</para>
     /// </remarks>
     internal static void TakeOwnershipOfDispatcherLifetime()
     {
@@ -927,6 +944,38 @@ public static partial class ReactorApp
         EvaluateShutdownPolicy(closedWasPrimary: false);
     }
 
+    /// <summary>
+    /// Applies the zero-surface startup decision (spec 036 §6.2): a launch that
+    /// produced no window and no tray icon must not leave the process running
+    /// under a policy that does not permit it. UI-thread only.
+    /// </summary>
+    /// <remarks>
+    /// <para>With the default <see cref="ShutdownPolicy.OnPrimaryWindowClosed"/>
+    /// this is the "I forgot to OpenWindow" guard. Apps that intend a
+    /// zero-surface startup pick <see cref="ShutdownPolicy.Explicit"/> or
+    /// <see cref="ShutdownPolicy.OnLastSurfaceClosed"/>; the latter still exits
+    /// here when no tray icon was opened either, because then nothing is left.</para>
+    /// <para>This is evaluated the moment the launch path finishes, so it reads
+    /// whatever <see cref="ShutdownPolicy"/> holds at that instant — a policy
+    /// written asynchronously from another thread during startup may not have
+    /// landed yet. Set the policy before <c>Run</c>, or on the UI thread before
+    /// the startup callback returns.</para>
+    /// <para>Called from a <c>finally</c> on both launch paths: once dispatcher
+    /// ownership has been taken, a startup that throws and is then marked handled
+    /// by the app's <c>OnUnhandledException</c> would otherwise leave the event
+    /// loop pumping with nothing on screen.</para>
+    /// </remarks>
+    internal static void ExitIfStartupOpenedNoSurface()
+    {
+        if (Windows.Count != 0) return;
+
+        var policy = ShutdownPolicy;
+        if (policy == ShutdownPolicy.Explicit) return;
+        if (policy == ShutdownPolicy.OnLastSurfaceClosed && TrayIconCount != 0) return;
+
+        try { Application.Current?.Exit(); } catch { /* best effort */ }
+    }
+
     private static void SafeExit()
     {
         PrepareOpenWindowsForExit();
@@ -1239,24 +1288,18 @@ public partial class ReactorApplication : Application, IXamlMetadataProvider
             // Before the callback, so windows it opens are already governed.
             ReactorApp.TakeOwnershipOfDispatcherLifetime();
 
-            opts.Startup(ctx);
-
-            // Spec 036 §6.2: with the default OnPrimaryWindowClosed policy, a
-            // startup that opens zero windows must exit immediately — that's
-            // the only sane default for "I forgot to OpenWindow." Apps that
-            // want zero-window startup pick Explicit or OnLastSurfaceClosed
-            // before returning from the callback. OnLastSurfaceClosed exits
-            // here only if NO tray icon was opened either; otherwise the tray
-            // keeps the process alive.
-            var noWindows = ReactorApp.Windows.Count == 0;
-            var policy = ReactorApp.ShutdownPolicy;
-            if (noWindows && policy == ShutdownPolicy.OnPrimaryWindowClosed)
+            try
             {
-                try { Application.Current?.Exit(); } catch { /* best effort */ }
+                opts.Startup(ctx);
             }
-            else if (noWindows && policy == ShutdownPolicy.OnLastSurfaceClosed && ReactorApp.TrayIconCount == 0)
+            finally
             {
-                try { Application.Current?.Exit(); } catch { /* best effort */ }
+                // In a finally because ownership has already been taken: if the
+                // callback throws and the app's OnUnhandledException marks it
+                // handled, nothing else would end a process that never opened a
+                // surface. Before ownership, the platform's OnLastWindowClose
+                // rescued that case.
+                ReactorApp.ExitIfStartupOpenedNoSurface();
             }
             return;
         }
@@ -1286,7 +1329,17 @@ public partial class ReactorApplication : Application, IXamlMetadataProvider
 
         var spec = ReactorApp.BuildInitialWindowSpec(opts);
 
-        ReactorApp.OpenWindowCore(spec, opts.RootFactory, opts.RootRenderFunc, opts.Configure);
+        try
+        {
+            ReactorApp.OpenWindowCore(spec, opts.RootFactory, opts.RootRenderFunc, opts.Configure);
+        }
+        finally
+        {
+            // Same reasoning as the startup path: OpenWindowCore unregisters and
+            // disposes the window before rethrowing, so a handled failure here
+            // leaves zero surfaces under an owned dispatcher.
+            ReactorApp.ExitIfStartupOpenedNoSurface();
+        }
     }
 
 

--- a/src/Reactor/Hosting/ReactorApp.cs
+++ b/src/Reactor/Hosting/ReactorApp.cs
@@ -204,7 +204,14 @@ public static partial class ReactorApp
     /// makes the platform a second, uncoordinated decision-maker: it cannot see
     /// <see cref="ShutdownPolicy.Explicit"/>, a surviving tray icon, or a window
     /// that opted out via <c>ExcludeFromShutdownPolicy</c>, so it would end
-    /// processes §6.2 says should keep running.</para>
+    /// processes that §6.2 says should keep running.</para>
+    /// <para>Called from <c>OnLaunched</c> on the launch shapes Reactor drives —
+    /// the <c>Run(startup)</c> callback and the legacy <c>Run&lt;TRoot&gt;</c>
+    /// bridge — before any window exists. It is deliberately NOT called when
+    /// <see cref="ReactorApplication"/> was constructed directly without
+    /// <c>ReactorApp.Run</c> (the selftest harness shape): that host owns its own
+    /// windows, never reaches the zero-surface check, and would be left pumping
+    /// forever once its windows closed.</para>
     /// <para>Taking ownership unconditionally — rather than only for the
     /// policies that obviously need it — is what makes §6.2 exhaustive. Every
     /// exit then flows through one place: <see cref="EvaluateShutdownPolicy"/>
@@ -1221,13 +1228,6 @@ public partial class ReactorApplication : Application, IXamlMetadataProvider
         // process-wide UI thread reference. (spec 036 §4.3 / §6.1)
         ReactorApp.UIDispatcher = Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread();
 
-        // Application.Start just reset this thread's DispatcherShutdownMode to
-        // OnLastWindowClose, which would let WinUI end the process on
-        // last-window-close without consulting the policy. Take ownership before
-        // any window exists so EvaluateShutdownPolicy is the only thing that
-        // decides. (spec 036 §6.2)
-        ReactorApp.TakeOwnershipOfDispatcherLifetime();
-
         var opts = ReactorApp.Options;
         var activation = ParseLaunchActivation(args);
         var ctx = new ReactorAppContext(activation);
@@ -1236,6 +1236,9 @@ public partial class ReactorApplication : Application, IXamlMetadataProvider
         // ── Path 1: explicit Run(Action<ReactorAppContext>) startup callback.
         if (opts.Startup is not null)
         {
+            // Before the callback, so windows it opens are already governed.
+            ReactorApp.TakeOwnershipOfDispatcherLifetime();
+
             opts.Startup(ctx);
 
             // Spec 036 §6.2: with the default OnPrimaryWindowClosed policy, a
@@ -1270,7 +1273,16 @@ public partial class ReactorApplication : Application, IXamlMetadataProvider
         // creation. Skip the bridge so we don't try to open a window with
         // nothing to mount (which would otherwise cascade into shutdown
         // during OnLaunched). (spec 036 §4.3)
+        //
+        // Dispatcher ownership is skipped for the same reason it is skipped for
+        // a non-ReactorApplication host: this launch shape has no Reactor
+        // surfaces and never reaches the zero-surface check above, so Reactor is
+        // not the thing deciding when the process ends. Forcing
+        // OnExplicitShutdown here would leave such a host pumping forever once
+        // its own windows closed.
         if (opts.RootFactory is null && opts.RootRenderFunc is null) return;
+
+        ReactorApp.TakeOwnershipOfDispatcherLifetime();
 
         var spec = ReactorApp.BuildInitialWindowSpec(opts);
 

--- a/src/Reactor/Hosting/ReactorApp.cs
+++ b/src/Reactor/Hosting/ReactorApp.cs
@@ -886,14 +886,16 @@ public static partial class ReactorApp
         try { TrayIconClosed?.Invoke(null, icon); }
         catch (Exception ex) { global::System.Diagnostics.Debug.WriteLine($"[Reactor] TrayIconClosed threw: {ex.Message}"); }
 
-        // OnLastSurfaceClosed: closing the final tray icon when no windows
-        // remain should exit just like closing the final window.
-        if (ShutdownPolicy == ShutdownPolicy.OnLastSurfaceClosed
-            && Windows.Count == 0
-            && TrayIconCount == 0)
-        {
-            SafeExit();
-        }
+        // Closing the final tray icon when no windows remain should exit just
+        // like closing the final window, so it goes through the same evaluator
+        // rather than re-deriving the condition here. A tray icon is never the
+        // elected primary, hence closedWasPrimary: false — which makes the
+        // OnPrimaryWindowClosed and Explicit arms no-ops and leaves the
+        // OnLastSurfaceClosed arm, whose "no windows and no tray icons left"
+        // test is exactly what this used to spell out inline. Keeping one
+        // decision point is what lets §6.2 claim every surface-close exit is
+        // EvaluateShutdownPolicy's.
+        EvaluateShutdownPolicy(closedWasPrimary: false);
     }
 
     private static void SafeExit()

--- a/src/Reactor/Hosting/ReactorApp.cs
+++ b/src/Reactor/Hosting/ReactorApp.cs
@@ -800,8 +800,7 @@ public static partial class ReactorApp
     {
         ThreadAffinity.ThrowIfNotOnUIThread(nameof(Exit));
         PrepareOpenWindowsForExit();
-        try { Application.Current?.Exit(); }
-        catch { /* best effort */ }
+        RequestEventLoopExit();
         if (exitCode != 0)
             Environment.Exit(exitCode);
     }
@@ -973,14 +972,52 @@ public static partial class ReactorApp
         if (policy == ShutdownPolicy.Explicit) return;
         if (policy == ShutdownPolicy.OnLastSurfaceClosed && TrayIconCount != 0) return;
 
-        try { Application.Current?.Exit(); } catch { /* best effort */ }
+        try { RequestEventLoopExit(); } catch { /* best effort */ }
+    }
+
+    /// <summary>
+    /// Ends this thread's event loop. UI-thread only.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="Application.Exit"/> is the primary path.
+    /// <c>DispatcherQueue.EnqueueEventLoopExit</c> is the documented alternative
+    /// for a thread running under
+    /// <see cref="DispatcherShutdownMode.OnExplicitShutdown"/>, and it is the
+    /// reason this fallback exists at all: taking ownership of the loop removed
+    /// WinUI's automatic last-window shutdown, so a suppressed
+    /// <see cref="Application.Exit"/> failure would otherwise leave the process
+    /// pumping forever with no remaining way out. Both attempts are logged
+    /// through <see cref="AppLogger"/>; if both fail there is nothing further
+    /// Reactor can do from managed code, and the error is at least visible.
+    /// </remarks>
+    private static void RequestEventLoopExit()
+    {
+        try
+        {
+            Application.Current?.Exit();
+            return;
+        }
+        catch (Exception ex)
+        {
+            AppLogger?.LogError(ex, "ReactorApp: Application.Exit() failed; falling back to EnqueueEventLoopExit.");
+            global::System.Diagnostics.Debug.WriteLine($"[Reactor] Application.Exit threw: {ex.GetType().Name}: {ex.Message}");
+        }
+
+        try
+        {
+            UIDispatcher?.EnqueueEventLoopExit();
+        }
+        catch (Exception ex)
+        {
+            AppLogger?.LogError(ex, "ReactorApp: EnqueueEventLoopExit() also failed; the event loop may not terminate.");
+            global::System.Diagnostics.Debug.WriteLine($"[Reactor] EnqueueEventLoopExit threw: {ex.GetType().Name}: {ex.Message}");
+        }
     }
 
     private static void SafeExit()
     {
         PrepareOpenWindowsForExit();
-        try { Application.Current?.Exit(); }
-        catch (Exception ex) { global::System.Diagnostics.Debug.WriteLine($"[Reactor] Application.Exit threw: {ex.Message}"); }
+        RequestEventLoopExit();
     }
 
     // Issue #537 — Application.Exit() tears down every open window's native

--- a/src/Reactor/Hosting/ReactorApp.cs
+++ b/src/Reactor/Hosting/ReactorApp.cs
@@ -220,15 +220,18 @@ public static partial class ReactorApp
     /// manages its own windows; Reactor does not decide when that process ends,
     /// so it leaves that app's <see cref="Application.DispatcherShutdownMode"/>
     /// at whatever the app chose or inherited.</para>
-    /// <para>Failures are surfaced rather than swallowed. Only the exception
-    /// types a teardown-racing WinRT property write can realistically produce are
-    /// caught, matching <see cref="PrepareOpenWindowsForExit"/>, and those are
-    /// reported through <see cref="AppLogger"/> so they are visible in a release
-    /// build — a silent failure here would report the requested
-    /// <see cref="ShutdownPolicy"/> while leaving the platform free to end the
-    /// process, which is issue #1204 all over again. Anything else propagates:
-    /// this runs synchronously in <c>OnLaunched</c> before the startup callback,
-    /// so an unexpected fault is a startup bug and should not be hidden.</para>
+    /// <para>A failed write is fatal, not best-effort. This is the one write
+    /// standing between the app and issue #1204: continuing without it leaves
+    /// <see cref="ShutdownPolicy"/> reporting the requested value while the
+    /// platform is still free to end the process on last-window-close — the
+    /// original bug, now silent. The catch exists only to attach a diagnostic
+    /// explaining that consequence before rethrowing, because the bare WinRT
+    /// exception would not say it. And the caught types are not benign here:
+    /// this runs synchronously in <c>OnLaunched</c>, on the UI thread, against an
+    /// <see cref="Application"/> constructed moments earlier, so a disposed
+    /// object, an invalid operation, or a COM fault all mean the XAML runtime is
+    /// already broken. Failing at the point it is detectable beats limping into a
+    /// lifetime the app did not ask for.</para>
     /// </remarks>
     internal static void TakeOwnershipOfDispatcherLifetime()
     {
@@ -240,10 +243,11 @@ public static partial class ReactorApp
         catch (Exception ex) when (ex is ObjectDisposedException or InvalidOperationException or COMException)
         {
             const string message =
-                "Reactor could not take ownership of the dispatcher shutdown mode. WinUI may end the " +
-                "process when the last window closes, ignoring ReactorApp.ShutdownPolicy. (issue #1204)";
+                "Reactor could not take ownership of the dispatcher shutdown mode, so WinUI would end the " +
+                "process when the last window closes regardless of ReactorApp.ShutdownPolicy. (issue #1204)";
             AppLogger?.LogError(ex, message);
             global::System.Diagnostics.Debug.WriteLine($"[Reactor] {message} {ex.GetType().Name}: {ex.Message}");
+            throw;
         }
     }
 

--- a/src/Reactor/Hosting/ReactorApp.cs
+++ b/src/Reactor/Hosting/ReactorApp.cs
@@ -176,93 +176,56 @@ public static partial class ReactorApp
 
     /// <summary>Process-shutdown policy. Defaults to <see cref="ShutdownPolicy.OnPrimaryWindowClosed"/>.</summary>
     /// <remarks>
-    /// <para>Settable from any thread and at any point in the process lifetime.
-    /// Reading it back always reflects the last write; <b>when the platform
-    /// catches up depends on where you set it</b>, because WinUI's
-    /// <see cref="Application.DispatcherShutdownMode"/> — the property that
-    /// decides whether the event loop survives its last window — is per-thread
-    /// and cannot be written from another thread:</para>
-    /// <list type="bullet">
-    /// <item><description><b>Before <c>Run</c></b>: stored only; there is no
-    /// <see cref="Application"/> yet. <c>OnLaunched</c> applies it once WinUI has
-    /// bootstrapped, before any window opens.</description></item>
-    /// <item><description><b>On the UI thread</b> (startup callback, event
-    /// handler, tray command): applied before the setter returns.</description></item>
-    /// <item><description><b>Off the UI thread</b>: posted to
-    /// <see cref="UIDispatcher"/> and applied on a following dispatcher turn.
-    /// A window close that the UI thread happens to process first is still
-    /// judged by the previous policy, so set the policy on the UI thread when a
-    /// concurrent close is possible. The setter deliberately does not block on
-    /// the hop — a UI thread waiting on the caller would deadlock.</description></item>
-    /// </list>
-    /// <para><see cref="ShutdownPolicy.Explicit"/> and
-    /// <see cref="ShutdownPolicy.OnLastSurfaceClosed"/> map to
-    /// <see cref="DispatcherShutdownMode.OnExplicitShutdown"/>, handing process
-    /// lifetime to Reactor; <see cref="ShutdownPolicy.OnPrimaryWindowClosed"/>
-    /// keeps the platform default,
-    /// <see cref="DispatcherShutdownMode.OnLastWindowClose"/>. Reactor writes
-    /// that property only when it owns the <see cref="Application"/>, so an app
-    /// hosting <c>ReactorHostControl</c> in its own keeps its own lifetime.</para>
+    /// <para>Settable from any thread and at any point in the process lifetime,
+    /// and read back immediately. Reactor takes ownership of the event loop at
+    /// startup (see <see cref="TakeOwnershipOfDispatcherLifetime"/>), so this
+    /// value is consulted by <see cref="EvaluateShutdownPolicy"/> when a surface
+    /// closes rather than mirrored into platform state — there is no window in
+    /// which the policy and the platform can disagree.</para>
     /// </remarks>
     public static ShutdownPolicy ShutdownPolicy
     {
         get => (ShutdownPolicy)Volatile.Read(ref _shutdownPolicy);
-        set
-        {
-            Volatile.Write(ref _shutdownPolicy, (int)value);
-
-            var dispatcher = UIDispatcher;
-            if (dispatcher is null) return;
-            if (dispatcher.HasThreadAccess) SyncDispatcherShutdownMode();
-            else dispatcher.TryEnqueue(SyncDispatcherShutdownMode);
-        }
+        set => Volatile.Write(ref _shutdownPolicy, (int)value);
     }
 
     /// <summary>
-    /// The platform dispatcher-shutdown mode that lets <paramref name="policy"/>
-    /// be honoured. (spec 036 §6.2)
+    /// Hands the lifetime of this thread's event loop to
+    /// <see cref="EvaluateShutdownPolicy"/>. UI-thread only; called once from
+    /// <c>OnLaunched</c>. (spec 036 §6.2)
     /// </summary>
     /// <remarks>
-    /// WinUI quits the thread's <c>DispatcherQueue</c> event loop when the last
-    /// XAML window closes unless the mode is
-    /// <see cref="DispatcherShutdownMode.OnExplicitShutdown"/>. Both non-default
-    /// policies describe states where "no windows open" is still a running app —
-    /// a tray-only app under <see cref="ShutdownPolicy.Explicit"/>, or a window
-    /// closing while a tray icon survives under
-    /// <see cref="ShutdownPolicy.OnLastSurfaceClosed"/> — so the platform must
-    /// hand process lifetime to <see cref="EvaluateShutdownPolicy"/>. The default
-    /// policy keeps the platform default, which already agrees with it: closing
-    /// the primary window exits either way.
+    /// <para>WinUI quits the thread's <c>DispatcherQueue</c> event loop when the
+    /// last XAML window closes unless
+    /// <see cref="Application.DispatcherShutdownMode"/> is
+    /// <see cref="DispatcherShutdownMode.OnExplicitShutdown"/>, and
+    /// <c>Application.Start</c> resets that property to
+    /// <see cref="DispatcherShutdownMode.OnLastWindowClose"/>. Leaving it there
+    /// makes the platform a second, uncoordinated decision-maker: it cannot see
+    /// <see cref="ShutdownPolicy.Explicit"/>, a surviving tray icon, or a window
+    /// that opted out via <c>ExcludeFromShutdownPolicy</c>, so it would end
+    /// processes §6.2 says should keep running.</para>
+    /// <para>Taking ownership unconditionally — rather than only for the
+    /// policies that obviously need it — is what makes §6.2 exhaustive. Every
+    /// exit then flows through one place: <see cref="EvaluateShutdownPolicy"/>
+    /// on a surface close, the zero-surface check in <c>OnLaunched</c>, or an
+    /// explicit <see cref="Exit(int)"/>. The default policy reaches
+    /// <see cref="SafeExit"/> whenever the elected primary closes, and
+    /// <c>ReactorWindow</c> subscribes to the native <c>Window.Closed</c>, so a
+    /// user-initiated close is observed exactly like an app-initiated one.</para>
+    /// <para>Only written when Reactor owns the <see cref="Application"/>. An app
+    /// that embeds <c>ReactorHostControl</c> in its own <see cref="Application"/>
+    /// never calls <c>Application.Start</c>, so the platform has already
+    /// defaulted its mode to <see cref="DispatcherShutdownMode.OnExplicitShutdown"/>;
+    /// writing the other value there would make that app exit when its last
+    /// window closes. Best-effort: a teardown-racing write is logged rather than
+    /// thrown, matching <see cref="SafeExit"/>.</para>
     /// </remarks>
-    internal static DispatcherShutdownMode DispatcherShutdownModeFor(ShutdownPolicy policy) =>
-        policy switch
-        {
-            ShutdownPolicy.OnLastSurfaceClosed => DispatcherShutdownMode.OnExplicitShutdown,
-            ShutdownPolicy.Explicit => DispatcherShutdownMode.OnExplicitShutdown,
-            _ => DispatcherShutdownMode.OnLastWindowClose,
-        };
-
-    /// <summary>
-    /// Projects <see cref="ShutdownPolicy"/> onto
-    /// <see cref="Application.DispatcherShutdownMode"/>. UI-thread only — the
-    /// property is per-thread, so writing it from elsewhere would configure the
-    /// wrong thread.
-    /// </summary>
-    /// <remarks>
-    /// Only writes when Reactor owns the <see cref="Application"/>. An app that
-    /// embeds <c>ReactorHostControl</c> in its own <see cref="Application"/>
-    /// never calls <c>Application.Start</c>, so its mode already defaults to
-    /// <see cref="DispatcherShutdownMode.OnExplicitShutdown"/> — writing
-    /// <see cref="DispatcherShutdownMode.OnLastWindowClose"/> there would make
-    /// the host process exit when its last window closes, a lifetime change
-    /// Reactor has no business making. Best-effort: a teardown-racing write is
-    /// logged rather than thrown, matching <see cref="SafeExit"/>.
-    /// </remarks>
-    internal static void SyncDispatcherShutdownMode()
+    internal static void TakeOwnershipOfDispatcherLifetime()
     {
         if (Application.Current is not ReactorApplication app) return;
-        try { app.DispatcherShutdownMode = DispatcherShutdownModeFor(ShutdownPolicy); }
-        catch (Exception ex) { global::System.Diagnostics.Debug.WriteLine($"[Reactor] SyncDispatcherShutdownMode failed: {ex.GetType().Name}: {ex.Message}"); }
+        try { app.DispatcherShutdownMode = DispatcherShutdownMode.OnExplicitShutdown; }
+        catch (Exception ex) { global::System.Diagnostics.Debug.WriteLine($"[Reactor] TakeOwnershipOfDispatcherLifetime failed: {ex.GetType().Name}: {ex.Message}"); }
     }
 
     /// <summary>Fires on the UI thread when a <see cref="ReactorWindow"/> opens.</summary>
@@ -864,9 +827,13 @@ public static partial class ReactorApp
     // OnLastSurfaceClosed: exit when both windows and tray icons are gone.
     // Explicit: never exit from a surface-close event — the app drives Exit().
     //
-    // This is the sole authority on process lifetime for the two non-default
-    // policies: DispatcherShutdownModeFor puts the platform into
-    // OnExplicitShutdown for them, so nothing else will quit the event loop.
+    // This is the sole authority on process lifetime for every policy:
+    // TakeOwnershipOfDispatcherLifetime puts the platform into
+    // OnExplicitShutdown at launch, so nothing else will quit the event loop.
+    // That is what lets the OnPrimaryWindowClosed arm honour issue #647 — a
+    // window that opted out via ExcludeFromShutdownPolicy is never elected
+    // primary, so closing it leaves closedWasPrimary false and the app alive
+    // even when it was the last window on screen.
     internal static void EvaluateShutdownPolicy(bool closedWasPrimary)
     {
         var policy = ShutdownPolicy;
@@ -1230,12 +1197,11 @@ public partial class ReactorApplication : Application, IXamlMetadataProvider
         ReactorApp.UIDispatcher = Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread();
 
         // Application.Start just reset this thread's DispatcherShutdownMode to
-        // OnLastWindowClose, which would quit the event loop on last-window-close
-        // before EvaluateShutdownPolicy could veto it. Re-apply whatever policy
-        // the app picked before Run. Policies set later — inside the startup
-        // callback or from a tray command — are projected by the property setter.
-        // (spec 036 §6.2)
-        ReactorApp.SyncDispatcherShutdownMode();
+        // OnLastWindowClose, which would let WinUI end the process on
+        // last-window-close without consulting the policy. Take ownership before
+        // any window exists so EvaluateShutdownPolicy is the only thing that
+        // decides. (spec 036 §6.2)
+        ReactorApp.TakeOwnershipOfDispatcherLifetime();
 
         var opts = ReactorApp.Options;
         var activation = ParseLaunchActivation(args);

--- a/src/Reactor/Hosting/ReactorApp.cs
+++ b/src/Reactor/Hosting/ReactorApp.cs
@@ -733,8 +733,18 @@ public static partial class ReactorApp
         }
         catch (Exception)
         {
-            // Idempotent when the failure happened before RegisterWindow.
+            // Unregister BEFORE closing: UnregisterWindow no-ops when the window
+            // was never registered (a configure throw), and doing it first means
+            // the close cascade's own unregister is the no-op instead — so a
+            // failed open cannot run EvaluateShutdownPolicy and decide to exit.
+            // The zero-surface decision on the launch paths owns that call.
             UnregisterWindow(window);
+            // Dispose alone is not enough: it unsubscribes handlers and tears
+            // down the host, but never closes the native Window the
+            // ReactorWindow ctor already created. Without this, a failed open
+            // leaves a live untracked window on screen — most visibly under
+            // ShutdownPolicy.Explicit, where the process keeps running.
+            try { window.Close(); } catch { /* best effort */ }
             try { window.Dispose(); } catch { /* best effort */ }
             throw;
         }

--- a/src/Reactor/Hosting/ReactorApp.cs
+++ b/src/Reactor/Hosting/ReactorApp.cs
@@ -213,13 +213,14 @@ public static partial class ReactorApp
     /// <see cref="SafeExit"/> whenever the elected primary closes, and
     /// <c>ReactorWindow</c> subscribes to the native <c>Window.Closed</c>, so a
     /// user-initiated close is observed exactly like an app-initiated one.</para>
-    /// <para>Only written when Reactor owns the <see cref="Application"/>. An app
-    /// that embeds <c>ReactorHostControl</c> in its own <see cref="Application"/>
-    /// never calls <c>Application.Start</c>, so the platform has already
-    /// defaulted its mode to <see cref="DispatcherShutdownMode.OnExplicitShutdown"/>;
-    /// writing the other value there would make that app exit when its last
-    /// window closes. Best-effort: a teardown-racing write is logged rather than
-    /// thrown, matching <see cref="SafeExit"/>.</para>
+    /// <para>Only written when Reactor owns the <see cref="Application"/> — that
+    /// is, when <see cref="Application.Current"/> is a
+    /// <see cref="ReactorApplication"/>. A WinUI app that embeds
+    /// <c>ReactorHostControl</c> runs its own <see cref="Application"/> and
+    /// manages its own windows; Reactor does not decide when that process ends,
+    /// so it must leave that app's <see cref="Application.DispatcherShutdownMode"/>
+    /// at whatever the app chose or inherited. Best-effort: a teardown-racing
+    /// write is logged rather than thrown, matching <see cref="SafeExit"/>.</para>
     /// </remarks>
     internal static void TakeOwnershipOfDispatcherLifetime()
     {

--- a/src/Reactor/Hosting/ReactorApp.cs
+++ b/src/Reactor/Hosting/ReactorApp.cs
@@ -746,8 +746,8 @@ public static partial class ReactorApp
             // ReactorWindow ctor already created. Without this, a failed open
             // leaves a live untracked window on screen — most visibly under
             // ShutdownPolicy.Explicit, where the process keeps running.
-            try { window.Close(); } catch (Exception) { /* best effort */ }
-            try { window.Dispose(); } catch (Exception) { /* best effort */ }
+            try { window.Close(); } catch (Exception ex) when (ex is not OutOfMemoryException) { global::System.Diagnostics.Debug.WriteLine($"[Reactor] failed-open Close threw: {ex.Message}"); }
+            try { window.Dispose(); } catch (Exception ex) when (ex is not OutOfMemoryException) { global::System.Diagnostics.Debug.WriteLine($"[Reactor] failed-open Dispose threw: {ex.Message}"); }
             throw;
         }
         return window;
@@ -1025,19 +1025,21 @@ public static partial class ReactorApp
     /// </remarks>
     private static void RequestEventLoopExit()
     {
-        // Deliberately broad, on both attempts. Application.Exit() tears open
-        // windows down synchronously, and ReactorWindow.OnNativeClosed invokes
-        // user Closed callbacks without catching them, so an arbitrary app
-        // exception can surface here. Narrowing to the usual WinRT teardown set
-        // would let one escape before the fallback runs and leave an
-        // OnExplicitShutdown loop pumping with no remaining way out — which is
-        // the exact failure this method exists to prevent. Do not narrow these.
+        // Deliberately broad, on both attempts — filtered only to let a genuinely
+        // catastrophic OutOfMemoryException through rather than mask it.
+        // Application.Exit() tears open windows down synchronously, and
+        // ReactorWindow.OnNativeClosed invokes user Closed callbacks without
+        // catching them, so an arbitrary app exception can surface here.
+        // Narrowing to the usual WinRT teardown set would let one escape before
+        // the fallback runs and leave an OnExplicitShutdown loop pumping with no
+        // remaining way out — the exact failure this method exists to prevent.
+        // Do not narrow these further.
         try
         {
             Application.Current?.Exit();
             return;
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OutOfMemoryException)
         {
             AppLogger?.LogError(ex, "ReactorApp: Application.Exit() failed; falling back to EnqueueEventLoopExit.");
             global::System.Diagnostics.Debug.WriteLine($"[Reactor] Application.Exit threw: {ex.GetType().Name}: {ex.Message}");
@@ -1047,7 +1049,7 @@ public static partial class ReactorApp
         {
             UIDispatcher?.EnqueueEventLoopExit();
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OutOfMemoryException)
         {
             AppLogger?.LogError(ex, "ReactorApp: EnqueueEventLoopExit() also failed; the event loop may not terminate.");
             global::System.Diagnostics.Debug.WriteLine($"[Reactor] EnqueueEventLoopExit threw: {ex.GetType().Name}: {ex.Message}");

--- a/src/Reactor/Hosting/ReactorApp.cs
+++ b/src/Reactor/Hosting/ReactorApp.cs
@@ -720,14 +720,20 @@ public static partial class ReactorApp
     {
         ReactorWindow window = new ReactorWindow(spec);
         window.ExcludeFromShutdownPolicy = excludeFromShutdownPolicy;
-        configure?.Invoke(window.Host);
-        RegisterWindow(window);
         try
         {
+            // configure runs inside the cleanup region, not before it: the
+            // ReactorWindow ctor has already created the native Window and
+            // AppWindow, so a throwing pre-mount callback would otherwise leak
+            // one that is neither registered nor disposed — invisible to
+            // ReactorApp.Windows and therefore to PrepareOpenWindowsForExit.
+            configure?.Invoke(window.Host);
+            RegisterWindow(window);
             window.MountAndActivate(rootFactory, renderFunc);
         }
         catch (Exception)
         {
+            // Idempotent when the failure happened before RegisterWindow.
             UnregisterWindow(window);
             try { window.Dispose(); } catch { /* best effort */ }
             throw;

--- a/src/Reactor/Hosting/ReactorApp.cs
+++ b/src/Reactor/Hosting/ReactorApp.cs
@@ -988,7 +988,9 @@ public static partial class ReactorApp
         if (policy == ShutdownPolicy.Explicit) return;
         if (policy == ShutdownPolicy.OnLastSurfaceClosed && TrayIconCount != 0) return;
 
-        try { RequestEventLoopExit(); } catch { /* best effort */ }
+        // RequestEventLoopExit handles and logs its own failures, so there is
+        // nothing left to guard here.
+        RequestEventLoopExit();
     }
 
     /// <summary>
@@ -1013,7 +1015,7 @@ public static partial class ReactorApp
             Application.Current?.Exit();
             return;
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is ObjectDisposedException or InvalidOperationException or COMException)
         {
             AppLogger?.LogError(ex, "ReactorApp: Application.Exit() failed; falling back to EnqueueEventLoopExit.");
             global::System.Diagnostics.Debug.WriteLine($"[Reactor] Application.Exit threw: {ex.GetType().Name}: {ex.Message}");
@@ -1023,7 +1025,7 @@ public static partial class ReactorApp
         {
             UIDispatcher?.EnqueueEventLoopExit();
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is ObjectDisposedException or InvalidOperationException or COMException)
         {
             AppLogger?.LogError(ex, "ReactorApp: EnqueueEventLoopExit() also failed; the event loop may not terminate.");
             global::System.Diagnostics.Debug.WriteLine($"[Reactor] EnqueueEventLoopExit threw: {ex.GetType().Name}: {ex.Message}");

--- a/src/Reactor/Hosting/ReactorApp.cs
+++ b/src/Reactor/Hosting/ReactorApp.cs
@@ -218,15 +218,33 @@ public static partial class ReactorApp
     /// <see cref="ReactorApplication"/>. A WinUI app that embeds
     /// <c>ReactorHostControl</c> runs its own <see cref="Application"/> and
     /// manages its own windows; Reactor does not decide when that process ends,
-    /// so it must leave that app's <see cref="Application.DispatcherShutdownMode"/>
-    /// at whatever the app chose or inherited. Best-effort: a teardown-racing
-    /// write is logged rather than thrown, matching <see cref="SafeExit"/>.</para>
+    /// so it leaves that app's <see cref="Application.DispatcherShutdownMode"/>
+    /// at whatever the app chose or inherited.</para>
+    /// <para>Failures are surfaced rather than swallowed. Only the exception
+    /// types a teardown-racing WinRT property write can realistically produce are
+    /// caught, matching <see cref="PrepareOpenWindowsForExit"/>, and those are
+    /// reported through <see cref="AppLogger"/> so they are visible in a release
+    /// build — a silent failure here would report the requested
+    /// <see cref="ShutdownPolicy"/> while leaving the platform free to end the
+    /// process, which is issue #1204 all over again. Anything else propagates:
+    /// this runs synchronously in <c>OnLaunched</c> before the startup callback,
+    /// so an unexpected fault is a startup bug and should not be hidden.</para>
     /// </remarks>
     internal static void TakeOwnershipOfDispatcherLifetime()
     {
         if (Application.Current is not ReactorApplication app) return;
-        try { app.DispatcherShutdownMode = DispatcherShutdownMode.OnExplicitShutdown; }
-        catch (Exception ex) { global::System.Diagnostics.Debug.WriteLine($"[Reactor] TakeOwnershipOfDispatcherLifetime failed: {ex.GetType().Name}: {ex.Message}"); }
+        try
+        {
+            app.DispatcherShutdownMode = DispatcherShutdownMode.OnExplicitShutdown;
+        }
+        catch (Exception ex) when (ex is ObjectDisposedException or InvalidOperationException or COMException)
+        {
+            const string message =
+                "Reactor could not take ownership of the dispatcher shutdown mode. WinUI may end the " +
+                "process when the last window closes, ignoring ReactorApp.ShutdownPolicy. (issue #1204)";
+            AppLogger?.LogError(ex, message);
+            global::System.Diagnostics.Debug.WriteLine($"[Reactor] {message} {ex.GetType().Name}: {ex.Message}");
+        }
     }
 
     /// <summary>Fires on the UI thread when a <see cref="ReactorWindow"/> opens.</summary>

--- a/src/Reactor/Hosting/ReactorApp.cs
+++ b/src/Reactor/Hosting/ReactorApp.cs
@@ -175,10 +175,94 @@ public static partial class ReactorApp
     }
 
     /// <summary>Process-shutdown policy. Defaults to <see cref="ShutdownPolicy.OnPrimaryWindowClosed"/>.</summary>
+    /// <remarks>
+    /// <para>Settable from any thread and at any point in the process lifetime.
+    /// Reading it back always reflects the last write; <b>when the platform
+    /// catches up depends on where you set it</b>, because WinUI's
+    /// <see cref="Application.DispatcherShutdownMode"/> — the property that
+    /// decides whether the event loop survives its last window — is per-thread
+    /// and cannot be written from another thread:</para>
+    /// <list type="bullet">
+    /// <item><description><b>Before <c>Run</c></b>: stored only; there is no
+    /// <see cref="Application"/> yet. <c>OnLaunched</c> applies it once WinUI has
+    /// bootstrapped, before any window opens.</description></item>
+    /// <item><description><b>On the UI thread</b> (startup callback, event
+    /// handler, tray command): applied before the setter returns.</description></item>
+    /// <item><description><b>Off the UI thread</b>: posted to
+    /// <see cref="UIDispatcher"/> and applied on a following dispatcher turn.
+    /// A window close that the UI thread happens to process first is still
+    /// judged by the previous policy, so set the policy on the UI thread when a
+    /// concurrent close is possible. The setter deliberately does not block on
+    /// the hop — a UI thread waiting on the caller would deadlock.</description></item>
+    /// </list>
+    /// <para><see cref="ShutdownPolicy.Explicit"/> and
+    /// <see cref="ShutdownPolicy.OnLastSurfaceClosed"/> map to
+    /// <see cref="DispatcherShutdownMode.OnExplicitShutdown"/>, handing process
+    /// lifetime to Reactor; <see cref="ShutdownPolicy.OnPrimaryWindowClosed"/>
+    /// keeps the platform default,
+    /// <see cref="DispatcherShutdownMode.OnLastWindowClose"/>. Reactor writes
+    /// that property only when it owns the <see cref="Application"/>, so an app
+    /// hosting <c>ReactorHostControl</c> in its own keeps its own lifetime.</para>
+    /// </remarks>
     public static ShutdownPolicy ShutdownPolicy
     {
         get => (ShutdownPolicy)Volatile.Read(ref _shutdownPolicy);
-        set => Volatile.Write(ref _shutdownPolicy, (int)value);
+        set
+        {
+            Volatile.Write(ref _shutdownPolicy, (int)value);
+
+            var dispatcher = UIDispatcher;
+            if (dispatcher is null) return;
+            if (dispatcher.HasThreadAccess) SyncDispatcherShutdownMode();
+            else dispatcher.TryEnqueue(SyncDispatcherShutdownMode);
+        }
+    }
+
+    /// <summary>
+    /// The platform dispatcher-shutdown mode that lets <paramref name="policy"/>
+    /// be honoured. (spec 036 §6.2)
+    /// </summary>
+    /// <remarks>
+    /// WinUI quits the thread's <c>DispatcherQueue</c> event loop when the last
+    /// XAML window closes unless the mode is
+    /// <see cref="DispatcherShutdownMode.OnExplicitShutdown"/>. Both non-default
+    /// policies describe states where "no windows open" is still a running app —
+    /// a tray-only app under <see cref="ShutdownPolicy.Explicit"/>, or a window
+    /// closing while a tray icon survives under
+    /// <see cref="ShutdownPolicy.OnLastSurfaceClosed"/> — so the platform must
+    /// hand process lifetime to <see cref="EvaluateShutdownPolicy"/>. The default
+    /// policy keeps the platform default, which already agrees with it: closing
+    /// the primary window exits either way.
+    /// </remarks>
+    internal static DispatcherShutdownMode DispatcherShutdownModeFor(ShutdownPolicy policy) =>
+        policy switch
+        {
+            ShutdownPolicy.OnLastSurfaceClosed => DispatcherShutdownMode.OnExplicitShutdown,
+            ShutdownPolicy.Explicit => DispatcherShutdownMode.OnExplicitShutdown,
+            _ => DispatcherShutdownMode.OnLastWindowClose,
+        };
+
+    /// <summary>
+    /// Projects <see cref="ShutdownPolicy"/> onto
+    /// <see cref="Application.DispatcherShutdownMode"/>. UI-thread only — the
+    /// property is per-thread, so writing it from elsewhere would configure the
+    /// wrong thread.
+    /// </summary>
+    /// <remarks>
+    /// Only writes when Reactor owns the <see cref="Application"/>. An app that
+    /// embeds <c>ReactorHostControl</c> in its own <see cref="Application"/>
+    /// never calls <c>Application.Start</c>, so its mode already defaults to
+    /// <see cref="DispatcherShutdownMode.OnExplicitShutdown"/> — writing
+    /// <see cref="DispatcherShutdownMode.OnLastWindowClose"/> there would make
+    /// the host process exit when its last window closes, a lifetime change
+    /// Reactor has no business making. Best-effort: a teardown-racing write is
+    /// logged rather than thrown, matching <see cref="SafeExit"/>.
+    /// </remarks>
+    internal static void SyncDispatcherShutdownMode()
+    {
+        if (Application.Current is not ReactorApplication app) return;
+        try { app.DispatcherShutdownMode = DispatcherShutdownModeFor(ShutdownPolicy); }
+        catch (Exception ex) { global::System.Diagnostics.Debug.WriteLine($"[Reactor] SyncDispatcherShutdownMode failed: {ex.GetType().Name}: {ex.Message}"); }
     }
 
     /// <summary>Fires on the UI thread when a <see cref="ReactorWindow"/> opens.</summary>
@@ -779,6 +863,10 @@ public static partial class ReactorApp
     // OnPrimaryWindowClosed: exit when the just-closed window was the primary.
     // OnLastSurfaceClosed: exit when both windows and tray icons are gone.
     // Explicit: never exit from a surface-close event — the app drives Exit().
+    //
+    // This is the sole authority on process lifetime for the two non-default
+    // policies: DispatcherShutdownModeFor puts the platform into
+    // OnExplicitShutdown for them, so nothing else will quit the event loop.
     internal static void EvaluateShutdownPolicy(bool closedWasPrimary)
     {
         var policy = ShutdownPolicy;
@@ -1140,6 +1228,14 @@ public partial class ReactorApplication : Application, IXamlMetadataProvider
         // a startup callback that itself opens windows — sees the right
         // process-wide UI thread reference. (spec 036 §4.3 / §6.1)
         ReactorApp.UIDispatcher = Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread();
+
+        // Application.Start just reset this thread's DispatcherShutdownMode to
+        // OnLastWindowClose, which would quit the event loop on last-window-close
+        // before EvaluateShutdownPolicy could veto it. Re-apply whatever policy
+        // the app picked before Run. Policies set later — inside the startup
+        // callback or from a tray command — are projected by the property setter.
+        // (spec 036 §6.2)
+        ReactorApp.SyncDispatcherShutdownMode();
 
         var opts = ReactorApp.Options;
         var activation = ParseLaunchActivation(args);

--- a/tests/Reactor.AppTests.Host/Program.cs
+++ b/tests/Reactor.AppTests.Host/Program.cs
@@ -23,6 +23,20 @@ if (args.Contains("--list-fixtures"))
     return;
 }
 
+if (args.Contains(ShutdownPolicyProbe.Flag))
+{
+    // Issue #1204 — one-window process-lifetime probe. Reports via exit code
+    // whether the event loop outlived its last window; see ShutdownPolicyProbe.
+    Environment.Exit(ShutdownPolicyProbe.Run(args));
+}
+
+if (args.Contains(ShutdownPolicyGateProbe.Flag))
+{
+    // Issue #1204 — the ownership gate's negative case, which needs a process
+    // whose Application is NOT a ReactorApplication.
+    Environment.Exit(ShutdownPolicyGateProbe.Run());
+}
+
 if (args.Contains("--self-test"))
 {
     var filterIdx = Array.IndexOf(args, "--filter");

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ShutdownPolicyDispatcherModeFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ShutdownPolicyDispatcherModeFixtures.cs
@@ -56,21 +56,30 @@ internal static class ShutdownPolicyDispatcherModeFixtures
             var priorMode = Application.Current.DispatcherShutdownMode;
             try
             {
-                // Every policy, including the default. The default is the
-                // load-bearing case: deriving the mode from it is exactly what
-                // let the platform end an app whose last window was auxiliary.
+                // 1. Ownership. Seeded to the opposite value first, so a no-op
+                //    implementation is visible rather than masked by a mode that
+                //    was already correct.
+                Application.Current.DispatcherShutdownMode = DispatcherShutdownMode.OnLastWindowClose;
+                H.Check("ShutdownPolicy_Seed_Took",
+                    Application.Current.DispatcherShutdownMode == DispatcherShutdownMode.OnLastWindowClose);
+
+                ReactorApp.TakeOwnershipOfDispatcherLifetime();
+                await Harness.Render();
+
+                H.Check("ShutdownPolicy_Takes_Ownership",
+                    Application.Current.DispatcherShutdownMode == DispatcherShutdownMode.OnExplicitShutdown);
+
+                // 2. Policy independence, checked WITHOUT re-seeding: a setter
+                //    that wrote to the platform would show up as a mode that
+                //    moved off OnExplicitShutdown. Re-seeding between arms would
+                //    overwrite exactly that evidence, which is what made an
+                //    earlier version of this fixture unable to see it.
                 foreach (var policy in Enum.GetValues<ShutdownPolicy>())
                 {
                     ReactorApp.ShutdownPolicy = policy;
-
-                    Application.Current.DispatcherShutdownMode = DispatcherShutdownMode.OnLastWindowClose;
-                    H.Check($"ShutdownPolicy_{policy}_Seed_Took",
-                        Application.Current.DispatcherShutdownMode == DispatcherShutdownMode.OnLastWindowClose);
-
-                    ReactorApp.TakeOwnershipOfDispatcherLifetime();
                     await Harness.Render();
 
-                    H.Check($"ShutdownPolicy_{policy}_Takes_Ownership",
+                    H.Check($"ShutdownPolicy_{policy}_Does_Not_Move_The_Mode",
                         Application.Current.DispatcherShutdownMode == DispatcherShutdownMode.OnExplicitShutdown);
                 }
             }

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ShutdownPolicyDispatcherModeFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ShutdownPolicyDispatcherModeFixtures.cs
@@ -5,79 +5,79 @@ using Microsoft.UI.Xaml;
 namespace Microsoft.UI.Reactor.AppTests.Host.SelfTest.Fixtures;
 
 /// <summary>
-/// Issue #1204 — Reactor must own this thread's event loop, so that
-/// <c>ReactorApp.EvaluateShutdownPolicy</c> is the only thing that ends the
-/// process.
+/// Issue #1204 — <c>ReactorApp.TakeOwnershipOfDispatcherLifetime</c> must move
+/// this thread's <see cref="Application.DispatcherShutdownMode"/> to
+/// <see cref="DispatcherShutdownMode.OnExplicitShutdown"/>, and must do it
+/// regardless of the current <see cref="ShutdownPolicy"/>.
 /// </summary>
 /// <remarks>
 /// <para>WinUI quits the thread's <c>DispatcherQueue</c> event loop when the
-/// last XAML window closes unless
-/// <see cref="Application.DispatcherShutdownMode"/> is
+/// last XAML window closes unless that property is
 /// <see cref="DispatcherShutdownMode.OnExplicitShutdown"/>, and
-/// <c>Application.Start</c> resets that property to
+/// <c>Application.Start</c> resets it to
 /// <see cref="DispatcherShutdownMode.OnLastWindowClose"/>. Leaving it there was
 /// the bug: the platform cannot see <c>ShutdownPolicy.Explicit</c>, a surviving
 /// tray icon, or a window that opted out of the policy, so it ended processes
-/// spec 036 §6.2 says should keep running.</para>
-/// <para><c>ReactorApplication.OnLaunched</c> takes ownership once, before any
-/// window exists. This fixture asserts the state that leaves behind on the live
-/// host — a fixture cannot re-run <c>OnLaunched</c>, so the assertion is of the
-/// standing effect rather than of a re-application. It is not vacuous: deleting
-/// the <c>TakeOwnershipOfDispatcherLifetime</c> call reddens it, because
-/// <c>Application.Start</c>'s reset is then what remains.</para>
-/// <para>The policy-independence check is what guards the regression this PR's
-/// review surfaced. An earlier revision derived the mode from the policy, which
-/// (a) left the platform free to end an app whose last window was an auxiliary
-/// docking tear-off under the default policy, and (b) opened a window in which
-/// the policy and the mode could disagree. Ownership is now unconditional, so
-/// flipping the policy must not move the property at all.</para>
-/// <para>Process-lifetime consequences — surviving a close, zero-surface
-/// startup, reopening afterwards, and leaving a non-Reactor <c>Application</c>
-/// alone — need a real process and live in
+/// that spec 036 §6.2 says should keep running.</para>
+/// <para>The method is driven <b>directly</b> rather than by launching. This
+/// host constructs <see cref="ReactorApplication"/> itself instead of going
+/// through <c>ReactorApp.Run</c>, and that launch shape deliberately does not
+/// take ownership — the host owns its own windows — so asserting the ambient
+/// mode here would assert the opposite of what the product does. Calling the
+/// method is also what makes the check non-vacuous: the mode is seeded to
+/// <see cref="DispatcherShutdownMode.OnLastWindowClose"/> first, so a no-op
+/// implementation is visible rather than masked by a value that was already
+/// correct.</para>
+/// <para>The policy-independence arm guards the regression this PR's review
+/// surfaced. An earlier revision derived the mode from the policy, which left
+/// the platform free to end an app whose last window was an auxiliary docking
+/// tear-off under the default policy (issue #647), and opened a window in which
+/// the policy and the mode could disagree.</para>
+/// <para>Whether the process then actually survives — and whether a non-Reactor
+/// <see cref="Application"/> is left alone — needs a real process and lives in
 /// <c>ShutdownPolicyProcessLifetimeTests</c>.</para>
 /// </remarks>
 internal static class ShutdownPolicyDispatcherModeFixtures
 {
-    private static void EnsureUIDispatcher()
-    {
-        if (ReactorApp.UIDispatcher is null)
-            ReactorApp.UIDispatcher = DispatcherQueue.GetForCurrentThread();
-    }
-
     internal class ShutdownPolicyOwnsDispatcherLifetime(Harness h) : SelfTestFixtureBase(h)
     {
         public override async Task RunAsync()
         {
-            EnsureUIDispatcher();
+            if (ReactorApp.UIDispatcher is null)
+                ReactorApp.UIDispatcher = DispatcherQueue.GetForCurrentThread();
 
             // Ownership is gated on Reactor owning the Application, so a host
-            // that failed this precondition would fail the real check below for
-            // an unrelated reason. Name it separately.
+            // failing this precondition would fail every check below for an
+            // unrelated reason. Name it separately.
             H.Check("ShutdownPolicy_Host_Owns_ReactorApplication",
                 Application.Current is ReactorApplication);
 
-            H.Check("ShutdownPolicy_Launch_Took_Dispatcher_Ownership",
-                Application.Current.DispatcherShutdownMode == DispatcherShutdownMode.OnExplicitShutdown);
-
             var priorPolicy = ReactorApp.ShutdownPolicy;
+            var priorMode = Application.Current.DispatcherShutdownMode;
             try
             {
-                // Every policy, including the default, must leave the property
-                // alone. The default one is the load-bearing case: deriving the
-                // mode from it is exactly what let the platform end an app whose
-                // last window was an auxiliary one (issue #647).
+                // Every policy, including the default. The default is the
+                // load-bearing case: deriving the mode from it is exactly what
+                // let the platform end an app whose last window was auxiliary.
                 foreach (var policy in Enum.GetValues<ShutdownPolicy>())
                 {
                     ReactorApp.ShutdownPolicy = policy;
+
+                    Application.Current.DispatcherShutdownMode = DispatcherShutdownMode.OnLastWindowClose;
+                    H.Check($"ShutdownPolicy_{policy}_Seed_Took",
+                        Application.Current.DispatcherShutdownMode == DispatcherShutdownMode.OnLastWindowClose);
+
+                    ReactorApp.TakeOwnershipOfDispatcherLifetime();
                     await Harness.Render();
 
-                    H.Check($"ShutdownPolicy_{policy}_Leaves_Ownership_Intact",
+                    H.Check($"ShutdownPolicy_{policy}_Takes_Ownership",
                         Application.Current.DispatcherShutdownMode == DispatcherShutdownMode.OnExplicitShutdown);
                 }
             }
             finally
             {
                 ReactorApp.ShutdownPolicy = priorPolicy;
+                Application.Current.DispatcherShutdownMode = priorMode;
             }
         }
     }

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ShutdownPolicyDispatcherModeFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ShutdownPolicyDispatcherModeFixtures.cs
@@ -5,147 +5,79 @@ using Microsoft.UI.Xaml;
 namespace Microsoft.UI.Reactor.AppTests.Host.SelfTest.Fixtures;
 
 /// <summary>
-/// Issue #1204 — <see cref="ReactorApp.ShutdownPolicy"/> has to reach the
-/// platform, not just Reactor's own bookkeeping.
+/// Issue #1204 — Reactor must own this thread's event loop, so that
+/// <c>ReactorApp.EvaluateShutdownPolicy</c> is the only thing that ends the
+/// process.
 /// </summary>
 /// <remarks>
-/// <para>WinUI quits the thread's <c>DispatcherQueue</c> event loop when the last
-/// XAML window closes unless <see cref="Application.DispatcherShutdownMode"/> is
+/// <para>WinUI quits the thread's <c>DispatcherQueue</c> event loop when the
+/// last XAML window closes unless
+/// <see cref="Application.DispatcherShutdownMode"/> is
 /// <see cref="DispatcherShutdownMode.OnExplicitShutdown"/>, and
 /// <c>Application.Start</c> resets that property to
-/// <see cref="DispatcherShutdownMode.OnLastWindowClose"/>. So both non-default
-/// policies are inert unless Reactor writes the property — which is exactly the
-/// bug: the process exited on last-window-close as if the policy were
-/// <see cref="ShutdownPolicy.OnPrimaryWindowClosed"/>.</para>
-/// <para><b>Every arm forces the property to the opposite value first.</b> Without
-/// that, the check is a tautology: the windowing fixture families pin
-/// <see cref="ShutdownPolicy.Explicit"/> in their <c>EnsureUIDispatcher</c>
-/// helpers, so by the time this runs the property may already hold the value the
-/// arm expects, and a completely unwired build would still read green. The forced
-/// write doubles as a positive control — <c>_Precondition</c> proves the property
-/// is readable and writable on this thread, so a later no-change reading is a
-/// measurement rather than a broken probe.</para>
-/// <para>Expected modes are spelled out literally rather than obtained from
-/// <c>ReactorApp.DispatcherShutdownModeFor</c>: an oracle that asks the code under
-/// test what it should have done cannot catch a wrong mapping.</para>
-/// <para>This tier can observe the property but not the loop. That the process
-/// genuinely survives last-window-close is covered by
-/// <c>ShutdownPolicyProcessLifetimeTests</c> in <c>Reactor.SelfTests</c>, which
-/// drives a real <c>--shutdown-policy-probe</c> host to exit.</para>
+/// <see cref="DispatcherShutdownMode.OnLastWindowClose"/>. Leaving it there was
+/// the bug: the platform cannot see <c>ShutdownPolicy.Explicit</c>, a surviving
+/// tray icon, or a window that opted out of the policy, so it ended processes
+/// spec 036 §6.2 says should keep running.</para>
+/// <para><c>ReactorApplication.OnLaunched</c> takes ownership once, before any
+/// window exists. This fixture asserts the state that leaves behind on the live
+/// host — a fixture cannot re-run <c>OnLaunched</c>, so the assertion is of the
+/// standing effect rather than of a re-application. It is not vacuous: deleting
+/// the <c>TakeOwnershipOfDispatcherLifetime</c> call reddens it, because
+/// <c>Application.Start</c>'s reset is then what remains.</para>
+/// <para>The policy-independence check is what guards the regression this PR's
+/// review surfaced. An earlier revision derived the mode from the policy, which
+/// (a) left the platform free to end an app whose last window was an auxiliary
+/// docking tear-off under the default policy, and (b) opened a window in which
+/// the policy and the mode could disagree. Ownership is now unconditional, so
+/// flipping the policy must not move the property at all.</para>
+/// <para>Process-lifetime consequences — surviving a close, zero-surface
+/// startup, reopening afterwards, and leaving a non-Reactor <c>Application</c>
+/// alone — need a real process and live in
+/// <c>ShutdownPolicyProcessLifetimeTests</c>.</para>
 /// </remarks>
 internal static class ShutdownPolicyDispatcherModeFixtures
 {
     private static void EnsureUIDispatcher()
     {
-        // The setter only projects onto the platform when it can resolve a UI
-        // dispatcher. OnLaunched captures one for this host, but the windowing
-        // fixtures guard the same way and so does this.
         if (ReactorApp.UIDispatcher is null)
             ReactorApp.UIDispatcher = DispatcherQueue.GetForCurrentThread();
     }
 
-    private static DispatcherShutdownMode Opposite(DispatcherShutdownMode mode) =>
-        mode == DispatcherShutdownMode.OnExplicitShutdown
-            ? DispatcherShutdownMode.OnLastWindowClose
-            : DispatcherShutdownMode.OnExplicitShutdown;
-
-    /// <summary>
-    /// Drains one full turn of the UI dispatcher so a <c>TryEnqueue</c> posted
-    /// from another thread has demonstrably run before we read the property.
-    /// </summary>
-    private static Task DrainDispatcherAsync()
-    {
-        var dispatcher = ReactorApp.UIDispatcher!;
-        var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        if (!dispatcher.TryEnqueue(() => tcs.TrySetResult()))
-            tcs.TrySetResult();
-        return tcs.Task;
-    }
-
-    internal class ShutdownPolicyProjectsToDispatcherMode(Harness h) : SelfTestFixtureBase(h)
+    internal class ShutdownPolicyOwnsDispatcherLifetime(Harness h) : SelfTestFixtureBase(h)
     {
         public override async Task RunAsync()
         {
             EnsureUIDispatcher();
 
-            // The projection is gated on Reactor owning the Application, so a
-            // host that failed this precondition would make every check below
-            // fail for an unrelated reason. Name it explicitly.
+            // Ownership is gated on Reactor owning the Application, so a host
+            // that failed this precondition would fail the real check below for
+            // an unrelated reason. Name it separately.
             H.Check("ShutdownPolicy_Host_Owns_ReactorApplication",
                 Application.Current is ReactorApplication);
 
+            H.Check("ShutdownPolicy_Launch_Took_Dispatcher_Ownership",
+                Application.Current.DispatcherShutdownMode == DispatcherShutdownMode.OnExplicitShutdown);
+
             var priorPolicy = ReactorApp.ShutdownPolicy;
-            var priorMode = Application.Current.DispatcherShutdownMode;
             try
             {
-                (ShutdownPolicy Policy, DispatcherShutdownMode Expected, string Label)[] arms =
-                [
-                    (ShutdownPolicy.OnPrimaryWindowClosed, DispatcherShutdownMode.OnLastWindowClose, "OnPrimaryWindowClosed"),
-                    (ShutdownPolicy.OnLastSurfaceClosed, DispatcherShutdownMode.OnExplicitShutdown, "OnLastSurfaceClosed"),
-                    (ShutdownPolicy.Explicit, DispatcherShutdownMode.OnExplicitShutdown, "Explicit"),
-                ];
-
-                foreach (var (policy, expected, label) in arms)
+                // Every policy, including the default, must leave the property
+                // alone. The default one is the load-bearing case: deriving the
+                // mode from it is exactly what let the platform end an app whose
+                // last window was an auxiliary one (issue #647).
+                foreach (var policy in Enum.GetValues<ShutdownPolicy>())
                 {
-                    var seed = Opposite(expected);
-                    Application.Current.DispatcherShutdownMode = seed;
-                    H.Check($"ShutdownPolicy_{label}_Precondition",
-                        Application.Current.DispatcherShutdownMode == seed);
-
                     ReactorApp.ShutdownPolicy = policy;
                     await Harness.Render();
 
-                    H.Check($"ShutdownPolicy_{label}_Projects",
-                        Application.Current.DispatcherShutdownMode == expected);
+                    H.Check($"ShutdownPolicy_{policy}_Leaves_Ownership_Intact",
+                        Application.Current.DispatcherShutdownMode == DispatcherShutdownMode.OnExplicitShutdown);
                 }
             }
             finally
             {
                 ReactorApp.ShutdownPolicy = priorPolicy;
-                Application.Current.DispatcherShutdownMode = priorMode;
-            }
-        }
-    }
-
-    internal class ShutdownPolicyOffThreadSetMarshals(Harness h) : SelfTestFixtureBase(h)
-    {
-        public override async Task RunAsync()
-        {
-            EnsureUIDispatcher();
-
-            var priorPolicy = ReactorApp.ShutdownPolicy;
-            var priorMode = Application.Current.DispatcherShutdownMode;
-            try
-            {
-                Application.Current.DispatcherShutdownMode = DispatcherShutdownMode.OnLastWindowClose;
-                H.Check("ShutdownPolicy_OffThread_Precondition",
-                    Application.Current.DispatcherShutdownMode == DispatcherShutdownMode.OnLastWindowClose);
-
-                // DispatcherShutdownMode is a per-thread property, so a policy set
-                // from a background thread (a sync worker, a tray command handler
-                // posted off-thread) has to be marshalled rather than written where
-                // it was set.
-                bool hadThreadAccess = true;
-                await Task.Run(() =>
-                {
-                    hadThreadAccess = ReactorApp.UIDispatcher!.HasThreadAccess;
-                    ReactorApp.ShutdownPolicy = ShutdownPolicy.Explicit;
-                });
-
-                // Guards the arm itself: if this ran on the UI thread after all,
-                // it would exercise the inline branch and prove nothing about
-                // marshalling.
-                H.Check("ShutdownPolicy_OffThread_Really_Off_Thread", !hadThreadAccess);
-
-                await DrainDispatcherAsync();
-
-                H.Check("ShutdownPolicy_OffThread_Projects",
-                    Application.Current.DispatcherShutdownMode == DispatcherShutdownMode.OnExplicitShutdown);
-            }
-            finally
-            {
-                ReactorApp.ShutdownPolicy = priorPolicy;
-                Application.Current.DispatcherShutdownMode = priorMode;
             }
         }
     }

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ShutdownPolicyDispatcherModeFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ShutdownPolicyDispatcherModeFixtures.cs
@@ -1,0 +1,152 @@
+using Microsoft.UI.Dispatching;
+using Microsoft.UI.Reactor;
+using Microsoft.UI.Xaml;
+
+namespace Microsoft.UI.Reactor.AppTests.Host.SelfTest.Fixtures;
+
+/// <summary>
+/// Issue #1204 — <see cref="ReactorApp.ShutdownPolicy"/> has to reach the
+/// platform, not just Reactor's own bookkeeping.
+/// </summary>
+/// <remarks>
+/// <para>WinUI quits the thread's <c>DispatcherQueue</c> event loop when the last
+/// XAML window closes unless <see cref="Application.DispatcherShutdownMode"/> is
+/// <see cref="DispatcherShutdownMode.OnExplicitShutdown"/>, and
+/// <c>Application.Start</c> resets that property to
+/// <see cref="DispatcherShutdownMode.OnLastWindowClose"/>. So both non-default
+/// policies are inert unless Reactor writes the property — which is exactly the
+/// bug: the process exited on last-window-close as if the policy were
+/// <see cref="ShutdownPolicy.OnPrimaryWindowClosed"/>.</para>
+/// <para><b>Every arm forces the property to the opposite value first.</b> Without
+/// that, the check is a tautology: the windowing fixture families pin
+/// <see cref="ShutdownPolicy.Explicit"/> in their <c>EnsureUIDispatcher</c>
+/// helpers, so by the time this runs the property may already hold the value the
+/// arm expects, and a completely unwired build would still read green. The forced
+/// write doubles as a positive control — <c>_Precondition</c> proves the property
+/// is readable and writable on this thread, so a later no-change reading is a
+/// measurement rather than a broken probe.</para>
+/// <para>Expected modes are spelled out literally rather than obtained from
+/// <c>ReactorApp.DispatcherShutdownModeFor</c>: an oracle that asks the code under
+/// test what it should have done cannot catch a wrong mapping.</para>
+/// <para>This tier can observe the property but not the loop. That the process
+/// genuinely survives last-window-close is covered by
+/// <c>ShutdownPolicyProcessLifetimeTests</c> in <c>Reactor.SelfTests</c>, which
+/// drives a real <c>--shutdown-policy-probe</c> host to exit.</para>
+/// </remarks>
+internal static class ShutdownPolicyDispatcherModeFixtures
+{
+    private static void EnsureUIDispatcher()
+    {
+        // The setter only projects onto the platform when it can resolve a UI
+        // dispatcher. OnLaunched captures one for this host, but the windowing
+        // fixtures guard the same way and so does this.
+        if (ReactorApp.UIDispatcher is null)
+            ReactorApp.UIDispatcher = DispatcherQueue.GetForCurrentThread();
+    }
+
+    private static DispatcherShutdownMode Opposite(DispatcherShutdownMode mode) =>
+        mode == DispatcherShutdownMode.OnExplicitShutdown
+            ? DispatcherShutdownMode.OnLastWindowClose
+            : DispatcherShutdownMode.OnExplicitShutdown;
+
+    /// <summary>
+    /// Drains one full turn of the UI dispatcher so a <c>TryEnqueue</c> posted
+    /// from another thread has demonstrably run before we read the property.
+    /// </summary>
+    private static Task DrainDispatcherAsync()
+    {
+        var dispatcher = ReactorApp.UIDispatcher!;
+        var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        if (!dispatcher.TryEnqueue(() => tcs.TrySetResult()))
+            tcs.TrySetResult();
+        return tcs.Task;
+    }
+
+    internal class ShutdownPolicyProjectsToDispatcherMode(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            EnsureUIDispatcher();
+
+            // The projection is gated on Reactor owning the Application, so a
+            // host that failed this precondition would make every check below
+            // fail for an unrelated reason. Name it explicitly.
+            H.Check("ShutdownPolicy_Host_Owns_ReactorApplication",
+                Application.Current is ReactorApplication);
+
+            var priorPolicy = ReactorApp.ShutdownPolicy;
+            var priorMode = Application.Current.DispatcherShutdownMode;
+            try
+            {
+                (ShutdownPolicy Policy, DispatcherShutdownMode Expected, string Label)[] arms =
+                [
+                    (ShutdownPolicy.OnPrimaryWindowClosed, DispatcherShutdownMode.OnLastWindowClose, "OnPrimaryWindowClosed"),
+                    (ShutdownPolicy.OnLastSurfaceClosed, DispatcherShutdownMode.OnExplicitShutdown, "OnLastSurfaceClosed"),
+                    (ShutdownPolicy.Explicit, DispatcherShutdownMode.OnExplicitShutdown, "Explicit"),
+                ];
+
+                foreach (var (policy, expected, label) in arms)
+                {
+                    var seed = Opposite(expected);
+                    Application.Current.DispatcherShutdownMode = seed;
+                    H.Check($"ShutdownPolicy_{label}_Precondition",
+                        Application.Current.DispatcherShutdownMode == seed);
+
+                    ReactorApp.ShutdownPolicy = policy;
+                    await Harness.Render();
+
+                    H.Check($"ShutdownPolicy_{label}_Projects",
+                        Application.Current.DispatcherShutdownMode == expected);
+                }
+            }
+            finally
+            {
+                ReactorApp.ShutdownPolicy = priorPolicy;
+                Application.Current.DispatcherShutdownMode = priorMode;
+            }
+        }
+    }
+
+    internal class ShutdownPolicyOffThreadSetMarshals(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            EnsureUIDispatcher();
+
+            var priorPolicy = ReactorApp.ShutdownPolicy;
+            var priorMode = Application.Current.DispatcherShutdownMode;
+            try
+            {
+                Application.Current.DispatcherShutdownMode = DispatcherShutdownMode.OnLastWindowClose;
+                H.Check("ShutdownPolicy_OffThread_Precondition",
+                    Application.Current.DispatcherShutdownMode == DispatcherShutdownMode.OnLastWindowClose);
+
+                // DispatcherShutdownMode is a per-thread property, so a policy set
+                // from a background thread (a sync worker, a tray command handler
+                // posted off-thread) has to be marshalled rather than written where
+                // it was set.
+                bool hadThreadAccess = true;
+                await Task.Run(() =>
+                {
+                    hadThreadAccess = ReactorApp.UIDispatcher!.HasThreadAccess;
+                    ReactorApp.ShutdownPolicy = ShutdownPolicy.Explicit;
+                });
+
+                // Guards the arm itself: if this ran on the UI thread after all,
+                // it would exercise the inline branch and prove nothing about
+                // marshalling.
+                H.Check("ShutdownPolicy_OffThread_Really_Off_Thread", !hadThreadAccess);
+
+                await DrainDispatcherAsync();
+
+                H.Check("ShutdownPolicy_OffThread_Projects",
+                    Application.Current.DispatcherShutdownMode == DispatcherShutdownMode.OnExplicitShutdown);
+            }
+            finally
+            {
+                ReactorApp.ShutdownPolicy = priorPolicy;
+                Application.Current.DispatcherShutdownMode = priorMode;
+            }
+        }
+    }
+}

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -1259,6 +1259,9 @@ internal static class SelfTestFixtureRegistry
         "WindowModel_IgnorePointerInputRoundTrip",
         "WindowModel_OpacityIgnorePointerInvariants",
         "WindowModel_DefaultSizeDefersToOs",
+        // Issue #1204 — ShutdownPolicy projected onto Application.DispatcherShutdownMode.
+        "ShutdownPolicy_ProjectsToDispatcherMode",
+        "ShutdownPolicy_OffThreadSetMarshals",
         // Spec 054 Phase 1 — window position/z-order/display read-back.
         "Position_ReadBack",
         "PositionChanged_FiresOnMove",
@@ -3159,6 +3162,9 @@ internal static class SelfTestFixtureRegistry
         "WindowModel_IgnorePointerInputRoundTrip" => new WindowModelFixtures.WindowIgnorePointerInputRoundTrip(harness),
         "WindowModel_OpacityIgnorePointerInvariants" => new WindowModelFixtures.WindowOpacityIgnorePointerInvariants(harness),
         "WindowModel_DefaultSizeDefersToOs" => new WindowModelFixtures.WindowDefaultSizeDefersToOs(harness),
+        // Issue #1204 — ShutdownPolicy projected onto Application.DispatcherShutdownMode.
+        "ShutdownPolicy_ProjectsToDispatcherMode" => new ShutdownPolicyDispatcherModeFixtures.ShutdownPolicyProjectsToDispatcherMode(harness),
+        "ShutdownPolicy_OffThreadSetMarshals" => new ShutdownPolicyDispatcherModeFixtures.ShutdownPolicyOffThreadSetMarshals(harness),
         // Spec 054 Phase 1 — window position/z-order/display read-back.
         "Position_ReadBack" => new Phase1WindowingFixtures.PositionReadBack(harness),
         "PositionChanged_FiresOnMove" => new Phase1WindowingFixtures.PositionChangedFiresOnMove(harness),

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -1259,9 +1259,8 @@ internal static class SelfTestFixtureRegistry
         "WindowModel_IgnorePointerInputRoundTrip",
         "WindowModel_OpacityIgnorePointerInvariants",
         "WindowModel_DefaultSizeDefersToOs",
-        // Issue #1204 — ShutdownPolicy projected onto Application.DispatcherShutdownMode.
-        "ShutdownPolicy_ProjectsToDispatcherMode",
-        "ShutdownPolicy_OffThreadSetMarshals",
+        // Issue #1204 — Reactor owns the dispatcher loop; the policy alone decides exits.
+        "ShutdownPolicy_OwnsDispatcherLifetime",
         // Spec 054 Phase 1 — window position/z-order/display read-back.
         "Position_ReadBack",
         "PositionChanged_FiresOnMove",
@@ -3162,9 +3161,8 @@ internal static class SelfTestFixtureRegistry
         "WindowModel_IgnorePointerInputRoundTrip" => new WindowModelFixtures.WindowIgnorePointerInputRoundTrip(harness),
         "WindowModel_OpacityIgnorePointerInvariants" => new WindowModelFixtures.WindowOpacityIgnorePointerInvariants(harness),
         "WindowModel_DefaultSizeDefersToOs" => new WindowModelFixtures.WindowDefaultSizeDefersToOs(harness),
-        // Issue #1204 — ShutdownPolicy projected onto Application.DispatcherShutdownMode.
-        "ShutdownPolicy_ProjectsToDispatcherMode" => new ShutdownPolicyDispatcherModeFixtures.ShutdownPolicyProjectsToDispatcherMode(harness),
-        "ShutdownPolicy_OffThreadSetMarshals" => new ShutdownPolicyDispatcherModeFixtures.ShutdownPolicyOffThreadSetMarshals(harness),
+        // Issue #1204 — Reactor owns the dispatcher loop; the policy alone decides exits.
+        "ShutdownPolicy_OwnsDispatcherLifetime" => new ShutdownPolicyDispatcherModeFixtures.ShutdownPolicyOwnsDispatcherLifetime(harness),
         // Spec 054 Phase 1 — window position/z-order/display read-back.
         "Position_ReadBack" => new Phase1WindowingFixtures.PositionReadBack(harness),
         "PositionChanged_FiresOnMove" => new Phase1WindowingFixtures.PositionChangedFiresOnMove(harness),

--- a/tests/Reactor.AppTests.Host/ShutdownPolicyGateProbe.cs
+++ b/tests/Reactor.AppTests.Host/ShutdownPolicyGateProbe.cs
@@ -112,8 +112,14 @@ internal static partial class ShutdownPolicyGateProbe
                         _exitCode = GateViolatedExitCode;
                     }
                 }
-                catch (Exception ex)
+                catch (Exception ex) when (ex is ObjectDisposedException or InvalidOperationException or global::System.Runtime.InteropServices.COMException)
                 {
+                    // Narrow rather than generic: a WinRT/XAML fault here means
+                    // the probe could not establish its preconditions, which is
+                    // INCONCLUSIVE (46) — deliberately distinct from both
+                    // GATE-HELD and GATE-VIOLATED so a broken probe cannot be
+                    // mistaken for a passing one. Anything else is a bug in the
+                    // probe and should surface as a crash.
                     Console.WriteLine($"INCONCLUSIVE {ex.GetType().Name}: {ex.Message}");
                     _exitCode = InconclusiveExitCode;
                 }

--- a/tests/Reactor.AppTests.Host/ShutdownPolicyGateProbe.cs
+++ b/tests/Reactor.AppTests.Host/ShutdownPolicyGateProbe.cs
@@ -142,5 +142,5 @@ internal static partial class ShutdownPolicyGateProbe
     /// class deriving from a WinRT type: <c>CsWinRT1028</c> is an error under
     /// this repo's Release warnings-as-errors settings.
     /// </remarks>
-    private sealed partial class EmbedderApplication : Application;
+    private sealed partial class EmbedderApplication : Application { }
 }

--- a/tests/Reactor.AppTests.Host/ShutdownPolicyGateProbe.cs
+++ b/tests/Reactor.AppTests.Host/ShutdownPolicyGateProbe.cs
@@ -6,30 +6,28 @@ namespace Microsoft.UI.Reactor.AppTests.Host;
 
 /// <summary>
 /// Issue #1204 — the negative half of the ownership gate in
-/// <c>ReactorApp.SyncDispatcherShutdownMode</c>: when Reactor does <b>not</b>
-/// own the <see cref="Application"/>, setting
-/// <see cref="ReactorApp.ShutdownPolicy"/> must leave that app's
-/// <see cref="Application.DispatcherShutdownMode"/> alone.
+/// <c>ReactorApp.TakeOwnershipOfDispatcherLifetime</c>: when Reactor does
+/// <b>not</b> own the <see cref="Application"/>, nothing Reactor does may change
+/// that app's <see cref="Application.DispatcherShutdownMode"/>.
 /// </summary>
 /// <remarks>
-/// <para>The gate exists because an app embedding <c>ReactorHostControl</c> in
-/// its own <see cref="Application"/> never calls <c>Application.Start</c>, so
-/// the platform has already defaulted its mode to
-/// <see cref="DispatcherShutdownMode.OnExplicitShutdown"/>. Writing
-/// <see cref="DispatcherShutdownMode.OnLastWindowClose"/> there would make the
-/// host process exit when its last window closes — a lifetime change Reactor has
-/// no business making. <c>ReactorHost</c> also seeds
-/// <see cref="ReactorApp.UIDispatcher"/> in exactly that scenario, so the
-/// dispatcher check upstream of the gate does not stand in for it.</para>
+/// <para>The gate exists because a WinUI app that embeds
+/// <c>ReactorHostControl</c> runs its own <see cref="Application"/> and manages
+/// its own windows. Reactor does not decide when that process ends, so it must
+/// leave the property at whatever the app chose or inherited — writing
+/// <see cref="DispatcherShutdownMode.OnExplicitShutdown"/> there would stop that
+/// app exiting when its last window closes. <c>ReactorHost</c> also seeds
+/// <see cref="ReactorApp.UIDispatcher"/> in exactly that scenario, so a
+/// dispatcher check would not stand in for the gate.</para>
 /// <para>This needs its own process and its own mode because the gate's
 /// condition is <c>Application.Current is ReactorApplication</c>: inside the
 /// selftest host that is always true, so no in-process fixture can reach the
 /// branch. Here a plain <see cref="Application"/> subclass owns the process
 /// instead.</para>
-/// <para>The seeded mode is deliberately the one Reactor would write for the
-/// policy under test's <i>opposite</i>, so a gate that failed open would flip it
-/// and be caught. <c>GATE-VIOLATED</c> is therefore a reachable outcome, not a
-/// branch that can only ever print success.</para>
+/// <para>The seeded value is deliberately the opposite of what Reactor writes
+/// when it <i>does</i> own the app, so a gate that failed open would visibly flip
+/// it. <c>GATE-VIOLATED</c> is therefore a reachable outcome, not a branch that
+/// can only ever print success.</para>
 /// </remarks>
 internal static partial class ShutdownPolicyGateProbe
 {
@@ -76,9 +74,9 @@ internal static partial class ShutdownPolicyGateProbe
                     // ReactorHost's constructor does for ReactorHostControl.
                     ReactorApp.UIDispatcher = dispatcher;
 
-                    // OnLastWindowClose is what Reactor writes for the DEFAULT
-                    // policy, so seeding it here means a gate that failed open
-                    // would visibly flip it to OnExplicitShutdown below.
+                    // Seed the opposite of what Reactor writes when it owns the
+                    // app (OnExplicitShutdown), so a gate that failed open would
+                    // visibly flip this to OnExplicitShutdown below.
                     Application.Current.DispatcherShutdownMode = DispatcherShutdownMode.OnLastWindowClose;
                     var seeded = Application.Current.DispatcherShutdownMode;
                     Console.WriteLine($"SEEDED {seeded}");

--- a/tests/Reactor.AppTests.Host/ShutdownPolicyGateProbe.cs
+++ b/tests/Reactor.AppTests.Host/ShutdownPolicyGateProbe.cs
@@ -75,8 +75,7 @@ internal static partial class ShutdownPolicyGateProbe
                     ReactorApp.UIDispatcher = dispatcher;
 
                     // Seed the opposite of what Reactor writes when it owns the
-                    // app (OnExplicitShutdown), so a gate that failed open would
-                    // visibly flip this to OnExplicitShutdown below.
+                    // app, so a gate that failed open would visibly flip this.
                     Application.Current.DispatcherShutdownMode = DispatcherShutdownMode.OnLastWindowClose;
                     var seeded = Application.Current.DispatcherShutdownMode;
                     Console.WriteLine($"SEEDED {seeded}");
@@ -89,6 +88,15 @@ internal static partial class ShutdownPolicyGateProbe
                     }
 
                     ReactorApp.ShutdownPolicy = ShutdownPolicy.Explicit;
+
+                    // Drive the ownership path DIRECTLY. Setting the policy is
+                    // deliberately a plain store — it writes nothing to the
+                    // platform — so going through the setter would make
+                    // GATE-VIOLATED unreachable and this probe would report
+                    // success even with the gate deleted. The gate lives in
+                    // TakeOwnershipOfDispatcherLifetime, so that is what has to
+                    // be called here. OnLaunched invokes exactly this method.
+                    ReactorApp.TakeOwnershipOfDispatcherLifetime();
 
                     var after = Application.Current.DispatcherShutdownMode;
                     Console.WriteLine($"AFTER {after} policy={ReactorApp.ShutdownPolicy}");

--- a/tests/Reactor.AppTests.Host/ShutdownPolicyGateProbe.cs
+++ b/tests/Reactor.AppTests.Host/ShutdownPolicyGateProbe.cs
@@ -1,0 +1,134 @@
+using Microsoft.UI.Dispatching;
+using Microsoft.UI.Reactor;
+using Microsoft.UI.Xaml;
+
+namespace Microsoft.UI.Reactor.AppTests.Host;
+
+/// <summary>
+/// Issue #1204 — the negative half of the ownership gate in
+/// <c>ReactorApp.SyncDispatcherShutdownMode</c>: when Reactor does <b>not</b>
+/// own the <see cref="Application"/>, setting
+/// <see cref="ReactorApp.ShutdownPolicy"/> must leave that app's
+/// <see cref="Application.DispatcherShutdownMode"/> alone.
+/// </summary>
+/// <remarks>
+/// <para>The gate exists because an app embedding <c>ReactorHostControl</c> in
+/// its own <see cref="Application"/> never calls <c>Application.Start</c>, so
+/// the platform has already defaulted its mode to
+/// <see cref="DispatcherShutdownMode.OnExplicitShutdown"/>. Writing
+/// <see cref="DispatcherShutdownMode.OnLastWindowClose"/> there would make the
+/// host process exit when its last window closes — a lifetime change Reactor has
+/// no business making. <c>ReactorHost</c> also seeds
+/// <see cref="ReactorApp.UIDispatcher"/> in exactly that scenario, so the
+/// dispatcher check upstream of the gate does not stand in for it.</para>
+/// <para>This needs its own process and its own mode because the gate's
+/// condition is <c>Application.Current is ReactorApplication</c>: inside the
+/// selftest host that is always true, so no in-process fixture can reach the
+/// branch. Here a plain <see cref="Application"/> subclass owns the process
+/// instead.</para>
+/// <para>The seeded mode is deliberately the one Reactor would write for the
+/// policy under test's <i>opposite</i>, so a gate that failed open would flip it
+/// and be caught. <c>GATE-VIOLATED</c> is therefore a reachable outcome, not a
+/// branch that can only ever print success.</para>
+/// </remarks>
+internal static partial class ShutdownPolicyGateProbe
+{
+    internal const string Flag = "--shutdown-policy-gate-probe";
+
+    internal const int GateHeldExitCode = 43;
+    internal const int GateViolatedExitCode = 44;
+    internal const int InconclusiveExitCode = 46;
+
+    internal const string GateHeldMarker = "GATE-HELD";
+    internal const string GateViolatedMarker = "GATE-VIOLATED";
+
+    private static int _exitCode = InconclusiveExitCode;
+
+    public static int Run()
+    {
+        WinRT.ComWrappersSupport.InitializeComWrappers();
+
+        Application.Start(_ =>
+        {
+            var dispatcher = DispatcherQueue.GetForCurrentThread();
+            SynchronizationContext.SetSynchronizationContext(
+                new DispatcherQueueSynchronizationContext(dispatcher));
+
+            // A plain Application — NOT ReactorApplication. This is the whole
+            // point of the probe.
+            var app = new EmbedderApplication();
+
+            dispatcher.TryEnqueue(() =>
+            {
+                try
+                {
+                    Console.WriteLine($"OWNER {Application.Current.GetType().FullName}");
+
+                    if (Application.Current is ReactorApplication)
+                    {
+                        // Would make every assertion below meaningless.
+                        Console.WriteLine("INCONCLUSIVE Application.Current is a ReactorApplication");
+                        _exitCode = InconclusiveExitCode;
+                        return;
+                    }
+
+                    // Stand in for the embedder having seeded the dispatcher, as
+                    // ReactorHost's constructor does for ReactorHostControl.
+                    ReactorApp.UIDispatcher = dispatcher;
+
+                    // OnLastWindowClose is what Reactor writes for the DEFAULT
+                    // policy, so seeding it here means a gate that failed open
+                    // would visibly flip it to OnExplicitShutdown below.
+                    Application.Current.DispatcherShutdownMode = DispatcherShutdownMode.OnLastWindowClose;
+                    var seeded = Application.Current.DispatcherShutdownMode;
+                    Console.WriteLine($"SEEDED {seeded}");
+
+                    if (seeded != DispatcherShutdownMode.OnLastWindowClose)
+                    {
+                        Console.WriteLine("INCONCLUSIVE seed did not take");
+                        _exitCode = InconclusiveExitCode;
+                        return;
+                    }
+
+                    ReactorApp.ShutdownPolicy = ShutdownPolicy.Explicit;
+
+                    var after = Application.Current.DispatcherShutdownMode;
+                    Console.WriteLine($"AFTER {after} policy={ReactorApp.ShutdownPolicy}");
+
+                    if (after == DispatcherShutdownMode.OnLastWindowClose)
+                    {
+                        Console.WriteLine($"{GateHeldMarker} embedder mode untouched");
+                        _exitCode = GateHeldExitCode;
+                    }
+                    else
+                    {
+                        Console.WriteLine($"{GateViolatedMarker} Reactor rewrote a host app's lifetime");
+                        _exitCode = GateViolatedExitCode;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine($"INCONCLUSIVE {ex.GetType().Name}: {ex.Message}");
+                    _exitCode = InconclusiveExitCode;
+                }
+                finally
+                {
+                    Console.Out.Flush();
+                    // No window was ever opened, so nothing will end this loop
+                    // for us under either mode.
+                    app.Exit();
+                }
+            });
+        });
+
+        Console.Out.Flush();
+        return _exitCode;
+    }
+
+    /// <remarks>
+    /// <c>partial</c> because CsWinRT requires it (and any parent type) for a
+    /// class deriving from a WinRT type: <c>CsWinRT1028</c> is an error under
+    /// this repo's Release warnings-as-errors settings.
+    /// </remarks>
+    private sealed partial class EmbedderApplication : Application;
+}

--- a/tests/Reactor.AppTests.Host/ShutdownPolicyProbe.cs
+++ b/tests/Reactor.AppTests.Host/ShutdownPolicyProbe.cs
@@ -94,6 +94,23 @@ internal static class ShutdownPolicyProbe
     /// </summary>
     internal const string LegacyRunFlag = "--legacy-run";
 
+    /// <summary>
+    /// Throw from the launch path — <c>startup</c>, or the legacy <c>configure</c>
+    /// callback with <see cref="LegacyRunFlag"/> — and mark the exception handled
+    /// via <see cref="ReactorApplication.OnUnhandledException"/>.
+    /// </summary>
+    /// <remarks>
+    /// Intended to drive the <c>finally</c> that runs the zero-surface decision.
+    /// Measured caveat: an exception propagating out of <c>OnLaunched</c>
+    /// fast-fails the XAML runtime (exit <c>0xC000027B</c>) even when the handler
+    /// returns <c>true</c>, so the process terminates either way and the arms
+    /// built on this flag can only assert "does not hang". Kept because that is
+    /// still the regression worth catching, and because the legacy variant
+    /// exercises the <c>OpenWindowCore</c> cleanup for a window whose pre-mount
+    /// callback threw.
+    /// </remarks>
+    internal const string ThrowInStartupFlag = "--throw-in-startup";
+
     internal const int AliveExitCode = 42;
     internal const int LoopExitedExitCode = 1;
     internal const int UsageExitCode = 64;
@@ -103,6 +120,7 @@ internal static class ShutdownPolicyProbe
     internal const string LoopExitedMarker = "LOOP-EXITED";
     internal const string ClosingMarker = "CLOSING";
     internal const string ReopenedMarker = "REOPENED";
+    internal const string StartupThrewMarker = "STARTUP-THREW";
     internal const string TrayClosedMarker = "TRAY-CLOSED";
 
     /// <summary>Settle time before the window is closed.</summary>
@@ -124,7 +142,7 @@ internal static class ShutdownPolicyProbe
         {
             Console.Error.WriteLine(
                 $"usage: {Flag} <{string.Join('|', Enum.GetNames<ShutdownPolicy>())}> " +
-                $"[{TrayFlag}] [{NoWindowFlag}] [{ReopenFlag}] [{ExcludedWindowFlag}] [{CloseTrayFlag}] [{LegacyRunFlag}]");
+                $"[{TrayFlag}] [{NoWindowFlag}] [{ReopenFlag}] [{ExcludedWindowFlag}] [{CloseTrayFlag}] [{LegacyRunFlag}] [{ThrowInStartupFlag}]");
             return UsageExitCode;
         }
 
@@ -134,10 +152,41 @@ internal static class ShutdownPolicyProbe
         var excluded = args.Contains(ExcludedWindowFlag);
         var closeTray = args.Contains(CloseTrayFlag);
         var legacyRun = args.Contains(LegacyRunFlag);
+        var throwInStartup = args.Contains(ThrowInStartupFlag);
 
         ReactorApp.ShutdownPolicy = policy;
         Console.WriteLine(
-            $"POLICY {policy} tray={withTray} noWindow={noWindow} reopen={reopen} excluded={excluded} legacy={legacyRun}");
+            $"POLICY {policy} tray={withTray} noWindow={noWindow} reopen={reopen} excluded={excluded} legacy={legacyRun} throws={throwInStartup}");
+
+        if (throwInStartup)
+        {
+            // Handled, so the exception does not end the process on its own —
+            // which is the whole point: what ends it must be the zero-surface
+            // decision running from the finally.
+            ReactorApplication.OnUnhandledException = _ =>
+            {
+                Console.WriteLine(StartupThrewMarker);
+                Console.Out.Flush();
+                return true;
+            };
+
+            if (legacyRun)
+            {
+                ReactorApp.Run<ProbeContent>(
+                    "Shutdown Policy Probe (throwing configure)",
+                    width: 320,
+                    height: 200,
+                    configure: _ => throw new InvalidOperationException("probe: configure failed"));
+            }
+            else
+            {
+                ReactorApp.Run(_ => throw new InvalidOperationException("probe: startup failed"));
+            }
+
+            Console.WriteLine(LoopExitedMarker);
+            Console.Out.Flush();
+            return LoopExitedExitCode;
+        }
 
         if (legacyRun)
         {

--- a/tests/Reactor.AppTests.Host/ShutdownPolicyProbe.cs
+++ b/tests/Reactor.AppTests.Host/ShutdownPolicyProbe.cs
@@ -111,6 +111,23 @@ internal static class ShutdownPolicyProbe
     /// </remarks>
     internal const string ThrowInStartupFlag = "--throw-in-startup";
 
+    /// <summary>
+    /// Open a window whose root factory throws, so the failure lands in
+    /// <c>MountAndActivate</c> <b>after</b> <c>RegisterWindow</c> — the only way
+    /// to reach the failed-open cleanup with a window that was registered and
+    /// elected primary. The callback then opens a real window and the probe
+    /// reports whether the process survived.
+    /// </summary>
+    /// <remarks>
+    /// This is the arm that pins <c>evaluateShutdownPolicy: false</c>. Under
+    /// <c>OnPrimaryWindowClosed</c>, unregistering that window with the evaluator
+    /// enabled sees <c>closedWasPrimary: true</c> and calls <c>SafeExit</c> while
+    /// the caller is still unwinding, so the process dies over a handled
+    /// <c>OpenWindow</c> failure. The <see cref="ThrowInStartupFlag"/> arms
+    /// cannot cover it: they fail in <c>configure</c>, before registration.
+    /// </remarks>
+    internal const string ThrowInMountFlag = "--throw-in-mount";
+
     internal const int AliveExitCode = 42;
     internal const int LoopExitedExitCode = 1;
     internal const int UsageExitCode = 64;
@@ -121,6 +138,8 @@ internal static class ShutdownPolicyProbe
     internal const string ClosingMarker = "CLOSING";
     internal const string ReopenedMarker = "REOPENED";
     internal const string StartupThrewMarker = "STARTUP-THREW";
+    internal const string MountThrewMarker = "MOUNT-THREW";
+    internal const string SurvivorMarker = "SURVIVOR";
     internal const string TrayClosedMarker = "TRAY-CLOSED";
 
     /// <summary>Settle time before the window is closed.</summary>
@@ -142,7 +161,7 @@ internal static class ShutdownPolicyProbe
         {
             Console.Error.WriteLine(
                 $"usage: {Flag} <{string.Join('|', Enum.GetNames<ShutdownPolicy>())}> " +
-                $"[{TrayFlag}] [{NoWindowFlag}] [{ReopenFlag}] [{ExcludedWindowFlag}] [{CloseTrayFlag}] [{LegacyRunFlag}] [{ThrowInStartupFlag}]");
+                $"[{TrayFlag}] [{NoWindowFlag}] [{ReopenFlag}] [{ExcludedWindowFlag}] [{CloseTrayFlag}] [{LegacyRunFlag}] [{ThrowInStartupFlag}] [{ThrowInMountFlag}]");
             return UsageExitCode;
         }
 
@@ -153,10 +172,45 @@ internal static class ShutdownPolicyProbe
         var closeTray = args.Contains(CloseTrayFlag);
         var legacyRun = args.Contains(LegacyRunFlag);
         var throwInStartup = args.Contains(ThrowInStartupFlag);
+        var throwInMount = args.Contains(ThrowInMountFlag);
 
         ReactorApp.ShutdownPolicy = policy;
         Console.WriteLine(
             $"POLICY {policy} tray={withTray} noWindow={noWindow} reopen={reopen} excluded={excluded} legacy={legacyRun} throws={throwInStartup}");
+
+        if (throwInMount)
+        {
+            ReactorApp.Run(_ =>
+            {
+                var dq = ReactorApp.UIDispatcher!;
+                try
+                {
+                    // Throws inside MountAndActivate, i.e. after RegisterWindow
+                    // has already elected this window primary.
+                    ReactorApp.OpenWindow(
+                        new WindowSpec { Title = "Shutdown Policy Probe (doomed)", Width = 320, Height = 200 },
+                        () => throw new InvalidOperationException("probe: root factory failed"));
+                }
+                catch (InvalidOperationException)
+                {
+                    Console.WriteLine(
+                        $"{MountThrewMarker} windows={ReactorApp.Windows.Count} primary={ReactorApp.PrimaryWindow is not null}");
+                    Console.Out.Flush();
+                }
+
+                // Reaching this at all means the failed open did not take the
+                // process down with it.
+                OpenProbeWindow("Shutdown Policy Probe (survivor)");
+                Console.WriteLine($"{SurvivorMarker} windows={ReactorApp.Windows.Count}");
+                Console.Out.Flush();
+
+                StartAliveTimer(dq, reopen: false, closeTray: false);
+            });
+
+            Console.WriteLine(LoopExitedMarker);
+            Console.Out.Flush();
+            return LoopExitedExitCode;
+        }
 
         if (throwInStartup)
         {

--- a/tests/Reactor.AppTests.Host/ShutdownPolicyProbe.cs
+++ b/tests/Reactor.AppTests.Host/ShutdownPolicyProbe.cs
@@ -232,7 +232,16 @@ internal static class ShutdownPolicyProbe
                 // from "it did not".
                 foreach (var tray in ReactorApp.TrayIcons.ToArray())
                 {
-                    try { tray.Close(); } catch { /* best effort */ }
+                    // Narrow rather than generic: a shell/COM fault while
+                    // removing the notify-icon is survivable and the trayIcons
+                    // count below reports what actually happened, but anything
+                    // else is a probe bug and should crash rather than be
+                    // mistaken for a clean close.
+                    try { tray.Close(); }
+                    catch (Exception ex) when (ex is ObjectDisposedException or InvalidOperationException or global::System.Runtime.InteropServices.COMException)
+                    {
+                        Console.WriteLine($"TRAY-CLOSE-FAILED {ex.GetType().Name}: {ex.Message}");
+                    }
                 }
                 Console.WriteLine($"{TrayClosedMarker} trayIcons={ReactorApp.TrayIcons.Count}");
                 Console.Out.Flush();

--- a/tests/Reactor.AppTests.Host/ShutdownPolicyProbe.cs
+++ b/tests/Reactor.AppTests.Host/ShutdownPolicyProbe.cs
@@ -85,6 +85,15 @@ internal static class ShutdownPolicyProbe
     /// </summary>
     internal const string CloseTrayFlag = "--close-tray";
 
+    /// <summary>
+    /// Launch through the legacy <c>ReactorApp.Run&lt;TRoot&gt;</c> bridge rather
+    /// than the <c>Run(startup)</c> callback. The two entry points reach
+    /// <c>OnLaunched</c> by different branches and take dispatcher ownership at
+    /// different call sites, so an arm that only ever exercises one of them
+    /// leaves the other unobserved.
+    /// </summary>
+    internal const string LegacyRunFlag = "--legacy-run";
+
     internal const int AliveExitCode = 42;
     internal const int LoopExitedExitCode = 1;
     internal const int UsageExitCode = 64;
@@ -115,7 +124,7 @@ internal static class ShutdownPolicyProbe
         {
             Console.Error.WriteLine(
                 $"usage: {Flag} <{string.Join('|', Enum.GetNames<ShutdownPolicy>())}> " +
-                $"[{TrayFlag}] [{NoWindowFlag}] [{ReopenFlag}] [{ExcludedWindowFlag}] [{CloseTrayFlag}]");
+                $"[{TrayFlag}] [{NoWindowFlag}] [{ReopenFlag}] [{ExcludedWindowFlag}] [{CloseTrayFlag}] [{LegacyRunFlag}]");
             return UsageExitCode;
         }
 
@@ -124,10 +133,44 @@ internal static class ShutdownPolicyProbe
         var reopen = args.Contains(ReopenFlag);
         var excluded = args.Contains(ExcludedWindowFlag);
         var closeTray = args.Contains(CloseTrayFlag);
+        var legacyRun = args.Contains(LegacyRunFlag);
 
         ReactorApp.ShutdownPolicy = policy;
         Console.WriteLine(
-            $"POLICY {policy} tray={withTray} noWindow={noWindow} reopen={reopen} excluded={excluded}");
+            $"POLICY {policy} tray={withTray} noWindow={noWindow} reopen={reopen} excluded={excluded} legacy={legacyRun}");
+
+        if (legacyRun)
+        {
+            // Run<TRoot> has no startup callback, so the pre-mount `configure`
+            // hook is where the close gets scheduled. It runs on the UI thread
+            // before RegisterWindow, hence the timer: by the time it ticks,
+            // ReactorApp.PrimaryWindow is set.
+            ReactorApp.Run<ProbeContent>(
+                "Shutdown Policy Probe (legacy)",
+                width: 320,
+                height: 200,
+                configure: _ =>
+                {
+                    var dq = ReactorApp.UIDispatcher!;
+                    var timer = dq.CreateTimer();
+                    timer.Interval = TimeSpan.FromMilliseconds(SettleMs);
+                    timer.IsRepeating = false;
+                    timer.Tick += (_, _) =>
+                    {
+                        Console.WriteLine(
+                            $"OPENED primaryElected={ReactorApp.PrimaryWindow is not null} windows={ReactorApp.Windows.Count}");
+                        Console.WriteLine(ClosingMarker);
+                        Console.Out.Flush();
+                        ReactorApp.PrimaryWindow?.Close();
+                        StartAliveTimer(dq, reopen, closeTray);
+                    };
+                    timer.Start();
+                });
+
+            Console.WriteLine(LoopExitedMarker);
+            Console.Out.Flush();
+            return LoopExitedExitCode;
+        }
 
         ReactorApp.Run(_ =>
         {

--- a/tests/Reactor.AppTests.Host/ShutdownPolicyProbe.cs
+++ b/tests/Reactor.AppTests.Host/ShutdownPolicyProbe.cs
@@ -77,6 +77,14 @@ internal static class ShutdownPolicyProbe
     /// </summary>
     internal const string ExcludedWindowFlag = "--excluded-window";
 
+    /// <summary>
+    /// After the window has closed and the process has been confirmed alive,
+    /// close the tray icon too and look again. Covers the last-tray-icon exit
+    /// path, which <c>UnregisterTrayIcon</c> routes through
+    /// <c>EvaluateShutdownPolicy</c> rather than deciding for itself.
+    /// </summary>
+    internal const string CloseTrayFlag = "--close-tray";
+
     internal const int AliveExitCode = 42;
     internal const int LoopExitedExitCode = 1;
     internal const int UsageExitCode = 64;
@@ -86,6 +94,7 @@ internal static class ShutdownPolicyProbe
     internal const string LoopExitedMarker = "LOOP-EXITED";
     internal const string ClosingMarker = "CLOSING";
     internal const string ReopenedMarker = "REOPENED";
+    internal const string TrayClosedMarker = "TRAY-CLOSED";
 
     /// <summary>Settle time before the window is closed.</summary>
     private const int SettleMs = 400;
@@ -106,7 +115,7 @@ internal static class ShutdownPolicyProbe
         {
             Console.Error.WriteLine(
                 $"usage: {Flag} <{string.Join('|', Enum.GetNames<ShutdownPolicy>())}> " +
-                $"[{TrayFlag}] [{NoWindowFlag}] [{ReopenFlag}]");
+                $"[{TrayFlag}] [{NoWindowFlag}] [{ReopenFlag}] [{ExcludedWindowFlag}] [{CloseTrayFlag}]");
             return UsageExitCode;
         }
 
@@ -114,6 +123,7 @@ internal static class ShutdownPolicyProbe
         var noWindow = args.Contains(NoWindowFlag);
         var reopen = args.Contains(ReopenFlag);
         var excluded = args.Contains(ExcludedWindowFlag);
+        var closeTray = args.Contains(CloseTrayFlag);
 
         ReactorApp.ShutdownPolicy = policy;
         Console.WriteLine(
@@ -148,7 +158,7 @@ internal static class ShutdownPolicyProbe
                 // Nothing to close — the zero-surface startup decision has
                 // already been made by the time OnLaunched returns, so go
                 // straight to asking whether the loop is still running.
-                StartAliveTimer(dispatcher, reopen);
+                StartAliveTimer(dispatcher, reopen, closeTray);
                 return;
             }
 
@@ -183,7 +193,7 @@ internal static class ShutdownPolicyProbe
                 // identically. Revisit only with evidence that they can diverge.
                 window.Close();
 
-                StartAliveTimer(dispatcher, reopen);
+                StartAliveTimer(dispatcher, reopen, closeTray);
             };
             closeTimer.Start();
         });
@@ -204,7 +214,7 @@ internal static class ShutdownPolicyProbe
             configure: null,
             excludeFromShutdownPolicy: excludeFromShutdownPolicy);
 
-    private static void StartAliveTimer(DispatcherQueue dispatcher, bool reopen)
+    private static void StartAliveTimer(DispatcherQueue dispatcher, bool reopen, bool closeTray = false)
     {
         var aliveTimer = dispatcher.CreateTimer();
         aliveTimer.Interval = TimeSpan.FromMilliseconds(AliveCheckMs);
@@ -214,6 +224,21 @@ internal static class ShutdownPolicyProbe
             Console.WriteLine(
                 $"{AliveMarker} windows={ReactorApp.Windows.Count} trayIcons={ReactorApp.TrayIcons.Count}");
             Console.Out.Flush();
+
+            if (closeTray)
+            {
+                // Close the remaining surface and look again instead of exiting,
+                // so the caller can tell "the last tray icon ended the process"
+                // from "it did not".
+                foreach (var tray in ReactorApp.TrayIcons.ToArray())
+                {
+                    try { tray.Close(); } catch { /* best effort */ }
+                }
+                Console.WriteLine($"{TrayClosedMarker} trayIcons={ReactorApp.TrayIcons.Count}");
+                Console.Out.Flush();
+                StartAliveTimer(dispatcher, reopen);
+                return;
+            }
 
             if (reopen)
             {

--- a/tests/Reactor.AppTests.Host/ShutdownPolicyProbe.cs
+++ b/tests/Reactor.AppTests.Host/ShutdownPolicyProbe.cs
@@ -1,0 +1,229 @@
+using Microsoft.UI.Dispatching;
+using Microsoft.UI.Reactor;
+using Microsoft.UI.Reactor.Core;
+using static Microsoft.UI.Reactor.Factories;
+
+namespace Microsoft.UI.Reactor.AppTests.Host;
+
+/// <summary>
+/// Issue #1204 — end-to-end probe for whether
+/// <see cref="ReactorApp.ShutdownPolicy"/> actually governs process lifetime.
+/// </summary>
+/// <remarks>
+/// <para>The selftest tier can assert that Reactor writes
+/// <c>Application.DispatcherShutdownMode</c>, but it cannot assert the thing the
+/// bug was about: that the process is <i>still running</i> after the last window
+/// closes. Only a real process can answer that, so this mode opens one window,
+/// closes it, and reports what happened via the exit code.</para>
+/// <para>Exit codes are the oracle:</para>
+/// <list type="bullet">
+/// <item><description><see cref="AliveExitCode"/> + <see cref="AliveMarker"/> — the
+/// event loop outlived its last window and <see cref="ReactorApp.Exit(int)"/> was
+/// the thing that ended the process.</description></item>
+/// <item><description><see cref="LoopExitedExitCode"/> + <see cref="LoopExitedMarker"/>
+/// — <c>Application.Start</c> returned on its own, i.e. WinUI quit the loop on
+/// last-window-close.</description></item>
+/// </list>
+/// <para>Both outcomes are reachable by design: run this with
+/// <c>OnPrimaryWindowClosed</c> and the loop-exited branch is the <i>correct</i>
+/// result. That arm is the positive control — it proves the probe can distinguish
+/// the two states, so an <c>Explicit</c> run reporting "alive" is a measurement
+/// rather than a probe that can only ever print one thing.</para>
+/// <para><c>OnLastSurfaceClosed</c> needs <see cref="TrayFlag"/> to say anything:
+/// without a surviving surface that policy is <i>supposed</i> to end the process,
+/// so a tray-less run exits for the right reason and would look identical to the
+/// bug.</para>
+/// <para>No UI input is involved — the window closes itself from the dispatcher —
+/// so unlike the <c>winapp ui</c> tier this runs without an interactive desktop.
+/// See the comment on the close call for why it is an app-initiated close and how
+/// the user-initiated one was verified.</para>
+/// </remarks>
+internal static class ShutdownPolicyProbe
+{
+    internal const string Flag = "--shutdown-policy-probe";
+
+    /// <summary>
+    /// Opens a tray icon alongside the window. Required to exercise
+    /// <see cref="ShutdownPolicy.OnLastSurfaceClosed"/> meaningfully: with no
+    /// tray icon, "last window closed" and "last surface closed" coincide, so
+    /// that policy correctly ends the process and the run is indistinguishable
+    /// from the bug.
+    /// </summary>
+    internal const string TrayFlag = "--with-tray";
+
+    /// <summary>
+    /// Opens no window at all, exercising the zero-surface startup branch in
+    /// <c>OnLaunched</c> (spec 036 §6.2 allows a startup callback to open zero
+    /// surfaces). That branch decides process lifetime before any window has
+    /// ever existed, so it is reachable only without <see cref="TrayFlag"/>'s
+    /// sibling window.
+    /// </summary>
+    internal const string NoWindowFlag = "--no-window";
+
+    /// <summary>
+    /// After the process has outlived its last window, open another one. The
+    /// tray-app shape in spec 036 §13.6 depends on this: the tray icon reopens
+    /// the window on demand, so surviving the close is only half the promise.
+    /// </summary>
+    internal const string ReopenFlag = "--reopen";
+
+    internal const int AliveExitCode = 42;
+    internal const int LoopExitedExitCode = 1;
+    internal const int UsageExitCode = 64;
+    internal const int ReopenFailedExitCode = 45;
+
+    internal const string AliveMarker = "STILL-ALIVE";
+    internal const string LoopExitedMarker = "LOOP-EXITED";
+    internal const string ClosingMarker = "CLOSING";
+    internal const string ReopenedMarker = "REOPENED";
+
+    /// <summary>Settle time before the window is closed.</summary>
+    private const int SettleMs = 400;
+
+    /// <summary>
+    /// How long after the close we wait before declaring the process alive.
+    /// WinUI posts its quit message during the close itself — the reported
+    /// symptom was a process exit ~90 ms later — so this only has to be
+    /// comfortably longer than that, not long enough to "wait out" a race.
+    /// </summary>
+    private const int AliveCheckMs = 1000;
+
+    public static int Run(string[] args)
+    {
+        var index = Array.IndexOf(args, Flag);
+        if (index < 0 || index + 1 >= args.Length ||
+            !Enum.TryParse<ShutdownPolicy>(args[index + 1], ignoreCase: true, out var policy))
+        {
+            Console.Error.WriteLine(
+                $"usage: {Flag} <{string.Join('|', Enum.GetNames<ShutdownPolicy>())}> " +
+                $"[{TrayFlag}] [{NoWindowFlag}] [{ReopenFlag}]");
+            return UsageExitCode;
+        }
+
+        var withTray = args.Contains(TrayFlag);
+        var noWindow = args.Contains(NoWindowFlag);
+        var reopen = args.Contains(ReopenFlag);
+
+        ReactorApp.ShutdownPolicy = policy;
+        Console.WriteLine($"POLICY {policy} tray={withTray} noWindow={noWindow} reopen={reopen}");
+
+        ReactorApp.Run(_ =>
+        {
+            if (withTray)
+            {
+                // 16x16 opaque magenta, built inline so the probe needs no asset.
+                var pixels = new byte[16 * 16 * 4];
+                for (int i = 0; i < pixels.Length; i += 4)
+                {
+                    pixels[i] = 255;
+                    pixels[i + 2] = 255;
+                    pixels[i + 3] = 255;
+                }
+
+                ReactorApp.OpenTrayIcon(new TrayIconSpec(
+                    Icon: WindowIcon.FromRgba(pixels, 16, 16),
+                    Tooltip: "Shutdown Policy Probe",
+                    Key: WindowKey.Of("shutdown-policy-probe")));
+            }
+
+            var dispatcher = ReactorApp.UIDispatcher!;
+
+            // DispatcherQueueTimer rather than Task.Delay: a timer does not keep
+            // the loop alive, so in the broken case it simply never ticks and the
+            // process falls through to the LOOP-EXITED branch below.
+            if (noWindow)
+            {
+                // Nothing to close — the zero-surface startup decision has
+                // already been made by the time OnLaunched returns, so go
+                // straight to asking whether the loop is still running.
+                StartAliveTimer(dispatcher, reopen);
+                return;
+            }
+
+            var window = OpenProbeWindow("Shutdown Policy Probe");
+
+            var closeTimer = dispatcher.CreateTimer();
+            closeTimer.Interval = TimeSpan.FromMilliseconds(SettleMs);
+            closeTimer.IsRepeating = false;
+            closeTimer.Tick += (_, _) =>
+            {
+                Console.WriteLine(ClosingMarker);
+                Console.Out.Flush();
+
+                // App-initiated close. The issue describes a user close (Alt+F4 /
+                // the caption X, both of which post WM_CLOSE), and posting that
+                // message here would be the more faithful shape — but neither
+                // variant survives contact with this host: posting it inline
+                // re-enters native teardown from inside a dispatcher callback and
+                // faults the XAML runtime (0xC000027B), and posting it from a
+                // pool thread never reaches the window at all, leaving it open so
+                // the process trivially "survives". The second failure is the
+                // dangerous one: it turns every arm green, control included, for
+                // a reason that has nothing to do with the fix.
+                //
+                // So this asserts the path it can assert reliably. The
+                // user-initiated path was verified out-of-band against a
+                // standalone unpackaged app driven by a cross-process WM_CLOSE,
+                // with the fix reverted as the control; both close paths behaved
+                // identically. Revisit only with evidence that they can diverge.
+                window.Close();
+
+                StartAliveTimer(dispatcher, reopen);
+            };
+            closeTimer.Start();
+        });
+
+        // ReactorApp.Run blocks until Application.Start returns, and it only
+        // returns when the event loop unwinds on its own — the alive path exits
+        // the process from inside the dispatcher and never reaches this line.
+        Console.WriteLine(LoopExitedMarker);
+        Console.Out.Flush();
+        return LoopExitedExitCode;
+    }
+
+    private static ReactorWindow OpenProbeWindow(string title) =>
+        ReactorApp.OpenWindow(
+            new WindowSpec { Title = title, Width = 320, Height = 200 },
+            () => new ProbeContent());
+
+    private static void StartAliveTimer(DispatcherQueue dispatcher, bool reopen)
+    {
+        var aliveTimer = dispatcher.CreateTimer();
+        aliveTimer.Interval = TimeSpan.FromMilliseconds(AliveCheckMs);
+        aliveTimer.IsRepeating = false;
+        aliveTimer.Tick += (_, _) =>
+        {
+            Console.WriteLine(
+                $"{AliveMarker} windows={ReactorApp.Windows.Count} trayIcons={ReactorApp.TrayIcons.Count}");
+            Console.Out.Flush();
+
+            if (reopen)
+            {
+                // Surviving the close is only useful if the app can put UI back
+                // on screen afterwards. WinUI documents that new XAML windows can
+                // still be shown under OnExplicitShutdown; this asserts it for a
+                // Reactor window created after the process already outlived its
+                // last one.
+                var before = ReactorApp.Windows.Count;
+                var revived = OpenProbeWindow("Shutdown Policy Probe (reopened)");
+                var after = ReactorApp.Windows.Count;
+                Console.WriteLine($"{ReopenedMarker} before={before} after={after} id={revived.Id}");
+                Console.Out.Flush();
+
+                if (after != before + 1)
+                {
+                    ReactorApp.Exit(ReopenFailedExitCode);
+                    return;
+                }
+            }
+
+            ReactorApp.Exit(AliveExitCode);
+        };
+        aliveTimer.Start();
+    }
+
+    private sealed class ProbeContent : Component
+    {
+        public override Element Render() => TextBlock("shutdown policy probe").Padding(24);
+    }
+}

--- a/tests/Reactor.AppTests.Host/ShutdownPolicyProbe.cs
+++ b/tests/Reactor.AppTests.Host/ShutdownPolicyProbe.cs
@@ -67,6 +67,16 @@ internal static class ShutdownPolicyProbe
     /// </summary>
     internal const string ReopenFlag = "--reopen";
 
+    /// <summary>
+    /// Opens the window with <c>ExcludeFromShutdownPolicy</c>, the way a docking
+    /// tear-off does (issue #647), so no <c>PrimaryWindow</c> is ever elected.
+    /// Closing it under the DEFAULT policy must leave the process running — the
+    /// guarantee the windows guide already made and the platform used to break,
+    /// because <c>OnLastWindowClose</c> unwound the loop regardless of what
+    /// <c>EvaluateShutdownPolicy</c> decided.
+    /// </summary>
+    internal const string ExcludedWindowFlag = "--excluded-window";
+
     internal const int AliveExitCode = 42;
     internal const int LoopExitedExitCode = 1;
     internal const int UsageExitCode = 64;
@@ -103,9 +113,11 @@ internal static class ShutdownPolicyProbe
         var withTray = args.Contains(TrayFlag);
         var noWindow = args.Contains(NoWindowFlag);
         var reopen = args.Contains(ReopenFlag);
+        var excluded = args.Contains(ExcludedWindowFlag);
 
         ReactorApp.ShutdownPolicy = policy;
-        Console.WriteLine($"POLICY {policy} tray={withTray} noWindow={noWindow} reopen={reopen}");
+        Console.WriteLine(
+            $"POLICY {policy} tray={withTray} noWindow={noWindow} reopen={reopen} excluded={excluded}");
 
         ReactorApp.Run(_ =>
         {
@@ -140,7 +152,10 @@ internal static class ShutdownPolicyProbe
                 return;
             }
 
-            var window = OpenProbeWindow("Shutdown Policy Probe");
+            var window = OpenProbeWindow("Shutdown Policy Probe", excluded);
+            Console.WriteLine(
+                $"OPENED primaryElected={ReactorApp.PrimaryWindow is not null} windows={ReactorApp.Windows.Count}");
+            Console.Out.Flush();
 
             var closeTimer = dispatcher.CreateTimer();
             closeTimer.Interval = TimeSpan.FromMilliseconds(SettleMs);
@@ -181,10 +196,13 @@ internal static class ShutdownPolicyProbe
         return LoopExitedExitCode;
     }
 
-    private static ReactorWindow OpenProbeWindow(string title) =>
-        ReactorApp.OpenWindow(
+    private static ReactorWindow OpenProbeWindow(string title, bool excludeFromShutdownPolicy = false) =>
+        ReactorApp.OpenWindowCore(
             new WindowSpec { Title = title, Width = 320, Height = 200 },
-            () => new ProbeContent());
+            rootFactory: () => new ProbeContent(),
+            renderFunc: null,
+            configure: null,
+            excludeFromShutdownPolicy: excludeFromShutdownPolicy);
 
     private static void StartAliveTimer(DispatcherQueue dispatcher, bool reopen)
     {

--- a/tests/Reactor.SelfTests/HostProcess.cs
+++ b/tests/Reactor.SelfTests/HostProcess.cs
@@ -70,7 +70,7 @@ internal static class HostProcess
         }
 
         var dir = AppContext.BaseDirectory;
-        while (dir != null && !File.Exists(Path.Combine(dir, "Reactor.slnx")))
+        while (dir != null && !File.Exists(Path.Join(dir, "Reactor.slnx")))
             dir = Path.GetDirectoryName(dir);
 
         if (dir == null)
@@ -92,7 +92,13 @@ internal static class HostProcess
         var configuration = MetadataOr("ReactorSelfTestsConfiguration", "Debug");
         var tfm = MetadataOr("ReactorSelfTestsTargetFramework", "net10.0-windows10.0.22621.0");
 
-        var exe = Path.Combine(dir, "tests", "Reactor.AppTests.Host", "bin", platform,
+        // Path.Join rather than Path.Combine: Combine silently discards
+        // everything before a segment that happens to be rooted, and two of
+        // these segments come from assembly metadata rather than from literals,
+        // so a bad stamp could otherwise turn this into an absolute lookup
+        // somewhere else on disk. Join always concatenates. Same reasoning as
+        // PackagedHostDeployment.
+        var exe = Path.Join(dir, "tests", "Reactor.AppTests.Host", "bin", platform,
             configuration, tfm, "Reactor.AppTests.Host.exe");
 
         if (!File.Exists(exe))

--- a/tests/Reactor.SelfTests/HostProcess.cs
+++ b/tests/Reactor.SelfTests/HostProcess.cs
@@ -1,0 +1,111 @@
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.UI.Reactor.SelfTests;
+
+/// <summary>
+/// Locates and runs the selftest Host app as a child process. Shared by
+/// <see cref="SelfTestBatch"/> (which drives <c>--self-test</c> and
+/// <c>--list-fixtures</c>) and <see cref="ShutdownPolicyProcessLifetimeTests"/>
+/// (which drives <c>--shutdown-policy-probe</c>), so both agree on where the Host
+/// lives and how its streams are drained.
+/// </summary>
+internal static class HostProcess
+{
+    /// <summary>
+    /// Runs the Host to completion, or kills it once <paramref name="timeoutMs"/>
+    /// elapses. Both streams are read concurrently so neither pipe can block the
+    /// child by filling its OS buffer.
+    /// </summary>
+    internal static (string Stdout, string Stderr, int ExitCode, bool TimedOut) Run(
+        string exe, string args, int timeoutMs)
+    {
+        var psi = new ProcessStartInfo(exe, args)
+        {
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true,
+        };
+
+        using var process = Process.Start(psi)
+            ?? throw new InvalidOperationException($"Failed to start process: {exe} {args}");
+
+        var stdoutTask = process.StandardOutput.ReadToEndAsync();
+        var stderrTask = process.StandardError.ReadToEndAsync();
+        var exitTask = process.WaitForExitAsync();
+        var timeoutTask = Task.Delay(timeoutMs);
+
+        var completed = Task.WhenAny(exitTask, timeoutTask).GetAwaiter().GetResult();
+        var timedOut = completed != exitTask;
+
+        if (timedOut)
+        {
+            try { process.Kill(entireProcessTree: true); }
+            catch (InvalidOperationException) { /* already exited */ }
+            process.WaitForExit();
+        }
+
+        // At this point the process has exited; the stream tasks will complete.
+        var stdout = stdoutTask.GetAwaiter().GetResult();
+        var stderr = stderrTask.GetAwaiter().GetResult();
+
+        return (stdout, stderr, timedOut ? -1 : process.ExitCode, timedOut);
+    }
+
+    internal static string FindHostExe()
+    {
+        // Allow callers to point the harness at an AOT-published Host (which
+        // lives under a `publish` directory, not the standard build output)
+        // or any other custom build. This lets the same MSTest harness validate
+        // the AOT binary that the developer is actually trying to ship.
+        var overrideExe = Environment.GetEnvironmentVariable("REACTOR_SELFTEST_HOST_EXE");
+        if (!string.IsNullOrWhiteSpace(overrideExe))
+        {
+            if (!File.Exists(overrideExe))
+                throw new FileNotFoundException(
+                    $"REACTOR_SELFTEST_HOST_EXE points at a path that does not exist: {overrideExe}");
+            return overrideExe;
+        }
+
+        var dir = AppContext.BaseDirectory;
+        while (dir != null && !File.Exists(Path.Combine(dir, "Reactor.slnx")))
+            dir = Path.GetDirectoryName(dir);
+
+        if (dir == null)
+            throw new DirectoryNotFoundException("Could not find repo root (Reactor.slnx)");
+
+        var platform = RuntimeInformation.ProcessArchitecture switch
+        {
+            Architecture.X64 => "x64",
+            Architecture.Arm64 => "ARM64",
+            _ => "x64"
+        };
+
+        // Configuration and TFM are stamped into this assembly by the csproj
+        // rather than hardcoded: the Host is built by our ProjectReference under
+        // whatever configuration the test run used, so a literal "Debug" here
+        // silently runs a stale Debug host under `dotnet test -c Release` — or
+        // fails outright when one was never built. Same fix, same reason, as
+        // Reactor.PackagedTests. The fallbacks keep a hand-run assembly working.
+        var configuration = MetadataOr("ReactorSelfTestsConfiguration", "Debug");
+        var tfm = MetadataOr("ReactorSelfTestsTargetFramework", "net10.0-windows10.0.22621.0");
+
+        var exe = Path.Combine(dir, "tests", "Reactor.AppTests.Host", "bin", platform,
+            configuration, tfm, "Reactor.AppTests.Host.exe");
+
+        if (!File.Exists(exe))
+            throw new FileNotFoundException($"Host app not built. Expected: {exe}");
+
+        return exe;
+    }
+
+    private static string MetadataOr(string key, string fallback) =>
+        typeof(HostProcess).Assembly
+            .GetCustomAttributes<AssemblyMetadataAttribute>()
+            .Where(a => string.Equals(a.Key, key, StringComparison.Ordinal) &&
+                        !string.IsNullOrWhiteSpace(a.Value))
+            .Select(a => a.Value!)
+            .FirstOrDefault() ?? fallback;
+}

--- a/tests/Reactor.SelfTests/Reactor.SelfTests.csproj
+++ b/tests/Reactor.SelfTests/Reactor.SelfTests.csproj
@@ -16,6 +16,20 @@
     <PackageReference Include="MSTest.TestAdapter" />
     <PackageReference Include="MSTest.TestFramework" />
   </ItemGroup>
+  <!-- The Host's output path carries the configuration and TFM. Stamping in the values
+       MSBuild actually used lets HostProcess.FindHostExe locate the Host under any
+       configuration; hardcoding "Debug" made `dotnet test -c Release` run a stale Debug
+       host or fail outright. Mirrors Reactor.PackagedTests. -->
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
+      <_Parameter1>ReactorSelfTestsConfiguration</_Parameter1>
+      <_Parameter2>$(Configuration)</_Parameter2>
+    </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
+      <_Parameter1>ReactorSelfTestsTargetFramework</_Parameter1>
+      <_Parameter2>$(TargetFramework)</_Parameter2>
+    </AssemblyAttribute>
+  </ItemGroup>
   <ItemGroup>
     <!-- Build dependency: ensures Host is built before tests, no runtime reference -->
     <ProjectReference Include="..\Reactor.AppTests.Host\Reactor.AppTests.Host.csproj" ReferenceOutputAssembly="false" Private="false" />

--- a/tests/Reactor.SelfTests/SelfTestBatch.cs
+++ b/tests/Reactor.SelfTests/SelfTestBatch.cs
@@ -1,6 +1,5 @@
 using System.Collections.Concurrent;
 using System.Diagnostics;
-using System.Runtime.InteropServices;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.UI.Reactor.SelfTests;
@@ -1843,80 +1842,12 @@ public class SelfTestBatch
             .ToArray();
 
     // -- Process runner: async reads + timeout race with kill ------------------
+    //
+    // Lives in HostProcess so the shutdown-policy lifetime probe launches the
+    // Host exactly the way this batch does.
 
     private static (string Stdout, string Stderr, int ExitCode, bool TimedOut) RunProcess(
-        string exe, string args, int timeoutMs)
-    {
-        var psi = new ProcessStartInfo(exe, args)
-        {
-            UseShellExecute = false,
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            CreateNoWindow = true,
-        };
+        string exe, string args, int timeoutMs) => HostProcess.Run(exe, args, timeoutMs);
 
-        using var process = Process.Start(psi)
-            ?? throw new InvalidOperationException($"Failed to start process: {exe} {args}");
-
-        // Read both streams concurrently so neither pipe can block the child by
-        // filling its OS buffer.
-        var stdoutTask = process.StandardOutput.ReadToEndAsync();
-        var stderrTask = process.StandardError.ReadToEndAsync();
-        var exitTask = process.WaitForExitAsync();
-        var timeoutTask = Task.Delay(timeoutMs);
-
-        var completed = Task.WhenAny(exitTask, timeoutTask).GetAwaiter().GetResult();
-        var timedOut = completed != exitTask;
-
-        if (timedOut)
-        {
-            try { process.Kill(entireProcessTree: true); }
-            catch (InvalidOperationException) { /* already exited */ }
-            process.WaitForExit();
-        }
-
-        // At this point the process has exited; the stream tasks will complete.
-        var stdout = stdoutTask.GetAwaiter().GetResult();
-        var stderr = stderrTask.GetAwaiter().GetResult();
-
-        return (stdout, stderr, timedOut ? -1 : process.ExitCode, timedOut);
-    }
-
-    private static string FindHostExe()
-    {
-        // Allow callers to point the harness at an AOT-published Host (which
-        // lives under a `publish` directory, not the standard build output)
-        // or any other custom build. This lets the same MSTest harness validate
-        // the AOT binary that the developer is actually trying to ship.
-        var overrideExe = Environment.GetEnvironmentVariable("REACTOR_SELFTEST_HOST_EXE");
-        if (!string.IsNullOrWhiteSpace(overrideExe))
-        {
-            if (!File.Exists(overrideExe))
-                throw new FileNotFoundException(
-                    $"REACTOR_SELFTEST_HOST_EXE points at a path that does not exist: {overrideExe}");
-            return overrideExe;
-        }
-
-        var dir = AppContext.BaseDirectory;
-        while (dir != null && !File.Exists(Path.Combine(dir, "Reactor.slnx")))
-            dir = Path.GetDirectoryName(dir);
-
-        if (dir == null)
-            throw new DirectoryNotFoundException("Could not find repo root (Reactor.slnx)");
-
-        var platform = RuntimeInformation.ProcessArchitecture switch
-        {
-            Architecture.X64 => "x64",
-            Architecture.Arm64 => "ARM64",
-            _ => "x64"
-        };
-
-        var exe = Path.Combine(dir, "tests", "Reactor.AppTests.Host", "bin", platform,
-            "Debug", "net10.0-windows10.0.22621.0", "Reactor.AppTests.Host.exe");
-
-        if (!File.Exists(exe))
-            throw new FileNotFoundException($"Host app not built. Expected: {exe}");
-
-        return exe;
-    }
+    private static string FindHostExe() => HostProcess.FindHostExe();
 }

--- a/tests/Reactor.SelfTests/ShutdownPolicyProcessLifetimeTests.cs
+++ b/tests/Reactor.SelfTests/ShutdownPolicyProcessLifetimeTests.cs
@@ -40,6 +40,7 @@ public class ShutdownPolicyProcessLifetimeTests
     private const string ReopenFlag = "--reopen";
     private const string ExcludedWindowFlag = "--excluded-window";
     private const string CloseTrayFlag = "--close-tray";
+    private const string LegacyRunFlag = "--legacy-run";
     private const string ClosingMarker = "CLOSING";
     private const string GateProbeFlag = "--shutdown-policy-gate-probe";
     private const int AliveExitCode = 42;
@@ -240,6 +241,8 @@ public class ShutdownPolicyProcessLifetimeTests
         var result = RunProbe("Explicit", TrayFlag, ReopenFlag);
         var detail = Detail("Explicit", $"{ProbeFlag} {TrayFlag} {ReopenFlag}", result);
 
+        StringAssert.Contains(result.Stdout, "STILL-ALIVE windows=0 trayIcons=1",
+            $"The process had not actually outlived its last window when the reopen ran.\n{detail}");
         StringAssert.Contains(result.Stdout, ReopenedMarker,
             $"The probe never reached the reopen step.\n{detail}");
         StringAssert.Contains(result.Stdout, "before=0 after=1",
@@ -268,6 +271,38 @@ public class ShutdownPolicyProcessLifetimeTests
         StringAssert.Contains(result.Stdout, "windows=0",
             $"The auxiliary window never closed, so a live process proves nothing about closing one.\n{detail}");
         Assert.AreEqual(AliveExitCode, result.ExitCode, detail);
+    }
+
+    [TestMethod]
+    public void Explicit_Keeps_Process_Alive_Through_The_Legacy_Run_Entry_Point()
+    {
+        // ReactorApp.Run<TRoot> reaches OnLaunched by a different branch than
+        // Run(startup) and takes dispatcher ownership at its own call site.
+        // Every other arm goes through the callback overload, so without this
+        // one that call site could be deleted with the suite still green.
+        var result = RunProbe("Explicit", LegacyRunFlag);
+        var detail = Detail("Explicit", $"{ProbeFlag} {LegacyRunFlag}", result);
+
+        StringAssert.Contains(result.Stdout, "legacy=True",
+            $"This run did not take the legacy entry point.\n{detail}");
+        StringAssert.Contains(result.Stdout, AliveMarker,
+            $"The legacy Run<TRoot> entry point exited on last-window-close.\n{detail}");
+        StringAssert.Contains(result.Stdout, "windows=0",
+            $"The window was still open, so a live process proves nothing.\n{detail}");
+        Assert.AreEqual(AliveExitCode, result.ExitCode, detail);
+    }
+
+    [TestMethod]
+    public void OnPrimaryWindowClosed_Exits_Through_The_Legacy_Run_Entry_Point()
+    {
+        // Control for the arm above: same entry point, default policy, opposite
+        // outcome.
+        var result = RunProbe("OnPrimaryWindowClosed", LegacyRunFlag);
+        var detail = Detail("OnPrimaryWindowClosed", $"{ProbeFlag} {LegacyRunFlag}", result);
+
+        StringAssert.Contains(result.Stdout, LoopExitedMarker,
+            $"The legacy entry point must still exit when its primary window closes.\n{detail}");
+        Assert.AreEqual(LoopExitedExitCode, result.ExitCode, detail);
     }
 
     // ── ownership gate (negative case) ─────────────────────────────────────

--- a/tests/Reactor.SelfTests/ShutdownPolicyProcessLifetimeTests.cs
+++ b/tests/Reactor.SelfTests/ShutdownPolicyProcessLifetimeTests.cs
@@ -105,6 +105,21 @@ public class ShutdownPolicyProcessLifetimeTests
     }
 
     [TestMethod]
+    public void OnLastSurfaceClosed_Exits_When_The_Last_Window_Closes_With_No_Tray_Icon()
+    {
+        // Control for the arm above: same policy, no surviving surface, opposite
+        // outcome. Without it, a regression that made OnLastSurfaceClosed never
+        // exit would leave every other process test green — "stays alive" is the
+        // assertion everywhere else.
+        var result = RunProbe("OnLastSurfaceClosed");
+        var detail = Detail("OnLastSurfaceClosed", ProbeFlag, result);
+
+        StringAssert.Contains(result.Stdout, LoopExitedMarker,
+            $"With no window and no tray icon left, this policy must end the process.\n{detail}");
+        Assert.AreEqual(LoopExitedExitCode, result.ExitCode, detail);
+    }
+
+    [TestMethod]
     public void OnPrimaryWindowClosed_Still_Exits_When_Its_Window_Closes()
     {
         var result = RunProbe("OnPrimaryWindowClosed");

--- a/tests/Reactor.SelfTests/ShutdownPolicyProcessLifetimeTests.cs
+++ b/tests/Reactor.SelfTests/ShutdownPolicyProcessLifetimeTests.cs
@@ -82,7 +82,9 @@ public class ShutdownPolicyProcessLifetimeTests
         var detail = Detail("Explicit", ProbeFlag, result);
 
         StringAssert.Contains(result.Stdout, AliveMarker,
-            $"The process exited when its last window closed — DispatcherShutdownMode was never raised to OnExplicitShutdown.\n{detail}");
+            $"The process exited when its last window closed — Reactor never took ownership of the event loop.\n{detail}");
+        StringAssert.Contains(result.Stdout, "windows=0",
+            $"The window was still open, so the process staying alive proves nothing about last-window-close.\n{detail}");
         Assert.AreEqual(AliveExitCode, result.ExitCode,
             $"ReactorApp.Exit() should have been the only thing that ended the process.\n{detail}");
     }
@@ -99,8 +101,8 @@ public class ShutdownPolicyProcessLifetimeTests
 
         StringAssert.Contains(result.Stdout, AliveMarker,
             $"A live tray icon should have kept the process running after the last window closed.\n{detail}");
-        StringAssert.Contains(result.Stdout, "trayIcons=1",
-            $"The probe reported no tray icon, so this run did not exercise the surviving-surface case.\n{detail}");
+        StringAssert.Contains(result.Stdout, "windows=0 trayIcons=1",
+            $"This run did not reach 'last window closed, tray icon surviving', so a live process proves nothing.\n{detail}");
         Assert.AreEqual(AliveExitCode, result.ExitCode, detail);
     }
 
@@ -209,6 +211,8 @@ public class ShutdownPolicyProcessLifetimeTests
             $"The probe's window was elected primary, so this run never reached the auxiliary-window case.\n{detail}");
         StringAssert.Contains(result.Stdout, AliveMarker,
             $"Closing an auxiliary window ended the process, contradicting the documented issue-#647 behaviour.\n{detail}");
+        StringAssert.Contains(result.Stdout, "windows=0",
+            $"The auxiliary window never closed, so a live process proves nothing about closing one.\n{detail}");
         Assert.AreEqual(AliveExitCode, result.ExitCode, detail);
     }
 

--- a/tests/Reactor.SelfTests/ShutdownPolicyProcessLifetimeTests.cs
+++ b/tests/Reactor.SelfTests/ShutdownPolicyProcessLifetimeTests.cs
@@ -43,7 +43,10 @@ public class ShutdownPolicyProcessLifetimeTests
     private const string CloseTrayFlag = "--close-tray";
     private const string LegacyRunFlag = "--legacy-run";
     private const string ThrowInStartupFlag = "--throw-in-startup";
+    private const string ThrowInMountFlag = "--throw-in-mount";
     private const string StartupThrewMarker = "STARTUP-THREW";
+    private const string MountThrewMarker = "MOUNT-THREW";
+    private const string SurvivorMarker = "SURVIVOR";
     private const string ClosingMarker = "CLOSING";
     private const string GateProbeFlag = "--shutdown-policy-gate-probe";
     private const int AliveExitCode = 42;
@@ -82,7 +85,7 @@ public class ShutdownPolicyProcessLifetimeTests
         // and they carry their own marker (STARTUP-THREW) plus termination as the
         // oracle.
         var detail = Detail(policy, args, result);
-        if (flags.Contains(ThrowInStartupFlag))
+        if (flags.Contains(ThrowInStartupFlag) || flags.Contains(ThrowInMountFlag))
         {
             // nothing to assert here — the caller checks STARTUP-THREW.
         }
@@ -368,6 +371,28 @@ public class ShutdownPolicyProcessLifetimeTests
             $"The configure callback did not throw, so this run did not exercise the failure path.\n{detail}");
         Assert.AreNotEqual(AliveExitCode, result.ExitCode,
             $"A failed configure reported itself alive.\n{detail}");
+    }
+
+    [TestMethod]
+    public void A_Failed_Open_After_Registration_Does_Not_Shut_The_App_Down()
+    {
+        // The doomed window's root factory throws inside MountAndActivate, so it
+        // had already been registered and elected primary. Under the default
+        // policy, unregistering it with the shutdown evaluator enabled sees
+        // "primary closed" and calls SafeExit mid-unwind — killing the app over
+        // an OpenWindow failure the caller handled. This is the only arm that
+        // reaches that path; the --throw-in-startup ones fail in configure,
+        // before registration.
+        var result = RunProbe("OnPrimaryWindowClosed", ThrowInMountFlag);
+        var detail = Detail("OnPrimaryWindowClosed", $"{ProbeFlag} {ThrowInMountFlag}", result);
+
+        StringAssert.Contains(result.Stdout, $"{MountThrewMarker} windows=0",
+            $"The failed window was left in the registry, or never failed at all.\n{detail}");
+        StringAssert.Contains(result.Stdout, $"{SurvivorMarker} windows=1",
+            $"The process did not survive the failed open, so a later window could not be opened.\n{detail}");
+        StringAssert.Contains(result.Stdout, AliveMarker,
+            $"A handled OpenWindow failure took the whole app down.\n{detail}");
+        Assert.AreEqual(AliveExitCode, result.ExitCode, detail);
     }
 
     // ── ownership gate (negative case) ─────────────────────────────────────

--- a/tests/Reactor.SelfTests/ShutdownPolicyProcessLifetimeTests.cs
+++ b/tests/Reactor.SelfTests/ShutdownPolicyProcessLifetimeTests.cs
@@ -42,6 +42,8 @@ public class ShutdownPolicyProcessLifetimeTests
     private const string ExcludedWindowFlag = "--excluded-window";
     private const string CloseTrayFlag = "--close-tray";
     private const string LegacyRunFlag = "--legacy-run";
+    private const string ThrowInStartupFlag = "--throw-in-startup";
+    private const string StartupThrewMarker = "STARTUP-THREW";
     private const string ClosingMarker = "CLOSING";
     private const string GateProbeFlag = "--shutdown-policy-gate-probe";
     private const int AliveExitCode = 42;
@@ -75,8 +77,16 @@ public class ShutdownPolicyProcessLifetimeTests
         // which is also what a window that opened and closed leaves behind, so
         // bypassing the zero-surface branch would leave them green too. Requiring
         // the markers to be ABSENT is what pins them to the startup path.
+        //
+        // The throwing arms are exempt from both: they never reach either branch,
+        // and they carry their own marker (STARTUP-THREW) plus termination as the
+        // oracle.
         var detail = Detail(policy, args, result);
-        if (!flags.Contains(NoWindowFlag))
+        if (flags.Contains(ThrowInStartupFlag))
+        {
+            // nothing to assert here — the caller checks STARTUP-THREW.
+        }
+        else if (!flags.Contains(NoWindowFlag))
         {
             StringAssert.Contains(result.Stdout, "OPENED",
                 $"The probe never opened a window, so this is not a last-window-close run.\n{detail}");
@@ -316,6 +326,48 @@ public class ShutdownPolicyProcessLifetimeTests
         StringAssert.Contains(result.Stdout, LoopExitedMarker,
             $"The legacy entry point must still exit when its primary window closes.\n{detail}");
         Assert.AreEqual(LoopExitedExitCode, result.ExitCode, detail);
+    }
+
+    // ── handled startup failures ───────────────────────────────────────────
+    //
+    // Once Reactor owns the loop, a startup that throws has no surfaces and no
+    // platform fallback, so the zero-surface decision runs from a finally.
+    //
+    // These arms assert only that such a launch TERMINATES, and deliberately not
+    // that the finally is what terminated it. Measured: an exception propagating
+    // out of OnLaunched fast-fails the XAML runtime (exit 0xC000027B) even when
+    // ReactorApplication.OnUnhandledException returns true, so the hang the
+    // finally guards against is not reachable this way today and no assertion
+    // here can be attributed to it. They stay as a regression net — a future
+    // WinUI that lets a handled startup exception continue would turn this into
+    // a timeout — and the honest claim is "does not hang", nothing more.
+
+    [TestMethod]
+    public void A_Handled_Startup_Failure_Does_Not_Leave_The_Process_Running()
+    {
+        // RunHost asserts non-timeout, which is the substance of this test.
+        var result = RunProbe("OnPrimaryWindowClosed", ThrowInStartupFlag);
+        var detail = Detail("OnPrimaryWindowClosed", $"{ProbeFlag} {ThrowInStartupFlag}", result);
+
+        StringAssert.Contains(result.Stdout, StartupThrewMarker,
+            $"The startup callback did not throw, so this run did not exercise the failure path.\n{detail}");
+        Assert.AreNotEqual(AliveExitCode, result.ExitCode,
+            $"A failed startup reported itself alive.\n{detail}");
+    }
+
+    [TestMethod]
+    public void A_Handled_Configure_Failure_Does_Not_Leave_The_Process_Running()
+    {
+        // The legacy bridge's equivalent. configure runs after ReactorWindow has
+        // created its native window, so this also drives the OpenWindowCore
+        // cleanup that closes and disposes it.
+        var result = RunProbe("OnPrimaryWindowClosed", LegacyRunFlag, ThrowInStartupFlag);
+        var detail = Detail("OnPrimaryWindowClosed", $"{ProbeFlag} {LegacyRunFlag} {ThrowInStartupFlag}", result);
+
+        StringAssert.Contains(result.Stdout, StartupThrewMarker,
+            $"The configure callback did not throw, so this run did not exercise the failure path.\n{detail}");
+        Assert.AreNotEqual(AliveExitCode, result.ExitCode,
+            $"A failed configure reported itself alive.\n{detail}");
     }
 
     // ── ownership gate (negative case) ─────────────────────────────────────

--- a/tests/Reactor.SelfTests/ShutdownPolicyProcessLifetimeTests.cs
+++ b/tests/Reactor.SelfTests/ShutdownPolicyProcessLifetimeTests.cs
@@ -39,6 +39,7 @@ public class ShutdownPolicyProcessLifetimeTests
     private const string NoWindowFlag = "--no-window";
     private const string ReopenFlag = "--reopen";
     private const string ExcludedWindowFlag = "--excluded-window";
+    private const string CloseTrayFlag = "--close-tray";
     private const string GateProbeFlag = "--shutdown-policy-gate-probe";
     private const int AliveExitCode = 42;
     private const int LoopExitedExitCode = 1;
@@ -119,6 +120,42 @@ public class ShutdownPolicyProcessLifetimeTests
         StringAssert.Contains(result.Stdout, LoopExitedMarker,
             $"With no window and no tray icon left, this policy must end the process.\n{detail}");
         Assert.AreEqual(LoopExitedExitCode, result.ExitCode, detail);
+    }
+
+    [TestMethod]
+    public void OnLastSurfaceClosed_Exits_When_The_Last_Tray_Icon_Closes_Too()
+    {
+        // Covers the other half of "last surface": the window goes first, the
+        // tray icon keeps the process alive, and closing the tray icon is what
+        // finally ends it. UnregisterTrayIcon routes that through
+        // EvaluateShutdownPolicy rather than deciding for itself, so this is the
+        // arm that would catch that path diverging from the evaluator.
+        var result = RunProbe("OnLastSurfaceClosed", TrayFlag, CloseTrayFlag);
+        var detail = Detail("OnLastSurfaceClosed", $"{ProbeFlag} {TrayFlag} {CloseTrayFlag}", result);
+
+        StringAssert.Contains(result.Stdout, "windows=0 trayIcons=1",
+            $"The run never reached 'window closed, tray icon surviving'.\n{detail}");
+        StringAssert.Contains(result.Stdout, "TRAY-CLOSED trayIcons=0",
+            $"The tray icon never closed, so this run says nothing about the last-surface exit.\n{detail}");
+        StringAssert.Contains(result.Stdout, LoopExitedMarker,
+            $"Closing the last surface under OnLastSurfaceClosed must end the process.\n{detail}");
+        Assert.AreEqual(LoopExitedExitCode, result.ExitCode, detail);
+    }
+
+    [TestMethod]
+    public void Explicit_Survives_Even_When_Every_Surface_Is_Gone()
+    {
+        // Control for the arm above: identical sequence, opposite policy,
+        // opposite outcome. Explicit means zero surfaces is a valid running
+        // state, so only ReactorApp.Exit ends it.
+        var result = RunProbe("Explicit", TrayFlag, CloseTrayFlag);
+        var detail = Detail("Explicit", $"{ProbeFlag} {TrayFlag} {CloseTrayFlag}", result);
+
+        StringAssert.Contains(result.Stdout, "TRAY-CLOSED trayIcons=0",
+            $"The tray icon never closed, so this run never reached the zero-surface state.\n{detail}");
+        StringAssert.Contains(result.Stdout, AliveMarker,
+            $"Explicit must keep the process running with no surfaces at all.\n{detail}");
+        Assert.AreEqual(AliveExitCode, result.ExitCode, detail);
     }
 
     [TestMethod]

--- a/tests/Reactor.SelfTests/ShutdownPolicyProcessLifetimeTests.cs
+++ b/tests/Reactor.SelfTests/ShutdownPolicyProcessLifetimeTests.cs
@@ -1,0 +1,196 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.UI.Reactor.SelfTests;
+
+/// <summary>
+/// Issue #1204 — <see cref="Microsoft.UI.Reactor.ShutdownPolicy"/> has to govern
+/// process lifetime, not just Reactor's own bookkeeping.
+/// </summary>
+/// <remarks>
+/// <para>WinUI quits the thread's event loop when the last XAML window closes
+/// unless <c>Application.DispatcherShutdownMode</c> is <c>OnExplicitShutdown</c>,
+/// and <c>Application.Start</c> resets that property. The reported symptom was an
+/// app with <c>ShutdownPolicy.Explicit</c> and a live tray icon exiting with code
+/// 0 the moment its window closed.</para>
+/// <para>No other tier can see this. Headless tests cannot construct an
+/// <c>Application</c>; the in-process selftest fixtures can read the property but
+/// cannot observe the loop, because the selftest Host exits by terminating itself.
+/// Only a separate process can answer "is it still running?", so each test drives
+/// the Host's <c>--shutdown-policy-probe</c> mode, which opens a window, closes it
+/// from the dispatcher, and encodes the answer in its exit code.</para>
+/// <para><see cref="OnPrimaryWindowClosed_Still_Exits_When_Its_Window_Closes"/> is
+/// the positive control: it asserts the opposite outcome through the same probe,
+/// so a "still alive" result elsewhere is a measurement rather than a probe that
+/// can only ever report one thing. It also guards the default policy against
+/// regressing into a process that never exits.</para>
+/// <para>The probe needs no UI input — the window closes itself — so unlike the
+/// <c>winapp ui</c> tier this runs without an interactive desktop.</para>
+/// </remarks>
+[TestClass]
+public class ShutdownPolicyProcessLifetimeTests
+{
+    // Mirrors ShutdownPolicyProbe in Reactor.AppTests.Host. SelfTests references
+    // the Host for build ordering only (ReferenceOutputAssembly="false"), so the
+    // contract is duplicated rather than shared. Asserting the marker text as
+    // well as the exit code means a drift in either shows up as a failure here
+    // instead of a test that quietly stops proving anything.
+    private const string ProbeFlag = "--shutdown-policy-probe";
+    private const string TrayFlag = "--with-tray";
+    private const string NoWindowFlag = "--no-window";
+    private const string ReopenFlag = "--reopen";
+    private const string GateProbeFlag = "--shutdown-policy-gate-probe";
+    private const int AliveExitCode = 42;
+    private const int LoopExitedExitCode = 1;
+    private const int GateHeldExitCode = 43;
+    private const string AliveMarker = "STILL-ALIVE";
+    private const string LoopExitedMarker = "LOOP-EXITED";
+    private const string ReopenedMarker = "REOPENED";
+    private const string GateHeldMarker = "GATE-HELD";
+
+    /// <summary>
+    /// The probe itself spends ~1.4 s; the rest is WinUI process startup. Sized
+    /// as "could not legitimately take this long" rather than "usually takes this
+    /// long", matching <see cref="SelfTestBatch"/>'s backstop reasoning.
+    /// </summary>
+    private const int ProbeTimeoutMs = 60_000;
+
+    private static (int ExitCode, string Stdout, string Stderr) RunProbe(string policy, params string[] flags)
+    {
+        var exe = HostProcess.FindHostExe();
+        var args = $"{ProbeFlag} {policy}" + string.Concat(flags.Select(f => " " + f));
+        return RunHost(exe, args);
+    }
+
+    private static (int ExitCode, string Stdout, string Stderr) RunHost(string exe, string args)
+    {
+        var (stdout, stderr, exitCode, timedOut) = HostProcess.Run(exe, args, ProbeTimeoutMs);
+
+        Assert.IsFalse(timedOut,
+            $"Probe did not exit within {ProbeTimeoutMs}ms.\nHost: {exe} {args}\n--- stdout ---\n{stdout}\n--- stderr ---\n{stderr}");
+
+        return (exitCode, stdout, stderr);
+    }
+
+    private static string Detail(string policy, string args, (int ExitCode, string Stdout, string Stderr) result) =>
+        $"policy={policy} args={args}\nexit={result.ExitCode}\n--- stdout ---\n{result.Stdout}\n--- stderr ---\n{result.Stderr}";
+
+    [TestMethod]
+    public void Explicit_Keeps_Process_Alive_After_Last_Window_Closes()
+    {
+        var result = RunProbe("Explicit");
+        var detail = Detail("Explicit", ProbeFlag, result);
+
+        StringAssert.Contains(result.Stdout, AliveMarker,
+            $"The process exited when its last window closed — DispatcherShutdownMode was never raised to OnExplicitShutdown.\n{detail}");
+        Assert.AreEqual(AliveExitCode, result.ExitCode,
+            $"ReactorApp.Exit() should have been the only thing that ended the process.\n{detail}");
+    }
+
+    [TestMethod]
+    public void OnLastSurfaceClosed_Keeps_Process_Alive_While_A_Tray_Icon_Remains()
+    {
+        // The tray icon is what makes this arm meaningful: with no surviving
+        // surface, OnLastSurfaceClosed is *supposed* to end the process, and a
+        // tray-less run would exit for the right reason while looking exactly
+        // like the bug.
+        var result = RunProbe("OnLastSurfaceClosed", TrayFlag);
+        var detail = Detail("OnLastSurfaceClosed", $"{ProbeFlag} {TrayFlag}", result);
+
+        StringAssert.Contains(result.Stdout, AliveMarker,
+            $"A live tray icon should have kept the process running after the last window closed.\n{detail}");
+        StringAssert.Contains(result.Stdout, "trayIcons=1",
+            $"The probe reported no tray icon, so this run did not exercise the surviving-surface case.\n{detail}");
+        Assert.AreEqual(AliveExitCode, result.ExitCode, detail);
+    }
+
+    [TestMethod]
+    public void OnPrimaryWindowClosed_Still_Exits_When_Its_Window_Closes()
+    {
+        var result = RunProbe("OnPrimaryWindowClosed");
+        var detail = Detail("OnPrimaryWindowClosed", ProbeFlag, result);
+
+        StringAssert.Contains(result.Stdout, LoopExitedMarker,
+            $"The default policy must still end the process when the primary window closes.\n{detail}");
+        Assert.AreEqual(LoopExitedExitCode, result.ExitCode, detail);
+    }
+
+    // ── zero-surface startup (spec 036 §6.2) ───────────────────────────────
+    //
+    // A startup callback is allowed to open nothing at all. That decision is
+    // made in OnLaunched before any window has existed, so it is a different
+    // branch from the close-driven one above and needs its own arms — including
+    // the one that must still exit, which doubles as this pair's control.
+
+    [TestMethod]
+    public void Explicit_Keeps_Process_Alive_When_Startup_Opens_No_Surface()
+    {
+        var result = RunProbe("Explicit", NoWindowFlag);
+        var detail = Detail("Explicit", $"{ProbeFlag} {NoWindowFlag}", result);
+
+        StringAssert.Contains(result.Stdout, AliveMarker,
+            $"Explicit permits a zero-surface running state; the process should not have exited.\n{detail}");
+        StringAssert.Contains(result.Stdout, "windows=0",
+            $"The probe opened a window, so this run did not exercise zero-surface startup.\n{detail}");
+        Assert.AreEqual(AliveExitCode, result.ExitCode, detail);
+    }
+
+    [TestMethod]
+    public void OnLastSurfaceClosed_Keeps_Process_Alive_When_Startup_Opens_Only_A_Tray_Icon()
+    {
+        var result = RunProbe("OnLastSurfaceClosed", NoWindowFlag, TrayFlag);
+        var detail = Detail("OnLastSurfaceClosed", $"{ProbeFlag} {NoWindowFlag} {TrayFlag}", result);
+
+        StringAssert.Contains(result.Stdout, AliveMarker,
+            $"Tray-only startup is the documented shape for this policy (spec 036 §13.6).\n{detail}");
+        StringAssert.Contains(result.Stdout, "windows=0 trayIcons=1",
+            $"This run did not reach the tray-only state it is meant to assert.\n{detail}");
+        Assert.AreEqual(AliveExitCode, result.ExitCode, detail);
+    }
+
+    [TestMethod]
+    public void OnPrimaryWindowClosed_Exits_When_Startup_Opens_No_Surface()
+    {
+        // Control for the two arms above: same zero-surface startup, opposite
+        // outcome. "I forgot to OpenWindow" must still exit under the default.
+        var result = RunProbe("OnPrimaryWindowClosed", NoWindowFlag);
+        var detail = Detail("OnPrimaryWindowClosed", $"{ProbeFlag} {NoWindowFlag}", result);
+
+        StringAssert.Contains(result.Stdout, LoopExitedMarker,
+            $"A startup that opens zero windows under the default policy must exit immediately.\n{detail}");
+        Assert.AreEqual(LoopExitedExitCode, result.ExitCode, detail);
+    }
+
+    [TestMethod]
+    public void Explicit_Can_Reopen_A_Window_After_Outliving_The_Last_One()
+    {
+        // Surviving the close is only half of spec 036 §13.6 — the tray icon has
+        // to be able to put the window back.
+        var result = RunProbe("Explicit", TrayFlag, ReopenFlag);
+        var detail = Detail("Explicit", $"{ProbeFlag} {TrayFlag} {ReopenFlag}", result);
+
+        StringAssert.Contains(result.Stdout, ReopenedMarker,
+            $"The probe never reached the reopen step.\n{detail}");
+        StringAssert.Contains(result.Stdout, "before=0 after=1",
+            $"Reopening did not produce a registered window.\n{detail}");
+        Assert.AreEqual(AliveExitCode, result.ExitCode,
+            $"Exit code 45 means the reopened window never registered.\n{detail}");
+    }
+
+    // ── ownership gate (negative case) ─────────────────────────────────────
+
+    [TestMethod]
+    public void Setting_The_Policy_Does_Not_Touch_A_Host_Applications_Lifetime()
+    {
+        // Runs a process whose Application is NOT a ReactorApplication — the one
+        // shape no in-process fixture can reach, since inside the selftest host
+        // the gate's condition is always true.
+        var result = RunHost(HostProcess.FindHostExe(), GateProbeFlag);
+        var detail = Detail("Explicit", GateProbeFlag, result);
+
+        StringAssert.Contains(result.Stdout, GateHeldMarker,
+            $"Reactor rewrote DispatcherShutdownMode on an Application it does not own. An app embedding " +
+            $"ReactorHostControl would start exiting when its last window closes.\n{detail}");
+        Assert.AreEqual(GateHeldExitCode, result.ExitCode,
+            $"Exit 44 = gate violated, 46 = inconclusive (the probe could not establish its preconditions).\n{detail}");
+    }
+}

--- a/tests/Reactor.SelfTests/ShutdownPolicyProcessLifetimeTests.cs
+++ b/tests/Reactor.SelfTests/ShutdownPolicyProcessLifetimeTests.cs
@@ -318,7 +318,7 @@ public class ShutdownPolicyProcessLifetimeTests
 
         StringAssert.Contains(result.Stdout, GateHeldMarker,
             $"Reactor rewrote DispatcherShutdownMode on an Application it does not own. An app embedding " +
-            $"ReactorHostControl would start exiting when its last window closes.\n{detail}");
+            $"ReactorHostControl would stop exiting when its last window closes, and hang instead.\n{detail}");
         Assert.AreEqual(GateHeldExitCode, result.ExitCode,
             $"Exit 44 = gate violated, 46 = inconclusive (the probe could not establish its preconditions).\n{detail}");
     }

--- a/tests/Reactor.SelfTests/ShutdownPolicyProcessLifetimeTests.cs
+++ b/tests/Reactor.SelfTests/ShutdownPolicyProcessLifetimeTests.cs
@@ -40,6 +40,7 @@ public class ShutdownPolicyProcessLifetimeTests
     private const string ReopenFlag = "--reopen";
     private const string ExcludedWindowFlag = "--excluded-window";
     private const string CloseTrayFlag = "--close-tray";
+    private const string ClosingMarker = "CLOSING";
     private const string GateProbeFlag = "--shutdown-policy-gate-probe";
     private const int AliveExitCode = 42;
     private const int LoopExitedExitCode = 1;
@@ -60,7 +61,23 @@ public class ShutdownPolicyProcessLifetimeTests
     {
         var exe = HostProcess.FindHostExe();
         var args = $"{ProbeFlag} {policy}" + string.Concat(flags.Select(f => " " + f));
-        return RunHost(exe, args);
+        var result = RunHost(exe, args);
+
+        // Unless the arm is deliberately zero-surface, every one of these is a
+        // last-window-close probe, and that only means something if a window was
+        // opened and then closed. Without this, deleting OpenProbeWindow or the
+        // close timer would silently route several arms through the zero-surface
+        // startup path, where they would still report STILL-ALIVE and pass.
+        if (!flags.Contains(NoWindowFlag))
+        {
+            var detail = Detail(policy, args, result);
+            StringAssert.Contains(result.Stdout, "OPENED",
+                $"The probe never opened a window, so this is not a last-window-close run.\n{detail}");
+            StringAssert.Contains(result.Stdout, ClosingMarker,
+                $"The probe never reached the close step, so this is not a last-window-close run.\n{detail}");
+        }
+
+        return result;
     }
 
     private static (int ExitCode, string Stdout, string Stderr) RunHost(string exe, string args)

--- a/tests/Reactor.SelfTests/ShutdownPolicyProcessLifetimeTests.cs
+++ b/tests/Reactor.SelfTests/ShutdownPolicyProcessLifetimeTests.cs
@@ -38,6 +38,7 @@ public class ShutdownPolicyProcessLifetimeTests
     private const string TrayFlag = "--with-tray";
     private const string NoWindowFlag = "--no-window";
     private const string ReopenFlag = "--reopen";
+    private const string ExcludedWindowFlag = "--excluded-window";
     private const string GateProbeFlag = "--shutdown-policy-gate-probe";
     private const int AliveExitCode = 42;
     private const int LoopExitedExitCode = 1;
@@ -174,6 +175,26 @@ public class ShutdownPolicyProcessLifetimeTests
             $"Reopening did not produce a registered window.\n{detail}");
         Assert.AreEqual(AliveExitCode, result.ExitCode,
             $"Exit code 45 means the reopened window never registered.\n{detail}");
+    }
+
+    [TestMethod]
+    public void OnPrimaryWindowClosed_Stays_Alive_When_The_Last_Window_Opted_Out_Of_The_Policy()
+    {
+        // Issue #647's guarantee, which the windows guide already states:
+        // an auxiliary window (a docking tear-off) is never elected primary, so
+        // closing it never exits the app "even when it is the last visible
+        // window". The platform used to break that promise — OnLastWindowClose
+        // unwound the loop no matter what EvaluateShutdownPolicy decided — and
+        // it only holds now because Reactor owns the loop for every policy,
+        // including the default.
+        var result = RunProbe("OnPrimaryWindowClosed", ExcludedWindowFlag);
+        var detail = Detail("OnPrimaryWindowClosed", $"{ProbeFlag} {ExcludedWindowFlag}", result);
+
+        StringAssert.Contains(result.Stdout, "primaryElected=False",
+            $"The probe's window was elected primary, so this run never reached the auxiliary-window case.\n{detail}");
+        StringAssert.Contains(result.Stdout, AliveMarker,
+            $"Closing an auxiliary window ended the process, contradicting the documented issue-#647 behaviour.\n{detail}");
+        Assert.AreEqual(AliveExitCode, result.ExitCode, detail);
     }
 
     // ── ownership gate (negative case) ─────────────────────────────────────

--- a/tests/Reactor.SelfTests/ShutdownPolicyProcessLifetimeTests.cs
+++ b/tests/Reactor.SelfTests/ShutdownPolicyProcessLifetimeTests.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.UI.Reactor.SelfTests;
@@ -69,13 +70,25 @@ public class ShutdownPolicyProcessLifetimeTests
         // opened and then closed. Without this, deleting OpenProbeWindow or the
         // close timer would silently route several arms through the zero-surface
         // startup path, where they would still report STILL-ALIVE and pass.
+        //
+        // The zero-surface arms need the mirror image. They assert windows=0,
+        // which is also what a window that opened and closed leaves behind, so
+        // bypassing the zero-surface branch would leave them green too. Requiring
+        // the markers to be ABSENT is what pins them to the startup path.
+        var detail = Detail(policy, args, result);
         if (!flags.Contains(NoWindowFlag))
         {
-            var detail = Detail(policy, args, result);
             StringAssert.Contains(result.Stdout, "OPENED",
                 $"The probe never opened a window, so this is not a last-window-close run.\n{detail}");
             StringAssert.Contains(result.Stdout, ClosingMarker,
                 $"The probe never reached the close step, so this is not a last-window-close run.\n{detail}");
+        }
+        else
+        {
+            StringAssert.DoesNotMatch(result.Stdout, new Regex("OPENED"),
+                $"A window was opened, so this run exercised last-window-close rather than zero-surface startup.\n{detail}");
+            StringAssert.DoesNotMatch(result.Stdout, new Regex(ClosingMarker),
+                $"A window was closed, so this run exercised last-window-close rather than zero-surface startup.\n{detail}");
         }
 
         return result;

--- a/tests/Reactor.Tests/WindowShutdownPolicyTests.cs
+++ b/tests/Reactor.Tests/WindowShutdownPolicyTests.cs
@@ -135,23 +135,21 @@ public class WindowShutdownPolicyTests
     }
 
     [Fact]
-    public void EvaluateShutdownPolicy_Leaves_The_App_Alive_When_A_NonPrimary_Window_Closes()
+    public void EvaluateShutdownPolicy_Accepts_Both_Polarities_Of_ClosedWasPrimary()
     {
-        // Issue #647 / #1204: an auxiliary window (a docking tear-off) opts out
-        // of the shutdown policy and is never elected primary, so closing it —
-        // even as the last window on screen — must not end the process. That
-        // guarantee is only real because Reactor owns the event loop; while the
-        // platform still had OnLastWindowClose it would unwind anyway.
-        //
-        // Exit() is unobservable headlessly, so this asserts the reachable half:
-        // the default policy's non-primary path completes without taking the
-        // exit branch. The process-level half is the probe's --exclude-window arm.
+        // Bookkeeping only. The interesting behaviour — that a non-primary close
+        // under the default policy leaves the process running, which is issue
+        // #647's guarantee and only holds because Reactor owns the event loop —
+        // is NOT assertable here: SafeExit reduces to Application.Current?.Exit()
+        // with no Application, so both branches are indistinguishable. That case
+        // is covered by the probe's --excluded-window arm, which can observe the
+        // process. This keeps only the claim this tier can actually make.
         var prior = ReactorApp.ShutdownPolicy;
         try
         {
             ReactorApp.ShutdownPolicy = ShutdownPolicy.OnPrimaryWindowClosed;
             ReactorApp.EvaluateShutdownPolicy(closedWasPrimary: false);
-            Assert.Empty(ReactorApp.Windows);
+            ReactorApp.EvaluateShutdownPolicy(closedWasPrimary: true);
         }
         finally
         {

--- a/tests/Reactor.Tests/WindowShutdownPolicyTests.cs
+++ b/tests/Reactor.Tests/WindowShutdownPolicyTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.UI.Reactor;
+using Microsoft.UI.Xaml;
 using Xunit;
 
 namespace Microsoft.UI.Reactor.Tests;
@@ -87,6 +88,69 @@ public class WindowShutdownPolicyTests
                 ReactorApp.ShutdownPolicy = p;
                 Assert.Equal(p, ReactorApp.ShutdownPolicy);
             }
+        }
+        finally
+        {
+            ReactorApp.ShutdownPolicy = prior;
+        }
+    }
+
+    // ── issue #1204: the policy must reach the platform ────────────────────
+    //
+    // WinUI quits the thread's DispatcherQueue event loop on last-window-close
+    // unless Application.DispatcherShutdownMode is OnExplicitShutdown, so a
+    // policy that never gets projected onto that property is decorative. These
+    // assert the projection itself; the selftest fixture asserts it lands on a
+    // live Application, and the Reactor.SelfTests lifetime probe asserts the
+    // process actually survives.
+
+    [Theory]
+    [InlineData(ShutdownPolicy.OnPrimaryWindowClosed, DispatcherShutdownMode.OnLastWindowClose)]
+    [InlineData(ShutdownPolicy.OnLastSurfaceClosed, DispatcherShutdownMode.OnExplicitShutdown)]
+    [InlineData(ShutdownPolicy.Explicit, DispatcherShutdownMode.OnExplicitShutdown)]
+    public void DispatcherShutdownModeFor_Maps_Each_Policy(ShutdownPolicy policy, DispatcherShutdownMode expected)
+    {
+        Assert.Equal(expected, ReactorApp.DispatcherShutdownModeFor(policy));
+    }
+
+    [Fact]
+    public void DispatcherShutdownModeFor_Distinguishes_NonDefault_Policies_From_The_Default()
+    {
+        // Differential oracle: a mapping that collapsed to one constant would
+        // satisfy "returns a valid enum value" but would re-break the bug.
+        var platformDefault = ReactorApp.DispatcherShutdownModeFor(ShutdownPolicy.OnPrimaryWindowClosed);
+
+        Assert.NotEqual(platformDefault, ReactorApp.DispatcherShutdownModeFor(ShutdownPolicy.Explicit));
+        Assert.NotEqual(platformDefault, ReactorApp.DispatcherShutdownModeFor(ShutdownPolicy.OnLastSurfaceClosed));
+    }
+
+    [Fact]
+    public void DispatcherShutdownModeFor_Keeps_The_Platform_Default_For_Exactly_The_Default_Policy()
+    {
+        // Totality + shape: every policy is classified, and OnLastWindowClose —
+        // the mode that lets WinUI own process lifetime — is reserved for the
+        // one policy whose semantics already agree with it. A new enum member
+        // reaching the `_` arm gets caught here rather than in the field.
+        var keepPlatformOwnership = Enum.GetValues<ShutdownPolicy>()
+            .Where(p => ReactorApp.DispatcherShutdownModeFor(p) == DispatcherShutdownMode.OnLastWindowClose)
+            .ToArray();
+
+        Assert.Equal(new[] { ShutdownPolicy.OnPrimaryWindowClosed }, keepPlatformOwnership);
+    }
+
+    [Fact]
+    public void Setting_Policy_Without_A_UIDispatcher_Does_Not_Touch_WinUI()
+    {
+        // Headless: there is no Application and no UI dispatcher, so the setter
+        // must store the value and stop. Touching Application.Current here would
+        // throw a COMException and redden this test.
+        Assert.Null(ReactorApp.UIDispatcher);
+
+        var prior = ReactorApp.ShutdownPolicy;
+        try
+        {
+            ReactorApp.ShutdownPolicy = ShutdownPolicy.Explicit;
+            Assert.Equal(ShutdownPolicy.Explicit, ReactorApp.ShutdownPolicy);
         }
         finally
         {

--- a/tests/Reactor.Tests/WindowShutdownPolicyTests.cs
+++ b/tests/Reactor.Tests/WindowShutdownPolicyTests.cs
@@ -99,58 +99,59 @@ public class WindowShutdownPolicyTests
     //
     // WinUI quits the thread's DispatcherQueue event loop on last-window-close
     // unless Application.DispatcherShutdownMode is OnExplicitShutdown, so a
-    // policy that never gets projected onto that property is decorative. These
-    // assert the projection itself; the selftest fixture asserts it lands on a
-    // live Application, and the Reactor.SelfTests lifetime probe asserts the
-    // process actually survives.
-
-    [Theory]
-    [InlineData(ShutdownPolicy.OnPrimaryWindowClosed, DispatcherShutdownMode.OnLastWindowClose)]
-    [InlineData(ShutdownPolicy.OnLastSurfaceClosed, DispatcherShutdownMode.OnExplicitShutdown)]
-    [InlineData(ShutdownPolicy.Explicit, DispatcherShutdownMode.OnExplicitShutdown)]
-    public void DispatcherShutdownModeFor_Maps_Each_Policy(ShutdownPolicy policy, DispatcherShutdownMode expected)
-    {
-        Assert.Equal(expected, ReactorApp.DispatcherShutdownModeFor(policy));
-    }
+    // policy that never gets honoured is decorative. Reactor takes ownership of
+    // the loop at launch and lets EvaluateShutdownPolicy decide every exit.
+    //
+    // The observable behaviour of that lives in a live Application and a live
+    // process, so it is asserted by ShutdownPolicyDispatcherModeFixtures (the
+    // mode the host actually runs under) and by ShutdownPolicyProcessLifetimeTests
+    // (whether the process survives). What is left to check headlessly is that
+    // the setter stayed a plain store — the split-brain hazard it briefly had
+    // was that a policy could be published before the platform agreed with it.
 
     [Fact]
-    public void DispatcherShutdownModeFor_Distinguishes_NonDefault_Policies_From_The_Default()
+    public void Setting_Policy_Is_A_Plain_Store_With_No_Platform_Side_Effect()
     {
-        // Differential oracle: a mapping that collapsed to one constant would
-        // satisfy "returns a valid enum value" but would re-break the bug.
-        var platformDefault = ReactorApp.DispatcherShutdownModeFor(ShutdownPolicy.OnPrimaryWindowClosed);
-
-        Assert.NotEqual(platformDefault, ReactorApp.DispatcherShutdownModeFor(ShutdownPolicy.Explicit));
-        Assert.NotEqual(platformDefault, ReactorApp.DispatcherShutdownModeFor(ShutdownPolicy.OnLastSurfaceClosed));
-    }
-
-    [Fact]
-    public void DispatcherShutdownModeFor_Keeps_The_Platform_Default_For_Exactly_The_Default_Policy()
-    {
-        // Totality + shape: every policy is classified, and OnLastWindowClose —
-        // the mode that lets WinUI own process lifetime — is reserved for the
-        // one policy whose semantics already agree with it. A new enum member
-        // reaching the `_` arm gets caught here rather than in the field.
-        var keepPlatformOwnership = Enum.GetValues<ShutdownPolicy>()
-            .Where(p => ReactorApp.DispatcherShutdownModeFor(p) == DispatcherShutdownMode.OnLastWindowClose)
-            .ToArray();
-
-        Assert.Equal(new[] { ShutdownPolicy.OnPrimaryWindowClosed }, keepPlatformOwnership);
-    }
-
-    [Fact]
-    public void Setting_Policy_Without_A_UIDispatcher_Does_Not_Touch_WinUI()
-    {
-        // Headless: there is no Application and no UI dispatcher, so the setter
-        // must store the value and stop. Touching Application.Current here would
-        // throw a COMException and redden this test.
+        // Headless: there is no Application and no UI dispatcher. A setter that
+        // reached for either would throw a COMException and redden this test.
+        // It also documents the invariant that makes the policy safe to set from
+        // any thread: the value is never staged behind a dispatcher hop, so it
+        // cannot be observed out of step with the platform.
         Assert.Null(ReactorApp.UIDispatcher);
 
         var prior = ReactorApp.ShutdownPolicy;
         try
         {
-            ReactorApp.ShutdownPolicy = ShutdownPolicy.Explicit;
-            Assert.Equal(ShutdownPolicy.Explicit, ReactorApp.ShutdownPolicy);
+            foreach (var p in Enum.GetValues<ShutdownPolicy>())
+            {
+                ReactorApp.ShutdownPolicy = p;
+                Assert.Equal(p, ReactorApp.ShutdownPolicy);
+            }
+        }
+        finally
+        {
+            ReactorApp.ShutdownPolicy = prior;
+        }
+    }
+
+    [Fact]
+    public void EvaluateShutdownPolicy_Leaves_The_App_Alive_When_A_NonPrimary_Window_Closes()
+    {
+        // Issue #647 / #1204: an auxiliary window (a docking tear-off) opts out
+        // of the shutdown policy and is never elected primary, so closing it —
+        // even as the last window on screen — must not end the process. That
+        // guarantee is only real because Reactor owns the event loop; while the
+        // platform still had OnLastWindowClose it would unwind anyway.
+        //
+        // Exit() is unobservable headlessly, so this asserts the reachable half:
+        // the default policy's non-primary path completes without taking the
+        // exit branch. The process-level half is the probe's --exclude-window arm.
+        var prior = ReactorApp.ShutdownPolicy;
+        try
+        {
+            ReactorApp.ShutdownPolicy = ShutdownPolicy.OnPrimaryWindowClosed;
+            ReactorApp.EvaluateShutdownPolicy(closedWasPrimary: false);
+            Assert.Empty(ReactorApp.Windows);
         }
         finally
         {

--- a/tests/Reactor.Tests/WindowShutdownPolicyTests.cs
+++ b/tests/Reactor.Tests/WindowShutdownPolicyTests.cs
@@ -133,27 +133,4 @@ public class WindowShutdownPolicyTests
             ReactorApp.ShutdownPolicy = prior;
         }
     }
-
-    [Fact]
-    public void EvaluateShutdownPolicy_Accepts_Both_Polarities_Of_ClosedWasPrimary()
-    {
-        // Bookkeeping only. The interesting behaviour — that a non-primary close
-        // under the default policy leaves the process running, which is issue
-        // #647's guarantee and only holds because Reactor owns the event loop —
-        // is NOT assertable here: SafeExit reduces to Application.Current?.Exit()
-        // with no Application, so both branches are indistinguishable. That case
-        // is covered by the probe's --excluded-window arm, which can observe the
-        // process. This keeps only the claim this tier can actually make.
-        var prior = ReactorApp.ShutdownPolicy;
-        try
-        {
-            ReactorApp.ShutdownPolicy = ShutdownPolicy.OnPrimaryWindowClosed;
-            ReactorApp.EvaluateShutdownPolicy(closedWasPrimary: false);
-            ReactorApp.EvaluateShutdownPolicy(closedWasPrimary: true);
-        }
-        finally
-        {
-            ReactorApp.ShutdownPolicy = prior;
-        }
-    }
 }


### PR DESCRIPTION
Fixes #1204.

## The bug

`ShutdownPolicy` never reached the platform. `Application.Start` sets the UI thread's `Application.DispatcherShutdownMode` to `OnLastWindowClose`, so the XAML runtime quit the `DispatcherQueue` event loop on last-window-close — before `EvaluateShutdownPolicy` could veto it. An app with `ShutdownPolicy.Explicit` and a live tray icon exited with code 0 the moment its window closed. `git grep DispatcherShutdownMode` returned nothing.

## The fix

`OnLaunched` switches the mode to `OnExplicitShutdown` once, before any window exists, for **every** policy. The platform stops being a second, uncoordinated decision-maker — it cannot see `Explicit`, a surviving tray icon, or `ExcludeFromShutdownPolicy`.

Ownership is **unconditional**, not derived from the policy. Deriving it left two holes, both found in review: under the default policy the platform could still end a process whose last window was an auxiliary one (contradicting the #647 guarantee the guide already made), and the policy and the platform could disagree in the window between a setter and its dispatcher hop. With ownership unconditional, `ShutdownPolicy` is a plain store again — nothing to race.

Ownership is **scoped** to launches Reactor drives (the `Run(startup)` callback and the `Run<TRoot>` bridge) and to `Application.Current is ReactorApplication`. A host that constructs `ReactorApplication` directly, or embeds `ReactorHostControl` in its own `Application`, owns its own windows — Reactor would only leave it pumping forever.

Taking the loop over means Reactor must now own every exit, so the surrounding paths were closed up:

- Both launch paths run the zero-surface decision from a `finally`, shared as `ExitIfStartupOpenedNoSurface`.
- `UnregisterTrayIcon` stopped re-deriving the exit condition and calls the evaluator.
- Exits fall back to `DispatcherQueue.EnqueueEventLoopExit` if `Application.Exit()` throws — deliberately catching broadly, because `Exit()` runs user `Closed` callbacks.
- A failed `OpenWindow` no longer decides lifetime, and now closes the native window rather than only disposing it.

## Verified on a real app

The issue's repro, built as a standalone unpackaged WinUI app outside the repo and closed with a cross-process `WM_CLOSE` (what Alt+F4 sends). Same app binary, only Reactor rebuilt:

| Scenario | Before | After |
| --- | --- | --- |
| `Explicit` + tray | `EXITED(0)` | survives, loop still pumping |
| `Explicit`, no tray | `EXITED(0)` | survives |
| `OnLastSurfaceClosed` + tray | `EXITED(0)` | survives |
| `OnPrimaryWindowClosed` | `EXITED(0)` | `EXITED(0)` — unchanged |

`EXITED(0)` is verbatim the reported symptom. The full spec 036 §13.6 tray-app shape also works end to end: close → `windows=0 tray=1` → reopen a window → close → `ReactorApp.Exit(7)` exits cleanly with 7.

## Tests

- **Headless** — policy round-tripping, and that the setter stayed a plain store with no platform side effect.
- **Selftest** — the mode really moves to `OnExplicitShutdown`, and flipping the policy does **not** move it.
- **Out-of-process** (17 tests) — the only tier that can observe process lifetime or reach a branch guarded by `Application.Current is ReactorApplication`. Covers surviving last-window-close, zero-surface startup, reopening afterwards, the #647 auxiliary window, the last-tray-icon exit, the legacy `Run<TRoot>` entry point, handled startup/configure failures, a post-registration mount failure, and an embedder's `Application` being left alone.

Every "stays alive" arm has a counterpart asserting the opposite outcome, and the zero-surface arms assert the open/close markers are *absent* so they can't pass as an open-then-close. Each oracle was mutation-checked — removing the ownership call, no-opping the window close, deleting the ownership gate, bypassing the zero-surface branch, and re-enabling policy evaluation on a failed open each redden exactly the arms they should.

Suites: unit 13,902 pass / 0 fail; Release solution build 0 errors; CI green.

## Also here

- `Reactor.SelfTests` stamps its configuration and TFM into the assembly so the shared host locator stops hardcoding `Debug`, which would run a stale host under `dotnet test -c Release`.
- Docs: CHANGELOG, spec 036 §6.2, the `windows.md` guide (via its template), and a TESTING.md section on the probe modes.

No public API change, so no API-index regeneration.

<sub>Pre-review: the repo's `pr-review` skill flagged 1 high + 5 medium + 1 low across 8 dimensions, all fixed before opening. Sixteen Copilot review rounds and the CodeQL findings are addressed; all threads resolved.</sub>